### PR TITLE
docs: align M3 IPC slice status across spec and development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ The repository is currently at the point where:
 - Capability-space foundation + lifecycle transitions (M2) are implemented and machine-checked.
 - The executable demo path in `Main.lean` exercises scheduling, mint, revoke, and delete.
 
-The immediate focus is now preparing the next milestone slice (M3 IPC seed) without regressing the
-existing M1/M2 proof surface.
+The immediate focus is now completing the next milestone slice (M3 IPC seed) without regressing the
+existing M1/M2 proof surface. The model-first minimal IPC state and typed endpoint transition
+entrypoints are now in place, with IPC invariants/preservation proofs still pending.
 
 ## Quick start
 
@@ -59,9 +60,10 @@ lake exe sele4n
 
 ### Active planning target
 
-The next implementation slice is **M3 IPC seed**: typed endpoint send/receive transition entrypoints
-are now in place, with IPC safety invariants as the immediate follow-on work while preserving the
-established M1/M2 theorem surface.
+The next implementation slice is **M3 IPC seed**: the minimal endpoint state model and typed
+endpoint send/receive transition entrypoints are now in place, with IPC safety invariants and
+preservation proofs as the immediate follow-on work while preserving the established M1/M2 theorem
+surface.
 
 See:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,15 +34,16 @@ Keep changes narrow and compositional so M1/M2 proof obligations remain intact.
 
 Work in this order unless a blocking dependency requires adjustment:
 
-1. **Model-first minimal IPC state**
+1. **Model-first minimal IPC state** *(complete)*
    - Add only the endpoint state required for one send/receive story.
    - Favor explicit, typed fields over generic maps when possible.
+   - Status: endpoint object state (`EndpointState` + queue) is modeled in core structures.
 
-2. **Transitions second**
+2. **Transitions second** *(partially complete)*
    - Implement one send transition and one receive transition.
    - Keep transition semantics deterministic and easy to unfold in proofs.
-   - Current status: typed endpoint entrypoints (`endpointSend`, `endpointReceive`) are present;
-     continue by proving IPC-specific invariants against them.
+   - Status: typed endpoint entrypoints (`endpointSend`, `endpointReceive`) are present with
+     explicit error branches; preserve this API while proving IPC-specific invariants.
 
 3. **Invariant components third**
    - Define one endpoint queue well-formedness predicate.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -66,6 +66,16 @@ Implemented M2 scope includes:
 6. Preservation theorem entrypoints for lookup/insert/mint/delete/revoke progression.
 7. Executable trace in `Main.lean` showing scheduler + capability lifecycle behavior.
 
+### 3.4 M3 IPC seed (partial progress)
+
+Implemented pieces already landed for the active slice:
+
+1. Minimal explicit endpoint model state (`EndpointState` + queue on `Endpoint`).
+2. Typed endpoint transition entrypoints:
+   - `endpointSend`,
+   - `endpointReceive`.
+3. Explicit IPC error branches for mismatched endpoint/object states and empty-send-queue cases.
+
 ---
 
 ## 4. Next slice: M3 IPC seed (target outcomes)
@@ -77,31 +87,29 @@ safety invariants, while keeping M1/M2 theorems and executable path stable.
 
 ### 4.2 Required outcomes
 
-For this slice to be considered complete, all of the following must be true:
+For this slice to be considered complete, all of the following must be true.
+Status is tracked per outcome.
 
-> Status note: step 1 is now implemented with typed `endpointSend`/`endpointReceive` entrypoints
-> and explicit error branches; remaining items in this section are still open for M3 completion.
-
-1. **Endpoint transition API exists**
+1. **Endpoint transition API exists** *(complete)*
    - Add typed endpoint transition entrypoints (minimum one send path and one receive path).
    - Transitions must use existing `Kernel` style and explicit error handling.
 
-2. **State modeling remains minimal but explicit**
+2. **State modeling remains minimal but explicit** *(complete)*
    - Any new state needed for IPC queues or pending messages is represented in model structures
      with clear ownership and access discipline.
    - Avoid architecture-specific payload details in this slice.
 
-3. **First IPC invariant bundle component is introduced**
+3. **First IPC invariant bundle component is introduced** *(open)*
    - At minimum, define one queue well-formedness condition and one endpoint/object validity
      condition.
    - Bundle naming should align with existing invariant terminology and theorem style.
 
-4. **Preservation proof coverage lands for new transitions**
+4. **Preservation proof coverage lands for new transitions** *(open)*
    - At least one send transition preservation theorem.
    - At least one receive transition preservation theorem.
    - New proof entrypoints should be composable with existing M1/M2 bundles.
 
-5. **Executable trace includes IPC behavior**
+5. **Executable trace includes IPC behavior** *(open)*
    - Extend or add executable demonstration to show endpoint transition flow.
    - Existing scheduler + CSpace demo should remain available or equivalent coverage provided.
 


### PR DESCRIPTION
### Motivation

- Ensure project documentation accurately reflects the currently implemented subset of the M3 IPC seed so milestone claims match the active code surface. 
- The codebase already contains the minimal endpoint model and typed endpoint transitions, so the guides should mark those items as done while leaving proofs/invariants as pending. 

### Description

- Marked **Model-first minimal IPC state** as `(complete)` and added an explicit status line referencing `EndpointState` and the `Endpoint` queue in `docs/DEVELOPMENT.md`. 
- Marked **Transitions second** as `(partially complete)` and noted that `endpointSend`/`endpointReceive` exist with explicit error branches in `docs/DEVELOPMENT.md`. 
- Added a new `### 3.4 M3 IPC seed (partial progress)` section to `docs/SEL4_SPEC.md` documenting the landed pieces (`EndpointState`, `endpointSend`, `endpointReceive`, and explicit IPC error branches) and annotated the M3 required outcomes with per-item status labels (`complete` / `open`). 
- Updated `README.md` wording to consistently reflect that the minimal endpoint model and typed send/receive entrypoints are in place while IPC invariants/preservation proofs remain pending, and committed the changes. 

### Testing

- Attempted `lake build` but it failed in this environment because the `lake` command is not available (`command not found`). 
- Ran the hygiene scan `rg -n "axiom|sorry|TODO" SeLe4n Main.lean` which returned no matches indicating no obvious unresolved proof placeholders. 
- Verified the changes were staged and committed to the branch with a normal `git commit` operation which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69912a3bdbcc832bb8070842a873496c)