### PR TITLE
Complete M3 IPC seed Step 4: add local endpoint helper lemmas and bump version

### DIFF
--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -207,6 +207,78 @@ def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
     | some _ => .error .invalidCapability
     | none => .error .objectNotFound
 
+/-- Generic object-store update lemma: writing at `id` makes that slot resolve to `obj`. -/
+theorem storeObject_objects_eq
+    (st st' : SystemState)
+    (id : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hStore : storeObject id obj st = .ok ((), st')) :
+    st'.objects id = some obj := by
+  unfold storeObject at hStore
+  cases hStore
+  simp
+
+/-- Generic object-store update lemma: writing at `id` preserves all other object lookups. -/
+theorem storeObject_objects_ne
+    (st st' : SystemState)
+    (id oid : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hNe : oid ≠ id)
+    (hStore : storeObject id obj st = .ok ((), st')) :
+    st'.objects oid = st.objects oid := by
+  unfold storeObject at hStore
+  cases hStore
+  simp [hNe]
+
+/-- Local transition helper: successful send is exactly one endpoint-object update. -/
+theorem endpointSend_ok_as_storeObject
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    ∃ ep', storeObject endpointId (.endpoint ep') st = .ok ((), st') := by
+  unfold endpointSend at hStep
+  cases hObj : st.objects endpointId with
+  | none => simp [hObj] at hStep
+  | some obj =>
+      cases obj with
+      | tcb tcb => simp [hObj] at hStep
+      | cnode cn => simp [hObj] at hStep
+      | endpoint ep =>
+          cases hState : ep.state <;> simp [hObj, hState, storeObject] at hStep
+          case idle =>
+            refine ⟨{ state := .send, queue := [sender] }, ?_⟩
+            simp [storeObject, hStep]
+          case send =>
+            refine ⟨{ state := .send, queue := ep.queue ++ [sender] }, ?_⟩
+            simp [storeObject, hStep]
+
+/-- Local transition helper: successful receive is exactly one endpoint-object update. -/
+theorem endpointReceive_ok_as_storeObject
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    ∃ ep', storeObject endpointId (.endpoint ep') st = .ok ((), st') := by
+  unfold endpointReceive at hStep
+  cases hObj : st.objects endpointId with
+  | none => simp [hObj] at hStep
+  | some obj =>
+      cases obj with
+      | tcb tcb => simp [hObj] at hStep
+      | cnode cn => simp [hObj] at hStep
+      | endpoint ep =>
+          cases hState : ep.state <;> simp [hObj, hState] at hStep
+          case send =>
+            cases hQueue : ep.queue with
+            | nil => simp [hQueue] at hStep
+            | cons head tail =>
+                simp [hQueue, storeObject] at hStep
+                rcases hStep with ⟨_, hStore⟩
+                let nextState : EndpointState := if tail.isEmpty then .idle else .send
+                refine ⟨{ state := nextState, queue := tail }, ?_⟩
+                simp [storeObject, nextState, hStore]
+
 /-- Endpoint-local queue/state well-formedness for the M3 IPC seed.
 
 Policy for this slice is intentionally simple and deterministic:
@@ -314,18 +386,8 @@ theorem endpointSend_preserves_other_objects
     (hNe : oid ≠ endpointId)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
     st'.objects oid = st.objects oid := by
-  unfold endpointSend at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state <;> simp [hObj, hState, storeObject] at hStep
-          all_goals
-            cases hStep
-            simp [hNe]
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  exact storeObject_objects_ne st st' endpointId oid (.endpoint ep') hNe hStore
 
 theorem endpointReceive_preserves_other_objects
     (st st' : SystemState)
@@ -334,23 +396,8 @@ theorem endpointReceive_preserves_other_objects
     (hNe : oid ≠ endpointId)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
     st'.objects oid = st.objects oid := by
-  unfold endpointReceive at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state <;> simp [hObj, hState] at hStep
-          case send =>
-            cases hQueue : ep.queue with
-            | nil => simp [hQueue] at hStep
-            | cons head tail =>
-                simp [hQueue, storeObject] at hStep
-                rcases hStep with ⟨hSender, hStoreEq⟩
-                cases hStoreEq
-                simp [hNe]
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  exact storeObject_objects_ne st st' endpointId oid (.endpoint ep') hNe hStore
 
 theorem endpointSend_preserves_ipcInvariant
     (st st' : SystemState)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -51,9 +51,13 @@ Work in this order unless a blocking dependency requires adjustment:
    - Bundle under a clearly named IPC invariant entrypoint.
    - Status: `endpointQueueWellFormed` + `endpointObjectValid` are bundled under `endpointInvariant` and exposed through `ipcInvariant`.
 
-4. **Local helper lemmas fourth**
+4. **Local helper lemmas fourth** *(complete)*
    - Add lookup/update lemmas close to transition definitions.
    - Keep helper statements small and reusable.
+   - Status: transition-local object-store helpers (`storeObject_objects_eq`,
+     `storeObject_objects_ne`, `endpointSend_ok_as_storeObject`,
+     `endpointReceive_ok_as_storeObject`) are now placed adjacent to endpoint transitions and
+     consumed by preservation plumbing.
 
 5. **Preservation theorems fifth**
    - Prove send preserves IPC invariant bundle.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -82,6 +82,12 @@ Implemented pieces already landed for the active slice:
    - `ipcInvariant`,
    - `endpointSend_preserves_ipcInvariant`,
    - `endpointReceive_preserves_ipcInvariant`.
+5. Transition-local lookup/update helper lemmas are now in place near endpoint transition
+   definitions to keep preservation proofs compositional:
+   - `storeObject_objects_eq`,
+   - `storeObject_objects_ne`,
+   - `endpointSend_ok_as_storeObject`,
+   - `endpointReceive_ok_as_storeObject`.
 
 ---
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.3"
+version = "0.3.4"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Finish the Development Guide Step 4 for the active M3 IPC seed slice by adding small, local lookup/update helper lemmas placed adjacent to endpoint transitions to keep proofs compositional and reusable.
- Keep the change narrowly scoped so existing M1/M2 theorem surfaces and the executable demo remain stable.

### Description
- Added transition-local helper lemmas in `SeLe4n/Kernel/API.lean`: `storeObject_objects_eq`, `storeObject_objects_ne`, `endpointSend_ok_as_storeObject`, and `endpointReceive_ok_as_storeObject`, to make object-store updates explicit and reusable.
- Refactored endpoint preservation plumbing to consume the new helpers (`endpointSend_preserves_other_objects`, `endpointReceive_preserves_other_objects`) so transition-case analysis is centralized and proofs are smaller.
- Updated documentation to mark Step 4 complete and record the landed helper-lemma set in `docs/DEVELOPMENT.md` and `docs/SEL4_SPEC.md`.
- Bumped project version in `lakefile.toml` from `0.3.3` to `0.3.4`.

### Testing
- Ran `lake build`, which completed successfully after the changes and produced a successful build of `SeLe4n` and `Main`.
- Ran `lake exe sele4n`, which executed successfully and produced the expected demo output (scheduling/capability lifecycle messages).
- Ran the hygiene scan `rg -n "axiom|sorry|TODO" SeLe4n Main.lean` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991304286a8832b99213696c0c3471d)