### PR TITLE
Adjust version bump to patch release for partial M3 step

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ lake exe sele4n
 
 ### Active planning target
 
-The next implementation slice is **M3 IPC seed**: introduce typed endpoint operations and first IPC
-safety invariants while preserving the established M1/M2 theorem surface.
+The next implementation slice is **M3 IPC seed**: typed endpoint send/receive transition entrypoints
+are now in place, with IPC safety invariants as the immediate follow-on work while preserving the
+established M1/M2 theorem surface.
 
 See:
 

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -173,6 +173,40 @@ def cspaceRevoke (addr : CSpaceAddr) : Kernel Unit :=
             storeObject addr.cnode (.cnode cn') st'
         | _ => .error .objectNotFound
 
+/-- Add a sender to an endpoint wait queue with explicit state transition. -/
+def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel Unit :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        match ep.state with
+        | .idle =>
+            let ep' : Endpoint := { state := .send, queue := [sender] }
+            storeObject endpointId (.endpoint ep') st
+        | .send =>
+            let ep' : Endpoint := { state := .send, queue := ep.queue ++ [sender] }
+            storeObject endpointId (.endpoint ep') st
+        | .receive => .error .endpointStateMismatch
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Consume one queued sender from an endpoint wait queue. -/
+def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        match ep.state, ep.queue with
+        | .send, sender :: rest =>
+            let nextState : EndpointState := if rest.isEmpty then .idle else .send
+            let ep' : Endpoint := { state := nextState, queue := rest }
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') => .ok (sender, st')
+        | .send, [] => .error .endpointQueueEmpty
+        | .idle, _ => .error .endpointStateMismatch
+        | .receive, _ => .error .endpointStateMismatch
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
 /-- Slot-level uniqueness/no-alias policy: lookup is deterministic for each slot address. -/
 def cspaceSlotUnique (st : SystemState) : Prop :=
   ∀ addr cap₁ cap₂ st₁ st₂,

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -7,6 +7,8 @@ inductive KernelError where
   | invalidCapability
   | objectNotFound
   | schedulerInvariantViolation
+  | endpointStateMismatch
+  | endpointQueueEmpty
   | notImplemented
   deriving Repr, DecidableEq
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -41,6 +41,8 @@ Work in this order unless a blocking dependency requires adjustment:
 2. **Transitions second**
    - Implement one send transition and one receive transition.
    - Keep transition semantics deterministic and easy to unfold in proofs.
+   - Current status: typed endpoint entrypoints (`endpointSend`, `endpointReceive`) are present;
+     continue by proving IPC-specific invariants against them.
 
 3. **Invariant components third**
    - Define one endpoint queue well-formedness predicate.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -79,6 +79,9 @@ safety invariants, while keeping M1/M2 theorems and executable path stable.
 
 For this slice to be considered complete, all of the following must be true:
 
+> Status note: step 1 is now implemented with typed `endpointSend`/`endpointReceive` entrypoints
+> and explicit error branches; remaining items in this section are still open for M3 completion.
+
 1. **Endpoint transition API exists**
    - Add typed endpoint transition entrypoints (minimum one send path and one receive path).
    - Transitions must use existing `Kernel` style and explicit error handling.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.0"
+version = "0.3.1"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation

- Land a narrow M3 IPC seed so the repo has a concrete typed send/receive story for endpoints while keeping M1/M2 theorem surfaces intact.
- Correct review feedback about versioning policy by using a patch-level bump since the full M3 slice is not complete.

### Description

- Add typed endpoint transitions: `endpointSend` and `endpointReceive` were implemented in `SeLe4n/Kernel/API.lean` with explicit error branches. 
- Extend the error model with `endpointStateMismatch` and `endpointQueueEmpty` in `SeLe4n/Model/State.lean` to make endpoint failure modes explicit. 
- Update documentation to reflect the M3 seed status in `README.md`, `docs/DEVELOPMENT.md`, and `docs/SEL4_SPEC.md`.
- Adjust the project version in `lakefile.toml` from `0.4.0` to `0.3.1` to reflect a patch-level release for the partial M3 work; this change is only a versioning fix and introduces no functional code changes.

### Testing

- Ran `source "$HOME/.elan/env" && lake build`, which completed successfully.
- Ran `source "$HOME/.elan/env" && lake exe sele4n`, which executed successfully and produced the expected demo output.
- Ran `rg -n "axiom|sorry|TODO" SeLe4n Main.lean`, which returned no matches, indicating no introduced proof escapes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991258c3958832bbfa880abe1420cb1)