### PR TITLE
Complete M3 IPC seed demo: add endpoint IPC trace, docs, and version bump

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -5,8 +5,9 @@ open SeLe4n.Model
 def rootSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 0 }
 def mintedSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 3 }
 def siblingSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 4 }
+def demoEndpoint : SeLe4n.ObjId := 30
 
-/-- Demonstrate a tiny executable path through scheduler + CSpace transitions. -/
+/-- Demonstrate a tiny executable path through scheduler + CSpace + IPC transitions. -/
 def bootstrapState : SystemState :=
   { (default : SystemState) with
     objects := fun oid =>
@@ -32,6 +33,8 @@ def bootstrapState : SystemState :=
         })
       else if oid = 11 then
         some (.cnode CNode.empty)
+      else if oid = demoEndpoint then
+        some (.endpoint { state := .idle, queue := [] })
       else
         none
     scheduler := { runnable := [1, 2], current := none }
@@ -67,6 +70,26 @@ def main : IO Unit := do
                       | .error err => IO.println s!"post-delete lookup (expected error): {reprStr err}"
                       | .ok (cap, _) =>
                           IO.println s!"unexpected cap after delete: {reprStr cap}"
+                      match SeLe4n.Kernel.endpointSend demoEndpoint 1 st5 with
+                      | .error err => IO.println s!"endpoint send #1 error: {reprStr err}"
+                      | .ok (_, st6) =>
+                          match SeLe4n.Kernel.endpointSend demoEndpoint 2 st6 with
+                          | .error err => IO.println s!"endpoint send #2 error: {reprStr err}"
+                          | .ok (_, st7) =>
+                              IO.println "queued two senders on endpoint"
+                              match SeLe4n.Kernel.endpointReceive demoEndpoint st7 with
+                              | .error err => IO.println s!"endpoint receive #1 error: {reprStr err}"
+                              | .ok (sender1, st8) =>
+                                  IO.println s!"endpoint receive #1 sender: {sender1}"
+                                  match SeLe4n.Kernel.endpointReceive demoEndpoint st8 with
+                                  | .error err => IO.println s!"endpoint receive #2 error: {reprStr err}"
+                                  | .ok (sender2, st9) =>
+                                      IO.println s!"endpoint receive #2 sender: {sender2}"
+                                      match SeLe4n.Kernel.endpointReceive demoEndpoint st9 with
+                                      | .error err =>
+                                          IO.println s!"endpoint receive #3 (expected mismatch): {reprStr err}"
+                                      | .ok (sender3, _) =>
+                                          IO.println s!"unexpected endpoint receive #3 sender: {sender3}"
           match SeLe4n.Kernel.cspaceLookupSlot mintedSlot st2 with
           | .error err => IO.println s!"cspace lookup error: {reprStr err}"
           | .ok (cap, _) =>

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The repository is currently at the point where:
 
 - Scheduler integrity (M1) is implemented and machine-checked.
 - Capability-space foundation + lifecycle transitions (M2) are implemented and machine-checked.
-- The executable demo path in `Main.lean` exercises scheduling, mint, revoke, and delete.
+- The executable demo path in `Main.lean` exercises scheduling, CSpace lifecycle operations, and endpoint IPC send/receive behavior.
 
-The immediate focus is now completing the next milestone slice (M3 IPC seed) without regressing the
-existing M1/M2 proof surface. The model-first minimal IPC state, typed endpoint transition
-entrypoints, and first IPC invariant preservation proofs are now in place.
+The immediate focus is preserving completed M3 IPC seed behavior while preparing follow-on slices
+without regressing the M1/M2/M3 proof surface. The executable IPC trace and theorem-backed IPC
+invariant preservation entrypoints are now in place.
 
 ## Quick start
 
@@ -60,11 +60,10 @@ lake exe sele4n
 
 ### Active planning target
 
-The next implementation slice is **M3 IPC seed**: the minimal endpoint state model and typed
-endpoint send/receive transition entrypoints now have IPC safety invariant preservation theorems
-and composed preservation entrypoints for the M1/M2/M3 seed bundle (`m3IpcSeedInvariantBundle`);
-the remaining M3 work is extending executable IPC trace coverage while preserving the established
-theorem surface.
+The **M3 IPC seed** slice is now complete: the minimal endpoint state model, typed endpoint
+send/receive transitions, IPC safety invariant preservation theorems, composed M1/M2/M3 seed
+bundle preservation entrypoints (`m3IpcSeedInvariantBundle`), and executable IPC trace coverage
+are all present.
 
 See:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,9 +68,12 @@ Work in this order unless a blocking dependency requires adjustment:
      (`endpointSend_preserves_m3IpcSeedInvariantBundle`,
      `endpointReceive_preserves_m3IpcSeedInvariantBundle`) alongside existing M1/M2 bundles.
 
-6. **Executable demonstration last**
+6. **Executable demonstration last** *(complete)*
    - Extend `Main.lean` trace to include IPC behavior.
    - Confirm current demo behavior still executes.
+   - Status: `Main.lean` now demonstrates endpoint send/receive queue flow after the established
+     scheduler + CSpace lifecycle path, including an explicit expected error once the endpoint
+     returns to `idle`.
 
 ---
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -66,7 +66,7 @@ Implemented M2 scope includes:
 6. Preservation theorem entrypoints for lookup/insert/mint/delete/revoke progression.
 7. Executable trace in `Main.lean` showing scheduler + capability lifecycle behavior.
 
-### 3.4 M3 IPC seed (in progress)
+### 3.4 M3 IPC seed (complete)
 
 Implemented pieces already landed for the active slice:
 
@@ -125,9 +125,10 @@ Status is tracked per outcome.
    - At least one receive transition preservation theorem.
    - New proof entrypoints should be composable with existing M1/M2 bundles.
 
-5. **Executable trace includes IPC behavior** *(open)*
-   - Extend or add executable demonstration to show endpoint transition flow.
-   - Existing scheduler + CSpace demo should remain available or equivalent coverage provided.
+5. **Executable trace includes IPC behavior** *(complete)*
+   - `Main.lean` now extends the runnable trace with endpoint `endpointSend`/`endpointReceive`
+     transitions after the existing scheduler + CSpace lifecycle sequence.
+   - Existing scheduler + CSpace demonstration remains intact before IPC steps are executed.
 
 ### 4.3 Explicit out-of-scope for this slice
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.7"
+version = "0.3.8"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Ensure `lake build`/`lake exe` can run in this environment and validate executable behavior. 
- Finish the final step of the active M3 IPC seed slice by adding an executable endpoint IPC demonstration to `Main.lean` and mark that step as completed in the docs while preserving existing M1/M2 behavior. 

### Description
- Added a demo endpoint (`demoEndpoint`) to `Main.lean` bootstrap state and extended the runnable trace to perform two `endpointSend` calls followed by two successful `endpointReceive` calls and a final expected-error receive when the endpoint returns to `idle`. 
- Updated `docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`, and `README.md` to mark the M3 IPC demo step and executable-trace outcome as complete and to describe the new IPC trace behavior. 
- Bumped project version from `0.3.7` to `0.3.8` in `lakefile.toml`. 
- Ensured the build toolchain is available in the environment by installing `elan`/`lake` and exposing `lake`/`lean` on `PATH` for local validation. 

### Testing
- Ran `lake --version` and `lake build` successfully after installing the Lean toolchain, with `lake build` completing without errors. 
- Executed `lake exe sele4n` and observed the expected trace output showing scheduler selection, cspace mint/revoke/delete behavior, queued endpoint sends, two receives, and the expected receive error when idle. 
- Ran the hygiene scan `rg -n "axiom|sorry|TODO" SeLe4n Main.lean` which produced no matches. 
- All automated validation commands listed in the development guide (`lake build`, `lake exe sele4n`, hygiene scan) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699142665384832bb1c19e7e028e9e3b)