### PR TITLE
Complete M2 Foundation Step 3 capability invariant bundle

### DIFF
--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -158,7 +158,8 @@ def cspaceSlotUnique (st : SystemState) : Prop :=
 def cspaceLookupSound (st : SystemState) : Prop :=
   ∀ addr cap st',
     cspaceLookupSlot addr st = .ok (cap, st') →
-    ∃ cn, st.objects addr.cnode = some (.cnode cn) ∧ cn.lookup addr.slot = some cap
+    st' = st ∧ SystemState.ownsSlot st addr.cnode addr ∧
+      SystemState.lookupSlotCap st addr = some cap
 
 /-- Attenuation rule component used by the M2 capability invariant bundle. -/
 def cspaceAttenuationRule : Prop :=
@@ -273,26 +274,31 @@ theorem cspaceLookupSound_holds (st : SystemState) :
     cspaceLookupSound st := by
   intro addr cap st' hStep
   have hEq : st' = st := cspaceLookupSlot_preserves_state st st' addr cap hStep
-  have hOk : cspaceLookupSlot addr st = .ok (cap, st) := by
-    simpa [hEq] using hStep
+  have hOk : cspaceLookupSlot addr st = .ok (cap, st) := by simpa [hEq] using hStep
   have hCap : SystemState.lookupSlotCap st addr = some cap :=
     (cspaceLookupSlot_ok_iff_lookupSlotCap st addr cap).1 hOk
-  unfold SystemState.lookupSlotCap SystemState.lookupCNode at hCap
-  cases hObj : st.objects addr.cnode with
-  | none => simp [hObj] at hCap
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hCap
-      | endpoint ep => simp [hObj] at hCap
-      | cnode cn =>
-          simp [hObj] at hCap
-          exact ⟨cn, rfl, hCap⟩
+  have hOwn : SystemState.ownsSlot st addr.cnode addr :=
+    cspaceLookupSlot_ok_implies_ownsSlot st addr cap hOk
+  exact ⟨hEq, hOwn, hCap⟩
+
+theorem cspaceLookupSound_implies_ownsSlot
+    (st : SystemState)
+    (hSound : cspaceLookupSound st)
+    (addr : CSpaceAddr)
+    (cap : Capability)
+    (st' : SystemState)
+    (hStep : cspaceLookupSlot addr st = .ok (cap, st')) :
+    SystemState.ownsSlot st addr.cnode addr := by
+  exact (hSound addr cap st' hStep).2.1
+
+theorem cspaceAttenuationRule_holds :
+    cspaceAttenuationRule := by
+  intro parent child rights badge hMint
+  exact mintDerivedCap_attenuates parent child rights badge hMint
 
 theorem capabilityInvariantBundle_holds (st : SystemState) :
     capabilityInvariantBundle st := by
-  refine ⟨cspaceSlotUnique_holds st, cspaceLookupSound_holds st, ?_⟩
-  intro parent child rights badge hMint
-  exact mintDerivedCap_attenuates parent child rights badge hMint
+  exact ⟨cspaceSlotUnique_holds st, cspaceLookupSound_holds st, cspaceAttenuationRule_holds⟩
 
 theorem cspaceLookupSlot_preserves_capabilityInvariantBundle
     (st st' : SystemState)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,7 +13,7 @@ Target outcomes for this slice:
 
 - ~~add typed capability operations for lookup and write/update paths~~,
 - ~~add state/model helpers for slot-level capability ownership representation~~,
-- define and compose initial capability invariants,
+- ~~define and compose initial capability invariants~~,
 - prove preservation for at least one read and one write transition,
 - keep executable behavior and existing scheduler proofs stable.
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -69,8 +69,8 @@ In-scope for this slice:
    ~~- mint-like derivation with rights attenuation.~~
 2. ~~Add state/model helpers needed to represent slot-level capability ownership without adding
    architecture-specific detail.~~
-3. Define a first capability-safety invariant bundle for this slice (e.g., slot uniqueness,
-   lookup soundness, attenuation monotonicity).
+3. ~~Define a first capability-safety invariant bundle for this slice (e.g., slot uniqueness,
+   lookup soundness, attenuation monotonicity).~~
 4. Prove preservation for at least one write transition and one read transition in the new API.
 5. Keep `Main.lean` executable path functional; if changed, include a concrete demonstration of at
    least one CSpace operation.
@@ -183,8 +183,11 @@ and no open TODOs remain for the transitions introduced in this slice.
   attenuation theorems.
 - M2 Foundation **Step 2 state/model helpers** are implemented in `SeLe4n.Model.State` (`SlotRef`,
   ownership-oriented lookup/accessor helpers) and connected to kernel lookup/insert lemmas.
-- Remaining M2 work focuses on stronger capability invariants and broader capability lifecycle
-  transitions (revoke/delete), not yet claimed complete in this snapshot.
+- M2 Foundation **Step 3 invariant bundle** is now implemented in `SeLe4n.Kernel.API` as
+  `capabilityInvariantBundle` with explicit components (`cspaceSlotUnique`, `cspaceLookupSound`,
+  `cspaceAttenuationRule`) and dedicated helper lemmas/theorem entrypoints.
+- Remaining M2 work focuses on broader capability lifecycle transitions (revoke/delete) and
+  strengthening authority properties across those new operations.
 
 
 ## 7. Audit closure report (Bootstrap + M1)
@@ -230,7 +233,8 @@ Incremental plan:
 
 - ✅ Step 1 complete: typed CSpace lookup/insert/mint API with explicit rights attenuation policy and core theorems.
 - ✅ ~~Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.~~
-- 🔄 Next: define/strengthen capability invariant bundle components using the ownership helpers and add revoke/delete transitions.
+- ✅ Step 3 complete: first capability invariant bundle is defined/proven (slot uniqueness, lookup soundness, attenuation monotonicity).
+- 🔄 Next: add revoke/delete transitions and extend authority constraints across lifecycle operations.
 - 🔄 Later: authority monotonicity and reachability constraints across extended operations.
 
 ### 8.3 M3: IPC semantics

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.7"
+version = "0.2.8"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Strengthen the M2 foundation invariants so successful typed CSpace lookups are tied to concrete slot ownership and unchanged state, enabling composable preservation proofs for read/write CSpace transitions.

### Description
- Strengthened `cspaceLookupSound` to require `st' = st`, `SystemState.ownsSlot`, and `SystemState.lookupSlotCap = some cap` on successful lookup. 
- Added helper theorems `cspaceLookupSound_implies_ownsSlot` and `cspaceAttenuationRule_holds` and refactored `capabilityInvariantBundle_holds` to use explicit components. 
- Kept and reused existing preservation lemmas (`cspaceLookupSlot_preserves_state`, `cspaceInsertSlot_establishes_ownsSlot`, `cspaceMint_child_attenuates`) to compose the bundle proofs in `SeLe4n/Kernel/API.lean`. 
- Updated documentation to mark Step 3 complete (`docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`) and bumped project version to `0.2.8` in `lakefile.toml`.

### Testing
- Ran `lake build` and the build completed successfully (no new `axiom`/`sorry` introduced). 
- Ran `lake exe sele4n` and the executable ran, exercising the CSpace/mint path; the run completed successfully. 
- Ran `rg -n "axiom|TODO|sorry" SeLe4n Main.lean docs` and found no unresolved proof escapes; a non-fatal linter suggestion (`try 'simp' instead of 'simpa'`) was emitted but did not affect the build or proofs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991076e1ff8832ba0be2d0afc8ac7d4)