### PR TITLE
Strengthen the capability invariant bundle to include lifecycle transition obligations and prove composed preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The current active slice has already landed typed lifecycle transition primitive
 authority modeling:
 
 1. ✅ `cspaceDeleteSlot` and `cspaceRevoke` transitions over typed CSpace addresses.
-2. ✅ `lifecycleAuthorityMonotonicity` policy + helper theorems for attenuation/delete/revoke.
-3. 🔄 Remaining: fold lifecycle clauses into the composed capability bundle and prove composed
-   preservation theorems for lifecycle transitions.
+2. ✅ Lifecycle monotonicity coverage is modeled with `cspaceAttenuationRule` plus `lifecycleAuthorityMonotonicity` helper theorems for delete/revoke reduction.
+3. ✅ The composed capability bundle now includes lifecycle obligations, with lifecycle
+   preservation theorem entrypoints for `cspaceDeleteSlot` and `cspaceRevoke`.
 
 See `docs/SEL4_SPEC.md` for normative acceptance criteria and `docs/DEVELOPMENT.md` for the
 recommended implementation sequence and review checklist.

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -193,19 +193,14 @@ def cspaceAttenuationRule : Prop :=
     mintDerivedCap parent rights badge = .ok child →
     capAttenuates parent child
 
-/-- M2 foundation capability invariant bundle entrypoint. -/
-def capabilityInvariantBundle (st : SystemState) : Prop :=
-  cspaceSlotUnique st ∧ cspaceLookupSound st ∧ cspaceAttenuationRule
+/-- Lifecycle-transition authority monotonicity obligations for the active slice.
 
+This models transition-local non-escalation constraints:
+1. delete cannot leave authority in the deleted slot,
+2. local revoke cannot leave sibling authority to the revoked target.
 
-/-- Lifecycle-aware authority monotonicity bundle for the active slice.
-
-This models three policy obligations together:
-1. direct mint/derive attenuation,
-2. delete cannot leave authority in the deleted slot,
-3. local revoke cannot leave sibling authority to the revoked target. -/
+Direct mint/derive attenuation remains the dedicated `cspaceAttenuationRule` bundle component. -/
 def lifecycleAuthorityMonotonicity (st : SystemState) : Prop :=
-  cspaceAttenuationRule ∧
   (∀ addr st',
       cspaceDeleteSlot addr st = .ok ((), st') →
       SystemState.lookupSlotCap st' addr = none) ∧
@@ -216,6 +211,15 @@ def lifecycleAuthorityMonotonicity (st : SystemState) : Prop :=
         SystemState.lookupSlotCap st' { cnode := addr.cnode, slot := slot } = some cap →
         cap.target = parent.target →
         slot = addr.slot)
+
+/-- Composed capability invariant bundle entrypoint.
+
+The active lifecycle slice extends the M2 foundation bundle with explicit lifecycle-transition
+authority obligations (`delete`/`revoke`) so lifecycle preservation can be stated against a
+single invariant entrypoint. -/
+def capabilityInvariantBundle (st : SystemState) : Prop :=
+  cspaceSlotUnique st ∧ cspaceLookupSound st ∧ cspaceAttenuationRule ∧
+    lifecycleAuthorityMonotonicity st
 
 /-- Delete transition authority reduction clause. -/
 theorem cspaceDeleteSlot_authority_reduction
@@ -469,7 +473,7 @@ theorem cspaceAttenuationRule_holds :
 
 theorem lifecycleAuthorityMonotonicity_holds (st : SystemState) :
     lifecycleAuthorityMonotonicity st := by
-  refine ⟨cspaceAttenuationRule_holds, ?_, ?_⟩
+  refine ⟨?_, ?_⟩
   · intro addr st' hDelete
     exact cspaceDeleteSlot_authority_reduction st st' addr hDelete
   · intro addr st' parent hRevoke hParent slot cap hLookup hTarget
@@ -477,7 +481,8 @@ theorem lifecycleAuthorityMonotonicity_holds (st : SystemState) :
 
 theorem capabilityInvariantBundle_holds (st : SystemState) :
     capabilityInvariantBundle st := by
-  exact ⟨cspaceSlotUnique_holds st, cspaceLookupSound_holds st, cspaceAttenuationRule_holds⟩
+  exact ⟨cspaceSlotUnique_holds st, cspaceLookupSound_holds st, cspaceAttenuationRule_holds,
+    lifecycleAuthorityMonotonicity_holds st⟩
 
 theorem cspaceLookupSlot_preserves_capabilityInvariantBundle
     (st st' : SystemState)
@@ -497,8 +502,9 @@ theorem cspaceInsertSlot_preserves_capabilityInvariantBundle
     (hInv : capabilityInvariantBundle st)
     (_hStep : cspaceInsertSlot addr cap st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
-  rcases hInv with ⟨_hUnique, _hSound, hAttRule⟩
-  exact ⟨cspaceSlotUnique_holds st', cspaceLookupSound_holds st', hAttRule⟩
+  rcases hInv with ⟨_hUnique, _hSound, hAttRule, _hLifecycle⟩
+  exact ⟨cspaceSlotUnique_holds st', cspaceLookupSound_holds st', hAttRule,
+    lifecycleAuthorityMonotonicity_holds st'⟩
 
 theorem cspaceMint_preserves_capabilityInvariantBundle
     (st st' : SystemState)
@@ -521,6 +527,26 @@ theorem cspaceMint_preserves_capabilityInvariantBundle
           have hInsert : cspaceInsertSlot dst child st = .ok ((), st') := by
             simpa [hSrc, hMint] using hStep
           exact cspaceInsertSlot_preserves_capabilityInvariantBundle st st' dst child hInv hInsert
+
+theorem cspaceDeleteSlot_preserves_capabilityInvariantBundle
+    (st st' : SystemState)
+    (addr : CSpaceAddr)
+    (hInv : capabilityInvariantBundle st)
+    (_hStep : cspaceDeleteSlot addr st = .ok ((), st')) :
+    capabilityInvariantBundle st' := by
+  rcases hInv with ⟨_hUnique, _hSound, hAttRule, _hLifecycle⟩
+  exact ⟨cspaceSlotUnique_holds st', cspaceLookupSound_holds st', hAttRule,
+    lifecycleAuthorityMonotonicity_holds st'⟩
+
+theorem cspaceRevoke_preserves_capabilityInvariantBundle
+    (st st' : SystemState)
+    (addr : CSpaceAddr)
+    (hInv : capabilityInvariantBundle st)
+    (_hStep : cspaceRevoke addr st = .ok ((), st')) :
+    capabilityInvariantBundle st' := by
+  rcases hInv with ⟨_hUnique, _hSound, hAttRule, _hLifecycle⟩
+  exact ⟨cspaceSlotUnique_holds st', cspaceLookupSound_holds st', hAttRule,
+    lifecycleAuthorityMonotonicity_holds st'⟩
 
 /-- Choose the first runnable thread, if any. -/
 def chooseThread : Kernel (Option SeLe4n.ThreadId) :=

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -21,7 +21,7 @@ Current active-slice status:
 
 - ✅ typed revoke/delete transitions over typed CSpace addresses are implemented,
 - ✅ lifecycle-aware authority monotonicity constraints are implemented,
-- 🔄 composed capability-bundle lifecycle preservation remains the open proof target.
+- ✅ composed capability bundle now includes lifecycle clauses with lifecycle-preservation theorem entrypoints.
 
 ### 1.1 Active-slice outcome details (implementation-ready)
 
@@ -146,8 +146,8 @@ Additional active-slice closure checks:
 
 - [x] typed revoke/delete transitions compile and use typed CSpace addresses,
 - [x] lifecycle-aware authority monotonicity predicates are defined and used in theorem statements,
-- [ ] composed capability bundle includes lifecycle clauses,
-- [ ] at least one lifecycle preservation theorem is proven for the composed bundle.
+- [x] composed capability bundle includes lifecycle clauses,
+- [x] lifecycle preservation theorems are proven for delete and revoke on the composed bundle.
 - [x] executable example includes a lifecycle transition trace.
 
 ## 7. Audit protocol for milestone completion claims

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -223,8 +223,8 @@ and no open TODOs remain for the transitions introduced in this slice.
   `cspaceRevoke`) with local authority-reduction helper theorems.
 - Active-slice lifecycle authority monotonicity modeling is now defined as
   `lifecycleAuthorityMonotonicity` and proven to hold in the current model.
-- Remaining M2 work is to fold lifecycle clauses into the composed capability bundle and prove
-  composed lifecycle-preservation theorem entrypoints.
+- The composed capability invariant bundle now includes lifecycle clauses, and composed
+  lifecycle-preservation theorem entrypoints are established for `delete` and `revoke`.
 
 ### 6.6 Active-slice incremental target outcomes and sequencing
 
@@ -299,8 +299,8 @@ Incremental plan:
 - ✅ Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.
 - ✅ Step 3 complete: first capability invariant bundle is defined/proven (slot uniqueness, lookup soundness, attenuation monotonicity).
 - ✅ Next increment landed: typed revoke/delete transitions over `SlotRef`-style addresses (local revoke semantics in the modeled CNode scope).
-- ✅ Step 4 complete (partial active-slice closure): lifecycle-aware authority monotonicity constraints are defined for attenuation + delete/revoke reduction, with dedicated helper theorems.
-- 🔄 Step 5 in progress: extend composed `capabilityInvariantBundle` with lifecycle clauses and prove composed preservation for delete/revoke transitions.
+- ✅ Step 4 complete: lifecycle-aware authority monotonicity constraints are defined for attenuation + delete/revoke reduction, with dedicated helper theorems.
+- ✅ Step 5 complete: composed `capabilityInvariantBundle` is extended with lifecycle clauses and composed preservation theorem entrypoints are proven for delete/revoke transitions.
 - 🔄 Later: authority monotonicity and reachability constraints across extended operations.
 
 ### 8.3 M3: IPC semantics

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.2.12"
+version = "0.2.13"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
Strengthened the composed capability invariant entrypoint so capabilityInvariantBundle now explicitly includes lifecycle transition obligations via lifecycleAuthorityMonotonicity, with policy comments kept alongside the definitions. 

Updated bundle construction/preservation wiring to match the stronger bundle shape, including capabilityInvariantBundle_holds and existing insert/mint preservation flow. 

Added dedicated composed-bundle lifecycle preservation theorem entrypoints for both lifecycle operations:

cspaceDeleteSlot_preserves_capabilityInvariantBundle

cspaceRevoke_preserves_capabilityInvariantBundle. 

Bumped project version to 0.2.13 and updated status/progress documentation to mark this active-slice step complete.

I refined the invariant decomposition so lifecycleAuthorityMonotonicity now contains only lifecycle-transition obligations (delete/revoke non-escalation), while attenuation remains explicitly in cspaceAttenuationRule. This removes overlap and makes the composed bundle boundaries clearer. 

I updated the corresponding proof constructor lifecycleAuthorityMonotonicity_holds to match the two-clause lifecycle-only definition. 

I aligned README status wording with this refined decomposition (cspaceAttenuationRule + lifecycleAuthorityMonotonicity)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69911badf37c832bafb5fcc95de8f983)