### PR TITLE
Implement step 2 of Scheduler Invariant Bundle v1 (current-thread TCB validity)

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -5,6 +5,18 @@ open SeLe4n.Model
 /-- Demonstrate a tiny executable path through the kernel model. -/
 def bootstrapState : SystemState :=
   { (default : SystemState) with
+    objects := fun oid =>
+      if oid = 1 then
+        some (.tcb {
+          tid := 1
+          priority := 100
+          domain := 0
+          cspaceRoot := 10
+          vspaceRoot := 20
+          ipcBuffer := 4096
+        })
+      else
+        none
     scheduler := { runnable := [1, 2], current := none }
   }
 

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -14,9 +14,16 @@ def schedulerWellFormed (s : SchedulerState) : Prop :=
 def runQueueUnique (s : SchedulerState) : Prop :=
   s.runnable.Nodup
 
+/-- Scheduler invariant component #2 (M1 bundle v1): the selected current thread, if any,
+resolves to a TCB in the object store. -/
+def currentThreadValid (st : SystemState) : Prop :=
+  match st.scheduler.current with
+  | none => True
+  | some tid => ∃ tcb : TCB, st.objects tid = some (.tcb tcb)
+
 /-- Invariant bundle that should eventually mirror seL4 proof obligations. -/
 def kernelInvariant (st : SystemState) : Prop :=
-  schedulerWellFormed st.scheduler ∧ runQueueUnique st.scheduler
+  schedulerWellFormed st.scheduler ∧ runQueueUnique st.scheduler ∧ currentThreadValid st
 
 /-- Choose the first runnable thread, if any. -/
 def chooseThread : Kernel (Option SeLe4n.ThreadId) :=
@@ -25,12 +32,16 @@ def chooseThread : Kernel (Option SeLe4n.ThreadId) :=
     | [] => .ok (none, st)
     | t :: _ => .ok (some t, st)
 
-/-- Simple scheduler step for the bootstrap model. -/
+/-- Simple scheduler step for the bootstrap model. If the selected runnable TID does not map
+to a TCB object, the scheduler clears `current` instead of selecting an invalid thread. -/
 def schedule : Kernel Unit :=
   fun st =>
     match st.scheduler.runnable with
     | [] => setCurrentThread none st
-    | t :: _ => setCurrentThread (some t) st
+    | t :: _ =>
+        match st.objects t with
+        | some (.tcb _) => setCurrentThread (some t) st
+        | _ => setCurrentThread none st
 
 /-- Placeholder syscall dispatcher with one implemented path for now. -/
 def handleYield : Kernel Unit :=
@@ -40,13 +51,20 @@ theorem schedule_eq_chooseThread_then_setCurrent :
     schedule = (fun st =>
       match chooseThread st with
       | .error e => .error e
-      | .ok (next, st') => setCurrentThread next st') := by
+      | .ok (next, st') =>
+          match next with
+          | none => setCurrentThread none st'
+          | some tid =>
+              match st'.objects tid with
+              | some (.tcb _) => setCurrentThread (some tid) st'
+              | _ => setCurrentThread none st') := by
   funext st
   cases hRun : st.scheduler.runnable with
   | nil =>
       simp [schedule, chooseThread, setCurrentThread, hRun]
   | cons t ts =>
-      simp [schedule, chooseThread, setCurrentThread, hRun]
+      cases hObj : st.objects t <;>
+      simp [schedule, chooseThread, setCurrentThread, hRun, hObj]
 
 theorem setCurrentThread_preserves_wellFormed
     (st st' : SystemState)
@@ -67,6 +85,24 @@ theorem setCurrentThread_preserves_runQueueUnique
   simp [setCurrentThread] at hStep
   cases hStep
   simpa [runQueueUnique] using hUnique
+
+theorem setCurrentThread_none_preserves_currentThreadValid
+    (st st' : SystemState)
+    (hStep : setCurrentThread none st = .ok ((), st')) :
+    currentThreadValid st' := by
+  simp [setCurrentThread] at hStep
+  cases hStep
+  simp [currentThreadValid]
+
+theorem setCurrentThread_some_preserves_currentThreadValid
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (hObj : ∃ tcb : TCB, st.objects tid = some (.tcb tcb))
+    (hStep : setCurrentThread (some tid) st = .ok ((), st')) :
+    currentThreadValid st' := by
+  simp [setCurrentThread] at hStep
+  cases hStep
+  simpa [currentThreadValid] using hObj
 
 theorem chooseThread_returns_runnable_or_none
     (st st' : SystemState)
@@ -101,9 +137,25 @@ theorem schedule_preserves_wellFormed
       cases hStep
       simp [schedulerWellFormed]
   | cons t ts =>
-      simp [schedule, setCurrentThread, hRun] at hStep
-      cases hStep
-      simp [schedulerWellFormed]
+      cases hObj : st.objects t with
+      | none =>
+          simp [schedule, setCurrentThread, hRun, hObj] at hStep
+          cases hStep
+          simp [schedulerWellFormed]
+      | some obj =>
+          cases obj with
+          | tcb tcb =>
+              simp [schedule, setCurrentThread, hRun, hObj] at hStep
+              cases hStep
+              simp [schedulerWellFormed]
+          | endpoint ep =>
+              simp [schedule, setCurrentThread, hRun, hObj] at hStep
+              cases hStep
+              simp [schedulerWellFormed]
+          | cnode cn =>
+              simp [schedule, setCurrentThread, hRun, hObj] at hStep
+              cases hStep
+              simp [schedulerWellFormed]
 
 theorem chooseThread_preserves_runQueueUnique
     (st st' : SystemState)
@@ -115,6 +167,16 @@ theorem chooseThread_preserves_runQueueUnique
   subst hSt
   simpa using hUnique
 
+theorem chooseThread_preserves_currentThreadValid
+    (st st' : SystemState)
+    (next : Option SeLe4n.ThreadId)
+    (hValid : currentThreadValid st)
+    (hStep : chooseThread st = .ok (next, st')) :
+    currentThreadValid st' := by
+  rcases chooseThread_returns_runnable_or_none st st' next hStep with ⟨hSt, _⟩
+  subst hSt
+  simpa using hValid
+
 theorem schedule_preserves_runQueueUnique
     (st st' : SystemState)
     (hUnique : runQueueUnique st.scheduler)
@@ -125,8 +187,47 @@ theorem schedule_preserves_runQueueUnique
       exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
         simpa [schedule, hRun] using hStep)
   | cons t ts =>
-      exact setCurrentThread_preserves_runQueueUnique st st' (some t) hUnique (by
+      cases hObj : st.objects t with
+      | none =>
+          exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
+            simpa [schedule, hRun, hObj] using hStep)
+      | some obj =>
+          cases obj with
+          | tcb tcb =>
+              exact setCurrentThread_preserves_runQueueUnique st st' (some t) hUnique (by
+                simpa [schedule, hRun, hObj] using hStep)
+          | endpoint ep =>
+              exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
+                simpa [schedule, hRun, hObj] using hStep)
+          | cnode cn =>
+              exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
+                simpa [schedule, hRun, hObj] using hStep)
+
+theorem schedule_preserves_currentThreadValid
+    (st st' : SystemState)
+    (hStep : schedule st = .ok ((), st')) :
+    currentThreadValid st' := by
+  cases hRun : st.scheduler.runnable with
+  | nil =>
+      exact setCurrentThread_none_preserves_currentThreadValid st st' (by
         simpa [schedule, hRun] using hStep)
+  | cons t ts =>
+      cases hObj : st.objects t with
+      | none =>
+          exact setCurrentThread_none_preserves_currentThreadValid st st' (by
+            simpa [schedule, hRun, hObj] using hStep)
+      | some obj =>
+          cases obj with
+          | tcb tcb =>
+              exact setCurrentThread_some_preserves_currentThreadValid st st' t
+                ⟨tcb, hObj⟩
+                (by simpa [schedule, hRun, hObj] using hStep)
+          | endpoint ep =>
+              exact setCurrentThread_none_preserves_currentThreadValid st st' (by
+                simpa [schedule, hRun, hObj] using hStep)
+          | cnode cn =>
+              exact setCurrentThread_none_preserves_currentThreadValid st st' (by
+                simpa [schedule, hRun, hObj] using hStep)
 
 theorem handleYield_preserves_wellFormed
     (st st' : SystemState)
@@ -141,13 +242,35 @@ theorem handleYield_preserves_runQueueUnique
     runQueueUnique st'.scheduler := by
   simpa [handleYield] using schedule_preserves_runQueueUnique st st' hUnique hStep
 
+theorem handleYield_preserves_currentThreadValid
+    (st st' : SystemState)
+    (hStep : handleYield st = .ok ((), st')) :
+    currentThreadValid st' := by
+  simpa [handleYield] using schedule_preserves_currentThreadValid st st' hStep
+
+theorem chooseThread_preserves_kernelInvariant
+    (st st' : SystemState)
+    (next : Option SeLe4n.ThreadId)
+    (hInv : kernelInvariant st)
+    (hStep : chooseThread st = .ok (next, st')) :
+    kernelInvariant st' := by
+  exact ⟨
+    by
+      rcases chooseThread_returns_runnable_or_none st st' next hStep with ⟨hSt, _⟩
+      subst hSt
+      simpa using hInv.1,
+    chooseThread_preserves_runQueueUnique st st' next hInv.2.1 hStep,
+    chooseThread_preserves_currentThreadValid st st' next hInv.2.2 hStep
+  ⟩
+
 theorem schedule_preserves_kernelInvariant
     (st st' : SystemState)
     (hInv : kernelInvariant st)
     (hStep : schedule st = .ok ((), st')) :
     kernelInvariant st' := by
   exact ⟨schedule_preserves_wellFormed st st' hStep,
-    schedule_preserves_runQueueUnique st st' hInv.2 hStep⟩
+    schedule_preserves_runQueueUnique st st' hInv.2.1 hStep,
+    schedule_preserves_currentThreadValid st st' hStep⟩
 
 theorem handleYield_preserves_kernelInvariant
     (st st' : SystemState)
@@ -155,6 +278,7 @@ theorem handleYield_preserves_kernelInvariant
     (hStep : handleYield st = .ok ((), st')) :
     kernelInvariant st' := by
   exact ⟨handleYield_preserves_wellFormed st st' hStep,
-    handleYield_preserves_runQueueUnique st st' hInv.2 hStep⟩
+    handleYield_preserves_runQueueUnique st st' hInv.2.1 hStep,
+    handleYield_preserves_currentThreadValid st st' hStep⟩
 
 end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,7 +13,8 @@ The active implementation target is **Scheduler Invariant Bundle v1**.
 Current status:
 
 - ✅ Step 1 complete: runnable queue uniqueness (`runQueueUnique`) is defined and preserved,
-- ⏳ Next: current-thread object validity and explicit queue/current policy,
+- ✅ Step 2 complete: current-thread object validity (`currentThreadValid`) is defined and preserved,
+- ⏳ Next: explicit queue/current policy,
 - ⏳ Then: composed preservation coverage over `chooseThread`, `schedule`, and `handleYield`.
 
 ## 2. Working agreement

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -45,7 +45,7 @@ The immediate next step is to complete a **Scheduler Invariant Bundle v1** with 
 proof coverage. The repository shall implement and prove:
 
 1. ✅ Runnable queue uniqueness (no duplicate TIDs in `runQueue`).
-2. ⏳ Current-thread object validity (if `currentThread = some tid`, object lookup resolves to a
+2. ✅ Current-thread object validity (if `currentThread = some tid`, object lookup resolves to a
    `TCB`).
 3. ⏳ Queue/current consistency under an explicitly chosen policy:
    - **strict policy**: current thread must be in `runQueue`, or
@@ -110,7 +110,7 @@ The project shall preserve the following through M1:
 ## 6. Acceptance criteria and evidence mapping
 
 The next step (M1 Scheduler Invariant Bundle v1) is complete when all checks below are satisfied.
-Current proof debt after landing step 1: complete items (2) and (3), then discharge composed preservation for all three transitions:
+Current proof debt after landing step 2: complete item (3), then discharge composed preservation for all three transitions:
 
 ### 6.1 Functional and proof acceptance criteria
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.1"
+version = "0.2.2"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation

- Complete Scheduler Invariant Bundle v1 by implementing step 2: ensure that if `scheduler.current = some tid` then `lookupObject tid` resolves to a `TCB` object. 
- Make the invariant actionable in the scheduler so runtime selection does not produce an invalid `current` pointer.

### Description

- Added a new predicate `currentThreadValid` in `SeLe4n.Kernel.API` and folded it into the composed `kernelInvariant` so the bundle now requires `currentThreadValid` in addition to `schedulerWellFormed` and `runQueueUnique`.
- Modified `schedule` so that when the head runnable `tid` does not map to a `TCB` in `st.objects` the scheduler clears `current` (`none`) instead of selecting an invalid thread, and refactored `schedule_eq_chooseThread_then_setCurrent` accordingly.
- Added helper lemmas and preservation proofs in `SeLe4n.Kernel.API` for the new invariant, including `setCurrentThread_none_preserves_currentThreadValid`, `setCurrentThread_some_preserves_currentThreadValid`, `chooseThread_preserves_currentThreadValid`, `schedule_preserves_currentThreadValid`, and `handleYield_preserves_currentThreadValid`, and updated composed preservation theorems to include the new component.
- Updated runtime demo in `Main.lean` to provide a concrete `TCB` in the `objects` store for the bootstrap state so the executable example remains runnable, updated docs (`docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`) to mark step 2 complete, and bumped the project version in `lakefile.toml` to `0.2.2`.

### Testing

- Ran `lake build` which completed successfully and produced a successful build of the library and executable. 
- Ran `lake exe sele4n` which executed the demo and printed `scheduled thread: some 1`, confirming the scheduler selects a valid `TCB`-backed thread. 
- No new `axiom` introduced and changes were confined to scheduler semantics, invariant definitions, proofs, docs, and the demo state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f009ef84832bb5fbed4e6e66f0e3)