### PR TITLE
Harden Lean test entrypoints and document tiered validation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ The next development slice should deliver:
 4. Preservation theorem entrypoints for updated transitions and bundle composition.
 5. Executable trace evidence for one waiting-to-delivery IPC scenario.
 
+## Testing quick reference
+
+Use the tiered test entrypoints for local validation:
+
+```bash
+./scripts/test_fast.sh      # Tier 0 + Tier 1
+./scripts/test_smoke.sh     # Tier 0 + Tier 1 + Tier 2 (fixture-backed trace gate)
+./scripts/test_full.sh      # smoke + explicit Tier 3 extension-point notice
+./scripts/test_nightly.sh   # full + explicit Tier 4 extension-point notice
+./scripts/audit_testing_framework.sh
+```
+
+The test scripts automatically source `$HOME/.elan/env` when present so `lake` is available even in
+fresh shells after running `./scripts/setup_lean_env.sh`.
+
 ## Daily contributor verification loop
 
 Run this as a minimum before opening a PR:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -123,6 +123,13 @@ If docs are intentionally deferred, state why and when they will be updated.
 Run this minimum set before opening a PR:
 
 ```bash
+./scripts/test_fast.sh
+./scripts/test_smoke.sh
+```
+
+Keep these direct checks in your local loop when debugging specific failures:
+
+```bash
 lake build
 lake exe sele4n
 rg -n "axiom|sorry|TODO" SeLe4n Main.lean
@@ -130,7 +137,8 @@ rg -n "axiom|sorry|TODO" SeLe4n Main.lean
 
 If any command cannot run due to environment constraints, report the constraint and its impact.
 
-For fresh environments without `lake` on `PATH`, run `./scripts/setup_lean_env.sh` before the validation loop.
+For fresh environments, run `./scripts/setup_lean_env.sh` once. Test scripts auto-source
+`$HOME/.elan/env` when available so `lake` can be found in non-interactive shells.
 
 ---
 

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -65,3 +65,21 @@ finalize_report() {
 
   log_section "META" "All checks passed."
 }
+
+ensure_lake_available() {
+  if command -v lake >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ -f "${HOME}/.elan/env" ]]; then
+    # shellcheck disable=SC1090
+    source "${HOME}/.elan/env"
+  fi
+
+  if command -v lake >/dev/null 2>&1; then
+    return 0
+  fi
+
+  record_failure "BUILD" "lake not found on PATH. Run ./scripts/setup_lean_env.sh or install elan."
+  finalize_report
+}

--- a/scripts/test_tier1_build.sh
+++ b/scripts/test_tier1_build.sh
@@ -8,6 +8,8 @@ source "${SCRIPT_DIR}/test_lib.sh"
 parse_common_args "$@"
 cd "${REPO_ROOT}"
 
+ensure_lake_available
+
 run_check "BUILD" lake build
 
 finalize_report

--- a/scripts/test_tier2_trace.sh
+++ b/scripts/test_tier2_trace.sh
@@ -8,6 +8,8 @@ source "${SCRIPT_DIR}/test_lib.sh"
 parse_common_args "$@"
 cd "${REPO_ROOT}"
 
+ensure_lake_available
+
 TRACE_FIXTURE="${TRACE_FIXTURE_PATH:-tests/fixtures/main_trace_smoke.expected}"
 TRACE_OUTPUT="$(mktemp)"
 MISSING_REPORT="$(mktemp)"


### PR DESCRIPTION
### Motivation

- Make the repository test entrypoints robust in non-interactive shells so `lake` is discoverable after running the provided environment bootstrap. 
- Ensure Tier 1 (build) and Tier 2 (exe/trace) checks fail with clear guidance when Lean tooling is not available. 
- Improve contributor docs so developers use the tiered scripts (`test_fast.sh`, `test_smoke.sh`) as the canonical local validation loop.

### Description

- Add `ensure_lake_available()` to `scripts/test_lib.sh` which attempts to source `$HOME/.elan/env` and fails with a clear message if `lake` is still not on `PATH`.
- Call `ensure_lake_available` from `scripts/test_tier1_build.sh` and `scripts/test_tier2_trace.sh` so the build and trace gates run reliably in fresh/non-interactive shells.
- Add a "Testing quick reference" section to `README.md` with command examples for the tiered scripts and note that scripts auto-source `$HOME/.elan/env` when present.
- Update `docs/DEVELOPMENT.md` to recommend `./scripts/test_fast.sh` and `./scripts/test_smoke.sh` as the primary contributor validation entrypoints while keeping direct troubleshooting commands.

### Testing

- Ran `./scripts/setup_lean_env.sh` to install elán and the Lean toolchain; this completed successfully. 
- Ran `./scripts/test_fast.sh` and it completed successfully (Tier 0 hygiene + Tier 1 build passed). 
- Ran `./scripts/test_smoke.sh` and it completed successfully (Tier 0 + Tier 1 + Tier 2 with fixture comparison passed). 
- Ran `./scripts/audit_testing_framework.sh` and it completed successfully; the audit includes a control-data check that intentionally triggers a Tier 2 mismatch to verify failure detection and then reports the audit as successful once the behavior is confirmed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915406d160832b9fa906c40cf603c2)