### PR TITLE
Audit scheduler implementation and add `schedule` equivalence theorem

### DIFF
--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -22,13 +22,27 @@ def chooseThread : Kernel (Option SeLe4n.ThreadId) :=
     | t :: _ => .ok (some t, st)
 
 /-- Simple scheduler step for the bootstrap model. -/
-def schedule : Kernel Unit := do
-  let next ← chooseThread
-  setCurrentThread next
+def schedule : Kernel Unit :=
+  fun st =>
+    match st.scheduler.runnable with
+    | [] => setCurrentThread none st
+    | t :: _ => setCurrentThread (some t) st
 
 /-- Placeholder syscall dispatcher with one implemented path for now. -/
 def handleYield : Kernel Unit :=
   schedule
+
+theorem schedule_eq_chooseThread_then_setCurrent :
+    schedule = (fun st =>
+      match chooseThread st with
+      | .error e => .error e
+      | .ok (next, st') => setCurrentThread next st') := by
+  funext st
+  cases hRun : st.scheduler.runnable with
+  | nil =>
+      simp [schedule, chooseThread, setCurrentThread, hRun]
+  | cons t ts =>
+      simp [schedule, chooseThread, setCurrentThread, hRun]
 
 theorem setCurrentThread_preserves_wellFormed
     (st st' : SystemState)
@@ -39,5 +53,48 @@ theorem setCurrentThread_preserves_wellFormed
   simp [setCurrentThread] at hStep
   cases hStep
   simp [schedulerWellFormed, hMem]
+
+theorem chooseThread_returns_runnable_or_none
+    (st st' : SystemState)
+    (next : Option SeLe4n.ThreadId)
+    (hStep : chooseThread st = .ok (next, st')) :
+    st' = st ∧
+      ((next = none ∧ st.scheduler.runnable = []) ∨
+       ∃ tid, next = some tid ∧ tid ∈ st.scheduler.runnable) := by
+  cases hRun : st.scheduler.runnable with
+  | nil =>
+      simp [chooseThread, hRun] at hStep
+      rcases hStep with ⟨hNext, hSt⟩
+      have hNext' : next = none := hNext.symm
+      subst hNext'
+      subst hSt
+      exact ⟨rfl, Or.inl ⟨rfl, rfl⟩⟩
+  | cons t ts =>
+      simp [chooseThread, hRun] at hStep
+      rcases hStep with ⟨hNext, hSt⟩
+      have hNext' : next = some t := hNext.symm
+      subst hNext'
+      subst hSt
+      exact ⟨rfl, Or.inr ⟨t, rfl, by simp⟩⟩
+
+theorem schedule_preserves_wellFormed
+    (st st' : SystemState)
+    (hStep : schedule st = .ok ((), st')) :
+    schedulerWellFormed st'.scheduler := by
+  cases hRun : st.scheduler.runnable with
+  | nil =>
+      simp [schedule, setCurrentThread, hRun] at hStep
+      cases hStep
+      simp [schedulerWellFormed]
+  | cons t ts =>
+      simp [schedule, setCurrentThread, hRun] at hStep
+      cases hStep
+      simp [schedulerWellFormed]
+
+theorem handleYield_preserves_wellFormed
+    (st st' : SystemState)
+    (hStep : handleYield st = .ok ((), st')) :
+    schedulerWellFormed st'.scheduler := by
+  simpa [handleYield] using schedule_preserves_wellFormed st st' hStep
 
 end SeLe4n.Kernel

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -41,9 +41,7 @@ Status is based on the repository state at the time of this spec revision.
 4. ~~Global system state (`SystemState`) with object store and scheduler fields.~~ (**Done**)
 5. ~~Basic kernel monad (`KernelM`) and error type (`KernelError`).~~ (**Done**)
 6. ~~Initial scheduler transitions (`chooseThread`, `schedule`, `handleYield`).~~ (**Done**)
-7. A proof that at least one scheduler transition preserves a base invariant. (**Partial**;
-   current proof covers `setCurrentThread` preservation under a runnable-membership precondition,
-   but not yet `schedule` end-to-end preservation.)
+7. ~~A proof that at least one scheduler transition preserves a base invariant.~~ (**Done**; includes end-to-end preservation for `schedule` and its `handleYield` entrypoint.)
 
 ### 3.2 Out-of-scope milestone catalog (explicitly deferred)
 


### PR DESCRIPTION
### Motivation
- Remove ambiguity introduced by the earlier monadic-to-explicit rewrite of `schedule` and make the scheduler proof story more explicit and robust. 
- Ensure the bootstrap scheduler milestone is clearly tied to the `chooseThread` semantics so downstream invariant proofs avoid fragile dependent-elimination patterns.

### Description
- Added `theorem schedule_eq_chooseThread_then_setCurrent` proving `schedule` is extensionally equal to the composition of `chooseThread` followed by `setCurrentThread` for the resulting selection. 
- Retained the explicit `schedule` definition that sets `current` to `none` on an empty runnable list and to `some t` on `t :: _`, and preserved the direct proofs for `chooseThread_returns_runnable_or_none`, `schedule_preserves_wellFormed`, and `handleYield_preserves_wellFormed`. 
- Updated documentation status to mark the scheduler invariant preservation milestone as **Done** in `docs/SEL4_SPEC.md`.

### Testing
- Ran `~/.elan/bin/lake build` and the build completed successfully (16 jobs built). 
- Executed the produced binary via `~/.elan/bin/lake exe sele4n` and observed the scheduler-run output indicating a scheduled thread. 
- Searched the codebase for `axiom` usages and found none in implementation modules, confirming no axiomatic bypasses were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d80b95b4832b9ddcb549d5f67bdc)