### PR TITLE
Implement Scheduler Invariant Bundle v1 step 1: runQueue uniqueness

### DIFF
--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -10,9 +10,13 @@ def schedulerWellFormed (s : SchedulerState) : Prop :=
   | none => True
   | some tid => tid ∈ s.runnable
 
+/-- Scheduler invariant component #1 (M1 bundle v1): runnable queue has no duplicate TIDs. -/
+def runQueueUnique (s : SchedulerState) : Prop :=
+  s.runnable.Nodup
+
 /-- Invariant bundle that should eventually mirror seL4 proof obligations. -/
 def kernelInvariant (st : SystemState) : Prop :=
-  schedulerWellFormed st.scheduler
+  schedulerWellFormed st.scheduler ∧ runQueueUnique st.scheduler
 
 /-- Choose the first runnable thread, if any. -/
 def chooseThread : Kernel (Option SeLe4n.ThreadId) :=
@@ -54,6 +58,16 @@ theorem setCurrentThread_preserves_wellFormed
   cases hStep
   simp [schedulerWellFormed, hMem]
 
+theorem setCurrentThread_preserves_runQueueUnique
+    (st st' : SystemState)
+    (tid : Option SeLe4n.ThreadId)
+    (hUnique : runQueueUnique st.scheduler)
+    (hStep : setCurrentThread tid st = .ok ((), st')) :
+    runQueueUnique st'.scheduler := by
+  simp [setCurrentThread] at hStep
+  cases hStep
+  simpa [runQueueUnique] using hUnique
+
 theorem chooseThread_returns_runnable_or_none
     (st st' : SystemState)
     (next : Option SeLe4n.ThreadId)
@@ -91,10 +105,56 @@ theorem schedule_preserves_wellFormed
       cases hStep
       simp [schedulerWellFormed]
 
+theorem chooseThread_preserves_runQueueUnique
+    (st st' : SystemState)
+    (next : Option SeLe4n.ThreadId)
+    (hUnique : runQueueUnique st.scheduler)
+    (hStep : chooseThread st = .ok (next, st')) :
+    runQueueUnique st'.scheduler := by
+  rcases chooseThread_returns_runnable_or_none st st' next hStep with ⟨hSt, _⟩
+  subst hSt
+  simpa using hUnique
+
+theorem schedule_preserves_runQueueUnique
+    (st st' : SystemState)
+    (hUnique : runQueueUnique st.scheduler)
+    (hStep : schedule st = .ok ((), st')) :
+    runQueueUnique st'.scheduler := by
+  cases hRun : st.scheduler.runnable with
+  | nil =>
+      exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
+        simpa [schedule, hRun] using hStep)
+  | cons t ts =>
+      exact setCurrentThread_preserves_runQueueUnique st st' (some t) hUnique (by
+        simpa [schedule, hRun] using hStep)
+
 theorem handleYield_preserves_wellFormed
     (st st' : SystemState)
     (hStep : handleYield st = .ok ((), st')) :
     schedulerWellFormed st'.scheduler := by
   simpa [handleYield] using schedule_preserves_wellFormed st st' hStep
+
+theorem handleYield_preserves_runQueueUnique
+    (st st' : SystemState)
+    (hUnique : runQueueUnique st.scheduler)
+    (hStep : handleYield st = .ok ((), st')) :
+    runQueueUnique st'.scheduler := by
+  simpa [handleYield] using schedule_preserves_runQueueUnique st st' hUnique hStep
+
+theorem schedule_preserves_kernelInvariant
+    (st st' : SystemState)
+    (hInv : kernelInvariant st)
+    (hStep : schedule st = .ok ((), st')) :
+    kernelInvariant st' := by
+  exact ⟨schedule_preserves_wellFormed st st' hStep,
+    schedule_preserves_runQueueUnique st st' hInv.2 hStep⟩
+
+theorem handleYield_preserves_kernelInvariant
+    (st st' : SystemState)
+    (hInv : kernelInvariant st)
+    (hStep : handleYield st = .ok ((), st')) :
+    kernelInvariant st' := by
+  exact ⟨handleYield_preserves_wellFormed st st' hStep,
+    handleYield_preserves_runQueueUnique st st' hInv.2 hStep⟩
 
 end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,11 +8,13 @@ transitions before adding major new subsystems.
 
 ### Current objective slice (next step)
 
-The active implementation target is **Scheduler Invariant Bundle v1**:
+The active implementation target is **Scheduler Invariant Bundle v1**.
 
-- define the invariant components in a compositional form,
-- lock and document queue/current consistency policy,
-- prove preservation over `chooseThread`, `schedule`, and `handleYield`.
+Current status:
+
+- ✅ Step 1 complete: runnable queue uniqueness (`runQueueUnique`) is defined and preserved,
+- ⏳ Next: current-thread object validity and explicit queue/current policy,
+- ⏳ Then: composed preservation coverage over `chooseThread`, `schedule`, and `handleYield`.
 
 ## 2. Working agreement
 
@@ -76,9 +78,9 @@ M1 proof hygiene conventions:
 
 Before merging work intended for M1, verify:
 
-- [ ] invariant bundle entrypoint exists and contains all required components,
+- [~] invariant bundle entrypoint exists; currently includes scheduler well-formedness + runQueue uniqueness,
 - [ ] queue/current policy is documented in-code and in spec,
-- [ ] preservation lemmas exist for `chooseThread`, `schedule`, and `handleYield`,
+- [~] preservation lemmas exist for `chooseThread`, `schedule`, and `handleYield` for implemented components,
 - [ ] no new `axiom` introduced,
 - [ ] `lake build` passes,
 - [ ] `lake exe sele4n` still demonstrates scheduler execution,

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -44,10 +44,10 @@ Primary outcomes for this revision:
 The immediate next step is to complete a **Scheduler Invariant Bundle v1** with explicit policy and
 proof coverage. The repository shall implement and prove:
 
-1. Runnable queue uniqueness (no duplicate TIDs in `runQueue`).
-2. Current-thread object validity (if `currentThread = some tid`, object lookup resolves to a
+1. ✅ Runnable queue uniqueness (no duplicate TIDs in `runQueue`).
+2. ⏳ Current-thread object validity (if `currentThread = some tid`, object lookup resolves to a
    `TCB`).
-3. Queue/current consistency under an explicitly chosen policy:
+3. ⏳ Queue/current consistency under an explicitly chosen policy:
    - **strict policy**: current thread must be in `runQueue`, or
    - **relaxed policy**: current thread may be absent while blocked/idle.
 4. Preservation of the composed scheduler invariant bundle for:
@@ -109,7 +109,8 @@ The project shall preserve the following through M1:
 
 ## 6. Acceptance criteria and evidence mapping
 
-The next step (M1 Scheduler Invariant Bundle v1) is complete when all checks below are satisfied:
+The next step (M1 Scheduler Invariant Bundle v1) is complete when all checks below are satisfied.
+Current proof debt after landing step 1: complete items (2) and (3), then discharge composed preservation for all three transitions:
 
 ### 6.1 Functional and proof acceptance criteria
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.0"
+version = "0.2.1"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Implement the first component of the M1 scheduler invariant bundle: ensure the runnable queue contains no duplicate thread IDs.
- Keep the bootstrap executable behavior intact and follow the project's development guide for incremental invariant additions and preservation proofs.

### Description
- Added the `runQueueUnique` predicate (`List.Nodup` on `scheduler.runnable`) and folded it into the composed `kernelInvariant` in `SeLe4n/Kernel/API.lean`.
- Added preservation lemmas for the new predicate across scheduler operations: `setCurrentThread_preserves_runQueueUnique`, `chooseThread_preserves_runQueueUnique`, `schedule_preserves_runQueueUnique`, and `handleYield_preserves_runQueueUnique` and used `setCurrentThread` helper to simplify `schedule` proofs.
- Added composed preservation lemmas `schedule_preserves_kernelInvariant` and `handleYield_preserves_kernelInvariant` that combine well-formedness and run-queue uniqueness.
- Updated documentation to record step 1 completion (`docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`) and bumped project version in `lakefile.toml` to `0.2.1`.

### Testing
- Ran `~/.elan/bin/lake build` which completed successfully and built all targets including `SeLe4n.Kernel.API`.
- Ran `~/.elan/bin/lake exe sele4n` which executed `Main.lean` and printed the expected scheduler output (`scheduled thread: some 1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990edc0d1cc832b9e6a1814f7a9f29d)