### PR TITLE
Harden Tier 3 invariant checks, alias scheduler predicate, and add project audit rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Testing framework status:
 - ✅ Tier 0 hygiene gate (`axiom|sorry|TODO` scan).
 - ✅ Tier 1 build/theorem gate (`lake build`).
 - ✅ Tier 2 fixture-backed executable smoke regression gate.
-- 🧩 Tier 3/Tier 4 extension points are documented and script-wired for future expansion.
+- ✅ Tier 3 invariant/doc-surface checks are wired via `test_full.sh`.
+- 🧩 Tier 4 nightly extension point remains documented for broader confidence checks.
 
 CI status:
 
@@ -108,6 +109,7 @@ lake exe sele4n
 - `docs/SEL4_SPEC.md` — normative milestone spec and acceptance criteria.
 - `docs/DEVELOPMENT.md` — implementation workflow, proof standards, PR checklist.
 - `docs/TESTING_FRAMEWORK_PLAN.md` — testing tiers, CI strategy, and expansion path.
+- `docs/PROJECT_AUDIT.md` — current deep audit of code, tests, documentation, and roadmap.
 - `tests/scenarios/README.md` — fixture maintenance and trace regression workflow.
 
 ---
@@ -158,7 +160,7 @@ Use the tiered test entrypoints for local validation:
 ```bash
 ./scripts/test_fast.sh      # Tier 0 + Tier 1
 ./scripts/test_smoke.sh     # Tier 0 + Tier 1 + Tier 2 (fixture-backed trace gate)
-./scripts/test_full.sh      # smoke + explicit Tier 3 extension-point notice
+./scripts/test_full.sh      # smoke + Tier 3 invariant/doc-surface gate
 ./scripts/test_nightly.sh   # full + explicit Tier 4 extension-point notice
 ./scripts/audit_testing_framework.sh
 ```

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -4,12 +4,6 @@ namespace SeLe4n.Kernel
 
 open SeLe4n.Model
 
-/-- Minimal scheduling well-formedness condition for the bootstrap model. -/
-def schedulerWellFormed (s : SchedulerState) : Prop :=
-  match s.current with
-  | none => True
-  | some tid => tid ∈ s.runnable
-
 /-- Scheduler invariant component #3 (M1 bundle v1): queue/current consistency.
 
 Policy choice for this model is **strict**: when `current = some tid`, `tid` must appear in the
@@ -19,6 +13,13 @@ def queueCurrentConsistent (s : SchedulerState) : Prop :=
   match s.current with
   | none => True
   | some tid => tid ∈ s.runnable
+
+/-- Minimal scheduling well-formedness condition for the bootstrap model.
+
+At this stage the condition is intentionally identical to `queueCurrentConsistent` and is kept as
+an alias so milestone wording can evolve without duplicating theorem maintenance. -/
+abbrev schedulerWellFormed (s : SchedulerState) : Prop :=
+  queueCurrentConsistent s
 
 /-- Scheduler invariant component #1 (M1 bundle v1): runnable queue has no duplicate TIDs. -/
 def runQueueUnique (s : SchedulerState) : Prop :=
@@ -1031,7 +1032,7 @@ theorem setCurrentThread_preserves_wellFormed
     schedulerWellFormed st'.scheduler := by
   simp [setCurrentThread] at hStep
   cases hStep
-  simp [schedulerWellFormed, hMem]
+  simpa [schedulerWellFormed, queueCurrentConsistent] using hMem
 
 theorem setCurrentThread_preserves_queueCurrentConsistent
     (st st' : SystemState)
@@ -1102,27 +1103,27 @@ theorem schedule_preserves_wellFormed
   | nil =>
       simp [schedule, setCurrentThread, hRun] at hStep
       cases hStep
-      simp [schedulerWellFormed]
+      simp [schedulerWellFormed, queueCurrentConsistent]
   | cons t ts =>
       cases hObj : st.objects t with
       | none =>
           simp [schedule, setCurrentThread, hRun, hObj] at hStep
           cases hStep
-          simp [schedulerWellFormed]
+          simp [schedulerWellFormed, queueCurrentConsistent]
       | some obj =>
           cases obj with
           | tcb tcb =>
               simp [schedule, setCurrentThread, hRun, hObj] at hStep
               cases hStep
-              simp [schedulerWellFormed]
+              simp [schedulerWellFormed, queueCurrentConsistent]
           | endpoint ep =>
               simp [schedule, setCurrentThread, hRun, hObj] at hStep
               cases hStep
-              simp [schedulerWellFormed]
+              simp [schedulerWellFormed, queueCurrentConsistent]
           | cnode cn =>
               simp [schedule, setCurrentThread, hRun, hObj] at hStep
               cases hStep
-              simp [schedulerWellFormed]
+              simp [schedulerWellFormed, queueCurrentConsistent]
 
 theorem chooseThread_preserves_queueCurrentConsistent
     (st st' : SystemState)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,7 +24,7 @@ The following behavior is stable and must not regress unless intentionally redes
    preservation entrypoints.
 3. M3 endpoint seed APIs (`endpointSend`, `endpointReceive`) and IPC invariant bundle entrypoints.
 4. Runnable executable trace in `Main.lean` demonstrating scheduler + CSpace + IPC seed behavior.
-5. Tier 0/1/2 test entrypoints and CI required-gate behavior.
+5. Tier 0/1/2 required gates and Tier 3 full-suite invariant/doc-surface checks.
 
 If a change intentionally adjusts one of these contracts, call it out in docs + PR notes.
 
@@ -153,6 +153,7 @@ Direct checks for local debugging:
 lake build
 lake exe sele4n
 rg -n "axiom|sorry|TODO" SeLe4n Main.lean
+./scripts/test_full.sh
 ```
 
 If any command cannot run due to environment limits, report the constraint and impact.

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -1,0 +1,145 @@
+# seLe4n Project Audit (Code, Tests, Documentation, and Development Path)
+
+## 1. Scope and methodology
+
+This audit evaluates:
+
+1. **Codebase quality and optimization posture** (clarity, compositionality, proof-surface maintainability).
+2. **Testing framework completeness and correctness** (tiered gates, signal quality, CI parity).
+3. **Documentation richness and stage coherence** (current status + credible near-term roadmap).
+
+Validation commands used in this audit:
+
+- `./scripts/test_fast.sh`
+- `./scripts/test_smoke.sh`
+- `./scripts/test_full.sh`
+- `./scripts/test_nightly.sh`
+- `./scripts/audit_testing_framework.sh`
+
+---
+
+## 2. Executive summary
+
+Overall project health is **strong** for its milestone stage (post-M3 seed / pre-M3.5 handshake).
+
+- The codebase exhibits a disciplined, executable-and-provable style.
+- Required quality gates (hygiene/build/smoke fixture) are effective and deterministic.
+- Documentation is unusually explicit for a formalization repository, with clear stage boundaries.
+
+Key advancement in this audit cycle:
+
+- Tier 3 was moved from placeholder to an active full-suite gate (`test_tier3_invariant_surface.sh`) that checks critical invariant theorem surface anchors and doc stage markers.
+
+Primary remaining high-value path:
+
+- Develop M3.5 handshake semantics with scheduler-blocked/runnable coherence and strengthen Tier 3 from static surface checks toward semantic grouped invariant checks.
+
+---
+
+## 3. Codebase audit findings
+
+### 3.1 Strengths
+
+1. **Compositional invariant architecture**
+   - Scheduler, capability, and IPC invariants are separated and recomposed by bundle entrypoints.
+2. **Executable semantics + proof entrypoints**
+   - Transition functions support executable traces while theorem surfaces preserve safety properties.
+3. **Conservative milestone evolution style**
+   - Current slice constraints avoid destabilizing proven M1–M3 theorem structure.
+
+### 3.2 Improvements made during this audit
+
+1. **Duplicate scheduler predicate logic removed**
+   - `schedulerWellFormed` is now an alias of `queueCurrentConsistent`, reducing duplicate maintenance risk while preserving milestone terminology compatibility.
+
+### 3.3 Remaining optimization recommendations
+
+1. Introduce a small proof-style guide section for preferred lemma naming patterns by milestone bundle.
+2. Add focused theorem-group index comments around M3.5 additions to keep API discoverability high as file size grows.
+3. Keep transition-local helper theorems near transition definitions to maintain unfolding ergonomics.
+
+---
+
+## 4. Testing framework audit findings
+
+### 4.1 Current quality of implemented tiers
+
+- **Tier 0 hygiene**: correctly catches `axiom|sorry|TODO` markers in proof surface.
+- **Tier 1 build**: validates full Lean compilation and executable artifact.
+- **Tier 2 smoke fixture**: protects stable semantic trace fragments.
+
+### 4.2 Improvements made during this audit
+
+1. **Tier 3 gate implemented**
+   - New script `scripts/test_tier3_invariant_surface.sh` checks:
+     - presence of key invariant bundle definitions,
+     - presence of key M3 IPC preservation theorem entrypoints,
+     - stage coherence markers across core docs.
+2. **`test_full.sh` upgraded**
+   - now runs Tier 3 checks directly rather than only emitting an extension notice.
+
+### 4.3 Remaining testing roadmap
+
+1. Strengthen Tier 3 from static symbol-surface checks to grouped milestone semantic checks.
+2. Expand Tier 2 fixture scenarios once M3.5 waiting/handshake behavior lands.
+3. Convert Tier 4 nightly note into repeat-run determinism and broader scenario sweeps.
+
+---
+
+## 5. Documentation audit findings
+
+### 5.1 Strengths
+
+- Status, acceptance criteria, and non-goals are clearly separated.
+- Milestone progression from M3.5 to M4 is explicit and realistic.
+
+### 5.2 Improvements made during this audit
+
+1. README testing status updated to reflect active Tier 3 coverage.
+2. Testing framework plan updated to record Tier 3 implementation and next deepening steps.
+3. This audit document was added as a living baseline for future audits.
+
+### 5.3 Documentation development path (recommended)
+
+1. Update this audit after every milestone closure (M3.5, M4, …).
+2. Add a short “since last audit” changelog section in future revisions.
+3. Keep README, `SEL4_SPEC`, `DEVELOPMENT`, and testing plan synchronized in milestone-tagged PRs.
+
+---
+
+
+## 6. Change-by-change justification for this audit PR
+
+1. **`schedulerWellFormed` aliasing**
+   - Improvement: removes duplicated predicate definitions that could drift over time while preserving external milestone terminology.
+   - Why necessary: duplicated logical definitions create avoidable proof-maintenance risk.
+
+2. **Tier 3 script activation in `test_full.sh`**
+   - Improvement: converts a placeholder/full-suite notice into an executable gate.
+   - Why necessary: full-suite checks should fail when milestone-level invariant/doc surface contracts are accidentally removed.
+
+3. **Tier 3 surface checks (invariant/theorem/doc coherence)**
+   - Improvement: adds deterministic regression checks for bundle/theorem anchors and cross-doc stage consistency.
+   - Why necessary: these anchors are contract surfaces for milestone continuity and reviewer confidence.
+
+4. **README/DEVELOPMENT/TESTING docs synchronization**
+   - Improvement: aligns stated testing reality with script behavior and current roadmap posture.
+   - Why necessary: stale process docs create contributor and review friction.
+
+5. **Project audit document introduction**
+   - Improvement: provides a centralized audit baseline that can be updated per milestone closure.
+   - Why necessary: larger milestone transitions benefit from explicit, versioned quality/status narrative.
+
+## 7. Known limitations and next hardening steps
+
+1. Tier 3 currently validates named/theorem/doc surface contracts, not deep semantic equivalence.
+2. Highest-value next hardening is grouped invariant checks per milestone boundary once M3.5 handshake semantics land.
+3. Tier 4 remains intentionally lightweight until broader nightly determinism/scenario sweeps are defined.
+
+---
+
+## 8. Conclusion
+
+The project is in a healthy state and technically well-positioned for M3.5 handshake work.
+
+This audit cycle improved maintainability (predicate aliasing), strengthened confidence gates (Tier 3 activation), and expanded project-level status reporting (new audit document).

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -14,7 +14,7 @@ Current repository status:
 - ✅ Work package B (fixture-backed executable smoke baseline) implemented.
 - ✅ Work package C (CI wiring to script entrypoints) implemented.
 - ✅ Work package D (docs integration) implemented.
-- ⏳ Work package E (Tier 3 integration checks) prepared as extension points, not yet mandatory.
+- ✅ Work package E (Tier 3 invariant/doc-surface checks) implemented.
 
 ---
 
@@ -58,12 +58,12 @@ The framework is successful only if all of the following remain true.
 
 Both are required pull-request CI jobs.
 
-### 3.3 Optional extension tiers (prepared)
+### 3.3 Full/nightly tiers
 
-- `./scripts/test_full.sh` includes Tier 3 extension notice.
-- `./scripts/test_nightly.sh` includes Tier 4 extension notice.
+- `./scripts/test_full.sh` runs Tier 3 invariant/doc-surface checks.
+- `./scripts/test_nightly.sh` runs full plus Tier 4 extension notice.
 
-These are currently informational expansion hooks.
+Tier 3 is now active in the full suite; Tier 4 remains the next expansion hook.
 
 ---
 
@@ -123,8 +123,8 @@ These are the prioritized testing next steps once M3.5 semantics begin landing.
 1. **Tier 2 fixture growth for M3.5 stories**
    - add stable trace fragments for waiting/handshake behavior.
 
-2. **Tier 3 invariant-group checks**
-   - add grouped checks by milestone bundle boundary (M1/M2/M3/M3.5/M4).
+2. **Tier 3 invariant-group deepening**
+   - extend current invariant/doc-surface checks into richer milestone-bundle grouped checks.
 
 3. **Artifact ergonomics**
    - standardize artifact naming for any new tier scripts.

--- a/scripts/test_full.sh
+++ b/scripts/test_full.sh
@@ -13,6 +13,6 @@ if [[ "${CONTINUE_MODE}" -eq 1 ]]; then
 fi
 
 run_check "META" "${SCRIPT_DIR}/test_smoke.sh" "${sub_args[@]}"
-log_section "INVARIANT" "Tier 3 integration checks are not yet wired; this is an explicit extension point."
+run_check "META" "${SCRIPT_DIR}/test_tier3_invariant_surface.sh" "${sub_args[@]}"
 
 finalize_report

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+cd "${REPO_ROOT}"
+
+# Invariant bundle surface anchors (M1/M2/M3 composed entrypoints).
+run_check "INVARIANT" rg -n '^(def|abbrev) schedulerInvariantBundle' SeLe4n/Kernel/API.lean
+run_check "INVARIANT" rg -n '^def capabilityInvariantBundle' SeLe4n/Kernel/API.lean
+run_check "INVARIANT" rg -n '^def m3IpcSeedInvariantBundle' SeLe4n/Kernel/API.lean
+
+# M3 seed IPC preservation theorem anchors.
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/API.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/API.lean
+
+# Bundle composition guard: M3 seed bundle must still compose scheduler + capability + IPC invariants.
+run_check "INVARIANT" rg -n '^\s*schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st' SeLe4n/Kernel/API.lean
+
+# Active milestone docs should stay synchronized for both current and next slices.
+run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
+run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
+
+# Full-suite contract should continue to include Tier 3.
+run_check "DOC" rg -n 'test_tier3_invariant_surface\.sh' scripts/test_full.sh
+
+finalize_report


### PR DESCRIPTION
### Motivation

- Strengthen regression protection around milestone invariants by turning Tier 3 from a documented extension point into an active, deterministic gate.
- Reduce proof-maintenance risk by removing duplicated scheduler predicate logic while preserving external milestone terminology.
- Provide a clear, defensible audit narrative so every change in the audit PR is explainable to reviewers.

### Description

- Introduced `scripts/test_tier3_invariant_surface.sh` to assert invariant/theorem anchors, composed M3 bundle shape, cross-doc stage markers, and that `test_full.sh` remains wired to run Tier 3.
- Made `schedulerWellFormed` an `abbrev` alias of `queueCurrentConsistent` in `SeLe4n/Kernel/API.lean` and updated related proofs to use the alias/underlying definition (`simp`/`simpa`) to avoid duplicated predicate maintenance.
- Activated Tier 3 in the full-suite by replacing the notice in `scripts/test_full.sh` with a call to the new Tier 3 script.
- Added `docs/PROJECT_AUDIT.md` and expanded it with a change-by-change justification and known limitations, and synchronized the README, `docs/TESTING_FRAMEWORK_PLAN.md`, and `docs/DEVELOPMENT.md` to reflect the active Tier 3 gate and audit additions.

### Testing

- Ran `./scripts/test_fast.sh` and observed a successful pass for hygiene and build gates.
- Ran `./scripts/test_smoke.sh` and observed a successful pass for fixture-backed trace checks.
- Ran `./scripts/test_full.sh` and observed a successful pass including the new Tier 3 invariant/doc-surface checks.
- Ran `./scripts/test_nightly.sh` and observed the full-suite run successfully.
- Ran `./scripts/audit_testing_framework.sh` and observed the audit flow complete; the script intentionally injects a Tier 2 control mismatch which produced the expected Tier 2 failure while the audit harness completed as designed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69916a88f490832bb44b941e6cfdfaff)