### PR TITLE
Bootstrap Lean 4 seLe4 project scaffold and formal specification

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -1,0 +1,21 @@
+name: lean-ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+      - name: Verify toolchain
+        run: |
+          lean --version
+          lake --version
+      - name: Build
+        run: lake build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.lake/
+/build/
+/.elan/
+.DS_Store
+*.olean
+*.ilean
+*.trace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to seLe4
+
+## Branching and commits
+
+- Use focused branches per theorem-feature or subsystem change.
+- Keep commits small and proof-cohesive.
+- Include Lean file and docs updates together when semantics change.
+
+## Coding guidance
+
+- Maintain namespace hierarchy under `SeL4`.
+- Prefer total functions and explicit result types.
+- Avoid introducing axioms except where explicitly documented and reviewed.
+
+## Proof guidance
+
+- Start with theorem statements and `by` blocks that compile.
+- Decompose large goals into helper lemmas in `SeL4/Proofs`.
+- Minimize fragile `simp` usage across entire records; target fields directly.
+
+## PR checklist
+
+- [ ] `lake build` passes locally.
+- [ ] New definitions have doc comments.
+- [ ] New invariants include at least one supporting lemma.
+- [ ] `docs/SPECIFICATION.md` updated for boundary or roadmap shifts.

--- a/Main.lean
+++ b/Main.lean
@@ -1,0 +1,8 @@
+import SeL4
+
+/-
+A minimal executable entrypoint so `lake build` validates module imports and
+core definitions compile.
+-/
+def main : IO Unit :=
+  IO.println "seL4 Lean scaffold compiled successfully."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# seLe4: seL4-in-Lean Bootstrapping Repository
+
+This repository provides a complete starter environment for implementing and
+formally specifying core seL4 microkernel behavior in Lean 4.
+
+## What is included
+
+- Lean 4 project scaffold (`lakefile.toml`, `lean-toolchain`, `Main.lean`).
+- A modular namespace layout for kernel model, execution semantics, invariants,
+  and refinement proofs.
+- A thorough implementation specification and roadmap in `docs/SPECIFICATION.md`.
+- Contributor and environment setup documentation in `docs/ENVIRONMENT.md` and
+  `CONTRIBUTING.md`.
+- CI workflow for basic Lean build validation.
+
+## Quick start
+
+1. Install Lean tooling with `elan`.
+2. Run `lake build`.
+3. Read `docs/SPECIFICATION.md` and pick the next milestone.
+
+See `docs/ENVIRONMENT.md` for full setup details.

--- a/SeL4.lean
+++ b/SeL4.lean
@@ -1,0 +1,9 @@
+import SeL4.Model.Types
+import SeL4.Model.KernelState
+import SeL4.Model.Syscall
+import SeL4.Execution.Step
+import SeL4.Spec.Objects
+import SeL4.Spec.Capabilities
+import SeL4.Spec.IPC
+import SeL4.Refinement.Simulation
+import SeL4.Proofs.InvariantLemmas

--- a/SeL4/Execution/Step.lean
+++ b/SeL4/Execution/Step.lean
@@ -1,0 +1,26 @@
+import SeL4.Model.Syscall
+
+namespace SeL4
+namespace Execution
+open Model
+
+/-- Placeholder for a pure state transition relation for syscalls. -/
+def step (state : KernelState) (call : Syscall) : SyscallResult :=
+  match call with
+  | .yield =>
+      SyscallResult.ok {
+        state with
+        runnableQueue := state.runnableQueue ++ [state.currentThread]
+      }
+  | .send endpoint _ =>
+      match state.endpoints endpoint with
+      | none => .invalidEndpoint
+      | some _ => .blocked state
+  | .recv endpoint =>
+      match state.endpoints endpoint with
+      | none => .invalidEndpoint
+      | some _ => .blocked state
+  | .mintCap _ _ => .ok state
+
+end Execution
+end SeL4

--- a/SeL4/Model/KernelState.lean
+++ b/SeL4/Model/KernelState.lean
@@ -1,0 +1,48 @@
+import SeL4.Model.Types
+
+namespace SeL4
+namespace Model
+
+/-- Scheduling state for a thread. -/
+inductive ThreadStatus where
+  | running
+  | ready
+  | blockedOnReceive (endpoint : EndpointId)
+  | blockedOnSend (endpoint : EndpointId)
+  deriving DecidableEq, Repr
+
+structure ThreadControlBlock where
+  priority : Nat
+  status : ThreadStatus
+  messageRegisters : List Nat
+  deriving DecidableEq, Repr
+
+structure EndpointState where
+  sendQueue : List ThreadId
+  recvQueue : List ThreadId
+  deriving DecidableEq, Repr
+
+structure CNodeState where
+  slots : CapabilitySlot → Capability
+
+/-- Top-level abstract kernel state for the executable specification. -/
+structure KernelState where
+  currentThread : ThreadId
+  runnableQueue : List ThreadId
+  threads : ThreadId → Option ThreadControlBlock
+  endpoints : EndpointId → Option EndpointState
+  cnodes : CNodeId → Option CNodeState
+
+namespace KernelState
+
+def empty : KernelState := {
+  currentThread := 0
+  runnableQueue := []
+  threads := fun _ => none
+  endpoints := fun _ => none
+  cnodes := fun _ => none
+}
+
+end KernelState
+end Model
+end SeL4

--- a/SeL4/Model/Syscall.lean
+++ b/SeL4/Model/Syscall.lean
@@ -1,0 +1,15 @@
+import SeL4.Model.KernelState
+
+namespace SeL4
+namespace Model
+
+/-- Return codes for the abstract syscall semantics. -/
+inductive SyscallResult where
+  | ok (state : KernelState)
+  | blocked (state : KernelState)
+  | invalidCapability
+  | invalidEndpoint
+  deriving Repr
+
+end Model
+end SeL4

--- a/SeL4/Model/Types.lean
+++ b/SeL4/Model/Types.lean
@@ -1,0 +1,35 @@
+namespace SeL4
+namespace Model
+
+abbrev ThreadId : Type := Nat
+abbrev EndpointId : Type := Nat
+abbrev NotificationId : Type := Nat
+abbrev CNodeId : Type := Nat
+abbrev CapabilitySlot : Type := Nat
+
+/-- Rights attached to a capability. -/
+inductive Rights where
+  | read
+  | write
+  | grant
+  deriving DecidableEq, Repr
+
+/-- Capability references to kernel objects. -/
+inductive Capability where
+  | nullCap
+  | threadCap (tid : ThreadId)
+  | endpointCap (eid : EndpointId) (rights : List Rights)
+  | notificationCap (nid : NotificationId)
+  | cnodeCap (cid : CNodeId)
+  deriving DecidableEq, Repr
+
+/-- User-facing system call surface we model initially. -/
+inductive Syscall where
+  | send (endpoint : EndpointId) (message : List Nat)
+  | recv (endpoint : EndpointId)
+  | yield
+  | mintCap (srcCNode : CNodeId) (srcSlot : CapabilitySlot)
+  deriving DecidableEq, Repr
+
+end Model
+end SeL4

--- a/SeL4/Proofs/InvariantLemmas.lean
+++ b/SeL4/Proofs/InvariantLemmas.lean
@@ -1,0 +1,15 @@
+import SeL4.Refinement.Simulation
+
+namespace SeL4
+namespace Proofs
+open Model
+open Refinement
+
+/-- Initial reusable theorem exposing the global invariant frame. -/
+theorem invariant_of_empty_state :
+    KernelInvariant Model.KernelState.empty := by
+  unfold KernelInvariant Spec.ObjectsWellFormed Spec.CapabilitySafe Spec.IPCQueuesConsistent
+  simp [Model.KernelState.empty]
+
+end Proofs
+end SeL4

--- a/SeL4/Refinement/Simulation.lean
+++ b/SeL4/Refinement/Simulation.lean
@@ -1,0 +1,29 @@
+import SeL4.Execution.Step
+import SeL4.Spec.Objects
+import SeL4.Spec.Capabilities
+import SeL4.Spec.IPC
+
+namespace SeL4
+namespace Refinement
+open Model
+open Execution
+open Spec
+
+/-- Aggregate invariant used for early refinement proofs. -/
+def KernelInvariant (s : KernelState) : Prop :=
+  ObjectsWellFormed s ∧ CapabilitySafe s ∧ IPCQueuesConsistent s
+
+/-- Simulation theorem statement placeholder (to be completed incrementally). -/
+theorem step_preserves_invariant
+    (s : KernelState)
+    (c : Syscall)
+    (hInv : KernelInvariant s)
+    : match step s c with
+      | .ok s' => KernelInvariant s'
+      | .blocked s' => KernelInvariant s'
+      | .invalidCapability => True
+      | .invalidEndpoint => True := by
+  cases c <;> simp [step, KernelInvariant] at *
+
+end Refinement
+end SeL4

--- a/SeL4/Spec/Capabilities.lean
+++ b/SeL4/Spec/Capabilities.lean
@@ -1,0 +1,20 @@
+import SeL4.Model.KernelState
+
+namespace SeL4
+namespace Spec
+open Model
+
+/-- Capability safety policy (starter skeleton). -/
+def CapabilitySafe (s : KernelState) : Prop :=
+  ∀ cnodeId cnode,
+    s.cnodes cnodeId = some cnode →
+      ∀ slot,
+        match cnode.slots slot with
+        | .nullCap => True
+        | .threadCap tid => (s.threads tid).isSome
+        | .endpointCap eid _ => (s.endpoints eid).isSome
+        | .notificationCap _ => True
+        | .cnodeCap cid => (s.cnodes cid).isSome
+
+end Spec
+end SeL4

--- a/SeL4/Spec/IPC.lean
+++ b/SeL4/Spec/IPC.lean
@@ -1,0 +1,17 @@
+import SeL4.Model.KernelState
+
+namespace SeL4
+namespace Spec
+open Model
+
+/-- IPC consistency invariant between endpoint queues and blocked thread states. -/
+def IPCQueuesConsistent (s : KernelState) : Prop :=
+  ∀ endpointId endpoint,
+    s.endpoints endpointId = some endpoint →
+      (∀ tid, tid ∈ endpoint.sendQueue →
+        ∃ tcb, s.threads tid = some tcb ∧ tcb.status = .blockedOnSend endpointId) ∧
+      (∀ tid, tid ∈ endpoint.recvQueue →
+        ∃ tcb, s.threads tid = some tcb ∧ tcb.status = .blockedOnReceive endpointId)
+
+end Spec
+end SeL4

--- a/SeL4/Spec/Objects.lean
+++ b/SeL4/Spec/Objects.lean
@@ -1,0 +1,13 @@
+import SeL4.Model.KernelState
+
+namespace SeL4
+namespace Spec
+open Model
+
+/-- Object invariants expected from the abstract object graph. -/
+def ObjectsWellFormed (s : KernelState) : Prop :=
+  (∀ tcb, tcb ∈ s.runnableQueue → (s.threads tcb).isSome) ∧
+  (s.threads s.currentThread).isSome
+
+end Spec
+end SeL4

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,66 @@
+# Environment Setup for seLe4
+
+This document creates a production-ready local environment for starting the seL4
+formalization effort in Lean.
+
+## 1) Required Toolchain
+
+- **Lean**: Lean 4 (managed by `elan`)
+- **Build tool**: `lake` (installed with Lean)
+- **Git**: for version control and collaboration
+- **Optional editor tooling**:
+  - VS Code + `lean4` extension
+  - Neovim with Lean LSP support
+
+## 2) Install Lean via elan
+
+```bash
+curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
+source "$HOME/.elan/env"
+lean --version
+lake --version
+```
+
+The repository pins Lean through:
+
+- `lean-toolchain` → `leanprover/lean4:stable`
+
+## 3) Build the project
+
+```bash
+lake build
+```
+
+This compiles:
+
+- The `SeL4` Lean library
+- The `seL4-spec-check` executable in `Main.lean`
+
+## 4) Recommended editor setup
+
+### VS Code
+
+1. Install the **Lean 4** extension.
+2. Open the repo root.
+3. Run “Lean: Restart File” if initial server warmup is slow.
+
+### Formatting and style
+
+- Prefer explicit namespaces and module-level documentation comments.
+- Keep proof scripts minimal and composable.
+- Avoid introducing external dependencies until needed by proof goals.
+
+## 5) CI behavior
+
+GitHub Actions runs `lake build` on pushes and pull requests.
+
+If you add dependencies or proofs requiring additional automation:
+
+- update `lakefile.toml`
+- ensure CI remains deterministic
+
+## 6) Suggested next tools (optional)
+
+- **Alectryon / doc-gen4** for documentation extraction.
+- **LeanDojo** or custom theorem mining scripts for proof search analytics.
+- Property-based scenario generators for syscall traces via extracted interpreters.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,0 +1,172 @@
+# seL4-in-Lean Specification and Boilerplate Plan
+
+## Mission
+
+Build a mechanically checked Lean model of seL4 with a layered refinement story:
+
+1. **Abstract functional model** of kernel state transitions
+2. **Executable specification** of syscall behavior
+3. **Security and safety invariants** preserved by transitions
+4. **Refinement interface** for connecting to lower-level implementations
+
+---
+
+## Scope and Non-Goals (initial phase)
+
+### In scope
+
+- Core object model (threads, endpoints, CNodes, capabilities)
+- Deterministic syscall transition relation
+- Invariant framework for capability safety and IPC consistency
+- Initial theorem skeletons to drive proof decomposition
+
+### Out of scope (phase 1)
+
+- Full binary compatibility with existing seL4 C implementation
+- Machine-level memory model and hardware interrupts
+- Verified compiler integration
+
+---
+
+## Repository Architecture
+
+```text
+SeL4/
+  Model/
+    Types.lean          -- primitive IDs, capabilities, syscall syntax
+    KernelState.lean    -- abstract kernel object/state representation
+    Syscall.lean        -- syscall result type and status channel
+  Execution/
+    Step.lean           -- executable small-step syscall semantics
+  Spec/
+    Objects.lean        -- object graph/well-formedness invariants
+    Capabilities.lean   -- capability validity/safety invariants
+    IPC.lean            -- endpoint queue consistency invariants
+  Refinement/
+    Simulation.lean     -- aggregate invariants + preservation theorem shell
+  Proofs/
+    InvariantLemmas.lean -- starter theorem over empty state
+```
+
+---
+
+## Formal Model Requirements
+
+### 1) Object Universe
+
+- Thread IDs, endpoint IDs, notification IDs, CNode IDs are abstract naturals.
+- Capability slots are indexed by naturals.
+- Capabilities include null, thread, endpoint-with-rights, notification, and CNode forms.
+
+### 2) Kernel State
+
+The top-level state must include:
+
+- current thread pointer
+- runnable queue
+- thread table (`ThreadId → Option TCB`)
+- endpoint table (`EndpointId → Option EndpointState`)
+- cspace table (`CNodeId → Option CNodeState`)
+
+### 3) Syscall Surface
+
+The initial syscall algebra supports:
+
+- send
+- recv
+- yield
+- mintCap
+
+Each syscall returns either:
+
+- successful state (`ok`)
+- blocked state (`blocked`)
+- error condition (`invalidCapability`, `invalidEndpoint`)
+
+### 4) Invariant Stack
+
+`KernelInvariant` is defined as conjunction of:
+
+- `ObjectsWellFormed`
+- `CapabilitySafe`
+- `IPCQueuesConsistent`
+
+All future proofs should use this layered invariant to avoid monolithic theorem statements.
+
+---
+
+## Proof Engineering Strategy
+
+### Phase A: Structural invariants
+
+- prove easy constructor lemmas
+- derive read-only framing lemmas for unaffected substructures
+
+### Phase B: Syscall-by-syscall preservation
+
+- one theorem per syscall constructor
+- combine via dispatch theorem (`step_preserves_invariant`)
+
+### Phase C: Refinement adapters
+
+- define relation between abstract state and concrete state record
+- prove forward simulation for each syscall
+
+### Phase D: Security and authority
+
+- non-interference style lemmas over capability graph reachability
+- integrity properties for CSpace updates (mint/move/revoke)
+
+---
+
+## Milestone Backlog
+
+1. Expand object model with notifications and reply objects.
+2. Replace placeholder `step` semantics with realistic queue transfer behavior.
+3. Add scheduler model (priority queues, budget accounting, time slicing).
+4. Introduce memory capability regions and untyped retype semantics.
+5. Mechanize Hoare-style API layer for compositional syscall proof scripts.
+6. Connect abstract model with executable test traces.
+
+---
+
+## Definition of Done (for each feature)
+
+A change is complete only if it adds:
+
+1. Data structure updates in `SeL4/Model/*` (if needed)
+2. Transition semantics updates in `SeL4/Execution/Step.lean`
+3. Invariant updates in `SeL4/Spec/*`
+4. Preservation/update theorem adjustments in `SeL4/Refinement/*`
+5. At least one proof lemma in `SeL4/Proofs/*`
+6. Documentation update in this file if the model boundary changed
+
+---
+
+## Development Workflow
+
+1. Write/adjust state and syntax definitions.
+2. Encode transition semantics.
+3. State invariants narrowly, then aggregate.
+4. Prove local lemmas before global theorem closure.
+5. Keep theorem statements stable; evolve proof internals incrementally.
+
+---
+
+## Risks and Mitigations
+
+- **Risk**: Overly concrete early model hampers refinement.
+  - **Mitigation**: Keep IDs abstract and tables functional (`Option` maps).
+- **Risk**: Proof brittleness from giant simplification steps.
+  - **Mitigation**: build named helper lemmas and local simp sets.
+- **Risk**: Scope explosion.
+  - **Mitigation**: preserve milestone boundaries and enforce phase gates.
+
+---
+
+## Immediate Next Tasks
+
+- Implement real send/recv queue state transitions.
+- Add ownership/authority relation to capabilities.
+- Extend `invariant_of_empty_state` with more reusable helper lemmas.
+- Add trace-level properties (`step*`) for multi-syscall executions.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,0 +1,9 @@
+name = "seLe4"
+defaultTargets = ["SeL4"]
+
+[[lean_lib]]
+name = "SeL4"
+
+[[lean_exe]]
+name = "seL4-spec-check"
+root = "Main"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:stable


### PR DESCRIPTION
### Motivation
- Provide a complete, opinionated starter environment to begin mechanizing the seL4 microkernel in Lean 4 and accelerate proof-driven development. 
- Establish a minimal but extensible namespace layout and invariant stack to guide early modelling and refinement work. 
- Enable continuous validation via CI and document developer setup and workflow so contributors can reproduce a local environment. 

### Description
- Add a Lean 4 project scaffold with `lakefile.toml`, `lean-toolchain`, `Main.lean`, `SeL4.lean`, and a `.gitignore` tuned for Lean artifacts. 
- Add a modular seL4 formalization boilerplate under `SeL4/` including `Model` (`Types.lean`, `KernelState.lean`, `Syscall.lean`), `Execution/Step.lean` (small-step syscall skeleton), `Spec/` invariants (`Objects.lean`, `Capabilities.lean`, `IPC.lean`), `Refinement/Simulation.lean` (aggregate invariant and theorem shell), and `Proofs/InvariantLemmas.lean` (starter lemma for the empty state). 
- Add documentation and onboarding materials: `README.md`, `docs/ENVIRONMENT.md`, `docs/SPECIFICATION.md`, and `CONTRIBUTING.md` describing mission, architecture, development workflow, milestones, and environment setup. 
- Add a GitHub Actions workflow `.github/workflows/lean.yml` to install `elan`, verify the toolchain, and run `lake build` on pushes and pull requests. 

### Testing
- Attempted `lake build` in this runtime but it failed because `lake` is not installed in the environment (command error: `bash: command not found: lake`). 
- Attempted to bootstrap `elan` via the standard installer (`curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y`) but the network request returned HTTP 403 in this environment, preventing toolchain installation. 
- Verified repository operations succeeded: ran `git add`/`git commit` and confirmed the new commit and branch state (`work` branch, commit message recorded). 
- The PR was created summarizing the bootstrap and test results so CI in a proper developer/CI environment can validate `lake build` and complete the verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699012b81ed8832b8a6f28a69f7265ff)