### PR TITLE
Completed a repository-wide documentation audit and updated the development guide

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,13 +9,27 @@ Development has completed the **M2 Foundation Slice: typed CSpace lookup and min
 
 The active implementation target is capability-lifecycle expansion beyond the completed M2 foundation slice.
 
-Target outcomes for this slice:
+Audited outcomes from the completed M2 foundation slice:
 
-- ~~add typed capability operations for lookup and write/update paths~~,
-- ~~add state/model helpers for slot-level capability ownership representation~~,
-- ~~define and compose initial capability invariants~~,
-- ~~prove preservation for at least one read and one write transition~~,
-- ~~keep executable behavior and existing scheduler proofs stable~~.
+- ✅ typed capability operations exist for lookup and write/update paths,
+- ✅ state/model helpers exist for slot-level capability ownership representation,
+- ✅ initial capability invariants are defined and composed,
+- ✅ preservation is proven for at least one read and one write transition,
+- ✅ executable behavior and existing scheduler proofs remain stable.
+
+Next target outcomes for the active slice:
+
+- add revoke/delete transitions over typed CSpace addresses,
+- define lifecycle-aware authority monotonicity constraints,
+- prove preservation of the capability invariant bundle across lifecycle transitions.
+
+### 1.1 Current audit evidence snapshot
+
+Latest repository-wide audit commands and expected outcomes:
+
+- `lake build` passes (current run: passes, with one non-blocking linter hint in `SeLe4n/Kernel/API.lean`),
+- `lake exe sele4n` runs scheduler + CSpace demonstration path,
+- `rg -n "axiom|TODO|sorry" SeLe4n Main.lean` returns no unresolved proof escapes or stale TODO markers.
 
 ## 2. Working agreement
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -62,16 +62,16 @@ mint model** that is proof-ready and does not destabilize completed scheduler re
 
 In-scope for this slice:
 
-1. ~~Introduce minimal CSpace transition API surface in `SeLe4n.Kernel.API` (or a sibling kernel
-   module) for:~~
-   ~~- slot lookup,~~
-   ~~- cap insertion/update,~~
-   ~~- mint-like derivation with rights attenuation.~~
-2. ~~Add state/model helpers needed to represent slot-level capability ownership without adding
-   architecture-specific detail.~~
-3. ~~Define a first capability-safety invariant bundle for this slice (e.g., slot uniqueness,
-   lookup soundness, attenuation monotonicity).~~
-4. ~~Prove preservation for at least one write transition and one read transition in the new API.~~
+1. ✅ Introduce minimal CSpace transition API surface in `SeLe4n.Kernel.API` (or a sibling kernel
+   module) for:
+   - slot lookup,
+   - cap insertion/update,
+   - mint-like derivation with rights attenuation.
+2. ✅ Add state/model helpers needed to represent slot-level capability ownership without adding
+   architecture-specific detail.
+3. ✅ Define a first capability-safety invariant bundle for this slice (e.g., slot uniqueness,
+   lookup soundness, attenuation monotonicity).
+4. ✅ Prove preservation for at least one write transition and one read transition in the new API.
 5. ✅ Keep `Main.lean` executable path functional; if changed, include a concrete demonstration of
    at least one CSpace operation.
 
@@ -192,6 +192,15 @@ and no open TODOs remain for the transitions introduced in this slice.
 - Remaining M2 work focuses on broader capability lifecycle transitions (revoke/delete) and
   strengthening authority properties across those new operations.
 
+### 6.6 Full-repository audit snapshot (documentation-to-code alignment)
+
+- Build proof check (`lake build`): passes; one non-blocking linter hint suggests `simp` in place
+  of one `simpa` in `SeLe4n.Kernel.API`.
+- Executable behavior check (`lake exe sele4n`): runs and demonstrates scheduler selection,
+  source-slot lookup, and rights-attenuated mint into destination slot.
+- Proof-hygiene check (`rg -n "axiom|TODO|sorry" SeLe4n Main.lean`): no unresolved proof escapes
+  or stale TODO markers found in Lean code.
+
 
 ## 7. Audit closure report (Bootstrap + M1)
 
@@ -235,7 +244,7 @@ Incremental plan:
 ### 8.2 M2 (current): capability and CSpace semantics
 
 - ✅ Step 1 complete: typed CSpace lookup/insert/mint API with explicit rights attenuation policy and core theorems.
-- ✅ ~~Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.~~
+- ✅ Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.
 - ✅ Step 3 complete: first capability invariant bundle is defined/proven (slot uniqueness, lookup soundness, attenuation monotonicity).
 - 🔄 Next: add revoke/delete transitions and extend authority constraints across lifecycle operations.
 - 🔄 Later: authority monotonicity and reachability constraints across extended operations.


### PR DESCRIPTION
Completed a repository-wide documentation audit and updated the development guide to clearly separate audited-complete M2 foundation outcomes from the next active lifecycle slice goals. This now explicitly records what is done vs. what is next, instead of relying on strikethrough-only status markers.

Added an explicit audit-evidence snapshot section to the development guide with the concrete verification commands and current expected outcomes, so milestone claims are directly tied to reproducible checks.

Updated the formal spec to convert crossed-out M2 foundation scope items into explicit ✅ completion entries and removed inconsistent struck-through “complete” text in the roadmap, aligning wording with implemented/proven status claims.

Added a dedicated full-repository documentation-to-code audit snapshot in the spec, including build/executable/proof-hygiene evidence summary tied to current repo behavior.
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910efa78c4832b8e6804a9ed03d563)