### PR TITLE
docs: refine M1 scheduler-invariant scope and development guidance

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,12 +6,26 @@ The project has completed bootstrap and is now in **M1: Scheduler Integrity**.
 Development should prioritize invariant strengthening and proof coverage for existing scheduling
 transitions before adding major new subsystems.
 
+### Current objective slice (next step)
+
+The active implementation target is **Scheduler Invariant Bundle v1**:
+
+- define the invariant components in a compositional form,
+- lock and document queue/current consistency policy,
+- prove preservation over `chooseThread`, `schedule`, and `handleYield`.
+
 ## 2. Working agreement
 
 1. Spec-first: update `docs/SEL4_SPEC.md` when scope or acceptance criteria change.
 2. Keep executable behavior intact (`Main.lean` path should remain runnable).
 3. Prove before broadening: land small, composable invariants with corresponding proofs.
 4. Prefer total functions and explicit error channels (`Except`) over partial definitions.
+
+Additional M1-specific agreements:
+
+5. Keep theorem statements stable once introduced; iterate via helper lemmas first.
+6. Make policy choices explicit near definitions (not only in PR text).
+7. When a proof blocks, land minimal supporting lemmas rather than broad refactors.
 
 ## 3. Recommended workflow per change
 
@@ -22,6 +36,18 @@ transitions before adding major new subsystems.
    - `lake build`
    - `lake exe sele4n` (when transition behavior is affected)
 5. Summarize proof obligations completed and remaining in PR notes.
+
+### 3.1 Suggested micro-slice workflow for M1
+
+For each invariant component:
+
+1. Add/adjust predicate definition.
+2. Add one small sanity lemma (shape/property) to constrain later proof drift.
+3. Add transition-specific preservation lemma(s).
+4. Fold result into composed invariant preservation theorem.
+5. Re-run build and executable checks.
+
+This sequence keeps each change reviewable and reduces proof breakage fan-out.
 
 ## 4. Coding conventions
 
@@ -36,18 +62,41 @@ transitions before adding major new subsystems.
 - Documentation:
   - add short comments when a design choice is non-obvious or policy-based.
 
-## 5. Milestone-oriented checklist
+M1 proof hygiene conventions:
+
+- Prefer explicit theorem names for bundle members, e.g.:
+  - `runQueueUnique`,
+  - `currentThreadValid`,
+  - `queueCurrentConsistent`.
+- Group helper lemmas by subject (`runQueue`, object lookup, transition step facts).
+- Keep `simp` sets predictable; avoid global simp attributes unless broadly safe.
+- Avoid introducing abstractions that hide transition state updates during M1.
+
+## 5. Acceptance-driven delivery checklist (M1)
 
 Before merging work intended for M1, verify:
 
-- [ ] invariant definition is explicit and compositional,
-- [ ] theorem(s) use the invariant in transition preservation,
+- [ ] invariant bundle entrypoint exists and contains all required components,
+- [ ] queue/current policy is documented in-code and in spec,
+- [ ] preservation lemmas exist for `chooseThread`, `schedule`, and `handleYield`,
 - [ ] no new `axiom` introduced,
 - [ ] `lake build` passes,
-- [ ] docs reflect the new state of completion.
+- [ ] `lake exe sele4n` still demonstrates scheduler execution,
+- [ ] docs reflect both progress and remaining proof debt.
 
-## 6. Anti-patterns to avoid
+## 6. Development path ahead (post-next-step preview)
+
+After Scheduler Invariant Bundle v1 is complete, expected follow-on work is:
+
+1. Strengthen scheduler model edges (idle/blocked transitions as needed).
+2. Begin M2 prep by isolating capability/CSpace interfaces from scheduler proofs.
+3. Carry forward reusable proof utilities while keeping scheduler theorems stable.
+
+This preview is directional only; M1 completion criteria remain authoritative.
+
+## 7. Anti-patterns to avoid
 
 - Expanding into IPC/MMU/retype semantics before M1 proofs stabilize.
 - Embedding milestone assumptions in code without documenting them in the spec.
 - Monolithic proof scripts that block incremental refactoring.
+- Deferring policy decisions (strict vs. relaxed consistency) until late in proof work.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -41,17 +41,36 @@ Primary outcomes for this revision:
 
 ### 3.2 Milestone M1 scope (in progress)
 
-The repository shall next implement and prove:
+The immediate next step is to complete a **Scheduler Invariant Bundle v1** with explicit policy and
+proof coverage. The repository shall implement and prove:
 
-1. Runnable queue uniqueness.
-2. Current-thread object validity (if current is set, it refers to a TCB object).
-3. Queue/current consistency (policy-driven; choose and document strict or relaxed form).
-4. Preservation of the strengthened invariant bundle for:
+1. Runnable queue uniqueness (no duplicate TIDs in `runQueue`).
+2. Current-thread object validity (if `currentThread = some tid`, object lookup resolves to a
+   `TCB`).
+3. Queue/current consistency under an explicitly chosen policy:
+   - **strict policy**: current thread must be in `runQueue`, or
+   - **relaxed policy**: current thread may be absent while blocked/idle.
+4. Preservation of the composed scheduler invariant bundle for:
    - `chooseThread`,
    - `schedule`,
    - `handleYield`.
 
-### 3.3 Deferred (explicitly out-of-scope for M1)
+### 3.3 M1 implementation boundary (normative)
+
+Within this step, changes should stay inside scheduler semantics and proofs. The following are in
+scope:
+
+- adding helper predicates/lemmas needed to define and prove scheduler invariants,
+- minor state-accessor refactors required for theorem clarity,
+- executable examples in `Main.lean` that exercise affected transitions.
+
+The following are out-of-scope for this step even if they appear adjacent:
+
+- introducing new kernel object classes,
+- extending capability operations beyond what scheduler proofs consume,
+- architecture-specific behavior (timer interrupts, MMU details, etc.).
+
+### 3.4 Deferred (explicitly out-of-scope for M1)
 
 - virtual memory and architecture-specific MMU semantics,
 - full capability derivation tree and revoke/delete cascade behavior,
@@ -90,27 +109,60 @@ The project shall preserve the following through M1:
 
 ## 6. Acceptance criteria and evidence mapping
 
-M1 is complete when all checks below are satisfied:
+The next step (M1 Scheduler Invariant Bundle v1) is complete when all checks below are satisfied:
 
-1. Strengthened scheduler invariants are present in `SeLe4n.Kernel.API`.
-2. Theorems show preservation for `chooseThread`, `schedule`, and `handleYield`.
-3. `lake build` passes with no axiomatic bypass introduced.
-4. `Main.lean` still runs a concrete transition path from an explicit bootstrap state.
-5. Documentation (`SEL4_SPEC.md` + `DEVELOPMENT.md`) reflects implemented behavior.
+### 6.1 Functional and proof acceptance criteria
+
+1. A single composed scheduler invariant entrypoint exists in `SeLe4n.Kernel.API` and includes at
+   least:
+   - runnable queue uniqueness,
+   - current-thread object validity,
+   - queue/current consistency with the documented policy.
+2. Each component invariant has at least one dedicated preservation lemma or helper theorem.
+3. Theorems show preservation of the composed invariant for:
+   - `chooseThread`,
+   - `schedule`,
+   - `handleYield`.
+4. The policy choice (strict vs. relaxed) is stated in comments/doc text close to the invariant
+   definition and reflected in theorem statements.
+
+### 6.2 Build and executability acceptance criteria
+
+5. `lake build` passes with no new `axiom` introduced to bypass missing proofs.
+6. `lake exe sele4n` (or equivalent `#eval` path used by `Main.lean`) still demonstrates at least
+   one concrete scheduler transition from an explicit state.
+
+### 6.3 Documentation acceptance criteria
+
+7. `docs/SEL4_SPEC.md` and `docs/DEVELOPMENT.md` both describe:
+   - current invariant bundle scope,
+   - remaining proof gaps (if any),
+   - next intended increment.
 
 Evidence sources:
 
 - theorem statements/proofs in `SeLe4n/Kernel/API.lean`,
 - executable path in `Main.lean`,
-- build output from local checks.
+- build/execution output from local checks.
+
+### 6.4 Definition of done for this step
+
+This step should be marked complete only when all acceptance criteria pass in one commit range,
+and no open TODOs remain for the three targeted transitions.
 
 ## 7. Roadmap
 
 ### 7.1 M1 (current): scheduler integrity
 
-- compose scheduler invariant bundle,
-- prove preservation across core scheduling transitions,
-- add small helper lemmas to keep proof scripts modular.
+Incremental plan:
+
+1. Lock invariant policy (strict vs. relaxed queue/current consistency).
+2. Encode component predicates and compose the bundle entrypoint.
+3. Prove preservation for `chooseThread`.
+4. Prove preservation for `schedule`.
+5. Prove preservation for `handleYield`.
+6. Consolidate helper lemmas and remove redundant proof scaffolding.
+7. Update docs to record what is complete and what remains.
 
 ### 7.2 M2: capability and CSpace semantics
 


### PR DESCRIPTION
### Motivation

- Provide a precise next-step target for M1 by turning the vague scheduler goal into a concrete "Scheduler Invariant Bundle v1" deliverable.  
- Reduce ambiguity for reviewers and contributors by stating explicit in-scope vs out-of-scope boundaries for the next implementation slice.  
- Improve developer productivity by expanding the development guide with micro-slice workflows and proof-hygiene rules tailored to M1 work.

### Description

- Updated `docs/SEL4_SPEC.md` to define `Scheduler Invariant Bundle v1`, enumerate the component invariants (run-queue uniqueness, current-thread validity, queue/current consistency), present strict vs relaxed policy choices, and add an implementation boundary and a definition-of-done.  
- Expanded acceptance criteria into functional/proof, build/executability, and documentation checks, added evidence mapping, and provided a concrete incremental M1 execution plan.  
- Updated `docs/DEVELOPMENT.md` with a new "current objective slice", M1-specific working agreements, a suggested micro-slice workflow, M1 proof-hygiene conventions (explicit invariant theorem names, grouping helper lemmas, simp guidance), and an acceptance-driven delivery checklist.  
- Changes are localized to documentation only and do not modify Lean source code or introduce axioms or behavioral changes to the model.

### Testing

- Attempted `lake build` in this environment but it failed because `lake` is not installed (`command not found`).  
- Attempted fallback `~/.elan/bin/lake build` but it also failed because the `elan`/`lake` binary was not present at that path.  
- No Lean/`lake`-based proof or build checks could be executed here; documentation changes were validated by inspecting the updated files locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990e4c05cd0832bb51874777a89df10)