### PR TITLE
Initial implementation of the new testing framework

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.8"
+version = "0.3.9"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/audit_testing_framework.sh
+++ b/scripts/audit_testing_framework.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+echo "[AUDIT] Running baseline tiered entrypoint checks"
+"${SCRIPT_DIR}/test_fast.sh"
+"${SCRIPT_DIR}/test_smoke.sh"
+"${SCRIPT_DIR}/test_full.sh"
+"${SCRIPT_DIR}/test_nightly.sh"
+
+echo "[AUDIT] Verifying Tier 2 control-data failure behavior"
+TMP_FIXTURE="$(mktemp)"
+trap 'rm -f "${TMP_FIXTURE}"' EXIT
+cp tests/fixtures/main_trace_smoke.expected "${TMP_FIXTURE}"
+echo "[CONTROL] impossible expected line" >> "${TMP_FIXTURE}"
+
+if TRACE_FIXTURE_PATH="${TMP_FIXTURE}" "${SCRIPT_DIR}/test_tier2_trace.sh"; then
+  echo "[AUDIT] ERROR: control-data mismatch did not fail Tier 2 as expected" >&2
+  exit 1
+fi
+
+echo "[AUDIT] Control-data mismatch correctly causes Tier 2 failure"
+echo "[AUDIT] Testing framework audit completed successfully"

--- a/scripts/test_fast.sh
+++ b/scripts/test_fast.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+
+sub_args=()
+if [[ "${CONTINUE_MODE}" -eq 1 ]]; then
+  sub_args+=("--continue")
+fi
+
+run_check "META" "${SCRIPT_DIR}/test_tier0_hygiene.sh" "${sub_args[@]}"
+run_check "META" "${SCRIPT_DIR}/test_tier1_build.sh" "${sub_args[@]}"
+
+finalize_report

--- a/scripts/test_full.sh
+++ b/scripts/test_full.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+
+sub_args=()
+if [[ "${CONTINUE_MODE}" -eq 1 ]]; then
+  sub_args+=("--continue")
+fi
+
+run_check "META" "${SCRIPT_DIR}/test_smoke.sh" "${sub_args[@]}"
+log_section "INVARIANT" "Tier 3 integration checks are not yet wired; this is an explicit extension point."
+
+finalize_report

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${TEST_LIB_DIR}/.." && pwd)"
+
+CONTINUE_MODE=0
+FAILURE_COUNT=0
+FAILURE_MESSAGES=()
+
+log_section() {
+  local category="$1"
+  local message="$2"
+  printf '[%s] %s\n' "${category}" "${message}"
+}
+
+parse_common_args() {
+  CONTINUE_MODE=0
+  for arg in "$@"; do
+    case "${arg}" in
+      --continue)
+        CONTINUE_MODE=1
+        ;;
+      *)
+        echo "error: unknown argument '${arg}'" >&2
+        exit 2
+        ;;
+    esac
+  done
+}
+
+record_failure() {
+  local category="$1"
+  local message="$2"
+  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  FAILURE_MESSAGES+=("${category}: ${message}")
+  log_section "${category}" "FAIL: ${message}"
+}
+
+run_check() {
+  local category="$1"
+  shift
+
+  log_section "${category}" "RUN: $*"
+  if "$@"; then
+    log_section "${category}" "PASS"
+    return 0
+  fi
+
+  record_failure "${category}" "Command failed: $*"
+  if [[ "${CONTINUE_MODE}" -eq 0 ]]; then
+    finalize_report
+  fi
+}
+
+finalize_report() {
+  if [[ "${FAILURE_COUNT}" -gt 0 ]]; then
+    log_section "META" "Completed with ${FAILURE_COUNT} failure(s)."
+    local entry
+    for entry in "${FAILURE_MESSAGES[@]}"; do
+      log_section "META" "${entry}"
+    done
+    exit 1
+  fi
+
+  log_section "META" "All checks passed."
+}

--- a/scripts/test_nightly.sh
+++ b/scripts/test_nightly.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+
+sub_args=()
+if [[ "${CONTINUE_MODE}" -eq 1 ]]; then
+  sub_args+=("--continue")
+fi
+
+run_check "META" "${SCRIPT_DIR}/test_full.sh" "${sub_args[@]}"
+log_section "INVARIANT" "Tier 4 nightly extensions are not yet wired; this is an explicit extension point."
+
+finalize_report

--- a/scripts/test_smoke.sh
+++ b/scripts/test_smoke.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+
+sub_args=()
+if [[ "${CONTINUE_MODE}" -eq 1 ]]; then
+  sub_args+=("--continue")
+fi
+
+run_check "META" "${SCRIPT_DIR}/test_tier0_hygiene.sh" "${sub_args[@]}"
+run_check "META" "${SCRIPT_DIR}/test_tier1_build.sh" "${sub_args[@]}"
+run_check "META" "${SCRIPT_DIR}/test_tier2_trace.sh" "${sub_args[@]}"
+
+finalize_report

--- a/scripts/test_tier0_hygiene.sh
+++ b/scripts/test_tier0_hygiene.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+cd "${REPO_ROOT}"
+
+run_check "HYGIENE" bash -lc 'if rg -n "axiom|sorry|TODO" SeLe4n Main.lean; then echo "Forbidden markers found in tracked proof surface." >&2; exit 1; fi'
+
+if command -v shellcheck >/dev/null 2>&1; then
+  run_check "HYGIENE" shellcheck scripts/*.sh
+else
+  log_section "HYGIENE" "shellcheck not installed; skipping optional lint."
+fi
+
+finalize_report

--- a/scripts/test_tier1_build.sh
+++ b/scripts/test_tier1_build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+cd "${REPO_ROOT}"
+
+run_check "BUILD" lake build
+
+finalize_report

--- a/scripts/test_tier2_trace.sh
+++ b/scripts/test_tier2_trace.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+cd "${REPO_ROOT}"
+
+TRACE_FIXTURE="tests/fixtures/main_trace_smoke.expected"
+TRACE_OUTPUT="$(mktemp)"
+trap 'rm -f "${TRACE_OUTPUT}"' EXIT
+
+run_check "TRACE" bash -lc "lake exe sele4n > '${TRACE_OUTPUT}'"
+
+if [[ -f "${TRACE_FIXTURE}" ]]; then
+  missing=0
+  while IFS= read -r expected_line || [[ -n "${expected_line}" ]]; do
+    [[ -z "${expected_line}" ]] && continue
+    if ! grep -Fq "${expected_line}" "${TRACE_OUTPUT}"; then
+      record_failure "TRACE" "Missing expected trace line: ${expected_line}"
+      missing=1
+      if [[ "${CONTINUE_MODE}" -eq 0 ]]; then
+        finalize_report
+      fi
+    fi
+  done < "${TRACE_FIXTURE}"
+
+  if [[ "${missing}" -eq 0 ]]; then
+    log_section "TRACE" "Fixture comparison passed (${TRACE_FIXTURE})."
+  fi
+else
+  log_section "TRACE" "Fixture ${TRACE_FIXTURE} not found; trace output was generated but no comparison was performed."
+fi
+
+finalize_report

--- a/scripts/test_tier2_trace.sh
+++ b/scripts/test_tier2_trace.sh
@@ -8,30 +8,39 @@ source "${SCRIPT_DIR}/test_lib.sh"
 parse_common_args "$@"
 cd "${REPO_ROOT}"
 
-TRACE_FIXTURE="tests/fixtures/main_trace_smoke.expected"
+TRACE_FIXTURE="${TRACE_FIXTURE_PATH:-tests/fixtures/main_trace_smoke.expected}"
 TRACE_OUTPUT="$(mktemp)"
-trap 'rm -f "${TRACE_OUTPUT}"' EXIT
+MISSING_REPORT="$(mktemp)"
+trap 'rm -f "${TRACE_OUTPUT}" "${MISSING_REPORT}"' EXIT
+
+if [[ ! -f "${TRACE_FIXTURE}" ]]; then
+  record_failure "TRACE" "Fixture not found: ${TRACE_FIXTURE}"
+  finalize_report
+fi
 
 run_check "TRACE" bash -lc "lake exe sele4n > '${TRACE_OUTPUT}'"
 
-if [[ -f "${TRACE_FIXTURE}" ]]; then
-  missing=0
-  while IFS= read -r expected_line || [[ -n "${expected_line}" ]]; do
-    [[ -z "${expected_line}" ]] && continue
-    if ! grep -Fq "${expected_line}" "${TRACE_OUTPUT}"; then
-      record_failure "TRACE" "Missing expected trace line: ${expected_line}"
-      missing=1
-      if [[ "${CONTINUE_MODE}" -eq 0 ]]; then
-        finalize_report
-      fi
+missing=0
+while IFS= read -r expected_line || [[ -n "${expected_line}" ]]; do
+  [[ -z "${expected_line}" ]] && continue
+  if ! grep -Fq "${expected_line}" "${TRACE_OUTPUT}"; then
+    printf '%s\n' "${expected_line}" >> "${MISSING_REPORT}"
+    record_failure "TRACE" "Missing expected trace line: ${expected_line}"
+    missing=1
+    if [[ "${CONTINUE_MODE}" -eq 0 ]]; then
+      finalize_report
     fi
-  done < "${TRACE_FIXTURE}"
-
-  if [[ "${missing}" -eq 0 ]]; then
-    log_section "TRACE" "Fixture comparison passed (${TRACE_FIXTURE})."
   fi
+done < "${TRACE_FIXTURE}"
+
+if [[ "${missing}" -eq 0 ]]; then
+  log_section "TRACE" "Fixture comparison passed (${TRACE_FIXTURE})."
 else
-  log_section "TRACE" "Fixture ${TRACE_FIXTURE} not found; trace output was generated but no comparison was performed."
+  log_section "TRACE" "Missing expectation lines:"
+  while IFS= read -r missing_line || [[ -n "${missing_line}" ]]; do
+    log_section "TRACE" "  - ${missing_line}"
+  done < "${MISSING_REPORT}"
+  log_section "TRACE" "If behavior changed intentionally, update ${TRACE_FIXTURE} in this PR."
 fi
 
 finalize_report

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -1,0 +1,10 @@
+scheduled thread: some 1
+source cap rights before mint:
+created sibling cap with the same target
+post-revoke sibling lookup: SeLe4n.Model.KernelError.invalidCapability
+post-delete lookup (expected error): SeLe4n.Model.KernelError.invalidCapability
+queued two senders on endpoint
+endpoint receive #1 sender: 1
+endpoint receive #2 sender: 2
+endpoint receive #3 (expected mismatch): SeLe4n.Model.KernelError.endpointStateMismatch
+minted cap rights:

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -1,0 +1,40 @@
+# Test scenarios and fixture maintenance
+
+This directory documents fixture-backed trace checks for `scripts/test_tier2_trace.sh`.
+
+## Current fixture
+
+- `tests/fixtures/main_trace_smoke.expected`
+  - line-oriented expected *substrings* for the `lake exe sele4n` smoke trace.
+  - each non-empty line must appear somewhere in actual output.
+
+## Intentional fixture update workflow
+
+When executable behavior changes intentionally:
+
+1. Run the executable and inspect output:
+   ```bash
+   source "$HOME/.elan/env"
+   lake exe sele4n
+   ```
+2. Update `tests/fixtures/main_trace_smoke.expected` with stable semantic lines only
+   (avoid timestamps / ordering-noise-sensitive strings).
+3. Re-run:
+   ```bash
+   ./scripts/test_tier2_trace.sh
+   ./scripts/test_smoke.sh
+   ```
+4. In your PR description, explain why fixture changes are expected.
+
+## Control-data audit tip
+
+Use an intentionally bad fixture line to verify deterministic failure behavior:
+
+```bash
+TMP_FIXTURE="$(mktemp)"
+cp tests/fixtures/main_trace_smoke.expected "$TMP_FIXTURE"
+echo "this line should never match" >> "$TMP_FIXTURE"
+TRACE_FIXTURE_PATH="$TMP_FIXTURE" ./scripts/test_tier2_trace.sh
+```
+
+The command should fail and report the missing expected line.


### PR DESCRIPTION
Implemented the shared testing helper library at scripts/test_lib.sh with the required script contract pieces: category-prefixed logging, reusable check execution, failure recording, --continue parsing, and final aggregated reporting. 

Added Tier 0/1/2 baseline test entrypoints under scripts/:

test_tier0_hygiene.sh for forbidden marker scanning plus optional shellcheck linting. 

test_tier1_build.sh for the lake build gate. 

test_tier2_trace.sh for lake exe sele4n execution and fixture-backed comparison hook against tests/fixtures/main_trace_smoke.expected when present. 

Added orchestration entrypoints for baseline and extension tiers:

test_fast.sh (Tier 0 + Tier 1), test_smoke.sh (Tier 0 + Tier 1 + Tier 2), test_full.sh (smoke + Tier 3 extension point), and test_nightly.sh (full + Tier 4 extension point). 

Bumped project version from 0.3.8 to 0.3.9 per your request.

Performed a full audit hardening pass on the current testing-framework iteration and fixed a key correctness gap in Tier 2: scripts/test_tier2_trace.sh now fails when the fixture is missing, supports TRACE_FIXTURE_PATH for controlled audits, and reports missing expected lines with actionable guidance. 

Added baseline control data fixture tests/fixtures/main_trace_smoke.expected using stable semantic trace substrings from lake exe sele4n, so Tier 2 now validates deterministic expected behavior instead of only command success. 

Added fixture maintenance and intentional-update instructions in tests/scenarios/README.md, including a documented negative-control injection workflow to verify mismatch detection. 

Added scripts/audit_testing_framework.sh to run a comprehensive framework audit: fast/smoke/full/nightly entrypoints plus an explicit negative control that appends an impossible expectation and asserts Tier 2 fails.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914e2db95c832bb0fedf00539b8116)