### PR TITLE
Fix lifecycle transition proofs and restore full buildability

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -4,6 +4,7 @@ open SeLe4n.Model
 
 def rootSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 0 }
 def mintedSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 3 }
+def siblingSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 4 }
 
 /-- Demonstrate a tiny executable path through scheduler + CSpace transitions. -/
 def bootstrapState : SystemState :=
@@ -48,6 +49,24 @@ def main : IO Unit := do
       match SeLe4n.Kernel.cspaceMint rootSlot mintedSlot [.read] none st1 with
       | .error err => IO.println s!"cspace mint error: {reprStr err}"
       | .ok (_, st2) =>
+          match SeLe4n.Kernel.cspaceMint rootSlot siblingSlot [.read] none st2 with
+          | .error err => IO.println s!"sibling mint error: {reprStr err}"
+          | .ok (_, st3) =>
+              IO.println "created sibling cap with the same target"
+              match SeLe4n.Kernel.cspaceRevoke mintedSlot st3 with
+              | .error err => IO.println s!"cspace revoke error: {reprStr err}"
+              | .ok (_, st4) =>
+                  match SeLe4n.Kernel.cspaceLookupSlot siblingSlot st4 with
+                  | .error err => IO.println s!"post-revoke sibling lookup: {reprStr err}"
+                  | .ok (cap, _) =>
+                      IO.println s!"unexpected sibling cap after revoke: {reprStr cap}"
+                  match SeLe4n.Kernel.cspaceDeleteSlot mintedSlot st4 with
+                  | .error err => IO.println s!"cspace delete error: {reprStr err}"
+                  | .ok (_, st5) =>
+                      match SeLe4n.Kernel.cspaceLookupSlot mintedSlot st5 with
+                      | .error err => IO.println s!"post-delete lookup (expected error): {reprStr err}"
+                      | .ok (cap, _) =>
+                          IO.println s!"unexpected cap after delete: {reprStr cap}"
           match SeLe4n.Kernel.cspaceLookupSlot mintedSlot st2 with
           | .error err => IO.println s!"cspace lookup error: {reprStr err}"
           | .ok (cap, _) =>

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -147,6 +147,31 @@ def cspaceMint
         | .error e => .error e
         | .ok child => cspaceInsertSlot dst child st'
 
+/-- Delete the capability currently stored in `addr`. -/
+def cspaceDeleteSlot (addr : CSpaceAddr) : Kernel Unit :=
+  fun st =>
+    match st.objects addr.cnode with
+    | some (.cnode cn) =>
+        let cn' := cn.remove addr.slot
+        storeObject addr.cnode (.cnode cn') st
+    | _ => .error .objectNotFound
+
+/-- Revoke capabilities with the same target as the source in the containing CNode.
+
+This first lifecycle transition is intentionally local to one CNode while derivation-tree state is
+still out-of-scope for the active slice. The source slot remains present and sibling slots naming
+the same target are removed. -/
+def cspaceRevoke (addr : CSpaceAddr) : Kernel Unit :=
+  fun st =>
+    match cspaceLookupSlot addr st with
+    | .error e => .error e
+    | .ok (parent, st') =>
+        match st'.objects addr.cnode with
+        | some (.cnode cn) =>
+            let cn' := cn.revokeTargetLocal addr.slot parent.target
+            storeObject addr.cnode (.cnode cn') st'
+        | _ => .error .objectNotFound
+
 /-- Slot-level uniqueness/no-alias policy: lookup is deterministic for each slot address. -/
 def cspaceSlotUnique (st : SystemState) : Prop :=
   ∀ addr cap₁ cap₂ st₁ st₂,
@@ -215,6 +240,60 @@ theorem cspaceInsertSlot_establishes_ownsSlot
   have hLookup : cspaceLookupSlot addr st' = .ok (cap, st') :=
     cspaceInsertSlot_lookup_eq st st' addr cap hStep
   exact cspaceLookupSlot_ok_implies_ownsSlot st' addr cap hLookup
+
+theorem cspaceDeleteSlot_lookup_eq_none
+    (st st' : SystemState)
+    (addr : CSpaceAddr)
+    (hStep : cspaceDeleteSlot addr st = .ok ((), st')) :
+    cspaceLookupSlot addr st' = .error .invalidCapability := by
+  rcases addr with ⟨cnodeId, slot⟩
+  cases hObj : st.objects cnodeId with
+  | none => simp [cspaceDeleteSlot, hObj] at hStep
+  | some obj =>
+      cases obj with
+      | tcb tcb => simp [cspaceDeleteSlot, hObj] at hStep
+      | endpoint ep => simp [cspaceDeleteSlot, hObj] at hStep
+      | cnode cn =>
+          simp [cspaceDeleteSlot, hObj] at hStep
+          cases hStep
+          simp [cspaceLookupSlot, SystemState.lookupSlotCap, SystemState.lookupCNode,
+            CNode.lookup_remove_eq_none]
+
+theorem cspaceRevoke_preserves_source
+    (st st' : SystemState)
+    (addr : CSpaceAddr)
+    (hStep : cspaceRevoke addr st = .ok ((), st')) :
+    ∃ cap, cspaceLookupSlot addr st' = .ok (cap, st') := by
+  unfold cspaceRevoke at hStep
+  cases hLookup : cspaceLookupSlot addr st with
+  | error e => simp [hLookup] at hStep
+  | ok pair =>
+      rcases pair with ⟨parent, st1⟩
+      have hSt1 : st1 = st := cspaceLookupSlot_preserves_state st st1 addr parent hLookup
+      subst st1
+      cases hObj : st.objects addr.cnode with
+      | none => simp [hLookup, hObj] at hStep
+      | some obj =>
+          cases obj with
+          | tcb tcb => simp [hLookup, hObj] at hStep
+          | endpoint ep => simp [hLookup, hObj] at hStep
+          | cnode cn =>
+              simp [hLookup, hObj] at hStep
+              cases hStep
+              have hCap : SystemState.lookupSlotCap st addr = some parent :=
+                (cspaceLookupSlot_ok_iff_lookupSlotCap st addr parent).1 hLookup
+              refine ⟨parent, ?_⟩
+              apply (cspaceLookupSlot_ok_iff_lookupSlotCap
+                { st with
+                  objects :=
+                    fun oid =>
+                      if oid = addr.cnode then
+                        some (.cnode (cn.revokeTargetLocal addr.slot parent.target))
+                      else
+                        st.objects oid }
+                addr parent).2
+              simpa [SystemState.lookupSlotCap, SystemState.lookupCNode,
+                CNode.lookup_revokeTargetLocal_source_eq_lookup, hObj] using hCap
 
 theorem mintDerivedCap_attenuates
     (parent child : Capability)

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -69,6 +69,37 @@ def insert (node : CNode) (slot : SeLe4n.Slot) (cap : Capability) : CNode :=
 def remove (node : CNode) (slot : SeLe4n.Slot) : CNode :=
   { node with slots := node.slots.filter (fun entry => entry.fst ≠ slot) }
 
+/-- Local revoke helper for the current modeled slice.
+
+This keeps the authority-bearing source slot while deleting sibling slots in the same CNode that
+name the same capability target. Full cross-CNode revoke requires an explicit derivation graph and
+is intentionally deferred. -/
+def revokeTargetLocal (node : CNode) (sourceSlot : SeLe4n.Slot) (target : CapTarget) : CNode :=
+  {
+    node with
+      slots := node.slots.filter (fun entry => entry.fst = sourceSlot ∨ entry.snd.target ≠ target)
+  }
+
+theorem lookup_remove_eq_none (node : CNode) (slot : SeLe4n.Slot) :
+    (node.remove slot).lookup slot = none := by
+  unfold remove lookup
+  simp
+
+theorem lookup_revokeTargetLocal_source_eq_lookup
+    (node : CNode)
+    (sourceSlot : SeLe4n.Slot)
+    (target : CapTarget) :
+    (node.revokeTargetLocal sourceSlot target).lookup sourceSlot = node.lookup sourceSlot := by
+  unfold revokeTargetLocal lookup
+  have hPred :
+      (fun entry : SeLe4n.Slot × Capability =>
+        (decide (entry.fst = sourceSlot) || !decide (entry.snd.target = target)) &&
+          decide (entry.fst = sourceSlot)) =
+      (fun entry : SeLe4n.Slot × Capability => decide (entry.fst = sourceSlot)) := by
+    funext entry
+    by_cases hEq : entry.fst = sourceSlot <;> simp [hEq]
+  simp [hPred]
+
 end CNode
 
 inductive KernelObject where

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -144,7 +144,7 @@ Before merging work intended for the active M2 slice, verify:
 
 Additional active-slice closure checks:
 
-- [ ] typed revoke/delete transitions compile and use typed CSpace addresses,
+- [x] typed revoke/delete transitions compile and use typed CSpace addresses,
 - [ ] lifecycle-aware authority monotonicity predicates are defined and used in theorem statements,
 - [ ] composed capability bundle includes lifecycle clauses,
 - [ ] at least one lifecycle preservation theorem is proven for the composed bundle,

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -295,7 +295,8 @@ Incremental plan:
 - ✅ Step 1 complete: typed CSpace lookup/insert/mint API with explicit rights attenuation policy and core theorems.
 - ✅ Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.
 - ✅ Step 3 complete: first capability invariant bundle is defined/proven (slot uniqueness, lookup soundness, attenuation monotonicity).
-- 🔄 Next: add revoke/delete transitions and extend authority constraints across lifecycle operations.
+- ✅ Next increment landed: typed revoke/delete transitions over `SlotRef`-style addresses (local revoke semantics in the modeled CNode scope).
+- 🔄 Next: extend lifecycle-aware authority constraints across the new lifecycle operations.
 - 🔄 Later: authority monotonicity and reachability constraints across extended operations.
 
 ### 8.3 M3: IPC semantics

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.10"
+version = "0.2.11"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Repair proof failures introduced by the new typed lifecycle transitions so the kernel API theorems remain provable and the project stays buildable.
- Make the local revoke/delete reasoning explicit at the CNode level so lifecycle operations preserve expected lookup behavior without expanding scope to cross-CNode derivation state.

### Description
- Added CNode helper definitions/lemmas: `revokeTargetLocal`, `lookup_remove_eq_none`, and `lookup_revokeTargetLocal_source_eq_lookup` in `SeLe4n/Model/Object.lean` to express local-slot preservation and removal properties.
- Updated `SeLe4n/Kernel/API.lean` proofs for lifecycle theorems (`cspaceDeleteSlot_lookup_eq_none`, `cspaceRevoke_preserves_source`) to use the new CNode lemmas and the existing `cspaceLookupSlot_ok_iff_lookupSlotCap` equivalence, resolving prior unsolved goals.
- Adjusted the executable demo in `Main.lean` to exercise revoke on the same CNode (revoking `mintedSlot`) and to run delete afterward so the runtime trace demonstrates expected local-revoke and delete outcomes.
- Minor build metadata and documentation updates remain from the lifecycle increment; no API surface beyond the intended typed delete/revoke semantics was expanded.

### Testing
- Ran `lake build` and the full build completed successfully (no build failures).
- Executed `lake exe sele4n` and observed the runtime trace showing the revoke and delete behaviors as expected (post-revoke sibling lookup fails and post-delete lookup fails).
- Ran `rg -n "axiom|TODO|sorry" SeLe4n Main.lean` which returned no matches, indicating no unresolved proof escapes.
- Noted a non-blocking linter hint about `simpa` vs `simp` in `SeLe4n/Kernel/API.lean`, which does not affect correctness or buildability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991145da914832ba19f92e1100b5a0e)