### PR TITLE
Harden M3.5 step‑1: enforce endpoint/waiter ownership, strengthen invariants and tests

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -19,6 +19,7 @@ def bootstrapState : SystemState :=
           cspaceRoot := 10
           vspaceRoot := 20
           ipcBuffer := 4096
+          ipcState := .ready
         })
       else if oid = 10 then
         some (.cnode {
@@ -34,7 +35,7 @@ def bootstrapState : SystemState :=
       else if oid = 11 then
         some (.cnode CNode.empty)
       else if oid = demoEndpoint then
-        some (.endpoint { state := .idle, queue := [] })
+        some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
       else
         none
     scheduler := { runnable := [1, 2], current := none }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
 - ✅ **M1 complete**: scheduler integrity invariants and preservation entrypoints.
 - ✅ **M2 complete**: capability + CSpace operations, attenuation/lifecycle rules, composed invariants.
 - ✅ **M3 complete**: endpoint IPC seed (`endpointSend`/`endpointReceive`) plus preservation theorem surface.
-- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations.
+- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (step 1 state-model refinement complete: endpoint/thread handshake fields landed).
 - 📌 **Next slice after M3.5 (planned M4)**: object lifecycle/retype safety and capability-object interaction invariants.
 
 Testing framework status:

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -181,10 +181,10 @@ def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel
     | some (.endpoint ep) =>
         match ep.state with
         | .idle =>
-            let ep' : Endpoint := { state := .send, queue := [sender] }
+            let ep' : Endpoint := { state := .send, queue := [sender], waitingReceiver := none }
             storeObject endpointId (.endpoint ep') st
         | .send =>
-            let ep' : Endpoint := { state := .send, queue := ep.queue ++ [sender] }
+            let ep' : Endpoint := { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }
             storeObject endpointId (.endpoint ep') st
         | .receive => .error .endpointStateMismatch
     | some _ => .error .invalidCapability
@@ -198,7 +198,7 @@ def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
         match ep.state, ep.queue with
         | .send, sender :: rest =>
             let nextState : EndpointState := if rest.isEmpty then .idle else .send
-            let ep' : Endpoint := { state := nextState, queue := rest }
+            let ep' : Endpoint := { state := nextState, queue := rest, waitingReceiver := none }
             match storeObject endpointId (.endpoint ep') st with
             | .error e => .error e
             | .ok ((), st') => .ok (sender, st')
@@ -259,10 +259,10 @@ theorem endpointSend_ok_as_storeObject
       | endpoint ep =>
           cases hState : ep.state <;> simp [hObj, hState, storeObject] at hStep
           case idle =>
-            refine ⟨{ state := .send, queue := [sender] }, ?_⟩
+            refine ⟨{ state := .send, queue := [sender], waitingReceiver := none }, ?_⟩
             simp [storeObject, hStep]
           case send =>
-            refine ⟨{ state := .send, queue := ep.queue ++ [sender] }, ?_⟩
+            refine ⟨{ state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }, ?_⟩
             simp [storeObject, hStep]
 
 /-- Local transition helper: successful receive is exactly one endpoint-object update. -/
@@ -288,29 +288,30 @@ theorem endpointReceive_ok_as_storeObject
                 simp [hQueue, storeObject] at hStep
                 rcases hStep with ⟨_, hStore⟩
                 let nextState : EndpointState := if tail.isEmpty then .idle else .send
-                refine ⟨{ state := nextState, queue := tail }, ?_⟩
+                refine ⟨{ state := nextState, queue := tail, waitingReceiver := none }, ?_⟩
                 simp [storeObject, nextState, hStore]
 
-/-- Endpoint-local queue/state well-formedness for the M3 IPC seed.
+/-- Endpoint-local queue/state well-formedness for the M3.5 handshake scaffold.
 
-Policy for this slice is intentionally simple and deterministic:
-- `idle` endpoints have empty queues,
-- `send` endpoints have a non-empty sender queue,
-- `receive` endpoints have empty queues (receive waiters are out-of-scope in this seed). -/
+Policy for this slice stays deterministic and ownership-explicit:
+- `idle` endpoints have an empty sender queue and no waiting receiver,
+- `send` endpoints have a non-empty sender queue and no waiting receiver,
+- `receive` endpoints have an empty sender queue and one waiting receiver identity. -/
 def endpointQueueWellFormed (ep : Endpoint) : Prop :=
   match ep.state with
-  | .idle => ep.queue = []
-  | .send => ep.queue ≠ []
-  | .receive => ep.queue = []
+  | .idle => ep.queue = [] ∧ ep.waitingReceiver = none
+  | .send => ep.queue ≠ [] ∧ ep.waitingReceiver = none
+  | .receive => ep.queue = [] ∧ ep.waitingReceiver.isSome
 
-/-- Endpoint/object validity component for the M3 IPC seed.
+/-- Endpoint/object validity component for the active IPC slice.
 
-This predicate captures a minimal object-level discipline: explicit `receive` state is represented
-without queued senders in this first slice. -/
+Ownership discipline for the waiting counterpart identity:
+- no waiting receiver implies endpoint is not in `.receive`,
+- a waiting receiver id implies endpoint is in `.receive`. -/
 def endpointObjectValid (ep : Endpoint) : Prop :=
-  match ep.state with
-  | .receive => ep.queue = []
-  | _ => True
+  match ep.waitingReceiver with
+  | none => ep.state ≠ .receive
+  | some _ => ep.state = .receive
 
 /-- IPC invariant component bundle for one endpoint object. -/
 def endpointInvariant (ep : Endpoint) : Prop :=
@@ -326,12 +327,8 @@ theorem endpointObjectValid_of_queueWellFormed
     (ep : Endpoint)
     (hWf : endpointQueueWellFormed ep) :
     endpointObjectValid ep := by
-  cases ep with
-  | mk state queue =>
-      cases state
-      · simp [endpointObjectValid]
-      · simp [endpointObjectValid]
-      · simpa [endpointQueueWellFormed, endpointObjectValid] using hWf
+  cases hState : ep.state <;> cases hWait : ep.waitingReceiver <;>
+    simp [endpointQueueWellFormed, endpointObjectValid, hState, hWait] at hWf ⊢
 
 theorem endpointSend_result_wellFormed
     (st st' : SystemState)
@@ -351,13 +348,13 @@ theorem endpointSend_result_wellFormed
           | idle =>
               simp [hObj, hState, storeObject] at hStep
               cases hStep
-              refine ⟨{ state := .send, queue := [sender] }, ?_, ?_⟩
+              refine ⟨{ state := .send, queue := [sender], waitingReceiver := none }, ?_, ?_⟩
               · simp
               · simp [endpointQueueWellFormed]
           | send =>
               simp [hObj, hState, storeObject] at hStep
               cases hStep
-              refine ⟨{ state := .send, queue := ep.queue ++ [sender] }, ?_, ?_⟩
+              refine ⟨{ state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }, ?_, ?_⟩
               · simp
               · simp [endpointQueueWellFormed]
           | receive => simp [hObj, hState] at hStep
@@ -384,7 +381,7 @@ theorem endpointReceive_result_wellFormed
                 simp [hQueue, storeObject] at hStep
                 rcases hStep with ⟨hSender, hStoreEq⟩
                 let nextState : EndpointState := if tail.isEmpty then .idle else .send
-                refine ⟨{ state := nextState, queue := tail }, ?_, ?_⟩
+                refine ⟨{ state := nextState, queue := tail, waitingReceiver := none }, ?_, ?_⟩
                 · cases hStoreEq
                   simp [nextState]
                 · cases hTail : tail with

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -28,6 +28,16 @@ def hasRight (cap : Capability) (right : AccessRight) : Bool :=
 
 end Capability
 
+/-- Minimal per-thread IPC scheduler-visible status for M3.5 handshake scaffolding.
+
+This is intentionally narrow: only endpoint-local blocking states needed to model one deterministic
+waiting-thread handshake story. -/
+inductive ThreadIpcState where
+  | ready
+  | blockedOnSend (endpoint : SeLe4n.ObjId)
+  | blockedOnReceive (endpoint : SeLe4n.ObjId)
+  deriving Repr, DecidableEq
+
 structure TCB where
   tid : SeLe4n.ThreadId
   priority : SeLe4n.Priority
@@ -35,6 +45,7 @@ structure TCB where
   cspaceRoot : SeLe4n.ObjId
   vspaceRoot : SeLe4n.ObjId
   ipcBuffer : SeLe4n.VAddr
+  ipcState : ThreadIpcState := .ready
   deriving Repr, DecidableEq
 
 inductive EndpointState where
@@ -46,6 +57,7 @@ inductive EndpointState where
 structure Endpoint where
   state : EndpointState
   queue : List SeLe4n.ThreadId
+  waitingReceiver : Option SeLe4n.ThreadId := none
   deriving Repr, DecidableEq
 
 structure CNode where

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -56,9 +56,10 @@ Do **not** include the following in M3.5 PRs unless explicitly approved:
 
 Use this order unless a concrete dependency forces adjustment.
 
-1. **State-model refinement first**
-   - add only endpoint/thread fields needed for one deterministic handshake story,
-   - keep state ownership clear.
+1. **State-model refinement first** ✅ **completed**
+   - added only endpoint/thread fields needed for one deterministic handshake story (`Endpoint.waitingReceiver`, `TCB.ipcState`),
+   - state ownership remains explicit: endpoint-owned waiting counterpart identity + thread-owned IPC blocking status,
+   - endpoint local well-formedness now constrains queue shape and waiting-receiver ownership together for deterministic unfolding in later transition/proof work.
 
 2. **Transition updates second**
    - add/update endpoint transitions with explicit success/error branches,

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -138,7 +138,17 @@ A change set claiming M3.5 completion must satisfy all outcomes below.
 7. New/updated endpoint transitions have machine-checked preservation theorem entrypoints.
 8. `README.md`, `docs/SEL4_SPEC.md`, and `docs/DEVELOPMENT.md` are internally stage-consistent.
 
-### 4.5 Explicit non-goals for M3.5
+### 4.5 M3.5 implementation sequence progress
+
+- ✅ **Step 1 complete (state-model refinement)**
+  - endpoint model now includes explicit waiting-counterpart identity for deterministic handshake setup (`waitingReceiver`),
+  - TCB model now carries explicit IPC blocking status (`ready`, `blockedOnSend endpoint`, `blockedOnReceive endpoint`) to keep scheduler-facing ownership clear,
+  - endpoint well-formedness now captures ownership coupling between endpoint mode and waiting-receiver identity (non-receive states require `none`, receive requires `some`),
+  - remaining M3.5 steps (transition updates onward) stay in progress.
+
+---
+
+### 4.6 Explicit non-goals for M3.5
 
 Out of scope for this slice:
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.3.11"
+version = "0.3.13"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -20,6 +20,13 @@ run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m3IpcSeedInvaria
 # Bundle composition guard: M3 seed bundle must still compose scheduler + capability + IPC invariants.
 run_check "INVARIANT" rg -n '^\s*schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st' SeLe4n/Kernel/API.lean
 
+# M3.5 step-1 state-model anchors must remain present.
+run_check "INVARIANT" rg -n '^inductive ThreadIpcState' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^\s*ipcState\s*:\s*ThreadIpcState' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^\s*waitingReceiver\s*:\s*Option SeLe4n\.ThreadId' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^def endpointQueueWellFormed' SeLe4n/Kernel/API.lean
+run_check "INVARIANT" rg -n '^def endpointObjectValid' SeLe4n/Kernel/API.lean
+
 # Active milestone docs should stay synchronized for both current and next slices.
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md


### PR DESCRIPTION
### Motivation
- Clarify and harden the M3.5 step‑1 state model so endpoint waiting identity and thread IPC status express explicit ownership and cannot be accidentally carried across transitions.
- Make endpoint queue shape and waiting‑receiver ownership deterministic to simplify subsequent transition updates and preservation proofs.

### Description
- Added a minimal per‑thread status `ThreadIpcState` and `TCB.ipcState` with default `.ready`, and added `Endpoint.waitingReceiver : Option ThreadId` with default `none`, and updated `Main.lean` to include these fields in the demo state (`ipcState` and `waitingReceiver`).
- Normalized endpoint transition outcomes so `endpointSend` and `endpointReceive` explicitly write `waitingReceiver := none` for `.idle`/`.send` outcomes to avoid stale waiter carry‑through. 
- Strengthened invariants: `endpointQueueWellFormed` now couples queue shape and `waitingReceiver` presence, and `endpointObjectValid` encodes the ownership relationship between `waitingReceiver` and `.receive` mode; updated helper theorem `endpointObjectValid_of_queueWellFormed` accordingly.
- Extended the Tier‑3 invariant surface checks by adding anchors to `scripts/test_tier3_invariant_surface.sh` for `ThreadIpcState`, `TCB.ipcState`, `Endpoint.waitingReceiver`, and the new endpoint invariant definitions, synchronized docs in `docs/DEVELOPMENT.md` and `docs/SEL4_SPEC.md`, and bumped the project version to `0.3.13` in `lakefile.toml`.

### Testing
- Ran `source "$HOME/.elan/env" && lake build && lake exe sele4n` and the executable built and ran successfully producing expected IPC trace output (build and demo run passed).
- Ran `./scripts/test_fast.sh` and `./scripts/test_smoke.sh` and both completed successfully (Tier 0–2 checks passed).
- Ran `./scripts/test_full.sh` (which includes `scripts/test_tier3_invariant_surface.sh`) and all checks passed, including the new invariant anchors and documentation surface checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917b561ec0832b859aed00218d6e53)