### PR TITLE
docs: refresh project docs for post-M2 status and M3 IPC seed plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,78 @@
 # seLe4n
 
-A Lean 4 development environment and formalization scaffold for implementing and verifying
-key parts of the [seL4 microkernel](https://sel4.systems).
+A Lean 4 formalization project for building an executable and provable model of key
+[seL4 microkernel](https://sel4.systems) semantics.
 
-This repository now contains:
+The repository is currently at the point where:
 
-- A working Lean 4 / Lake project that builds locally.
-- A typed, executable high-level model skeleton for core seL4 concepts.
-- A formal specification roadmap in `docs/SEL4_SPEC.md`.
-- Development conventions in `docs/DEVELOPMENT.md`.
+- Scheduler integrity (M1) is implemented and machine-checked.
+- Capability-space foundation + lifecycle transitions (M2) are implemented and machine-checked.
+- The executable demo path in `Main.lean` exercises scheduling, mint, revoke, and delete.
+
+The immediate focus is now preparing the next milestone slice (M3 IPC seed) without regressing the
+existing M1/M2 proof surface.
 
 ## Quick start
 
-### 1) Install Lean tooling (Elan)
+### 1) Install Lean tooling
 
 ```bash
 curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-```
-
-Then open a new shell (or source Elan env):
-
-```bash
 source "$HOME/.elan/env"
 ```
 
-### 2) Build
+### 2) Build and run
 
 ```bash
 lake build
-```
-
-### 3) Run the sample executable
-
-```bash
 lake exe sele4n
 ```
 
 ## Repository layout
 
-- `SeLe4n.lean`: library root exports.
-- `SeLe4n/Prelude.lean`: shared base definitions.
-- `SeLe4n/Machine.lean`: abstract machine/model primitives.
-- `SeLe4n/Model/`: high-level state and kernel object model.
-- `SeLe4n/Kernel/`: kernel interface skeleton and invariants.
-- `docs/SEL4_SPEC.md`: complete implementation specification.
-- `docs/DEVELOPMENT.md`: coding/testing/documentation guidance.
+- `SeLe4n.lean` — library export root.
+- `SeLe4n/Prelude.lean` — shared IDs, aliases, and the kernel monad definition.
+- `SeLe4n/Machine.lean` — abstract machine state and primitive state updates.
+- `SeLe4n/Model/Object.lean` — kernel object types (`TCB`, `Endpoint`, `CNode`, `Capability`).
+- `SeLe4n/Model/State.lean` — global state model + typed CSpace lookup helpers.
+- `SeLe4n/Kernel/API.lean` — executable transitions + preservation and policy theorems.
+- `Main.lean` — runnable transition trace used as an executable integration sanity check.
+- `docs/SEL4_SPEC.md` — milestone specification, status, and acceptance criteria.
+- `docs/DEVELOPMENT.md` — implementation workflow, proof hygiene, and review checklist.
 
-## Current status
+## Current development stage
 
-Bootstrap and M1 scheduler-integrity goals are complete and validated in code. Milestone M2
-foundation work (typed CSpace lookup/insert/mint model plus invariant-preservation proofs and
-executable CSpace demonstration) is also complete.
+### Completed milestones
 
-The current active slice has already landed typed lifecycle transition primitives and initial
-authority modeling:
+- **Bootstrap**: project wiring, state/object model, kernel transition skeleton.
+- **M1 Scheduler Integrity Bundle v1**:
+  - queue/current consistency,
+  - runnable queue uniqueness,
+  - current-thread object validity,
+  - preservation across `chooseThread`, `schedule`, and `handleYield`.
+- **M2 Capability & CSpace Semantics (current completion boundary)**:
+  - typed slot lookup/insert,
+  - mint-like derivation with rights attenuation,
+  - lifecycle transitions (`cspaceDeleteSlot`, `cspaceRevoke`),
+  - lifecycle-aware authority monotonicity claims,
+  - composed capability invariant bundle entrypoints and preservation theorems.
 
-1. ✅ `cspaceDeleteSlot` and `cspaceRevoke` transitions over typed CSpace addresses.
-2. ✅ Lifecycle monotonicity coverage is modeled with `cspaceAttenuationRule` plus `lifecycleAuthorityMonotonicity` helper theorems for delete/revoke reduction.
-3. ✅ The composed capability bundle now includes lifecycle obligations, with lifecycle
-   preservation theorem entrypoints for `cspaceDeleteSlot` and `cspaceRevoke`.
-4. ✅ Existing scheduler invariant proofs continue to build unchanged, and `Main.lean`
-   keeps the executable scheduler + lifecycle trace path stable.
+### Active planning target
 
-See `docs/SEL4_SPEC.md` for normative acceptance criteria and `docs/DEVELOPMENT.md` for the
-recommended implementation sequence and review checklist.
+The next implementation slice is **M3 IPC seed**: introduce typed endpoint operations and first IPC
+safety invariants while preserving the established M1/M2 theorem surface.
+
+See:
+
+- `docs/SEL4_SPEC.md` for normative target outcomes and acceptance gates.
+- `docs/DEVELOPMENT.md` for the recommended implementation sequence and PR checklist.
+
+## Daily contributor loop
+
+```bash
+lake build
+lake exe sele4n
+rg -n "axiom|sorry|TODO" SeLe4n Main.lean
+```
+
+Use this loop as a minimum pre-PR verification baseline.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,199 +1,146 @@
-# Development Guide
+# seLe4n Development Guide
 
-## 1. Current phase
+## 1. Purpose
 
-The project has completed bootstrap and **M1: Scheduler Integrity**.
-Development has completed the **M2 Foundation Slice: typed CSpace lookup and mint model** and now focuses on post-foundation capability lifecycle work.
+This guide defines the day-to-day implementation workflow for seLe4n, with emphasis on:
 
-### Current objective slice (next step)
+- maintaining executable semantics,
+- preserving established theorem surfaces,
+- delivering milestones in small, reviewable proof slices.
 
-The active implementation target is capability-lifecycle expansion beyond the completed M2 foundation slice.
+The codebase is currently in a **post-M2 / pre-M3** phase.
 
-Audited outcomes from the completed M2 foundation slice:
+---
 
-- ✅ typed capability operations exist for lookup and write/update paths,
-- ✅ state/model helpers exist for slot-level capability ownership representation,
-- ✅ initial capability invariants are defined and composed,
-- ✅ preservation is proven for at least one read and one write transition,
-- ✅ executable behavior and existing scheduler proofs remain stable.
+## 2. Current baseline and active focus
 
-Current active-slice status:
+### 2.1 Baseline guarantees to keep stable
 
-- ✅ typed revoke/delete transitions over typed CSpace addresses are implemented,
-- ✅ lifecycle-aware authority monotonicity constraints are implemented,
-- ✅ composed capability bundle now includes lifecycle clauses with lifecycle-preservation theorem entrypoints,
-- ✅ existing scheduler invariant proofs and `Main.lean` executable behavior are preserved.
+The following are considered stable and must not regress:
 
-### 1.1 Active-slice outcome details (implementation-ready)
+1. M1 scheduler invariant bundle entrypoints and preservation behavior.
+2. M2 capability lifecycle transitions (`lookup`, `insert`, `mint`, `delete`, `revoke`).
+3. Capability invariant bundle structure and lifecycle authority monotonicity entrypoints.
+4. Executable sanity path in `Main.lean`.
 
-To keep scope tight and proofs composable, treat the current slice as three explicit outcomes.
+### 2.2 Active focus: M3 IPC seed
 
-1. **Typed lifecycle transitions (`revoke`/`delete`)**
-   - Operate on typed CSpace addresses (`SlotRef`/equivalent typed slot handle).
-   - Keep failure behavior explicit via existing kernel error channels.
-   - Reuse existing lookup/insert helper style to avoid branching state-access idioms.
-2. **Lifecycle-aware authority monotonicity**
-   - Capture that lifecycle operations cannot increase rights or introduce stronger authority.
-   - Distinguish local attenuation constraints from global non-escalation constraints.
-   - Document policy near definitions to keep theorem intent reviewable.
-3. **Capability bundle preservation over lifecycle transitions**
-   - Extend bundle composition rather than replacing existing components.
-   - Add dedicated preservation theorem entrypoints for lifecycle operations.
-   - Preserve existing read/write preservation results and scheduler proof stability.
+Current development should prioritize a small endpoint IPC seed with theorem-backed invariants.
+Keep changes narrow and compositional so M1/M2 proof obligations remain intact.
 
-### 1.2 Current audit evidence snapshot
+---
 
-Latest repository-wide audit commands and outcomes:
+## 3. Recommended implementation sequence (M3 IPC seed)
 
-- `lake build` passes,
-- `lake exe sele4n` runs scheduler + mint + revoke + delete demonstration path,
-- `rg -n "axiom|TODO|sorry" SeLe4n Main.lean` returns no unresolved proof escapes or stale TODO markers.
+Work in this order unless a blocking dependency requires adjustment:
 
-## 2. Working agreement
+1. **Model-first minimal IPC state**
+   - Add only the endpoint state required for one send/receive story.
+   - Favor explicit, typed fields over generic maps when possible.
 
-1. Spec-first: update `docs/SEL4_SPEC.md` when scope or acceptance criteria change.
-2. Keep executable behavior intact (`Main.lean` path should remain runnable).
-3. Prove before broadening: land small, composable invariants with corresponding proofs.
-4. Prefer total functions and explicit error channels (`Except`) over partial definitions.
+2. **Transitions second**
+   - Implement one send transition and one receive transition.
+   - Keep transition semantics deterministic and easy to unfold in proofs.
 
-Additional milestone agreements:
+3. **Invariant components third**
+   - Define one endpoint queue well-formedness predicate.
+   - Define one endpoint/object validity predicate.
+   - Bundle under a clearly named IPC invariant entrypoint.
 
-5. Keep theorem statements stable once introduced; iterate via helper lemmas first.
-6. Make policy choices explicit near definitions (not only in commit/PR text).
-7. When a proof blocks, land minimal supporting lemmas rather than broad refactors.
-8. Do not regress completed M1 scheduler invariants while extending M2 semantics.
-9. For lifecycle transitions, prefer one transition = one clearly stated policy obligation,
-   followed by helper lemmas and then composed-bundle preservation.
-10. Avoid broad state-model rewrites while active-slice authority properties are still settling.
+4. **Local helper lemmas fourth**
+   - Add lookup/update lemmas close to transition definitions.
+   - Keep helper statements small and reusable.
 
-## 3. Recommended workflow per change
+5. **Preservation theorems fifth**
+   - Prove send preserves IPC invariant bundle.
+   - Prove receive preserves IPC invariant bundle.
+   - Compose with existing M1/M2 bundle entrypoints only after local proofs are stable.
 
-1. Confirm milestone impact (M2 foundation-only vs. future milestone prep).
-2. Update spec text if acceptance criteria/scope move.
-3. Implement Lean model/theorem changes in smallest coherent slices.
-4. Run checks:
-   - `lake build`
-   - `lake exe sele4n` (when transition behavior is affected)
-   - targeted repository scans (`rg -n "axiom|TODO|sorry"`) before merge
-5. Summarize obligations completed and remaining in commit/PR notes.
+6. **Executable demonstration last**
+   - Extend `Main.lean` trace to include IPC behavior.
+   - Confirm current demo behavior still executes.
 
-### 3.1 Suggested micro-slice workflow for the active lifecycle slice
+---
 
-For each lifecycle transition (`delete`, `revoke`) and each authority rule:
+## 4. Proof hygiene standards
 
-1. Add/adjust predicate definition (authority + lifecycle safety component).
-2. Add one local sanity lemma constraining theorem drift.
-3. Add transition-local preservation theorem (`<transition>_preserves_<component>`).
-4. Fold transition result into composed invariant theorem.
-5. Re-run build and executable checks.
+1. Prefer theorem names in `<transition>_preserves_<invariant>` form.
+2. Keep conjunction-heavy invariant bundles factored with named components.
+3. Avoid broad global simp attribute changes; use local `simp` scopes.
+4. Keep proof scripts short and layered:
+   - unfold transition,
+   - split success/error branches,
+   - dispatch local helper lemmas.
+5. Preserve theorem statement stability when refactoring internals.
+6. Do not introduce `axiom` or `sorry` into core Lean modules.
 
-This sequence keeps each change reviewable and reduces proof breakage fan-out.
+---
 
-### 3.2 Recommended implementation order for active-slice delivery
+## 5. Documentation update requirements
 
-1. Land typed delete transition and local lemmas.
-2. Land typed revoke transition and local lemmas.
-3. Introduce lifecycle-aware authority monotonicity predicates.
-4. Extend composed capability invariant bundle.
-5. Add composed preservation theorems for new transitions.
-6. Refresh executable demonstration path and docs.
+Any PR that changes transitions or invariant composition must update docs in the same commit range:
 
-## 4. Coding and proof conventions
+1. `docs/SEL4_SPEC.md`:
+   - scope/status,
+   - acceptance criteria,
+   - next-slice outcomes.
+2. `docs/DEVELOPMENT.md`:
+   - implementation order,
+   - proof workflow,
+   - review checklist.
+3. `README.md`:
+   - current milestone stage summary,
+   - quick contributor verification loop.
 
-- Namespaces:
-  - `SeLe4n.Model` for state/object definitions,
-  - `SeLe4n.Kernel` for transitions/invariants/proofs.
-- Theorem naming:
-  - use `<transition>_preserves_<invariant>` style where practical.
-- Proof structure:
-  - isolate helper lemmas for list/set facts,
-  - keep theorem statements stable and refactor proof terms beneath them.
-- Documentation:
-  - add short comments when a design choice is non-obvious or policy-based.
+---
 
-M2 proof hygiene conventions:
+## 6. Validation commands
 
-- Use explicit names for bundle members and avoid anonymous conjunctions without aliases.
-- Group helper lemmas by subject (`lookup`, slot mutations, rights attenuation facts).
-- Keep `simp` sets predictable; avoid global simp attributes unless broadly safe.
-- Avoid introducing abstractions that hide state updates while invariants are still evolving.
-- For lifecycle operations, separate “address resolution” lemmas from “authority effect” lemmas.
-- Keep revoke/delete proofs structurally parallel where possible to minimize maintenance burden.
+Run this minimum command set before opening a PR:
 
-## 5. Repository readability checklist
+```bash
+lake build
+lake exe sele4n
+rg -n "axiom|sorry|TODO" SeLe4n Main.lean
+```
 
-When touching a module, check the following to keep codebase comprehension high:
+If a command cannot be run due to environment constraints, document the limitation explicitly in
+PR notes.
 
-- exported names are discoverable from `SeLe4n.lean`,
-- top-level doc comments exist for new public definitions,
-- transition semantics are accompanied by at least one theorem use-site,
-- docs reference the same milestone terminology as the code,
-- examples in `Main.lean` remain concrete and executable.
+---
 
-## 6. Acceptance-driven delivery checklist (M2 active lifecycle slice)
+## 7. PR checklist (required)
 
-Before merging work intended for the active M2 slice, verify:
+Include this checklist in your PR description and mark each item:
 
-- [x] capability invariant bundle entrypoint exists and includes uniqueness + lookup soundness + attenuation rule,
-- [x] attenuation policy is documented in code and spec,
-- [x] preservation lemmas exist for one read and one write transition,
-- [x] completed M1 scheduler theorems still build unchanged,
-- [x] no new `axiom`/`sorry` introduced,
-- [x] `lake build` passes,
-- [x] `lake exe sele4n` demonstrates executable transition behavior,
-- [x] docs reflect progress and remaining proof debt.
+- [ ] Scope is limited to one coherent milestone slice.
+- [ ] New transitions have explicit error branches.
+- [ ] New invariant components are named and documented.
+- [ ] Preservation theorem entrypoints compile.
+- [ ] `lake build` executed.
+- [ ] `lake exe sele4n` executed.
+- [ ] Hygiene scan (`axiom|sorry|TODO`) executed.
+- [ ] Docs updated to match current implementation stage.
+- [ ] Remaining proof debt is explicitly identified.
 
-Additional active-slice closure checks:
+---
 
-- [x] typed revoke/delete transitions compile and use typed CSpace addresses,
-- [x] lifecycle-aware authority monotonicity predicates are defined and used in theorem statements,
-- [x] composed capability bundle includes lifecycle clauses,
-- [x] lifecycle preservation theorems are proven for delete and revoke on the composed bundle.
-- [x] executable example includes a lifecycle transition trace.
+## 8. Review heuristics for maintainers
 
-## 7. Audit protocol for milestone completion claims
+Reviewers should verify:
 
-When marking any milestone item complete, record evidence in the same commit range:
+1. Transition semantics are readable without deep tactic archaeology.
+2. Helper lemmas match transition granularity (not overly generic).
+3. Invariant bundle changes are justified and scoped.
+4. New executable examples provide concrete behavior evidence.
+5. Milestone claims in docs match the code present in the same range.
 
-1. **Code evidence**: definitions and theorem statements exist in tracked Lean modules.
-2. **Proof evidence**: preservation theorem(s) compile under `lake build`.
-3. **Executable evidence**: runnable example path (`lake exe sele4n` or equivalent).
-4. **Hygiene evidence**: no unresolved proof escapes (`axiom`, `sorry`) and no stale TODO markers
-   in Lean code.
+---
 
-Recommended command set:
+## 9. Anti-patterns to avoid
 
-- `lake build`
-- `lake exe sele4n`
-- `rg -n "axiom|TODO|sorry" SeLe4n Main.lean`
-
-## 8. Development path ahead
-
-Near-term sequence after the completed M2 foundation slice:
-
-1. Expand CSpace operations to revoke/delete over typed addresses.
-2. Land lifecycle-aware authority monotonicity constraints and helper lemmas.
-3. Prove composed capability bundle preservation for lifecycle transitions.
-4. Start M3 IPC semantics with endpoint transition definitions.
-5. Lift reusable capability and scheduler proof utilities into stable helper modules.
-
-Longer-term sequence:
-
-6. Object lifecycle/retype safety (M4).
-7. Refinement and correspondence track (M5+).
-
-## 9. PR and review notes for the active slice
-
-When submitting lifecycle-slice changes, include a short “proof-impact summary” in PR text:
-
-1. New/changed transitions.
-2. New/changed invariant components.
-3. New/changed preservation theorem entrypoints.
-4. Any intentional proof debt carried to next increment.
-
-## 10. Anti-patterns to avoid
-
-- Expanding into IPC/MMU/retype semantics before current-slice proofs stabilize.
-- Embedding milestone assumptions in code without documenting them in the spec.
-- Monolithic proof scripts that block incremental refactoring.
-- Deferring policy decisions (e.g., attenuation constraints) until late in proof work.
+- Mixing large model redesign with new proof obligations in one PR.
+- Introducing IPC/MMU/retype details simultaneously during M3 seed.
+- Hiding semantics in abstraction layers that make transition unfolding opaque.
+- Deferring policy decisions that proofs depend on.
+- Marking milestone completion without executable and theorem evidence.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -1,330 +1,163 @@
-# seL4-in-Lean Specification and Milestone Plan
-
-## 1. Purpose and intent
-
-This document captures the current specification baseline for seLe4n after bootstrap completion,
-records closure evidence for M1, and defines the immediate plan for Milestone M2.
-
-The project now targets a disciplined progression from an executable abstract kernel model to a
-proof-oriented scheduler and capability semantics stack.
-
-Primary outcomes for this revision:
-
-- codify that bootstrap requirements are complete,
-- record that M1 Scheduler Invariant Bundle v1 is complete with verification evidence,
-- establish explicit acceptance criteria for the next implementation step (M2 foundation),
-- tighten change-control expectations for upcoming milestones,
-- define an implementation-ready post-foundation active slice plan for lifecycle transitions.
-
-## 2. Definitions
+# seLe4n Specification and Milestone Plan
 
-- **Bootstrap milestone**: the initial semantic core with executable transitions and at least one
-  machine-checked invariant-preservation proof.
-- **M1 (Scheduler Integrity)**: completed milestone that strengthened scheduler invariants and
-  proved preservation across core scheduling transitions.
-- **M2 (Capability & CSpace Semantics)**: active milestone for typed CSpace operations and
-  authority-safety properties.
-- **Executable semantics**: Lean definitions evaluable via `lake exe sele4n` or `#eval` without
-  axiomatic escape hatches.
-- **Kernel transition**: a `Kernel` computation from `SystemState` to either `(result,
-  SystemState)` or `KernelError`.
-- **Invariant bundle**: a compositional predicate over `SystemState` made from smaller,
-  independently provable properties.
+## 1. Purpose
 
-## 3. Scope and status
+This document defines the current normative specification baseline for seLe4n and the immediate
+next delivery target.
 
-### 3.1 Bootstrap milestones (complete)
+It serves three roles:
 
-1. ✅ Core type aliases for kernel identifiers.
-2. ✅ Abstract machine state (`RegisterFile`, `MachineState`).
-3. ✅ Kernel object universe (`TCB`, `Endpoint`, `CNode`, capabilities).
-4. ✅ Global system state (`SystemState`) with object store and scheduler fields.
-5. ✅ Basic kernel monad (`KernelM`) and error type (`KernelError`).
-6. ✅ Initial scheduler transitions (`chooseThread`, `schedule`, `handleYield`).
-7. ✅ Preservation theorem entrypoint for scheduler well-formedness.
+1. Record **what is already complete** in the Lean codebase.
+2. Define **what the next slice must deliver**.
+3. Provide **acceptance criteria** that can be validated with local commands.
 
-### 3.2 Milestone M1 scope (complete)
+---
 
-M1 **Scheduler Invariant Bundle v1** is complete. Implemented and proven artifacts:
+## 2. Milestone glossary
 
-1. ✅ Runnable queue uniqueness (no duplicate TIDs in `runQueue`).
-2. ✅ Current-thread object validity (if `currentThread = some tid`, object lookup resolves to a
-   `TCB`).
-3. ✅ Queue/current consistency under explicit strict policy.
-4. ✅ Preservation of the composed scheduler invariant bundle for:
-   - `chooseThread`,
-   - `schedule`,
-   - `handleYield`.
+- **Bootstrap**: executable core model and initial invariant-preservation theorem pipeline.
+- **M1 (Scheduler Integrity Bundle v1)**: scheduler-focused invariant components + preservation.
+- **M2 (Capability & CSpace Semantics)**: typed CSpace operations, attenuation, lifecycle effects.
+- **M3 (IPC seed)**: first endpoint transition model and IPC safety invariants.
 
-### 3.3 Immediate next step scope: M2 foundation slice (completed)
+---
 
-The completed immediate step was a narrow **M2 Foundation Slice: typed CSpace lookup and
-mint model** that is proof-ready and does not destabilize completed scheduler results.
+## 3. Current status (implemented)
 
-In-scope for this slice:
+### 3.1 Bootstrap (complete)
 
-1. ✅ Introduce minimal CSpace transition API surface in `SeLe4n.Kernel.API` (or a sibling kernel
-   module) for:
-   - slot lookup,
-   - cap insertion/update,
-   - mint-like derivation with rights attenuation.
-2. ✅ Add state/model helpers needed to represent slot-level capability ownership without adding
-   architecture-specific detail.
-3. ✅ Define a first capability-safety invariant bundle for this slice (e.g., slot uniqueness,
-   lookup soundness, attenuation monotonicity).
-4. ✅ Prove preservation for at least one write transition and one read transition in the new API.
-5. ✅ Keep `Main.lean` executable path functional; if changed, include a concrete demonstration of
-   at least one CSpace operation.
-
-Out-of-scope for this slice:
-
-- full revoke/delete cascade semantics,
-- endpoint IPC/reply-cap lifecycle,
-- untyped retype/allocation semantics,
-- correspondence/refinement obligations to external artifacts.
-
-### 3.4 Active slice scope (new): lifecycle transitions and authority monotonicity
-
-The active slice now extends the completed M2 foundation with lifecycle operations over typed
-CSpace addresses and stronger authority preservation constraints.
-
-In-scope for the active slice:
-
-1. ✅ Add revoke/delete transitions over typed `SlotRef`-style addresses already used by lookup and
-   mint semantics.
-2. ✅ Define lifecycle-aware authority monotonicity constraints that cover both direct cap
-   attenuation and authority reduction through revoke/delete.
-3. ✅ Strengthen the capability invariant bundle to include lifecycle transition obligations and
-   prove composed preservation for lifecycle operations.
-4. ✅ Preserve existing scheduler invariant proofs and executable behavior in `Main.lean`.
+The repository includes:
 
-Out-of-scope for the active slice:
+1. Core object/thread/slot identifiers and kernel monad structure.
+2. Abstract machine model (`RegisterFile`, `MachineState`).
+3. Kernel object universe (`TCB`, `Endpoint`, `CNode`, `Capability`).
+4. Global `SystemState` with object store and scheduler state.
+5. Executable kernel transitions and error handling path.
 
-- full derivation-tree global revoke semantics across unmodeled object classes,
-- IPC/reply-cap protocol proofs,
-- retype/allocation correctness,
-- external refinement correspondence obligations.
+### 3.2 M1 Scheduler Integrity Bundle v1 (complete)
 
-### 3.5 M2 foundation and active-slice implementation boundary (normative)
+The following invariants are modeled and used in preservation entrypoints:
 
-Within this step, changes should stay inside CSpace/capability semantics and proofs. The following
-are in scope:
+1. `runQueueUnique`: runnable queue has no duplicate TIDs.
+2. `currentThreadValid`: current thread resolves to a TCB.
+3. `queueCurrentConsistent`: current thread must be in runnable queue under strict policy.
+4. `schedulerInvariantBundle` composed entrypoint and preservation alignment.
 
-- adding helper predicates/lemmas needed to define and prove capability invariants,
-- minor state-accessor refactors required for theorem clarity,
-- executable examples in `Main.lean` that exercise affected transitions.
+### 3.3 M2 Capability & CSpace Semantics (complete)
 
-The following are out-of-scope for this step even if they appear adjacent:
+Implemented M2 scope includes:
 
-- introducing new architecture-specific object classes,
-- extending capability operations beyond the M2 foundation slice,
-- architecture-specific behavior (timer interrupts, MMU details, etc.).
-
-### 3.6 Deferred (explicitly out-of-scope for M2 active lifecycle slice)
-
-- virtual memory and architecture-specific MMU semantics,
-- full capability derivation tree with architecture-complete revoke/delete cascade behavior,
-- full IPC/reply-cap lifecycle correctness,
-- untyped memory allocation and retype proofs,
-- Isabelle/HOL correspondence and refinement-to-C obligations.
-
-## 4. Architecture and module responsibilities
-
-### 4.1 Core layers
-
-- `SeLe4n.Prelude`: identifiers and base kernel monad infrastructure.
-- `SeLe4n.Machine`: machine state/register/memory abstractions.
-- `SeLe4n.Model.Object`: kernel object and capability model.
-- `SeLe4n.Model.State`: global state, scheduler state, and utility accessors.
-- `SeLe4n.Kernel.API`: transition semantics and invariant theorems.
-
-### 4.2 Documentation layers
-
-- `docs/SEL4_SPEC.md`: normative scope and acceptance requirements.
-- `docs/DEVELOPMENT.md`: implementation workflow and review checks.
-
-## 5. Normative requirements
-
-The project shall preserve the following through the active M2 lifecycle slice:
-
-1. `lake build` succeeds from a clean checkout.
-2. `Main.lean` continues to demonstrate executable transition behavior.
-3. No `axiom` is introduced to bypass missing proofs.
-4. Every new capability invariant has:
-   - a clear definition,
-   - at least one proof use-site,
-   - placement in the composed invariant entrypoint.
-5. Lifecycle transitions use typed addresses and explicit error behavior (e.g., missing slot,
-   invalid object class, unsupported operation).
-6. Milestone changes that affect scope or acceptance criteria update this document in the same
-   commit.
-
-## 6. Acceptance criteria and evidence mapping
-
-The active step is **M2 Lifecycle Slice: revoke/delete transitions + authority monotonicity**.
-This step is complete when all checks below are satisfied.
-
-### 6.1 M2 active-slice functional and proof acceptance criteria
-
-1. A composed capability invariant bundle entrypoint exists and includes at least:
-   - slot-level uniqueness/no-alias property for the modeled structure,
-   - lookup soundness (resolved slot points to the modeled capability),
-   - rights attenuation monotonicity for mint/derive-style operations.
-2. Lifecycle-aware authority monotonicity is explicitly modeled and includes constraints for:
-   - mint/derive attenuation,
-   - delete non-escalation,
-   - revoke non-escalation for reachable descendants in the modeled slice.
-3. Each invariant component has at least one dedicated preservation lemma or helper theorem.
-4. Theorems show preservation of the composed capability invariant for at least:
-   - one read transition (`lookup`-style),
-   - one write transition (`insert`/`mint`-style),
-   - one lifecycle transition (`delete` and/or `revoke`-style).
-5. The attenuation policy is stated in code comments/doc text near definitions and reflected in
-   theorem statements.
-
-### 6.2 Build and executability acceptance criteria
-
-6. `lake build` passes with no new `axiom` introduced to bypass missing proofs.
-7. `lake exe sele4n` (or equivalent `#eval` path used by `Main.lean`) demonstrates at least one
-   concrete transition (scheduler and/or capability path) from an explicit state.
-
-### 6.3 Documentation acceptance criteria
+1. Typed CSpace address model (`SlotRef` / `CSpaceAddr`).
+2. Read/write transitions:
+   - `cspaceLookupSlot`,
+   - `cspaceInsertSlot`,
+   - `cspaceMint`.
+3. Lifecycle transitions:
+   - `cspaceDeleteSlot`,
+   - `cspaceRevoke`.
+4. Authority policy components:
+   - rights attenuation (`capAttenuates`),
+   - lifecycle authority reduction statements.
+5. Composed capability invariant entrypoint:
+   - slot uniqueness,
+   - lookup soundness,
+   - attenuation rule,
+   - lifecycle authority monotonicity.
+6. Preservation theorem entrypoints for lookup/insert/mint/delete/revoke progression.
+7. Executable trace in `Main.lean` showing scheduler + capability lifecycle behavior.
 
-8. `docs/SEL4_SPEC.md` and `docs/DEVELOPMENT.md` both describe:
-   - current M2 foundation scope,
-   - remaining proof gaps (if any),
-   - next intended increment.
-
-Evidence sources:
-
-- theorem statements/proofs in `SeLe4n/Kernel/API.lean` (or adjacent kernel semantics module),
-- executable path in `Main.lean`,
-- build/execution output from local checks.
-
-### 6.4 Definition of done for this step
-
-This step should be marked complete only when all acceptance criteria pass in one commit range,
-and no open TODOs remain for the transitions introduced in this slice.
-
-### 6.5 Progress snapshot (current repository state)
-
-- M2 Foundation **Step 1 API surface** is implemented in `SeLe4n.Kernel.API` with `cspaceLookupSlot`,
-  `cspaceInsertSlot`, `mintDerivedCap`, and `cspaceMint`, including read/write preservation and
-  attenuation theorems.
-- M2 Foundation **Step 2 state/model helpers** are implemented in `SeLe4n.Model.State` (`SlotRef`,
-  ownership-oriented lookup/accessor helpers) and connected to kernel lookup/insert lemmas.
-- M2 Foundation **Step 3 invariant bundle** is now implemented in `SeLe4n.Kernel.API` as
-  `capabilityInvariantBundle` with explicit components (`cspaceSlotUnique`, `cspaceLookupSound`,
-  `cspaceAttenuationRule`) and dedicated helper lemmas/theorem entrypoints.
-- M2 Foundation **Step 4 preservation proofs** are now established for one read transition (`cspaceLookupSlot_preserves_capabilityInvariantBundle`) and one write transition (`cspaceMint_preserves_capabilityInvariantBundle`) in `SeLe4n.Kernel.API`.
-- M2 Foundation **Step 5 executable path** is now demonstrated in `Main.lean` via explicit source
-  slot lookup plus mint + destination lookup on concrete CSpace addresses.
-- Active-slice lifecycle transition surface is now implemented (`cspaceDeleteSlot`,
-  `cspaceRevoke`) with local authority-reduction helper theorems.
-- Active-slice lifecycle authority monotonicity modeling is now defined as
-  `lifecycleAuthorityMonotonicity` and proven to hold in the current model.
-- The composed capability invariant bundle now includes lifecycle clauses, and composed
-  lifecycle-preservation theorem entrypoints are established for `delete` and `revoke`.
-- Existing scheduler invariant proofs still build unchanged, and `Main.lean` retains executable
-  scheduler + lifecycle transition behavior for the active slice.
+---
 
-### 6.6 Active-slice incremental target outcomes and sequencing
+## 4. Next slice: M3 IPC seed (target outcomes)
 
-To reduce proof breakage and keep review units small, the active slice should be delivered in
-four target increments:
+### 4.1 Objective
 
-1. **Lifecycle transition surface**
-   - Add `cspaceDelete` and `cspaceRevoke`-style transitions over typed addresses.
-   - Specify exact preconditions and kernel errors in transition-level comments.
-2. **Authority monotonicity formalization**
-   - Introduce lifecycle-aware monotonicity predicates as reusable definitions.
-   - Prove helper lemmas showing each lifecycle primitive cannot introduce stronger authority than
-     the source state permits.
-3. **Composed invariant uplift**
-   - Extend `capabilityInvariantBundle` with lifecycle clauses and update existing proof entrypoints
-     with minimal theorem-statement churn.
-4. **Executable and documentation closure**
-   - Demonstrate at least one lifecycle path in `Main.lean`.
-   - Update this spec and `docs/DEVELOPMENT.md` with delivered scope and next proof debt.
+Land a narrow, typed IPC model centered on endpoint send/receive transitions and prove first-order
+safety invariants, while keeping M1/M2 theorems and executable path stable.
 
-### 6.7 Full-repository audit snapshot (documentation-to-code alignment)
+### 4.2 Required outcomes
 
-- Build proof check (`lake build`): passes.
-- Executable behavior check (`lake exe sele4n`): runs and demonstrates scheduler selection,
-  source-slot lookup, rights-attenuated mint, local revoke, and delete transitions.
-- Proof-hygiene check (`rg -n "axiom|TODO|sorry" SeLe4n Main.lean`): no unresolved proof escapes
-  or stale TODO markers found in Lean code.
-- Milestone-audit check (definitions + preservation theorem entrypoints): completed milestone claims in this spec map to implemented symbols in `SeLe4n/Kernel/API.lean` and executable lifecycle traces in `Main.lean`.
+For this slice to be considered complete, all of the following must be true:
 
+1. **Endpoint transition API exists**
+   - Add typed endpoint transition entrypoints (minimum one send path and one receive path).
+   - Transitions must use existing `Kernel` style and explicit error handling.
 
-## 7. Audit closure report (Bootstrap + M1)
+2. **State modeling remains minimal but explicit**
+   - Any new state needed for IPC queues or pending messages is represented in model structures
+     with clear ownership and access discipline.
+   - Avoid architecture-specific payload details in this slice.
 
-The repository has been audited against completed milestone claims.
+3. **First IPC invariant bundle component is introduced**
+   - At minimum, define one queue well-formedness condition and one endpoint/object validity
+     condition.
+   - Bundle naming should align with existing invariant terminology and theorem style.
 
-### 7.1 Bootstrap verification summary
+4. **Preservation proof coverage lands for new transitions**
+   - At least one send transition preservation theorem.
+   - At least one receive transition preservation theorem.
+   - New proof entrypoints should be composable with existing M1/M2 bundles.
 
-- Core identifiers, machine state, object universe, and global state are implemented in
-  `Prelude`, `Machine`, `Model.Object`, and `Model.State` modules.
-- `KernelM`, `KernelError`, and executable scheduling transitions are present and buildable.
+5. **Executable trace includes IPC behavior**
+   - Extend or add executable demonstration to show endpoint transition flow.
+   - Existing scheduler + CSpace demo should remain available or equivalent coverage provided.
 
-### 7.2 M1 verification summary
+### 4.3 Explicit out-of-scope for this slice
 
-- Invariant components (`runQueueUnique`, `currentThreadValid`, `queueCurrentConsistent`) and
-  composed entrypoint (`schedulerInvariantBundle`) are implemented.
-- Preservation theorems exist for `chooseThread`, `schedule`, and `handleYield` over bundle
-  components and composed bundle.
-- Strict queue/current policy is documented in-code at invariant definition.
-- Repository search shows no `axiom`, `sorry`, or unresolved `TODO` markers in Lean code.
+- Full blocking/wakeup scheduler semantics.
+- Reply-cap semantics and complete endpoint protocol states.
+- Architecture/MMU/ASID-specific details.
+- Global refinement relation to C implementation.
 
-### 7.3 Audit evidence commands
+---
 
-- `lake build`
-- `lake exe sele4n`
-- `rg -n "axiom|TODO|sorry"`
+## 5. Acceptance criteria for M3 IPC seed
 
-## 8. Roadmap
+A change set claiming M3 slice completion must satisfy all criteria below:
 
-### 8.1 M1 (completed): scheduler integrity
+1. `lake build` succeeds.
+2. `lake exe sele4n` succeeds and demonstrates IPC-related behavior.
+3. No new unresolved proof escapes in core Lean sources:
+   - `rg -n "axiom|sorry|TODO" SeLe4n Main.lean`.
+4. New IPC transitions have machine-checked preservation theorem entrypoints.
+5. `docs/SEL4_SPEC.md` and `docs/DEVELOPMENT.md` reflect delivered API and proof status.
 
-Incremental plan:
+---
 
-1. ✅ Lock invariant policy (strict vs. relaxed queue/current consistency).
-2. ✅ Encode component predicates and compose the bundle entrypoint.
-3. ✅ Prove preservation for `chooseThread`.
-4. ✅ Prove preservation for `schedule`.
-5. ✅ Prove preservation for `handleYield`.
-6. ✅ Consolidate helper lemmas and remove redundant proof scaffolding.
-7. ✅ Update docs to record what is complete and what remains.
+## 6. Change-control and documentation policy
 
-### 8.2 M2 (current): capability and CSpace semantics
+When milestone scope changes, update docs first (or in the same commit range) with:
 
-- ✅ Step 1 complete: typed CSpace lookup/insert/mint API with explicit rights attenuation policy and core theorems.
-- ✅ Step 2 complete: state/model helpers for slot-level capability ownership without architecture-specific details.
-- ✅ Step 3 complete: first capability invariant bundle is defined/proven (slot uniqueness, lookup soundness, attenuation monotonicity).
-- ✅ Next increment landed: typed revoke/delete transitions over `SlotRef`-style addresses (local revoke semantics in the modeled CNode scope).
-- ✅ Step 4 complete: lifecycle-aware authority monotonicity constraints are defined for attenuation + delete/revoke reduction, with dedicated helper theorems.
-- ✅ Step 5 complete: composed `capabilityInvariantBundle` is extended with lifecycle clauses and composed preservation theorem entrypoints are proven for delete/revoke transitions.
-- 🔄 Later: authority monotonicity and reachability constraints across extended operations.
+1. New/changed transition names.
+2. New invariant components and bundle composition.
+3. New preservation theorem entrypoints.
+4. Remaining proof debt explicitly called out as deferred.
 
-### 8.3 M3: IPC semantics
+Claims of milestone completion must include evidence in code, proofs, and executable behavior.
 
-- endpoint send/receive transitions,
-- queue discipline invariants,
-- call/reply correspondence lemmas.
+---
 
-### 8.4 M4: memory/object lifecycle
+## 7. Evidence checklist for milestone closure
 
-- untyped memory + retype operations,
-- object creation/deletion safety,
-- alignment/disjointness constraints.
+Use this checklist in PR descriptions:
 
-### 8.5 M5+: refinement and correspondence
+- [ ] Transition definitions for the claimed slice exist.
+- [ ] Invariant components for the slice are defined and bundled.
+- [ ] Preservation theorem entrypoints compile.
+- [ ] Executable path demonstrates slice behavior.
+- [ ] `lake build` output is clean.
+- [ ] Hygiene scan (`axiom|sorry|TODO`) is clean for core Lean sources.
+- [ ] Docs updated to match implementation stage and next-slice plan.
 
-- abstract-to-lower-level refinement relation,
-- staged correspondence strategy toward external seL4 artifacts.
+---
 
-## 9. Change control
+## 8. Medium-term roadmap (post-M3)
 
-- Keep milestone status conservative; only mark complete when code and proofs validate.
-- Any regression in completed criteria must be reflected immediately in this spec.
-- Avoid speculative requirement text that lacks code-path ownership.
+Planned sequence after M3 seed stabilization:
+
+1. **M3 expansion**: blocking semantics, endpoint state refinements, reply-cap scaffolding.
+2. **M4 Object lifecycle/retype safety**: typed object creation/retyping invariants.
+3. **M5+ Refinement/correspondence track**: progressively connect abstract model obligations to
+   lower-level semantics.
+
+This roadmap is intentionally staged to keep proof breakage localized and reviewable.


### PR DESCRIPTION
### Motivation

- Align project documentation with the current repository state (post‑M2: typed CSpace + lifecycle transitions implemented and machine‑checked). 
- Make the next incremental development target explicit by defining the M3 IPC seed outcomes, acceptance criteria, and in‑scope/out‑of‑scope boundaries. 
- Improve contributor workflow guidance, proof hygiene expectations, and PR/review checklists so incremental proof slices remain small and reviewable.

### Description

- Rewrote `README.md` to reflect current milestone status, consolidate quickstart instructions, and include a minimal daily verification loop (`lake build`, `lake exe sele4n`, `rg ...`).
- Replaced `docs/SEL4_SPEC.md` with a tightened, normative specification that records completed Bootstrap/M1/M2 work, enumerates required outcomes for the M3 IPC seed, and provides explicit acceptance/evidence checklists.
- Replaced `docs/DEVELOPMENT.md` with an updated development guide that prescribes the recommended M3 implementation sequence, proof hygiene conventions, validation commands, and a PR checklist for reviewers and contributors.
- This is documentation-only: no Lean source semantics were changed by the edits.

### Testing

- Ran `rg -n "axiom|sorry|TODO" SeLe4n Main.lean` and found no matches, indicating no unresolved proof escapes in core sources.
- Attempted `lake build` but the `lake` tool is not available in the current environment (command returned `command not found`), so a local build could not be executed here.
- Attempted `lake exe sele4n` but `lake` is not available in the environment (command returned `command not found`), so the executable demonstration could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991231c9c00832ba24c4a23559ed886)