### PR TITLE
Fix linter warnings in IPC proofs; add M3 IPC composed bundle and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ lake exe sele4n
 ### Active planning target
 
 The next implementation slice is **M3 IPC seed**: the minimal endpoint state model and typed
-endpoint send/receive transition entrypoints now have first IPC safety invariant components
-(`endpointQueueWellFormed` + `endpointObjectValid`) bundled through `ipcInvariant` and backed by
-preservation theorems; the remaining M3 work is extending executable IPC trace coverage while
-preserving the established M1/M2 theorem surface.
+endpoint send/receive transition entrypoints now have IPC safety invariant preservation theorems
+and composed preservation entrypoints for the M1/M2/M3 seed bundle (`m3IpcSeedInvariantBundle`);
+the remaining M3 work is extending executable IPC trace coverage while preserving the established
+theorem surface.
 
 See:
 

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -230,6 +230,17 @@ theorem storeObject_objects_ne
   cases hStore
   simp [hNe]
 
+theorem storeObject_scheduler_eq
+    (st st' : SystemState)
+    (id : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hStore : storeObject id obj st = .ok ((), st')) :
+    st'.scheduler = st.scheduler := by
+  unfold storeObject at hStore
+  cases hStore
+  rfl
+
+
 /-- Local transition helper: successful send is exactly one endpoint-object update. -/
 theorem endpointSend_ok_as_storeObject
     (st st' : SystemState)
@@ -444,6 +455,104 @@ theorem endpointReceive_preserves_ipcInvariant
       exact endpointReceive_preserves_other_objects st st' endpointId oid sender hEq hStep
     have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
     exact hInv oid ep hOrig
+
+theorem endpointSend_ok_implies_endpoint_object
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    ∃ ep, st.objects endpointId = some (.endpoint ep) := by
+  unfold endpointSend at hStep
+  cases hObj : st.objects endpointId with
+  | none => simp [hObj] at hStep
+  | some obj =>
+      cases obj with
+      | tcb tcb => simp [hObj] at hStep
+      | cnode cn => simp [hObj] at hStep
+      | endpoint ep =>
+          refine ⟨ep, rfl⟩
+
+theorem endpointReceive_ok_implies_endpoint_object
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    ∃ ep, st.objects endpointId = some (.endpoint ep) := by
+  unfold endpointReceive at hStep
+  cases hObj : st.objects endpointId with
+  | none => simp [hObj] at hStep
+  | some obj =>
+      cases obj with
+      | tcb tcb => simp [hObj] at hStep
+      | cnode cn => simp [hObj] at hStep
+      | endpoint ep =>
+          refine ⟨ep, rfl⟩
+
+theorem endpointSend_preserves_schedulerInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : schedulerInvariantBundle st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    schedulerInvariantBundle st' := by
+  rcases hInv with ⟨hQueue, hRunq, hCur⟩
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  have hCurEq : st'.scheduler.current = st.scheduler.current := by simp [hSchedEq]
+  refine ⟨?_, ?_, ?_⟩
+  · simpa [hSchedEq] using hQueue
+  · simpa [hSchedEq] using hRunq
+  · cases hCurrent : st.scheduler.current with
+    | none =>
+        simp [currentThreadValid, hCurEq, hCurrent]
+    | some tid =>
+        have hCurSome : ∃ tcb : TCB, st.objects tid = some (.tcb tcb) := by
+          simpa [currentThreadValid, hCurrent] using hCur
+        rcases hCurSome with ⟨tcb, hTcbObj⟩
+        have hTidNe : tid ≠ endpointId := by
+          intro hEq
+          subst hEq
+          rcases endpointSend_ok_implies_endpoint_object st st' tid sender hStep with ⟨ep, hEpObj⟩
+          rw [hEpObj] at hTcbObj
+          cases hTcbObj
+        have hTcbObj' : st'.objects tid = some (.tcb tcb) := by
+          rw [endpointSend_preserves_other_objects st st' endpointId tid sender hTidNe hStep]
+          exact hTcbObj
+        simp [currentThreadValid, hCurEq, hCurrent, hTcbObj']
+
+theorem endpointReceive_preserves_schedulerInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : schedulerInvariantBundle st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    schedulerInvariantBundle st' := by
+  rcases hInv with ⟨hQueue, hRunq, hCur⟩
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  have hCurEq : st'.scheduler.current = st.scheduler.current := by simp [hSchedEq]
+  refine ⟨?_, ?_, ?_⟩
+  · simpa [hSchedEq] using hQueue
+  · simpa [hSchedEq] using hRunq
+  · cases hCurrent : st.scheduler.current with
+    | none =>
+        simp [currentThreadValid, hCurEq, hCurrent]
+    | some tid =>
+        have hCurSome : ∃ tcb : TCB, st.objects tid = some (.tcb tcb) := by
+          simpa [currentThreadValid, hCurrent] using hCur
+        rcases hCurSome with ⟨tcb, hTcbObj⟩
+        have hTidNe : tid ≠ endpointId := by
+          intro hEq
+          subst hEq
+          rcases endpointReceive_ok_implies_endpoint_object st st' tid sender hStep with ⟨ep, hEpObj⟩
+          rw [hEpObj] at hTcbObj
+          cases hTcbObj
+        have hTcbObj' : st'.objects tid = some (.tcb tcb) := by
+          rw [endpointReceive_preserves_other_objects st st' endpointId tid sender hTidNe hStep]
+          exact hTcbObj
+        simp [currentThreadValid, hCurEq, hCurrent, hTcbObj']
 
 /-- Slot-level uniqueness/no-alias policy: lookup is deterministic for each slot address. -/
 def cspaceSlotUnique (st : SystemState) : Prop :=
@@ -819,6 +928,59 @@ theorem cspaceRevoke_preserves_capabilityInvariantBundle
   rcases hInv with ⟨_hUnique, _hSound, hAttRule, _hLifecycle⟩
   exact ⟨cspaceSlotUnique_holds st', cspaceLookupSound_holds st', hAttRule,
     lifecycleAuthorityMonotonicity_holds st'⟩
+
+
+/-- M3 composed bundle entrypoint: M1 scheduler + M2 capability + M3 IPC. -/
+def m3IpcSeedInvariantBundle (st : SystemState) : Prop :=
+  schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st
+
+theorem endpointSend_preserves_capabilityInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : capabilityInvariantBundle st)
+    (_hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    capabilityInvariantBundle st' := by
+  rcases hInv with ⟨_hUnique, _hSound, hAttRule, _hLifecycle⟩
+  exact ⟨cspaceSlotUnique_holds st', cspaceLookupSound_holds st', hAttRule,
+    lifecycleAuthorityMonotonicity_holds st'⟩
+
+theorem endpointReceive_preserves_capabilityInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : capabilityInvariantBundle st)
+    (_hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    capabilityInvariantBundle st' := by
+  rcases hInv with ⟨_hUnique, _hSound, hAttRule, _hLifecycle⟩
+  exact ⟨cspaceSlotUnique_holds st', cspaceLookupSound_holds st', hAttRule,
+    lifecycleAuthorityMonotonicity_holds st'⟩
+
+theorem endpointSend_preserves_m3IpcSeedInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : m3IpcSeedInvariantBundle st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    m3IpcSeedInvariantBundle st' := by
+  rcases hInv with ⟨hSched, hCap, hIpc⟩
+  refine ⟨?_, ?_, ?_⟩
+  · exact endpointSend_preserves_schedulerInvariantBundle st st' endpointId sender hSched hStep
+  · exact endpointSend_preserves_capabilityInvariantBundle st st' endpointId sender hCap hStep
+  · exact endpointSend_preserves_ipcInvariant st st' endpointId sender hIpc hStep
+
+theorem endpointReceive_preserves_m3IpcSeedInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : m3IpcSeedInvariantBundle st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    m3IpcSeedInvariantBundle st' := by
+  rcases hInv with ⟨hSched, hCap, hIpc⟩
+  refine ⟨?_, ?_, ?_⟩
+  · exact endpointReceive_preserves_schedulerInvariantBundle st st' endpointId sender hSched hStep
+  · exact endpointReceive_preserves_capabilityInvariantBundle st st' endpointId sender hCap hStep
+  · exact endpointReceive_preserves_ipcInvariant st st' endpointId sender hIpc hStep
 
 /-- Choose the first runnable thread, if any. -/
 def chooseThread : Kernel (Option SeLe4n.ThreadId) :=

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -59,10 +59,14 @@ Work in this order unless a blocking dependency requires adjustment:
      `endpointReceive_ok_as_storeObject`) are now placed adjacent to endpoint transitions and
      consumed by preservation plumbing.
 
-5. **Preservation theorems fifth**
+5. **Preservation theorems fifth** *(complete)*
    - Prove send preserves IPC invariant bundle.
    - Prove receive preserves IPC invariant bundle.
    - Compose with existing M1/M2 bundle entrypoints only after local proofs are stable.
+   - Status: local IPC preservation proofs (`endpointSend_preserves_ipcInvariant`,
+     `endpointReceive_preserves_ipcInvariant`) now feed composed M3 bundle entrypoints
+     (`endpointSend_preserves_m3IpcSeedInvariantBundle`,
+     `endpointReceive_preserves_m3IpcSeedInvariantBundle`) alongside existing M1/M2 bundles.
 
 6. **Executable demonstration last**
    - Extend `Main.lean` trace to include IPC behavior.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -81,7 +81,10 @@ Implemented pieces already landed for the active slice:
    - `endpointInvariant`,
    - `ipcInvariant`,
    - `endpointSend_preserves_ipcInvariant`,
-   - `endpointReceive_preserves_ipcInvariant`.
+   - `endpointReceive_preserves_ipcInvariant`,
+   - `m3IpcSeedInvariantBundle`,
+   - `endpointSend_preserves_m3IpcSeedInvariantBundle`,
+   - `endpointReceive_preserves_m3IpcSeedInvariantBundle`.
 5. Transition-local lookup/update helper lemmas are now in place near endpoint transition
    definitions to keep preservation proofs compositional:
    - `storeObject_objects_eq`,

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.4"
+version = "0.3.7"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Clean up Lean linter warnings in endpoint send/receive preservation proofs to satisfy `lake build` hygiene. 
- Expose small helper lemmas and composed M3 IPC bundle entrypoints so IPC preservation can be composed with existing M1/M2 bundles. 
- Bump the project version to reflect the minor hygiene/composition update.

### Description
- Replaced unnecessary `simpa` uses with `simp` in the endpoint send/receive scheduler-bundle preservation proofs to remove `linter.unnecessarySimpa` warnings in `SeLe4n/Kernel/API.lean`.
- Added small local helper lemmas in `SeLe4n/Kernel/API.lean`: `storeObject_scheduler_eq`, `endpointSend_ok_implies_endpoint_object`, and `endpointReceive_ok_implies_endpoint_object` to simplify preservation reasoning.
- Implemented scheduler-preservation theorems for endpoints and capability-preservation plumbing plus the composed M3 entrypoint `m3IpcSeedInvariantBundle`, and the composed preservation theorems `endpointSend_preserves_m3IpcSeedInvariantBundle` and `endpointReceive_preserves_m3IpcSeedInvariantBundle` in `SeLe4n/Kernel/API.lean`.
- Updated docs and metadata to match the new composition points and bump the project version in `lakefile.toml` from `0.3.6`/`0.3.4` to `0.3.7` and adjusted README/DEV/SEL4_SPEC text to reflect the composed M3 seed bundle.

### Testing
- Ran `~/.elan/bin/lake build`, which completed successfully with no linter warnings reported for the modified proofs. (success)
- Ran the executable via `~/.elan/bin/lake exe sele4n` and validated the demo output (success).
- Ran a hygiene scan `rg -n "axiom|sorry|TODO" SeLe4n Main.lean` and confirmed no matches (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699132a2c988832bb303dc3c6976ac76)