### PR TITLE
Add abstract machine state and mark core alias milestone complete

### DIFF
--- a/SeLe4n/Machine.lean
+++ b/SeLe4n/Machine.lean
@@ -2,20 +2,49 @@ import SeLe4n.Prelude
 
 namespace SeLe4n
 
+/-- General-purpose register index in the abstract machine model. -/
+abbrev RegName := Nat
+
+/-- Register-sized machine word in the abstract machine model. -/
+abbrev RegValue := Nat
+
+/-- Byte-addressed memory store used by the abstract machine model. -/
+abbrev Memory := PAddr → UInt8
+
+/-- Pure register file state used by scheduler/context-switch modeling. -/
 structure RegisterFile where
-  pc : Nat
-  sp : Nat
-  gpr : Nat → Nat
+  pc : RegValue
+  sp : RegValue
+  gpr : RegName → RegValue
 
 instance : Inhabited RegisterFile where
   default := { pc := 0, sp := 0, gpr := fun _ => 0 }
 
+/-- Top-level abstract machine state manipulated by kernel transitions. -/
 structure MachineState where
   regs : RegisterFile
-  memory : Nat → UInt8
+  memory : Memory
   timer : Nat
 
 instance : Inhabited MachineState where
   default := { regs := default, memory := fun _ => 0, timer := 0 }
+
+def readReg (rf : RegisterFile) (r : RegName) : RegValue :=
+  rf.gpr r
+
+def writeReg (rf : RegisterFile) (r : RegName) (v : RegValue) : RegisterFile :=
+  { rf with gpr := fun r' => if r' = r then v else rf.gpr r' }
+
+def readMem (ms : MachineState) (addr : PAddr) : UInt8 :=
+  ms.memory addr
+
+def writeMem (ms : MachineState) (addr : PAddr) (value : UInt8) : MachineState :=
+  { ms with memory := fun a => if a = addr then value else ms.memory a }
+
+def setPC (ms : MachineState) (pc : RegValue) : MachineState :=
+  { ms with regs := { ms.regs with pc := pc } }
+
+def tick (ms : MachineState) : MachineState :=
+  { ms with timer := ms.timer + 1 }
 
 end SeLe4n

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -28,8 +28,8 @@ The bootstrap milestone optimizes for:
 
 The following are required in this milestone:
 
-1. Core type aliases for kernel identifiers.
-2. Abstract machine state (`RegisterFile`, `MachineState`).
+1. ~~Core type aliases for kernel identifiers.~~
+2. ~~Abstract machine state (`RegisterFile`, `MachineState`).~~
 3. Kernel object universe (`TCB`, `Endpoint`, `CNode`, capabilities).
 4. Global system state (`SystemState`) with object store and scheduler fields.
 5. Basic kernel monad (`KernelM`) and error type (`KernelError`).


### PR DESCRIPTION
### Motivation

- Provide a small, usable abstract machine model for the kernel layer to enable executable semantics and scheduler modeling. 
- Expose simple read/write helpers and small-step utilities so higher-level kernel transitions can manipulate registers, memory, and the program counter. 
- Align the written specification with the actual code by verifying and marking the core identifier aliases milestone as complete.

### Description

- Added `RegName`, `RegValue`, and `Memory` aliases and refined `RegisterFile` to use typed register indices and values by changing `pc`, `sp`, and `gpr` to `RegValue`/`RegName` in `SeLe4n.Machine`.
- Replaced the generic memory type with `Memory := PAddr → UInt8` and updated `MachineState.memory` accordingly in `SeLe4n.Machine`.
- Implemented simple accessors and mutators: `readReg`, `writeReg`, `readMem`, `writeMem`, `setPC`, and `tick` to operate on `RegisterFile` and `MachineState`.
- Updated `docs/SEL4_SPEC.md` to cross through the milestone item for core type aliases after verifying those aliases are present in `SeLe4n.Prelude` (e.g. `ObjId`, `ThreadId`, `DomainId`, `Priority`, `Irq`, `CPtr`, `Slot`, `Badge`, `ASID`, `VAddr`, `PAddr`).

### Testing

- Attempted to run `source "$HOME/.elan/env" && lake build`, which failed because the environment bootstrap was not present in the container. 
- Installed `elan` via the official installer and then ran `~/.elan/bin/lake build`, which completed successfully and built the project (all modules and executable built). 
- The build output indicates a successful compilation of `SeLe4n` and `sele4n:exe` (build completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699035f40a2c832b8691ece5867c0844)