### PR TITLE
Refined and Expand Entire Project Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,14 @@ lake exe sele4n
 
 Bootstrap and M1 scheduler-integrity goals are complete and validated in code. Milestone M2 foundation
 work (typed CSpace lookup/insert/mint model plus invariant-preservation proofs and executable
-CSpace demonstration) is complete. Next increments focus on capability lifecycle expansion
-(revoke/delete) and stronger authority monotonicity constraints.
+CSpace demonstration) is complete.
+
+The active development slice now focuses on capability lifecycle expansion with three concrete
+outcomes:
+
+1. Add revoke/delete transitions over typed CSpace addresses.
+2. Define lifecycle-aware authority monotonicity constraints.
+3. Prove preservation of the capability invariant bundle across lifecycle transitions.
+
+See `docs/SEL4_SPEC.md` for normative acceptance criteria and `docs/DEVELOPMENT.md` for the
+recommended implementation sequence and review checklist.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,7 +23,24 @@ Next target outcomes for the active slice:
 - define lifecycle-aware authority monotonicity constraints,
 - prove preservation of the capability invariant bundle across lifecycle transitions.
 
-### 1.1 Current audit evidence snapshot
+### 1.1 Active-slice outcome details (implementation-ready)
+
+To keep scope tight and proofs composable, treat the current slice as three explicit outcomes.
+
+1. **Typed lifecycle transitions (`revoke`/`delete`)**
+   - Operate on typed CSpace addresses (`SlotRef`/equivalent typed slot handle).
+   - Keep failure behavior explicit via existing kernel error channels.
+   - Reuse existing lookup/insert helper style to avoid branching state-access idioms.
+2. **Lifecycle-aware authority monotonicity**
+   - Capture that lifecycle operations cannot increase rights or introduce stronger authority.
+   - Distinguish local attenuation constraints from global non-escalation constraints.
+   - Document policy near definitions to keep theorem intent reviewable.
+3. **Capability bundle preservation over lifecycle transitions**
+   - Extend bundle composition rather than replacing existing components.
+   - Add dedicated preservation theorem entrypoints for lifecycle operations.
+   - Preserve existing read/write preservation results and scheduler proof stability.
+
+### 1.2 Current audit evidence snapshot
 
 Latest repository-wide audit commands and expected outcomes:
 
@@ -44,6 +61,9 @@ Additional milestone agreements:
 6. Make policy choices explicit near definitions (not only in commit/PR text).
 7. When a proof blocks, land minimal supporting lemmas rather than broad refactors.
 8. Do not regress completed M1 scheduler invariants while extending M2 semantics.
+9. For lifecycle transitions, prefer one transition = one clearly stated policy obligation,
+   followed by helper lemmas and then composed-bundle preservation.
+10. Avoid broad state-model rewrites while active-slice authority properties are still settling.
 
 ## 3. Recommended workflow per change
 
@@ -56,18 +76,26 @@ Additional milestone agreements:
    - targeted repository scans (`rg -n "axiom|TODO|sorry"`) before merge
 5. Summarize obligations completed and remaining in commit/PR notes.
 
-### 3.1 Suggested micro-slice workflow for M2 foundation
+### 3.1 Suggested micro-slice workflow for the active lifecycle slice
 
-For each capability invariant component:
+For each lifecycle transition (`delete`, `revoke`) and each authority rule:
 
-1. Add/adjust predicate definition.
-2. Add one sanity lemma constraining theorem drift.
-3. Add read-path preservation lemma (`lookup`-style).
-4. Add write-path preservation lemma (`insert`/`mint`-style).
-5. Fold results into composed invariant theorem.
-6. Re-run build and executable checks.
+1. Add/adjust predicate definition (authority + lifecycle safety component).
+2. Add one local sanity lemma constraining theorem drift.
+3. Add transition-local preservation theorem (`<transition>_preserves_<component>`).
+4. Fold transition result into composed invariant theorem.
+5. Re-run build and executable checks.
 
 This sequence keeps each change reviewable and reduces proof breakage fan-out.
+
+### 3.2 Recommended implementation order for active-slice delivery
+
+1. Land typed delete transition and local lemmas.
+2. Land typed revoke transition and local lemmas.
+3. Introduce lifecycle-aware authority monotonicity predicates.
+4. Extend composed capability invariant bundle.
+5. Add composed preservation theorems for new transitions.
+6. Refresh executable demonstration path and docs.
 
 ## 4. Coding and proof conventions
 
@@ -88,6 +116,8 @@ M2 proof hygiene conventions:
 - Group helper lemmas by subject (`lookup`, slot mutations, rights attenuation facts).
 - Keep `simp` sets predictable; avoid global simp attributes unless broadly safe.
 - Avoid introducing abstractions that hide state updates while invariants are still evolving.
+- For lifecycle operations, separate “address resolution” lemmas from “authority effect” lemmas.
+- Keep revoke/delete proofs structurally parallel where possible to minimize maintenance burden.
 
 ## 5. Repository readability checklist
 
@@ -99,7 +129,7 @@ When touching a module, check the following to keep codebase comprehension high:
 - docs reference the same milestone terminology as the code,
 - examples in `Main.lean` remain concrete and executable.
 
-## 6. Acceptance-driven delivery checklist (M2 foundation)
+## 6. Acceptance-driven delivery checklist (M2 active lifecycle slice)
 
 Before merging work intended for the active M2 slice, verify:
 
@@ -111,6 +141,14 @@ Before merging work intended for the active M2 slice, verify:
 - [x] `lake build` passes,
 - [x] `lake exe sele4n` demonstrates executable transition behavior,
 - [x] docs reflect progress and remaining proof debt.
+
+Additional active-slice closure checks:
+
+- [ ] typed revoke/delete transitions compile and use typed CSpace addresses,
+- [ ] lifecycle-aware authority monotonicity predicates are defined and used in theorem statements,
+- [ ] composed capability bundle includes lifecycle clauses,
+- [ ] at least one lifecycle preservation theorem is proven for the composed bundle,
+- [ ] executable example includes a lifecycle transition trace.
 
 ## 7. Audit protocol for milestone completion claims
 
@@ -132,16 +170,27 @@ Recommended command set:
 
 Near-term sequence after the completed M2 foundation slice:
 
-1. Expand CSpace operations to revoke/delete and prove local authority constraints.
-2. Start M3 IPC semantics with endpoint transition definitions.
-3. Lift reusable capability and scheduler proof utilities into stable helper modules.
+1. Expand CSpace operations to revoke/delete over typed addresses.
+2. Land lifecycle-aware authority monotonicity constraints and helper lemmas.
+3. Prove composed capability bundle preservation for lifecycle transitions.
+4. Start M3 IPC semantics with endpoint transition definitions.
+5. Lift reusable capability and scheduler proof utilities into stable helper modules.
 
 Longer-term sequence:
 
-4. Object lifecycle/retype safety (M4).
-5. Refinement and correspondence track (M5+).
+6. Object lifecycle/retype safety (M4).
+7. Refinement and correspondence track (M5+).
 
-## 9. Anti-patterns to avoid
+## 9. PR and review notes for the active slice
+
+When submitting lifecycle-slice changes, include a short “proof-impact summary” in PR text:
+
+1. New/changed transitions.
+2. New/changed invariant components.
+3. New/changed preservation theorem entrypoints.
+4. Any intentional proof debt carried to next increment.
+
+## 10. Anti-patterns to avoid
 
 - Expanding into IPC/MMU/retype semantics before current-slice proofs stabilize.
 - Embedding milestone assumptions in code without documenting them in the spec.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,8 @@ Primary outcomes for this revision:
 - codify that bootstrap requirements are complete,
 - record that M1 Scheduler Invariant Bundle v1 is complete with verification evidence,
 - establish explicit acceptance criteria for the next implementation step (M2 foundation),
-- tighten change-control expectations for upcoming milestones.
+- tighten change-control expectations for upcoming milestones,
+- define an implementation-ready post-foundation active slice plan for lifecycle transitions.
 
 ## 2. Definitions
 
@@ -55,9 +56,9 @@ M1 **Scheduler Invariant Bundle v1** is complete. Implemented and proven artifac
    - `schedule`,
    - `handleYield`.
 
-### 3.3 Immediate next step scope: M2 foundation slice (active)
+### 3.3 Immediate next step scope: M2 foundation slice (completed)
 
-The immediate next step is to deliver a narrow **M2 Foundation Slice: typed CSpace lookup and
+The completed immediate step was a narrow **M2 Foundation Slice: typed CSpace lookup and
 mint model** that is proof-ready and does not destabilize completed scheduler results.
 
 In-scope for this slice:
@@ -82,7 +83,29 @@ Out-of-scope for this slice:
 - untyped retype/allocation semantics,
 - correspondence/refinement obligations to external artifacts.
 
-### 3.4 M2 foundation implementation boundary (normative)
+### 3.4 Active slice scope (new): lifecycle transitions and authority monotonicity
+
+The active slice now extends the completed M2 foundation with lifecycle operations over typed
+CSpace addresses and stronger authority preservation constraints.
+
+In-scope for the active slice:
+
+1. Add revoke/delete transitions over typed `SlotRef`-style addresses already used by lookup and
+   mint semantics.
+2. Define lifecycle-aware authority monotonicity constraints that cover both direct cap
+   attenuation and authority reduction through revoke/delete.
+3. Strengthen the capability invariant bundle to include lifecycle transition obligations and
+   prove composed preservation for lifecycle operations.
+4. Preserve existing scheduler invariant proofs and executable behavior in `Main.lean`.
+
+Out-of-scope for the active slice:
+
+- full derivation-tree global revoke semantics across unmodeled object classes,
+- IPC/reply-cap protocol proofs,
+- retype/allocation correctness,
+- external refinement correspondence obligations.
+
+### 3.5 M2 foundation and active-slice implementation boundary (normative)
 
 Within this step, changes should stay inside CSpace/capability semantics and proofs. The following
 are in scope:
@@ -97,10 +120,10 @@ The following are out-of-scope for this step even if they appear adjacent:
 - extending capability operations beyond the M2 foundation slice,
 - architecture-specific behavior (timer interrupts, MMU details, etc.).
 
-### 3.5 Deferred (explicitly out-of-scope for M2 foundation slice)
+### 3.6 Deferred (explicitly out-of-scope for M2 active lifecycle slice)
 
 - virtual memory and architecture-specific MMU semantics,
-- full capability derivation tree and revoke/delete cascade behavior,
+- full capability derivation tree with architecture-complete revoke/delete cascade behavior,
 - full IPC/reply-cap lifecycle correctness,
 - untyped memory allocation and retype proofs,
 - Isabelle/HOL correspondence and refinement-to-C obligations.
@@ -122,7 +145,7 @@ The following are out-of-scope for this step even if they appear adjacent:
 
 ## 5. Normative requirements
 
-The project shall preserve the following through M2 foundation:
+The project shall preserve the following through the active M2 lifecycle slice:
 
 1. `lake build` succeeds from a clean checkout.
 2. `Main.lean` continues to demonstrate executable transition behavior.
@@ -131,36 +154,43 @@ The project shall preserve the following through M2 foundation:
    - a clear definition,
    - at least one proof use-site,
    - placement in the composed invariant entrypoint.
-5. Milestone changes that affect scope or acceptance criteria update this document in the same
+5. Lifecycle transitions use typed addresses and explicit error behavior (e.g., missing slot,
+   invalid object class, unsupported operation).
+6. Milestone changes that affect scope or acceptance criteria update this document in the same
    commit.
 
 ## 6. Acceptance criteria and evidence mapping
 
-The next step is **M2 Foundation Slice: typed CSpace lookup and mint model**. This step is
-complete when all checks below are satisfied.
+The active step is **M2 Lifecycle Slice: revoke/delete transitions + authority monotonicity**.
+This step is complete when all checks below are satisfied.
 
-### 6.1 M2 functional and proof acceptance criteria
+### 6.1 M2 active-slice functional and proof acceptance criteria
 
 1. A composed capability invariant bundle entrypoint exists and includes at least:
    - slot-level uniqueness/no-alias property for the modeled structure,
    - lookup soundness (resolved slot points to the modeled capability),
    - rights attenuation monotonicity for mint/derive-style operations.
-2. Each invariant component has at least one dedicated preservation lemma or helper theorem.
-3. Theorems show preservation of the composed capability invariant for at least:
+2. Lifecycle-aware authority monotonicity is explicitly modeled and includes constraints for:
+   - mint/derive attenuation,
+   - delete non-escalation,
+   - revoke non-escalation for reachable descendants in the modeled slice.
+3. Each invariant component has at least one dedicated preservation lemma or helper theorem.
+4. Theorems show preservation of the composed capability invariant for at least:
    - one read transition (`lookup`-style),
-   - one write transition (`insert`/`mint`-style).
-4. The attenuation policy is stated in code comments/doc text near definitions and reflected in
+   - one write transition (`insert`/`mint`-style),
+   - one lifecycle transition (`delete` and/or `revoke`-style).
+5. The attenuation policy is stated in code comments/doc text near definitions and reflected in
    theorem statements.
 
 ### 6.2 Build and executability acceptance criteria
 
-5. `lake build` passes with no new `axiom` introduced to bypass missing proofs.
-6. `lake exe sele4n` (or equivalent `#eval` path used by `Main.lean`) demonstrates at least one
+6. `lake build` passes with no new `axiom` introduced to bypass missing proofs.
+7. `lake exe sele4n` (or equivalent `#eval` path used by `Main.lean`) demonstrates at least one
    concrete transition (scheduler and/or capability path) from an explicit state.
 
 ### 6.3 Documentation acceptance criteria
 
-7. `docs/SEL4_SPEC.md` and `docs/DEVELOPMENT.md` both describe:
+8. `docs/SEL4_SPEC.md` and `docs/DEVELOPMENT.md` both describe:
    - current M2 foundation scope,
    - remaining proof gaps (if any),
    - next intended increment.
@@ -192,7 +222,26 @@ and no open TODOs remain for the transitions introduced in this slice.
 - Remaining M2 work focuses on broader capability lifecycle transitions (revoke/delete) and
   strengthening authority properties across those new operations.
 
-### 6.6 Full-repository audit snapshot (documentation-to-code alignment)
+### 6.6 Active-slice incremental target outcomes and sequencing
+
+To reduce proof breakage and keep review units small, the active slice should be delivered in
+four target increments:
+
+1. **Lifecycle transition surface**
+   - Add `cspaceDelete` and `cspaceRevoke`-style transitions over typed addresses.
+   - Specify exact preconditions and kernel errors in transition-level comments.
+2. **Authority monotonicity formalization**
+   - Introduce lifecycle-aware monotonicity predicates as reusable definitions.
+   - Prove helper lemmas showing each lifecycle primitive cannot introduce stronger authority than
+     the source state permits.
+3. **Composed invariant uplift**
+   - Extend `capabilityInvariantBundle` with lifecycle clauses and update existing proof entrypoints
+     with minimal theorem-statement churn.
+4. **Executable and documentation closure**
+   - Demonstrate at least one lifecycle path in `Main.lean`.
+   - Update this spec and `docs/DEVELOPMENT.md` with delivered scope and next proof debt.
+
+### 6.7 Full-repository audit snapshot (documentation-to-code alignment)
 
 - Build proof check (`lake build`): passes; one non-blocking linter hint suggests `simp` in place
   of one `simpa` in `SeLe4n.Kernel.API`.


### PR DESCRIPTION
Expanded the spec to mark the M2 foundation slice as completed, introduce a new active lifecycle slice, and explicitly scope the revoke/delete + authority-monotonicity workstream. 

Added stronger normative requirements and acceptance criteria for the active slice, including lifecycle-aware authority monotonicity and preservation requirements that now include lifecycle transitions in addition to read/write transitions. 

Added a concrete incremental delivery sequence for the active slice (transition surface → authority formalization → invariant uplift → executable/doc closure). 

Expanded the development guide with implementation-ready active-slice outcomes, lifecycle-focused workflow steps, additional proof-hygiene rules, and a dedicated active-slice closure checklist. 

Updated the near-term roadmap and review guidance to align PR expectations with lifecycle transition and invariant-preservation work. 

Updated README current status to reflect the three explicit active outcomes and direct readers to the spec/development docs for execution details. 
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69911209d5b0832bb21a6301643fa1df)