### PR TITLE
Codex-generated pull request

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -38,10 +38,10 @@ def main : IO Unit := do
   | .error err => IO.println s!"scheduler error: {reprStr err}"
   | .ok (_, st1) =>
       IO.println s!"scheduled thread: {reprStr st1.scheduler.current}"
-      match SeLe4n.Kernel.cspaceMint (10, 0) (11, 3) [.read] none st1 with
+      match SeLe4n.Kernel.cspaceMint { cnode := 10, slot := 0 } { cnode := 11, slot := 3 } [.read] none st1 with
       | .error err => IO.println s!"cspace mint error: {reprStr err}"
       | .ok (_, st2) =>
-          match SeLe4n.Kernel.cspaceLookupSlot (11, 3) st2 with
+          match SeLe4n.Kernel.cspaceLookupSlot { cnode := 11, slot := 3 } st2 with
           | .error err => IO.println s!"cspace lookup error: {reprStr err}"
           | .ok (cap, _) =>
               IO.println s!"minted cap rights: {reprStr cap.rights}"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ lake exe sele4n
 ## Current status
 
 Bootstrap and M1 scheduler-integrity goals are complete and validated in code. The next active
-step is Milestone M2 foundation work. Step 1 (typed CSpace lookup/insert/mint surface with
-attenuation lemmas) is implemented; next increments will strengthen non-trivial capability
-invariants and extend operations beyond mint/lookup while maintaining runnable transitions.
+step is Milestone M2 foundation work. Step 1 (typed CSpace lookup/insert/mint surface with attenuation lemmas) and Step 2
+(model/state helpers for slot-level capability ownership) are implemented; next increments
+focus on strengthening non-trivial capability invariants and extending operations beyond
+mint/lookup while maintaining runnable transitions.

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -52,7 +52,7 @@ theorem queueCurrentConsistent_when_no_current
   simp [queueCurrentConsistent, hNone]
 
 /-- Address of a capability slot in the modeled CSpace. -/
-abbrev CSpaceAddr := SeLe4n.ObjId × SeLe4n.Slot
+abbrev CSpaceAddr := SlotRef
 
 /-- Rights attenuation policy for the M2 foundation slice.
 
@@ -64,23 +64,54 @@ def capAttenuates (parent derived : Capability) : Prop :=
 /-- Lookup a capability at `(cnode, slot)` with typed CNode checking. -/
 def cspaceLookupSlot (addr : CSpaceAddr) : Kernel Capability :=
   fun st =>
-    let (cnodeId, slot) := addr
-    match st.objects cnodeId with
-    | some (.cnode cn) =>
-        match cn.lookup slot with
-        | some cap => .ok (cap, st)
-        | none => .error .invalidCapability
-    | _ => .error .objectNotFound
+    match SystemState.lookupSlotCap st addr with
+    | some cap => .ok (cap, st)
+    | none =>
+        match st.objects addr.cnode with
+        | some (.cnode _) => .error .invalidCapability
+        | _ => .error .objectNotFound
 
 /-- Insert or replace a capability in `(cnode, slot)`. -/
 def cspaceInsertSlot (addr : CSpaceAddr) (cap : Capability) : Kernel Unit :=
   fun st =>
-    let (cnodeId, slot) := addr
-    match st.objects cnodeId with
+    match st.objects addr.cnode with
     | some (.cnode cn) =>
-        let cn' := cn.insert slot cap
-        storeObject cnodeId (.cnode cn') st
+        let cn' := cn.insert addr.slot cap
+        storeObject addr.cnode (.cnode cn') st
     | _ => .error .objectNotFound
+
+theorem cspaceLookupSlot_ok_iff_lookupSlotCap
+    (st : SystemState)
+    (addr : CSpaceAddr)
+    (cap : Capability) :
+    cspaceLookupSlot addr st = .ok (cap, st) ↔
+      SystemState.lookupSlotCap st addr = some cap := by
+  constructor
+  · intro hOk
+    unfold cspaceLookupSlot at hOk
+    cases hLookup : SystemState.lookupSlotCap st addr with
+    | none =>
+        cases hObj : st.objects addr.cnode with
+        | none => simp [hLookup, hObj] at hOk
+        | some obj =>
+            cases obj <;> simp [hLookup, hObj] at hOk
+    | some cap' =>
+        simp [hLookup] at hOk
+        simpa [hOk] using hLookup
+  · intro hCap
+    unfold cspaceLookupSlot
+    simp [hCap]
+
+/-- Successful lookup yields slot ownership by the containing CNode object id. -/
+theorem cspaceLookupSlot_ok_implies_ownsSlot
+    (st : SystemState)
+    (addr : CSpaceAddr)
+    (cap : Capability)
+    (hLookup : cspaceLookupSlot addr st = .ok (cap, st)) :
+    SystemState.ownsSlot st addr.cnode addr := by
+  have hCap : SystemState.lookupSlotCap st addr = some cap :=
+    (cspaceLookupSlot_ok_iff_lookupSlotCap st addr cap).1 hLookup
+  exact (SystemState.ownsSlot_iff st addr.cnode addr).2 ⟨rfl, ⟨cap, hCap⟩⟩
 
 /-- Requested rights must be contained in allowed rights. -/
 def rightsSubset (requested allowed : List AccessRight) : Bool :=
@@ -127,7 +158,7 @@ def cspaceSlotUnique (st : SystemState) : Prop :=
 def cspaceLookupSound (st : SystemState) : Prop :=
   ∀ addr cap st',
     cspaceLookupSlot addr st = .ok (cap, st') →
-    ∃ cn, st.objects addr.1 = some (.cnode cn) ∧ cn.lookup addr.2 = some cap
+    ∃ cn, st.objects addr.cnode = some (.cnode cn) ∧ cn.lookup addr.slot = some cap
 
 /-- Attenuation rule component used by the M2 capability invariant bundle. -/
 def cspaceAttenuationRule : Prop :=
@@ -145,19 +176,16 @@ theorem cspaceLookupSlot_preserves_state
     (cap : Capability)
     (hStep : cspaceLookupSlot addr st = .ok (cap, st')) :
     st' = st := by
-  rcases addr with ⟨cnodeId, slot⟩
-  cases hObj : st.objects cnodeId with
-  | none => simp [cspaceLookupSlot, hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [cspaceLookupSlot, hObj] at hStep
-      | endpoint ep => simp [cspaceLookupSlot, hObj] at hStep
-      | cnode cn =>
-          cases hLookup : cn.lookup slot with
-          | none => simp [cspaceLookupSlot, hObj, hLookup] at hStep
-          | some foundCap =>
-              simp [cspaceLookupSlot, hObj, hLookup] at hStep
-              exact hStep.2.symm
+  unfold cspaceLookupSlot at hStep
+  cases hLookup : SystemState.lookupSlotCap st addr with
+  | none =>
+      cases hObj : st.objects addr.cnode with
+      | none => simp [hLookup, hObj] at hStep
+      | some obj =>
+          cases obj <;> simp [hLookup, hObj] at hStep
+  | some foundCap =>
+      simp [hLookup] at hStep
+      exact hStep.2.symm
 
 theorem cspaceInsertSlot_lookup_eq
     (st st' : SystemState)
@@ -175,7 +203,17 @@ theorem cspaceInsertSlot_lookup_eq
       | cnode cn =>
           simp [cspaceInsertSlot, hObj] at hStep
           cases hStep
-          simp [cspaceLookupSlot, CNode.lookup, CNode.insert]
+          simp [cspaceLookupSlot, SystemState.lookupSlotCap, SystemState.lookupCNode, CNode.lookup, CNode.insert]
+
+theorem cspaceInsertSlot_establishes_ownsSlot
+    (st st' : SystemState)
+    (addr : CSpaceAddr)
+    (cap : Capability)
+    (hStep : cspaceInsertSlot addr cap st = .ok ((), st')) :
+    SystemState.ownsSlot st' addr.cnode addr := by
+  have hLookup : cspaceLookupSlot addr st' = .ok (cap, st') :=
+    cspaceInsertSlot_lookup_eq st st' addr cap hStep
+  exact cspaceLookupSlot_ok_implies_ownsSlot st' addr cap hLookup
 
 theorem mintDerivedCap_attenuates
     (parent child : Capability)
@@ -234,22 +272,21 @@ theorem cspaceSlotUnique_holds (st : SystemState) :
 theorem cspaceLookupSound_holds (st : SystemState) :
     cspaceLookupSound st := by
   intro addr cap st' hStep
-  rcases addr with ⟨cnodeId, slot⟩
-  cases hObj : st.objects cnodeId with
-  | none => simp [cspaceLookupSlot, hObj] at hStep
+  have hEq : st' = st := cspaceLookupSlot_preserves_state st st' addr cap hStep
+  have hOk : cspaceLookupSlot addr st = .ok (cap, st) := by
+    simpa [hEq] using hStep
+  have hCap : SystemState.lookupSlotCap st addr = some cap :=
+    (cspaceLookupSlot_ok_iff_lookupSlotCap st addr cap).1 hOk
+  unfold SystemState.lookupSlotCap SystemState.lookupCNode at hCap
+  cases hObj : st.objects addr.cnode with
+  | none => simp [hObj] at hCap
   | some obj =>
       cases obj with
-      | tcb tcb => simp [cspaceLookupSlot, hObj] at hStep
-      | endpoint ep => simp [cspaceLookupSlot, hObj] at hStep
+      | tcb tcb => simp [hObj] at hCap
+      | endpoint ep => simp [hObj] at hCap
       | cnode cn =>
-          cases hLookup : cn.lookup slot with
-          | none => simp [cspaceLookupSlot, hObj, hLookup] at hStep
-          | some foundCap =>
-              simp [cspaceLookupSlot, hObj, hLookup] at hStep
-              rcases hStep with ⟨hCap, hSt⟩
-              subst hCap
-              refine ⟨cn, ?_, hLookup⟩
-              simp at hObj ⊢
+          simp [hObj] at hCap
+          exact ⟨cn, rfl, hCap⟩
 
 theorem capabilityInvariantBundle_holds (st : SystemState) :
     capabilityInvariantBundle st := by

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -21,6 +21,15 @@ structure SystemState where
   scheduler : SchedulerState
   irqHandlers : SeLe4n.Irq → Option SeLe4n.ObjId
 
+/-- Architecture-neutral address of a capability slot inside a CNode object. -/
+structure SlotRef where
+  cnode : SeLe4n.ObjId
+  slot : SeLe4n.Slot
+  deriving Repr, DecidableEq
+
+/-- Abstract owner identity for a slot in this model: the containing CNode object id. -/
+abbrev CSpaceOwner := SeLe4n.ObjId
+
 instance : Inhabited SchedulerState where
   default := { runnable := [], current := none }
 
@@ -51,5 +60,57 @@ def setCurrentThread (tid : Option SeLe4n.ThreadId) : Kernel Unit :=
   fun st =>
     let sched := { st.scheduler with current := tid }
     .ok ((), { st with scheduler := sched })
+
+namespace SystemState
+
+/-- Read a CNode object from the global object store. -/
+def lookupCNode (st : SystemState) (id : SeLe4n.ObjId) : Option CNode :=
+  match st.objects id with
+  | some (.cnode cn) => some cn
+  | _ => none
+
+/-- Read a capability from a typed slot reference. -/
+def lookupSlotCap (st : SystemState) (ref : SlotRef) : Option Capability :=
+  match lookupCNode st ref.cnode with
+  | none => none
+  | some cn => cn.lookup ref.slot
+
+/-- The modeled owner of a slot is its containing CNode. -/
+def ownerOfSlot (ref : SlotRef) : CSpaceOwner :=
+  ref.cnode
+
+/-- Logical ownership relation for occupied slots. -/
+def ownsSlot (st : SystemState) (owner : CSpaceOwner) (ref : SlotRef) : Prop :=
+  owner = ownerOfSlot ref ∧ ∃ cap, lookupSlotCap st ref = some cap
+
+/-- Enumerate all concrete capability entries held by one modeled owner CNode. -/
+def ownedSlots (st : SystemState) (owner : CSpaceOwner) : List (SeLe4n.Slot × Capability) :=
+  match lookupCNode st owner with
+  | some cn => cn.slots
+  | none => []
+
+theorem lookupSlotCap_eq_none_of_lookupCNode_eq_none
+    (st : SystemState)
+    (ref : SlotRef)
+    (hNone : lookupCNode st ref.cnode = none) :
+    lookupSlotCap st ref = none := by
+  simp [lookupSlotCap, hNone]
+
+theorem ownsSlot_iff
+    (st : SystemState)
+    (owner : CSpaceOwner)
+    (ref : SlotRef) :
+    ownsSlot st owner ref ↔
+      owner = ref.cnode ∧ ∃ cap, lookupSlotCap st ref = some cap := by
+  simp [ownsSlot, ownerOfSlot]
+
+theorem ownedSlots_eq_nil_of_lookupCNode_eq_none
+    (st : SystemState)
+    (owner : CSpaceOwner)
+    (hNone : lookupCNode st owner = none) :
+    ownedSlots st owner = [] := by
+  simp [ownedSlots, hNone]
+
+end SystemState
 
 end SeLe4n.Model

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,11 +7,12 @@ Development is now focused on **M2 Foundation Slice: typed CSpace lookup and min
 
 ### Current objective slice (next step)
 
-The active implementation target is a minimal, proof-ready M2 slice.
+The active implementation target is the remaining minimal, proof-ready M2 slice increments.
 
 Target outcomes for this slice:
 
-- add typed capability operations for lookup and write/update paths,
+- ~~add typed capability operations for lookup and write/update paths~~,
+- ~~add state/model helpers for slot-level capability ownership representation~~,
 - define and compose initial capability invariants,
 - prove preservation for at least one read and one write transition,
 - keep executable behavior and existing scheduler proofs stable.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -62,13 +62,13 @@ mint model** that is proof-ready and does not destabilize completed scheduler re
 
 In-scope for this slice:
 
-1. Introduce minimal CSpace transition API surface in `SeLe4n.Kernel.API` (or a sibling kernel
+1. ~~Introduce minimal CSpace transition API surface in `SeLe4n.Kernel.API` (or a sibling kernel
    module) for:
    - slot lookup,
    - cap insertion/update,
-   - mint-like derivation with rights attenuation.
-2. Add state/model helpers needed to represent slot-level capability ownership without adding
-   architecture-specific detail.
+   - mint-like derivation with rights attenuation.~~ ✅
+2. ~~Add state/model helpers needed to represent slot-level capability ownership without adding
+   architecture-specific detail.~~ ✅
 3. Define a first capability-safety invariant bundle for this slice (e.g., slot uniqueness,
    lookup soundness, attenuation monotonicity).
 4. Prove preservation for at least one write transition and one read transition in the new API.
@@ -181,6 +181,8 @@ and no open TODOs remain for the transitions introduced in this slice.
 - M2 Foundation **Step 1 API surface** is implemented in `SeLe4n.Kernel.API` with `cspaceLookupSlot`,
   `cspaceInsertSlot`, `mintDerivedCap`, and `cspaceMint`, including read/write preservation and
   attenuation theorems.
+- M2 Foundation **Step 2 state/model helpers** are implemented in `SeLe4n.Model.State` (`SlotRef`,
+  ownership-oriented lookup/accessor helpers) and connected to kernel lookup/insert lemmas.
 - Remaining M2 work focuses on stronger capability invariants and broader capability lifecycle
   transitions (revoke/delete), not yet claimed complete in this snapshot.
 
@@ -227,7 +229,8 @@ Incremental plan:
 ### 8.2 M2 (current): capability and CSpace semantics
 
 - ✅ Step 1 complete: typed CSpace lookup/insert/mint API with explicit rights attenuation policy and core theorems.
-- 🔄 Next: strengthen capability invariants (non-trivial uniqueness/authority constraints) and add revoke/delete transitions.
+- ✅ ~~Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.~~
+- 🔄 Next: define/strengthen capability invariant bundle components using the ownership helpers and add revoke/delete transitions.
 - 🔄 Later: authority monotonicity and reachability constraints across extended operations.
 
 ### 8.3 M3: IPC semantics

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.6"
+version = "0.2.7"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
Implemented M2 Foundation Step 2 state/model ownership helpers by introducing a typed slot reference (SlotRef), ownership alias (CSpaceOwner), state accessors (lookupCNode, lookupSlotCap, ownedSlots), and ownership predicates/lemmas (ownerOfSlot, ownsSlot, ownsSlot_iff, etc.) in SeLe4n.Model.State.

Refactored the kernel CSpace API to use typed slot addresses (CSpaceAddr := SlotRef) and wired lookup/insert transitions through the new model helpers, plus added bridging proofs that connect lookup/insert behavior to slot ownership (cspaceLookupSlot_ok_iff_lookupSlotCap, cspaceLookupSlot_ok_implies_ownsSlot, cspaceInsertSlot_establishes_ownsSlot).

Updated preservation/soundness proof paths to remain valid with typed slot refs and helper-based lookup semantics (cspaceLookupSlot_preserves_state, cspaceLookupSound_holds).

Updated the executable demo path in Main.lean to construct typed slot refs explicitly for mint/lookup calls, keeping the runnable transition demonstration intact.

Bumped project version to 0.2.7.

Crossed through the milestone that was completed but not crossed through.

Updated milestone docs to mark Step 2 complete (including strikethrough/completion marks) and aligned current-status text in README/development/spec docs with remaining M2 work.
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910221ade8832ba41958a1eb496f62)