### PR TITLE
Implement lifecycle-aware authority monotonicity for delete/revoke

### DIFF
--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -97,7 +97,8 @@ theorem cspaceLookupSlot_ok_iff_lookupSlotCap
             cases obj <;> simp [hLookup, hObj] at hOk
     | some cap' =>
         simp [hLookup] at hOk
-        simpa [hOk] using hLookup
+        cases hOk
+        rfl
   · intro hCap
     unfold cspaceLookupSlot
     simp [hCap]
@@ -195,6 +196,96 @@ def cspaceAttenuationRule : Prop :=
 /-- M2 foundation capability invariant bundle entrypoint. -/
 def capabilityInvariantBundle (st : SystemState) : Prop :=
   cspaceSlotUnique st ∧ cspaceLookupSound st ∧ cspaceAttenuationRule
+
+
+/-- Lifecycle-aware authority monotonicity bundle for the active slice.
+
+This models three policy obligations together:
+1. direct mint/derive attenuation,
+2. delete cannot leave authority in the deleted slot,
+3. local revoke cannot leave sibling authority to the revoked target. -/
+def lifecycleAuthorityMonotonicity (st : SystemState) : Prop :=
+  cspaceAttenuationRule ∧
+  (∀ addr st',
+      cspaceDeleteSlot addr st = .ok ((), st') →
+      SystemState.lookupSlotCap st' addr = none) ∧
+  (∀ addr st' parent,
+      cspaceRevoke addr st = .ok ((), st') →
+      cspaceLookupSlot addr st = .ok (parent, st) →
+      ∀ slot cap,
+        SystemState.lookupSlotCap st' { cnode := addr.cnode, slot := slot } = some cap →
+        cap.target = parent.target →
+        slot = addr.slot)
+
+/-- Delete transition authority reduction clause. -/
+theorem cspaceDeleteSlot_authority_reduction
+    (st st' : SystemState)
+    (addr : CSpaceAddr)
+    (hStep : cspaceDeleteSlot addr st = .ok ((), st')) :
+    SystemState.lookupSlotCap st' addr = none := by
+  rcases addr with ⟨cnodeId, slot⟩
+  cases hObj : st.objects cnodeId with
+  | none => simp [cspaceDeleteSlot, hObj] at hStep
+  | some obj =>
+      cases obj with
+      | tcb tcb => simp [cspaceDeleteSlot, hObj] at hStep
+      | endpoint ep => simp [cspaceDeleteSlot, hObj] at hStep
+      | cnode cn =>
+          simp [cspaceDeleteSlot, hObj] at hStep
+          cases hStep
+          simp [SystemState.lookupSlotCap, SystemState.lookupCNode, CNode.lookup_remove_eq_none]
+
+/-- Revoke transition authority reduction clause: no sibling slot in the same CNode may retain
+the revoked target. -/
+theorem cspaceRevoke_local_target_reduction
+    (st st' : SystemState)
+    (addr : CSpaceAddr)
+    (parent : Capability)
+    (hStep : cspaceRevoke addr st = .ok ((), st'))
+    (hParent : cspaceLookupSlot addr st = .ok (parent, st))
+    (slot : SeLe4n.Slot)
+    (cap : Capability)
+    (hLookup : SystemState.lookupSlotCap st' { cnode := addr.cnode, slot := slot } = some cap)
+    (hTarget : cap.target = parent.target) :
+    slot = addr.slot := by
+  unfold cspaceRevoke at hStep
+  rw [hParent] at hStep
+  cases hObj : st.objects addr.cnode with
+  | none => simp [hObj] at hStep
+  | some obj =>
+      cases obj with
+      | tcb tcb => simp [hObj] at hStep
+      | endpoint ep => simp [hObj] at hStep
+      | cnode cn =>
+          simp [hObj] at hStep
+          cases hStep
+          simp [SystemState.lookupSlotCap, SystemState.lookupCNode, CNode.lookup, CNode.revokeTargetLocal] at hLookup
+          rcases hLookup with ⟨slot', hFind⟩
+          have hPred :
+              ((decide (slot' = addr.slot) || !decide (cap.target = parent.target)) &&
+                decide (slot' = slot)) = true := by
+            have hPredRaw := List.find?_some
+              (p := fun entry : SeLe4n.Slot × Capability =>
+                (decide (entry.fst = addr.slot) || !decide (entry.snd.target = parent.target)) &&
+                  decide (entry.fst = slot))
+              (a := (slot', cap)) hFind
+            simpa using hPredRaw
+          have hSplit :
+              (decide (slot' = addr.slot) || !decide (cap.target = parent.target)) = true ∧
+              decide (slot' = slot) = true := by
+            simpa [Bool.and_eq_true] using hPred
+          have hEqSlot : slot' = slot := by
+            simpa using hSplit.2
+          have hOrProp : slot' = addr.slot ∨ cap.target ≠ parent.target := by
+            simpa using hSplit.1
+          by_cases hSlot : slot = addr.slot
+          · exact hSlot
+          · have hNotTarget : cap.target ≠ parent.target := by
+              rcases hOrProp with hSrc | hNe
+              · exfalso
+                exact hSlot (hEqSlot.symm.trans hSrc)
+              · exact hNe
+            exact False.elim (hNotTarget hTarget)
 
 theorem cspaceLookupSlot_preserves_state
     (st st' : SystemState)
@@ -374,6 +465,15 @@ theorem cspaceAttenuationRule_holds :
     cspaceAttenuationRule := by
   intro parent child rights badge hMint
   exact mintDerivedCap_attenuates parent child rights badge hMint
+
+
+theorem lifecycleAuthorityMonotonicity_holds (st : SystemState) :
+    lifecycleAuthorityMonotonicity st := by
+  refine ⟨cspaceAttenuationRule_holds, ?_, ?_⟩
+  · intro addr st' hDelete
+    exact cspaceDeleteSlot_authority_reduction st st' addr hDelete
+  · intro addr st' parent hRevoke hParent slot cap hLookup hTarget
+    exact cspaceRevoke_local_target_reduction st st' addr parent hRevoke hParent slot cap hLookup hTarget
 
 theorem capabilityInvariantBundle_holds (st : SystemState) :
     capabilityInvariantBundle st := by

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -145,7 +145,7 @@ Before merging work intended for the active M2 slice, verify:
 Additional active-slice closure checks:
 
 - [x] typed revoke/delete transitions compile and use typed CSpace addresses,
-- [ ] lifecycle-aware authority monotonicity predicates are defined and used in theorem statements,
+- [x] lifecycle-aware authority monotonicity predicates are defined and used in theorem statements,
 - [ ] composed capability bundle includes lifecycle clauses,
 - [ ] at least one lifecycle preservation theorem is proven for the composed bundle,
 - [ ] executable example includes a lifecycle transition trace.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -296,7 +296,7 @@ Incremental plan:
 - ✅ Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.
 - ✅ Step 3 complete: first capability invariant bundle is defined/proven (slot uniqueness, lookup soundness, attenuation monotonicity).
 - ✅ Next increment landed: typed revoke/delete transitions over `SlotRef`-style addresses (local revoke semantics in the modeled CNode scope).
-- 🔄 Next: extend lifecycle-aware authority constraints across the new lifecycle operations.
+- ✅ Step 2 complete: lifecycle-aware authority monotonicity constraints are defined for attenuation + delete/revoke reduction.
 - 🔄 Later: authority monotonicity and reachability constraints across extended operations.
 
 ### 8.3 M3: IPC semantics

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.11"
+version = "0.2.12"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation

- Formalize active-slice authority monotonicity obligations required by the M2 lifecycle work so lifecycle transitions (`delete`/`revoke`) are captured by a reusable predicate and helper lemmas.
- Keep changes narrowly scoped to CSpace/capability semantics, preserve existing transition semantics and ensure the project continues to build and run the demonstration path.

### Description

- Added `lifecycleAuthorityMonotonicity` in `SeLe4n.Kernel.API` which bundles `cspaceAttenuationRule` with lifecycle reduction clauses for `cspaceDeleteSlot` and local `cspaceRevoke` semantics.
- Implemented transition-local lemmas `cspaceDeleteSlot_authority_reduction` and `cspaceRevoke_local_target_reduction` and the aggregate proof `lifecycleAuthorityMonotonicity_holds` in `SeLe4n/Kernel/API.lean` to witness the constraints.
- Fixed a minor proof/linter issue in `cspaceLookupSlot_ok_iff_lookupSlotCap` by replacing an unnecessary `simpa` pattern to silence the linter and adjust proof flow.
- Updated metadata and docs: bumped project version to `0.2.12` in `lakefile.toml` and updated progress markers in `docs/DEVELOPMENT.md` and `docs/SEL4_SPEC.md` to reflect the landed lifecycle monotonicity work.

### Testing

- Ran `lake build` which completed successfully after the changes (no new `axiom`/`sorry` introduced and linter hint resolved).
- Ran `lake exe sele4n` and observed the demonstration trace exercising mint, revoke and delete paths (execution completed without error).
- Ran repository scan `rg -n "axiom|TODO|sorry" SeLe4n Main.lean` which returned no unresolved proof escapes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699117883ed8832bbb8209fd1dd6c053)