### PR TITLE
Finalize Scheduler Invariant Bundle v1, simplify proofs, and bump version to 0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ lake exe sele4n
 
 Bootstrap goals are complete and validated in code. The project is now entering the M1
 invariant-strengthening phase (scheduler integrity and richer preservation proofs), with the
-version advanced to `0.2.3` after landing Scheduler Invariant Bundle v1 (including an explicit strict queue/current consistency policy).
+version advanced to `0.2.4` after landing Scheduler Invariant Bundle v1 (including an explicit strict queue/current consistency policy).

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -35,6 +35,12 @@ def currentThreadValid (st : SystemState) : Prop :=
 def kernelInvariant (st : SystemState) : Prop :=
   queueCurrentConsistent st.scheduler ∧ runQueueUnique st.scheduler ∧ currentThreadValid st
 
+/-- Scheduler Invariant Bundle v1 entrypoint used by milestone wording in the spec/docs.
+This is an alias of `kernelInvariant` to keep theorem names aligned with the development guide
+without changing existing proof call sites. -/
+abbrev schedulerInvariantBundle (st : SystemState) : Prop :=
+  kernelInvariant st
+
 theorem schedulerWellFormed_iff_queueCurrentConsistent (s : SchedulerState) :
     schedulerWellFormed s ↔ queueCurrentConsistent s := by
   simp [schedulerWellFormed, queueCurrentConsistent]
@@ -350,8 +356,28 @@ theorem handleYield_preserves_kernelInvariant
     (hInv : kernelInvariant st)
     (hStep : handleYield st = .ok ((), st')) :
     kernelInvariant st' := by
-  exact ⟨handleYield_preserves_queueCurrentConsistent st st' hStep,
-    handleYield_preserves_runQueueUnique st st' hInv.2.1 hStep,
-    handleYield_preserves_currentThreadValid st st' hStep⟩
+  simpa [handleYield] using schedule_preserves_kernelInvariant st st' hInv hStep
+
+theorem chooseThread_preserves_schedulerInvariantBundle
+    (st st' : SystemState)
+    (next : Option SeLe4n.ThreadId)
+    (hInv : schedulerInvariantBundle st)
+    (hStep : chooseThread st = .ok (next, st')) :
+    schedulerInvariantBundle st' := by
+  exact chooseThread_preserves_kernelInvariant st st' next hInv hStep
+
+theorem schedule_preserves_schedulerInvariantBundle
+    (st st' : SystemState)
+    (hInv : schedulerInvariantBundle st)
+    (hStep : schedule st = .ok ((), st')) :
+    schedulerInvariantBundle st' := by
+  exact schedule_preserves_kernelInvariant st st' hInv hStep
+
+theorem handleYield_preserves_schedulerInvariantBundle
+    (st st' : SystemState)
+    (hInv : schedulerInvariantBundle st)
+    (hStep : handleYield st = .ok ((), st')) :
+    schedulerInvariantBundle st' := by
+  exact handleYield_preserves_kernelInvariant st st' hInv hStep
 
 end SeLe4n.Kernel

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.3"
+version = "0.2.4"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Provide the explicit composed entrypoint and preservation theorems required for Scheduler Invariant Bundle v1 so milestone wording and theorem names align with the development guide.
- Keep proof structure compositional and avoid duplicating existing `kernelInvariant` preservation logic.
- Ensure project metadata and documentation reflect the landed milestone version.

### Description
- Add `abbrev schedulerInvariantBundle (st : SystemState) := kernelInvariant st` as the composed entrypoint used by milestone wording.
- Add `chooseThread_preserves_schedulerInvariantBundle`, `schedule_preserves_schedulerInvariantBundle`, and `handleYield_preserves_schedulerInvariantBundle` that delegate to the corresponding `*_preserves_kernelInvariant` proofs.
- Simplify `handleYield_preserves_kernelInvariant` to reuse `schedule_preserves_kernelInvariant` via `simpa` for a compositional proof structure.
- Bump project package version to `0.2.4` in `lakefile.toml` and update the README note to match the package metadata.

### Testing
- Installed the Lean toolchain via the Elan installer using `curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y` and initialized the environment with `source "$HOME/.elan/env"`.
- Verified tool versions and built the project with `lake --version && lean --version && lake build`, which completed successfully.
- Ran the sample executable with `lake exe sele4n`, which executed successfully.
- Re-ran `lake build` followed by `lake exe sele4n` to validate end-to-end build and runtime, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f6fe0abc832ba25a93711660220b)