### PR TITLE
Enforce Tier Fast and Tier Smoke in PR CI; sync docs and bump version to 0.3.11

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -6,9 +6,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tier_fast:
+    name: Tier Fast (hygiene + build)
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
+      - name: Ensure test scripts are executable
+        run: chmod +x scripts/test_*.sh scripts/test_lib.sh
+      - name: Run fast required gate
+        run: |
+          echo "::group::test_fast"
+          ./scripts/test_fast.sh
+          echo "::endgroup::"
+
+  tier_smoke:
+    name: Tier Smoke (hygiene + build + trace)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: leanprover/lean-action@v1
+      - name: Ensure test scripts are executable
+        run: chmod +x scripts/test_*.sh scripts/test_lib.sh
+      - name: Run smoke required gate
+        run: |
+          echo "::group::test_smoke"
+          ./scripts/test_smoke.sh
+          echo "::endgroup::"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A Lean 4 formalization project for building an executable and machine-checked model of key
 [seL4 microkernel](https://sel4.systems) semantics.
 
+Current project version: **0.3.11**.
+
 ## Project status snapshot
 
 seLe4n is currently in a **post-M3 IPC seed** stage:
@@ -17,7 +19,8 @@ The active planning target is **M3.5 IPC handshake + scheduler interaction**, wh
 narrow blocking/wakeup IPC contract while preserving existing M1/M2/M3 guarantees.
 
 Testing framework status: Tier 0 (hygiene), Tier 1 (build), and Tier 2 (fixture-backed executable
-smoke regression checks) are implemented and usable via `scripts/test_*.sh` entrypoints.
+smoke regression checks) are implemented and enforced in pull request CI via repository
+`scripts/test_*.sh` entrypoints.
 
 ## Quick start
 
@@ -117,6 +120,17 @@ Run this as a minimum before opening a PR:
 ./scripts/test_fast.sh
 ./scripts/test_smoke.sh
 ```
+
+## Pull request CI gates
+
+Pull requests now run required tiered checks through workflow jobs that directly call repository
+scripts:
+
+- `tier_fast` runs `./scripts/test_fast.sh`.
+- `tier_smoke` runs `./scripts/test_smoke.sh`.
+
+This keeps local and CI behavior aligned and preserves category-labeled logs from the scripts
+(`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`).
 
 When debugging locally, you can still run individual commands:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -145,6 +145,20 @@ For fresh environments, run `./scripts/setup_lean_env.sh` once. Test scripts aut
 
 ---
 
+
+## 7.1 Pull request CI enforcement (required)
+
+Pull request CI now enforces the same required tiers used locally by calling repository scripts
+from `.github/workflows/lean_action_ci.yml`:
+
+- `tier_fast` job runs `./scripts/test_fast.sh`.
+- `tier_smoke` job runs `./scripts/test_smoke.sh`.
+
+Do not inline bespoke test commands in CI when updating gates; keep CI and local behavior aligned
+by extending script entrypoints under `scripts/` first.
+
+---
+
 ## 8. PR checklist (required)
 
 Copy this checklist into the PR description:
@@ -157,6 +171,7 @@ Copy this checklist into the PR description:
 - [ ] `lake exe sele4n` executed.
 - [ ] Hygiene scan (`axiom|sorry|TODO`) executed.
 - [ ] Docs updated in the same commit range.
+- [ ] CI required-tier workflow jobs still call repository script entrypoints.
 - [ ] Remaining proof debt is identified.
 
 ---

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -8,8 +8,8 @@ Current repository status against this plan:
 
 - ✅ Work package A (script scaffold) is implemented.
 - ✅ Work package B (fixture-backed executable smoke baseline) is implemented.
-- ⏳ Work package C (CI wiring to script entrypoints) is pending.
-- ⏳ Work package D (final doc integration pass) is in progress and should track script/CI reality.
+- ✅ Work package C (CI wiring to script entrypoints) is implemented.
+- ✅ Work package D (final doc integration pass) tracks script/CI reality.
 - ⏳ Work package E (Tier 3 hooks) is partially prepared via explicit extension points.
 
 ---
@@ -268,6 +268,8 @@ Acceptance criteria:
 
 ## 8.3 Work package C — CI wiring (day 2)
 
+Implementation status (current): Completed via required `tier_fast` and `tier_smoke` pull request jobs in `.github/workflows/lean_action_ci.yml`, both invoking repository scripts directly.
+
 Tasks:
 1. Update `.github/workflows/lean_action_ci.yml` to run smoke gate scripts.
 2. Ensure script paths and permissions are valid in CI.
@@ -319,7 +321,7 @@ Copy into implementation PR(s):
 - [ ] Added shared script helper library (or equivalent dedup strategy).
 - [ ] Added fixture directory and baseline expected trace file.
 - [ ] Implemented trace comparison and clear mismatch diagnostics.
-- [ ] Updated CI workflow to call repository test scripts.
+- [x] Updated CI workflow to call repository test scripts.
 - [ ] Updated README and development docs.
 - [ ] Ran local verification commands listed below.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.10"
+version = "0.3.11"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -48,3 +48,8 @@ The command should fail and report the missing expected line.
 - a reminder to update fixture + PR rationale when drift is intentional.
 
 This contract keeps smoke regressions deterministic and reviewable in both local runs and CI logs.
+
+## CI usage
+
+This fixture is enforced in pull requests by the `tier_smoke` workflow job, which runs
+`./scripts/test_smoke.sh` from `.github/workflows/lean_action_ci.yml`.


### PR DESCRIPTION
### Motivation

- Implement the TESTING_FRAMEWORK_PLAN step to run required tiers on pull requests by wiring CI to repository script entrypoints.
- Keep local and CI validation behaviour identical so contributors see the same failures locally and in PRs.
- Update project version and documentation so repository state, plan, and docs remain consistent with the new CI gates.

### Description

- Updated `.github/workflows/lean_action_ci.yml` to add `tier_fast` and `tier_smoke` jobs that call `./scripts/test_fast.sh` and `./scripts/test_smoke.sh` respectively and ensure scripts are executable in CI. 
- Bumped project version in `lakefile.toml` from `0.3.10` to `0.3.11`.
- Synchronized documentation: updated `README.md` with version and PR gate details, added a required PR CI enforcement section and checklist item to `docs/DEVELOPMENT.md`, and marked CI wiring/docs work as completed in `docs/TESTING_FRAMEWORK_PLAN.md`.
- Documented CI enforcement of the smoke fixture in `tests/scenarios/README.md` to clarify how `tests/fixtures/main_trace_smoke.expected` is checked in PRs.

### Testing

- Ran `./scripts/test_fast.sh` after bootstrapping the Lean environment; it initially failed because `lake` was not on `PATH`, then succeeded after running `./scripts/setup_lean_env.sh` to install `elan`/`lake`.
- Ran `source $HOME/.elan/env && ./scripts/test_smoke.sh`; the job completed successfully and the fixture comparison reported `Fixture comparison passed (10/10 matched)`.
- The `scripts/test_tier1_build.sh` (which runs `lake build`) and `scripts/test_tier2_trace.sh` (which runs `lake exe sele4n` and compares fixtures) were both exercised indirectly by the above script runs and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915b7b84b8832bb87036893f9046db)