### PR TITLE
Add core kernel identifier aliases (milestone 1)

### DIFF
--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -11,7 +11,7 @@ inductive AccessRight where
 structure Capability where
   target : SeLe4n.ObjId
   rights : List AccessRight
-  badge : Option Nat := none
+  badge : Option SeLe4n.Badge := none
   deriving Repr, DecidableEq
 
 structure TCB where
@@ -27,7 +27,7 @@ structure Endpoint where
   deriving Repr, DecidableEq
 
 structure CNode where
-  slots : Nat → Option Capability
+  slots : SeLe4n.Slot → Option Capability
 
 instance : Repr CNode where
   reprPrec _ _ := "CNode(<function>)"

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -1,10 +1,37 @@
 namespace SeLe4n
 
+/-- Identifier for objects in the global kernel object store. -/
 abbrev ObjId := Nat
+
+/-- Identifier for threads (TCBs). -/
 abbrev ThreadId := Nat
+
+/-- Scheduling domain identifier. -/
 abbrev DomainId := Nat
+
+/-- Scheduling priority level. -/
 abbrev Priority := Nat
+
+/-- Interrupt request line identifier. -/
 abbrev Irq := Nat
+
+/-- Capability-space pointer value. -/
+abbrev CPtr := Nat
+
+/-- Slot index within a CNode. -/
+abbrev Slot := Nat
+
+/-- Endpoint or notification badge value. -/
+abbrev Badge := Nat
+
+/-- Address-space identifier. -/
+abbrev ASID := Nat
+
+/-- Virtual-memory address in the abstract model. -/
+abbrev VAddr := Nat
+
+/-- Physical-memory address in the abstract model. -/
+abbrev PAddr := Nat
 
 /-- A tiny state/error monad used for executable kernel skeletons. -/
 abbrev KernelM (σ ε α : Type) := σ → Except ε (α × σ)


### PR DESCRIPTION
### Motivation
- Provide the canonical, documented type aliases for kernel identifiers required by the bootstrap milestone so the model can refer to `ObjId`, `ThreadId`, `DomainId`, `Priority`, `Irq` and other common kernel ID types from a single place.

### Description
- Add documented identifier aliases in `SeLe4n.Prelude` (`ObjId`, `ThreadId`, `DomainId`, `Priority`, `Irq`, `CPtr`, `Slot`, `Badge`, `ASID`, `VAddr`, `PAddr`) and update `SeLe4n.Model.Object` to use `Option SeLe4n.Badge` for `Capability.badge` and `SeLe4n.Slot` for `CNode.slots` so the object model consumes the new canonical types.

### Testing
- Ran the project build with `source $HOME/.elan/env && lake build`, which completed successfully (built all modules and the `sele4n` executable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990346dbb00832bab42cb6c2dad8477)