### PR TITLE
Add licensing stuff and fix "lake build" running issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 seLe4n contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ On smoke-trace failures, CI uploads diagnostics:
 
 ---
 
+## License
+
+This project is licensed under the MIT License. See [`LICENSE`](./LICENSE).
+
+### Provenance policy
+
+- Do not copy third-party code or text into this repository without explicit attribution.
+- Confirm incoming third-party material is license-compatible with MIT before committing it.
+
+---
+
 ## Daily contributor verification loop
 
 Run this minimum loop before opening a PR:

--- a/docs/LICENSE_REVIEW.md
+++ b/docs/LICENSE_REVIEW.md
@@ -1,0 +1,64 @@
+# License compatibility review (for adopting MIT)
+
+Requested by repository owner: review potential licensing conflicts **before** adding an MIT
+license, then complete pre-adoption actions and add the license.
+
+## Scope reviewed
+
+- Lean source in `SeLe4n/` plus `Main.lean` and `SeLe4n.lean`.
+- Project docs in `README.md` and `docs/`.
+- Build metadata (`lakefile.toml`, `lake-manifest.json`, `lean-toolchain`).
+- Local scripts and tests under `scripts/` and `tests/`.
+
+## Findings
+
+1. **No existing repository license file is present yet**
+   - There is currently no `LICENSE` / `COPYING` file in this repo.
+
+2. **No third-party package dependencies are declared in the Lake manifest**
+   - `lake-manifest.json` has an empty `packages` list, reducing immediate risk of pulling in
+     incompatible dependency licenses.
+
+3. **Project appears to be an original Lean model rather than vendored upstream seL4 code**
+   - The repository describes itself as a Lean formalization *of* seL4 semantics.
+   - The code and docs use seL4 terminology/references, but there are no in-file notices indicating
+     copied or embedded upstream source blocks.
+
+4. **MIT is likely appropriate for this codebase as it stands**
+   - Based on the current tree contents, there are no visible copyleft triggers or conflicting
+     license headers.
+
+## Risks to keep in mind
+
+- **Provenance risk (human process risk):** if any file was copied from external sources and that
+  provenance is not recorded, this review cannot detect it with certainty.
+- **Trademark/branding:** references to “seL4” are descriptive, but MIT licensing does not grant
+  trademark rights; keep naming usage factual and non-endorsing.
+- **Future dependency drift:** adding Lake packages later may introduce non-MIT-compatible terms;
+  re-run dependency license checks when that changes.
+
+## Recommendation before adding MIT
+
+1. Add a standard MIT `LICENSE` file at repository root.
+2. Add copyright holder line(s).
+3. Add a short note in `README.md` pointing to `LICENSE`.
+4. Keep a lightweight provenance policy for new contributions (e.g., “no copied code without
+   explicit attribution and license compatibility”).
+5. Re-check licenses whenever external packages are added to `lake-manifest.json`.
+
+## Recommendation completion status
+
+The pre-adoption recommendations above have now been completed in this repository:
+
+1. ✅ Added MIT `LICENSE` at repository root.
+2. ✅ Included a copyright holder line in the MIT text.
+3. ✅ Added a short `README.md` note pointing to `LICENSE`.
+4. ✅ Added a lightweight provenance policy note in `README.md` (no copied third-party code
+   without explicit attribution and license-compatibility confirmation).
+5. ✅ Kept dependency re-check guidance documented in this review; re-run this check whenever
+   external Lake packages are introduced.
+
+## Bottom line
+
+With the repository in its current state, I did **not** see a clear blocker to adopting MIT, and
+the repository now includes an MIT `LICENSE` plus the related process/documentation follow-ups.

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -81,6 +81,24 @@ ensure_lake_available() {
     return 0
   fi
 
-  record_failure "BUILD" "lake not found on PATH. Run ./scripts/setup_lean_env.sh or install elan."
+  local setup_script="${REPO_ROOT}/scripts/setup_lean_env.sh"
+  if [[ -x "${setup_script}" ]]; then
+    log_section "BUILD" "lake missing; attempting automatic Lean toolchain setup"
+    if "${setup_script}"; then
+      if [[ -f "${HOME}/.elan/env" ]]; then
+        # shellcheck disable=SC1090,SC1091
+        source "${HOME}/.elan/env"
+      fi
+    else
+      record_failure "BUILD" "automatic setup via ${setup_script} failed"
+      finalize_report
+    fi
+  fi
+
+  if command -v lake >/dev/null 2>&1; then
+    return 0
+  fi
+
+  record_failure "BUILD" "lake not found on PATH after auto-setup attempt. Run ./scripts/setup_lean_env.sh manually."
   finalize_report
 }

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -67,14 +67,22 @@ finalize_report() {
   log_section "META" "All checks passed."
 }
 
+resolve_elan_env_file() {
+  local elan_home_default="${HOME}/.elan"
+  local elan_home="${ELAN_HOME:-${elan_home_default}}"
+  printf '%s/env\n' "${elan_home}"
+}
+
 ensure_lake_available() {
   if command -v lake >/dev/null 2>&1; then
     return 0
   fi
 
-  if [[ -f "${HOME}/.elan/env" ]]; then
+  local elan_env_file
+  elan_env_file="$(resolve_elan_env_file)"
+  if [[ -f "${elan_env_file}" ]]; then
     # shellcheck disable=SC1090,SC1091
-    source "${HOME}/.elan/env"
+    source "${elan_env_file}"
   fi
 
   if command -v lake >/dev/null 2>&1; then
@@ -85,9 +93,10 @@ ensure_lake_available() {
   if [[ -x "${setup_script}" ]]; then
     log_section "BUILD" "lake missing; attempting automatic Lean toolchain setup"
     if "${setup_script}"; then
-      if [[ -f "${HOME}/.elan/env" ]]; then
+      elan_env_file="$(resolve_elan_env_file)"
+      if [[ -f "${elan_env_file}" ]]; then
         # shellcheck disable=SC1090,SC1091
-        source "${HOME}/.elan/env"
+        source "${elan_env_file}"
       fi
     else
       record_failure "BUILD" "automatic setup via ${setup_script} failed"


### PR DESCRIPTION
Added licensing stuff 

Fixed the lake PATH testing failure by hardening ensure_lake_available in scripts/test_lib.sh:

it now checks PATH,

sources $HOME/.elan/env if present,

auto-runs ./scripts/setup_lean_env.sh when lake is still missing,

re-sources elan env after setup,

then retries detection before failing with an updated message. 

This directly resolves the prior Tier 1 failure mode in fresh environments where Lean tooling was not preloaded on PATH. 
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699173fdbe08832b99246e904ee27f3c)