### PR TITLE
Complete M3 IPC invariant component step and update milestone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ lake exe sele4n
 ### Active planning target
 
 The next implementation slice is **M3 IPC seed**: the minimal endpoint state model and typed
-endpoint send/receive transition entrypoints now have a first IPC safety invariant and
+endpoint send/receive transition entrypoints now have first IPC safety invariant components
+(`endpointQueueWellFormed` + `endpointObjectValid`) bundled through `ipcInvariant` and backed by
 preservation theorems; the remaining M3 work is extending executable IPC trace coverage while
 preserving the established M1/M2 theorem surface.
 

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -219,11 +219,35 @@ def endpointQueueWellFormed (ep : Endpoint) : Prop :=
   | .send => ep.queue ≠ []
   | .receive => ep.queue = []
 
-/-- Global IPC seed invariant: every endpoint object satisfies queue/state well-formedness. -/
+/-- Endpoint/object validity component for the M3 IPC seed.
+
+This predicate captures a minimal object-level discipline: explicit `receive` state is represented
+without queued senders in this first slice. -/
+def endpointObjectValid (ep : Endpoint) : Prop :=
+  match ep.state with
+  | .receive => ep.queue = []
+  | _ => True
+
+/-- IPC invariant component bundle for one endpoint object. -/
+def endpointInvariant (ep : Endpoint) : Prop :=
+  endpointQueueWellFormed ep ∧ endpointObjectValid ep
+
+/-- Global IPC seed invariant entrypoint. -/
 def ipcInvariant (st : SystemState) : Prop :=
   ∀ oid ep,
     st.objects oid = some (.endpoint ep) →
-    endpointQueueWellFormed ep
+    endpointInvariant ep
+
+theorem endpointObjectValid_of_queueWellFormed
+    (ep : Endpoint)
+    (hWf : endpointQueueWellFormed ep) :
+    endpointObjectValid ep := by
+  cases ep with
+  | mk state queue =>
+      cases state
+      · simp [endpointObjectValid]
+      · simp [endpointObjectValid]
+      · simpa [endpointQueueWellFormed, endpointObjectValid] using hWf
 
 theorem endpointSend_result_wellFormed
     (st st' : SystemState)
@@ -343,7 +367,9 @@ theorem endpointSend_preserves_ipcInvariant
       rw [hStored] at hObj
       cases hObj
       rfl
-    simpa [hCast] using hWfNew
+    have hObjValidNew : endpointObjectValid epNew :=
+      endpointObjectValid_of_queueWellFormed epNew hWfNew
+    simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
   · have hUnchanged : st'.objects oid = st.objects oid := by
       exact endpointSend_preserves_other_objects st st' endpointId oid sender hEq hStep
     have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
@@ -364,7 +390,9 @@ theorem endpointReceive_preserves_ipcInvariant
       rw [hStored] at hObj
       cases hObj
       rfl
-    simpa [hCast] using hWfNew
+    have hObjValidNew : endpointObjectValid epNew :=
+      endpointObjectValid_of_queueWellFormed epNew hWfNew
+    simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
   · have hUnchanged : st'.objects oid = st.objects oid := by
       exact endpointReceive_preserves_other_objects st st' endpointId oid sender hEq hStep
     have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -45,11 +45,11 @@ Work in this order unless a blocking dependency requires adjustment:
    - Status: typed endpoint entrypoints (`endpointSend`, `endpointReceive`) are present with
      explicit error branches, and IPC-specific preservation lemmas are now proved for both.
 
-3. **Invariant components third** *(partially complete)*
+3. **Invariant components third** *(complete)*
    - Define one endpoint queue well-formedness predicate.
    - Define one endpoint/object validity predicate.
    - Bundle under a clearly named IPC invariant entrypoint.
-   - Status: `endpointQueueWellFormed` + `ipcInvariant` are defined; broader cross-bundle composition remains.
+   - Status: `endpointQueueWellFormed` + `endpointObjectValid` are bundled under `endpointInvariant` and exposed through `ipcInvariant`.
 
 4. **Local helper lemmas fourth**
    - Add lookup/update lemmas close to transition definitions.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -77,6 +77,8 @@ Implemented pieces already landed for the active slice:
 3. Explicit IPC error branches for mismatched endpoint/object states and empty-send-queue cases.
 4. IPC seed invariants and preservation theorem entrypoints:
    - `endpointQueueWellFormed`,
+   - `endpointObjectValid`,
+   - `endpointInvariant`,
    - `ipcInvariant`,
    - `endpointSend_preserves_ipcInvariant`,
    - `endpointReceive_preserves_ipcInvariant`.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.2"
+version = "0.3.3"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation

- Finish the “Invariant components third” step of the active M3 IPC seed by introducing an endpoint-level validity predicate and bundling it with the existing queue well-formedness so the IPC invariant is complete and well-scoped.
- Keep the change narrow and compositional so existing M1/M2 proofs and the executable demo remain intact.

### Description

- Add `endpointObjectValid` and `endpointInvariant` in `SeLe4n/Kernel/API.lean` and redefine `ipcInvariant` to quantify over the bundled `endpointInvariant` predicate.
- Add helper lemma `endpointObjectValid_of_queueWellFormed` and update `endpointSend_preserves_ipcInvariant` and `endpointReceive_preserves_ipcInvariant` to discharge the expanded invariant bundle on success paths.
- Update docs to mark the step complete and reflect the new components by editing `docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`, and `README.md` to reference `endpointObjectValid` and `endpointInvariant`.
- Bump project version in `lakefile.toml` from `0.3.2` to `0.3.3`.

### Testing

- Executed `lake build` which completed successfully and compiled the updated preservation theorems for the IPC bundle.
- Ran `lake exe sele4n` and observed the existing executable trace run successfully (scheduler + CSpace demo output present).
- Ran the hygiene scan `rg -n "axiom|sorry|TODO" SeLe4n Main.lean` which returned no results, indicating no new unresolved proof escapes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69912e615d28832b9fbb1e69d2a64b02)