### PR TITLE
Re-audit M3.5: scheduler↔IPC coherence predicates, preservation proofs, and warning-free Tier1 gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
+seLe4n is currently in a **post-M3 IPC seed / mid-M3.5 handshake** stage.
 
 ### Milestone board (authoritative)
 
@@ -13,13 +13,13 @@ seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
 - ✅ **M1 complete**: scheduler integrity invariants and preservation entrypoints.
 - ✅ **M2 complete**: capability + CSpace operations, attenuation/lifecycle rules, composed invariants.
 - ✅ **M3 complete**: endpoint IPC seed (`endpointSend`/`endpointReceive`) plus preservation theorem surface.
-- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-2 complete: endpoint/thread handshake fields plus explicit handshake transition branches landed).
+- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-3 complete: endpoint/thread handshake fields, explicit handshake transition branches, and targeted blocked-vs-runnable scheduler contract predicates plus transition-preservation theorem entrypoints landed).
 - 📌 **Next slice after M3.5 (planned M4)**: object lifecycle/retype safety and capability-object interaction invariants.
 
 Testing framework status:
 
 - ✅ Tier 0 hygiene gate (`axiom|sorry|TODO` scan).
-- ✅ Tier 1 build/theorem gate (`lake build`).
+- ✅ Tier 1 build/theorem gate (`lake build`, warning-free in required gate).
 - ✅ Tier 2 fixture-backed executable smoke regression gate.
 - ✅ Tier 3 invariant/doc-surface checks are wired via `test_full.sh`.
 - 🧩 Tier 4 nightly extension point remains documented for broader confidence checks.

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -209,6 +209,41 @@ def ipcInvariant (st : SystemState) : Prop :=
     st.objects oid = some (.endpoint ep) →
     endpointInvariant ep
 
+/-- IPC+scheduler coherence predicate #1 (targeted):
+threads blocked on send must not be runnable or currently executing. -/
+def blockedOnSendNotRunnable (st : SystemState) : Prop :=
+  ∀ tid tcb endpoint,
+    st.objects tid = some (.tcb tcb) →
+    tcb.ipcState = .blockedOnSend endpoint →
+    tid ∉ st.scheduler.runnable ∧ st.scheduler.current ≠ some tid
+
+/-- IPC+scheduler coherence predicate #2 (targeted):
+threads blocked on receive must not be runnable or currently executing. -/
+def blockedOnReceiveNotRunnable (st : SystemState) : Prop :=
+  ∀ tid tcb endpoint,
+    st.objects tid = some (.tcb tcb) →
+    tcb.ipcState = .blockedOnReceive endpoint →
+    tid ∉ st.scheduler.runnable ∧ st.scheduler.current ≠ some tid
+
+/-- IPC+scheduler coherence predicate #3 (targeted):
+runnable threads must advertise `ready` IPC state. -/
+def runnableThreadIpcReady (st : SystemState) : Prop :=
+  ∀ tid,
+    tid ∈ st.scheduler.runnable →
+    ∃ tcb, st.objects tid = some (.tcb tcb) ∧ tcb.ipcState = .ready
+
+/-- IPC+scheduler coherence predicate #4 (targeted):
+the current thread, if present, must advertise `ready` IPC state. -/
+def currentThreadIpcReady (st : SystemState) : Prop :=
+  match st.scheduler.current with
+  | none => True
+  | some tid => ∃ tcb, st.objects tid = some (.tcb tcb) ∧ tcb.ipcState = .ready
+
+/-- Targeted blocked-vs-runnable coherence bundle for the active M3.5 step-3 contract. -/
+def schedulerIpcCoherencePredicates (st : SystemState) : Prop :=
+  blockedOnSendNotRunnable st ∧ blockedOnReceiveNotRunnable st ∧
+    runnableThreadIpcReady st ∧ currentThreadIpcReady st
+
 theorem endpointObjectValid_of_queueWellFormed
     (ep : Endpoint)
     (hWf : endpointQueueWellFormed ep) :
@@ -554,6 +589,211 @@ theorem endpointReceive_preserves_schedulerInvariantBundle
           rw [endpointReceive_preserves_other_objects st st' endpointId tid sender hTidNe hStep]
           exact hTcbObj
         simp [currentThreadValid, hCurEq, hCurrent, hTcbObj']
+
+
+theorem endpointSend_tcb_lookup_iff
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (tid : SeLe4n.ThreadId)
+    (tcb : TCB)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    st'.objects tid = some (.tcb tcb) ↔ st.objects tid = some (.tcb tcb) := by
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hStoreEq : st'.objects endpointId = some (.endpoint ep') :=
+    storeObject_objects_eq st st' endpointId (.endpoint ep') hStore
+  constructor
+  · intro hObj'
+    by_cases hEq : tid = endpointId
+    · subst hEq
+      rw [hStoreEq] at hObj'
+      cases hObj'
+    · have hNe : tid ≠ endpointId := hEq
+      rw [endpointSend_preserves_other_objects st st' endpointId tid sender hNe hStep] at hObj'
+      exact hObj'
+  · intro hObj
+    by_cases hEq : tid = endpointId
+    · subst hEq
+      rcases endpointSend_ok_implies_endpoint_object st st' tid sender hStep with ⟨ep, hEpObj⟩
+      rw [hEpObj] at hObj
+      cases hObj
+    · have hNe : tid ≠ endpointId := hEq
+      rw [endpointSend_preserves_other_objects st st' endpointId tid sender hNe hStep]
+      exact hObj
+
+theorem endpointAwaitReceive_tcb_lookup_iff
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId)
+    (tid : SeLe4n.ThreadId)
+    (tcb : TCB)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    st'.objects tid = some (.tcb tcb) ↔ st.objects tid = some (.tcb tcb) := by
+  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
+  have hStoreEq : st'.objects endpointId = some (.endpoint ep') :=
+    storeObject_objects_eq st st' endpointId (.endpoint ep') hStore
+  constructor
+  · intro hObj'
+    by_cases hEq : tid = endpointId
+    · subst hEq
+      rw [hStoreEq] at hObj'
+      cases hObj'
+    · have hNe : tid ≠ endpointId := hEq
+      rw [endpointAwaitReceive_preserves_other_objects st st' endpointId tid receiver hNe hStep] at hObj'
+      exact hObj'
+  · intro hObj
+    by_cases hEq : tid = endpointId
+    · subst hEq
+      rcases endpointAwaitReceive_ok_implies_endpoint_object st st' tid receiver hStep with ⟨ep, hEpObj⟩
+      rw [hEpObj] at hObj
+      cases hObj
+    · have hNe : tid ≠ endpointId := hEq
+      rw [endpointAwaitReceive_preserves_other_objects st st' endpointId tid receiver hNe hStep]
+      exact hObj
+
+theorem endpointReceive_tcb_lookup_iff
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (tid : SeLe4n.ThreadId)
+    (tcb : TCB)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    st'.objects tid = some (.tcb tcb) ↔ st.objects tid = some (.tcb tcb) := by
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hStoreEq : st'.objects endpointId = some (.endpoint ep') :=
+    storeObject_objects_eq st st' endpointId (.endpoint ep') hStore
+  constructor
+  · intro hObj'
+    by_cases hEq : tid = endpointId
+    · subst hEq
+      rw [hStoreEq] at hObj'
+      cases hObj'
+    · have hNe : tid ≠ endpointId := hEq
+      rw [endpointReceive_preserves_other_objects st st' endpointId tid sender hNe hStep] at hObj'
+      exact hObj'
+  · intro hObj
+    by_cases hEq : tid = endpointId
+    · subst hEq
+      rcases endpointReceive_ok_implies_endpoint_object st st' tid sender hStep with ⟨ep, hEpObj⟩
+      rw [hEpObj] at hObj
+      cases hObj
+    · have hNe : tid ≠ endpointId := hEq
+      rw [endpointReceive_preserves_other_objects st st' endpointId tid sender hNe hStep]
+      exact hObj
+
+theorem endpointSend_preserves_schedulerIpcCoherencePredicates
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : schedulerIpcCoherencePredicates st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    schedulerIpcCoherencePredicates st' := by
+  rcases hInv with ⟨hSend, hRecv, hRun, hCur⟩
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjSt : st.objects tid = some (.tcb tcb) :=
+      (endpointSend_tcb_lookup_iff st st' endpointId sender tid tcb hStep).1 hObj
+    have hRes := hSend tid tcb endpoint hObjSt hBlocked
+    simpa [hSchedEq] using hRes
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjSt : st.objects tid = some (.tcb tcb) :=
+      (endpointSend_tcb_lookup_iff st st' endpointId sender tid tcb hStep).1 hObj
+    have hRes := hRecv tid tcb endpoint hObjSt hBlocked
+    simpa [hSchedEq] using hRes
+  · intro tid hIn
+    have hInSt : tid ∈ st.scheduler.runnable := by simpa [hSchedEq] using hIn
+    rcases hRun tid hInSt with ⟨tcb, hObjSt, hReady⟩
+    have hObj' : st'.objects tid = some (.tcb tcb) :=
+      (endpointSend_tcb_lookup_iff st st' endpointId sender tid tcb hStep).2 hObjSt
+    exact ⟨tcb, hObj', hReady⟩
+  · cases hCurrent : st.scheduler.current with
+    | none => simp [currentThreadIpcReady, hSchedEq, hCurrent]
+    | some tid =>
+        have hCurSt : ∃ tcb, st.objects tid = some (.tcb tcb) ∧ tcb.ipcState = .ready := by
+          simpa [currentThreadIpcReady, hCurrent] using hCur
+        rcases hCurSt with ⟨tcb, hObjSt, hReady⟩
+        have hObj' : st'.objects tid = some (.tcb tcb) :=
+          (endpointSend_tcb_lookup_iff st st' endpointId sender tid tcb hStep).2 hObjSt
+        simpa [currentThreadIpcReady, hSchedEq, hCurrent] using ⟨tcb, hObj', hReady⟩
+
+theorem endpointAwaitReceive_preserves_schedulerIpcCoherencePredicates
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId)
+    (hInv : schedulerIpcCoherencePredicates st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    schedulerIpcCoherencePredicates st' := by
+  rcases hInv with ⟨hSend, hRecv, hRun, hCur⟩
+  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjSt : st.objects tid = some (.tcb tcb) :=
+      (endpointAwaitReceive_tcb_lookup_iff st st' endpointId receiver tid tcb hStep).1 hObj
+    have hRes := hSend tid tcb endpoint hObjSt hBlocked
+    simpa [hSchedEq] using hRes
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjSt : st.objects tid = some (.tcb tcb) :=
+      (endpointAwaitReceive_tcb_lookup_iff st st' endpointId receiver tid tcb hStep).1 hObj
+    have hRes := hRecv tid tcb endpoint hObjSt hBlocked
+    simpa [hSchedEq] using hRes
+  · intro tid hIn
+    have hInSt : tid ∈ st.scheduler.runnable := by simpa [hSchedEq] using hIn
+    rcases hRun tid hInSt with ⟨tcb, hObjSt, hReady⟩
+    have hObj' : st'.objects tid = some (.tcb tcb) :=
+      (endpointAwaitReceive_tcb_lookup_iff st st' endpointId receiver tid tcb hStep).2 hObjSt
+    exact ⟨tcb, hObj', hReady⟩
+  · cases hCurrent : st.scheduler.current with
+    | none => simp [currentThreadIpcReady, hSchedEq, hCurrent]
+    | some tid =>
+        have hCurSt : ∃ tcb, st.objects tid = some (.tcb tcb) ∧ tcb.ipcState = .ready := by
+          simpa [currentThreadIpcReady, hCurrent] using hCur
+        rcases hCurSt with ⟨tcb, hObjSt, hReady⟩
+        have hObj' : st'.objects tid = some (.tcb tcb) :=
+          (endpointAwaitReceive_tcb_lookup_iff st st' endpointId receiver tid tcb hStep).2 hObjSt
+        simpa [currentThreadIpcReady, hSchedEq, hCurrent] using ⟨tcb, hObj', hReady⟩
+
+theorem endpointReceive_preserves_schedulerIpcCoherencePredicates
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : schedulerIpcCoherencePredicates st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    schedulerIpcCoherencePredicates st' := by
+  rcases hInv with ⟨hSend, hRecv, hRun, hCur⟩
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjSt : st.objects tid = some (.tcb tcb) :=
+      (endpointReceive_tcb_lookup_iff st st' endpointId sender tid tcb hStep).1 hObj
+    have hRes := hSend tid tcb endpoint hObjSt hBlocked
+    simpa [hSchedEq] using hRes
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjSt : st.objects tid = some (.tcb tcb) :=
+      (endpointReceive_tcb_lookup_iff st st' endpointId sender tid tcb hStep).1 hObj
+    have hRes := hRecv tid tcb endpoint hObjSt hBlocked
+    simpa [hSchedEq] using hRes
+  · intro tid hIn
+    have hInSt : tid ∈ st.scheduler.runnable := by simpa [hSchedEq] using hIn
+    rcases hRun tid hInSt with ⟨tcb, hObjSt, hReady⟩
+    have hObj' : st'.objects tid = some (.tcb tcb) :=
+      (endpointReceive_tcb_lookup_iff st st' endpointId sender tid tcb hStep).2 hObjSt
+    exact ⟨tcb, hObj', hReady⟩
+  · cases hCurrent : st.scheduler.current with
+    | none => simp [currentThreadIpcReady, hSchedEq, hCurrent]
+    | some tid =>
+        have hCurSt : ∃ tcb, st.objects tid = some (.tcb tcb) ∧ tcb.ipcState = .ready := by
+          simpa [currentThreadIpcReady, hCurrent] using hCur
+        rcases hCurSt with ⟨tcb, hObjSt, hReady⟩
+        have hObj' : st'.objects tid = some (.tcb tcb) :=
+          (endpointReceive_tcb_lookup_iff st st' endpointId sender tid tcb hStep).2 hObjSt
+        simpa [currentThreadIpcReady, hSchedEq, hCurrent] using ⟨tcb, hObj', hReady⟩
 
 
 end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines the expected engineering workflow for seLe4n contributors.
 
-Current project stage: **post-M3 seed / pre-M3.5 handshake completion**.
+Current project stage: **post-M3 seed / mid-M3.5 handshake completion**.
 
 Primary contributor goals:
 
@@ -67,9 +67,10 @@ Use this order unless a concrete dependency forces adjustment.
    - updated `endpointReceive` branching to keep explicit error outcomes for impossible waiting-receiver combinations,
    - preservation-entrypoint proofs for updated send/receive transitions remain unfold-friendly and machine-checked.
 
-3. **Scheduler contract predicates third**
-   - define targeted blocked-vs-runnable coherence predicates,
-   - avoid over-generalized abstraction.
+3. **Scheduler contract predicates third** ✅ **completed**
+   - added targeted blocked-vs-runnable coherence predicates (`blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`, `runnableThreadIpcReady`, `currentThreadIpcReady`),
+   - introduced explicit step-3 scheduler/IPC contract bundle entrypoint (`schedulerIpcCoherencePredicates`) without over-generalized abstraction,
+   - added transition preservation theorem entrypoints for this step-3 contract (`endpointSend|endpointAwaitReceive|endpointReceive_preserves_schedulerIpcCoherencePredicates`).
 
 4. **Invariant bundle composition fourth**
    - add named IPC+scheduler coherence components,

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -12,7 +12,7 @@ It has five jobs:
 4. Declare what is out of scope so review stays focused.
 5. Provide acceptance gates that can be validated locally.
 
-The project is currently in a **post-M3-seed / pre-M3.5** stage: M1 scheduler invariants, M2
+The project is currently in a **post-M3-seed / mid-M3.5** stage: M1 scheduler invariants, M2
 capability semantics, and M3 endpoint send/receive seed semantics are complete and executable.
 
 Testing baseline status: Tier 0 hygiene checks, Tier 1 build checks, and Tier 2 fixture-backed
@@ -149,8 +149,12 @@ A change set claiming M3.5 completion must satisfy all outcomes below.
   - `endpointSend` now has an explicit receive-handshake success path (`receive` + waiting receiver) and explicit state-mismatch error branches for illegal endpoint shapes,
   - `endpointReceive` now keeps explicit success/error splits over queue + waiting-receiver combinations,
   - send/receive preservation theorem entrypoints remain machine-checked after transition-surface updates.
+- ✅ **Step 3 complete (scheduler contract predicates)**
+  - added focused blocked-vs-runnable coherence predicates (`blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`, `runnableThreadIpcReady`, `currentThreadIpcReady`),
+  - introduced explicit grouped step-3 contract entrypoint (`schedulerIpcCoherencePredicates`) while keeping abstraction deliberately narrow,
+  - added machine-checked preservation theorem entrypoints for endpoint transitions over this step-3 contract.
 - ⏳ **Remaining M3.5 steps**
-  - scheduler contract predicates onward (steps 3-7) remain in progress.
+  - invariant-bundle composition onward (steps 4-7) remain in progress.
 
 ---
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -23,7 +23,7 @@ Current repository status:
 The framework is successful only if all of the following remain true.
 
 1. **Proof-surface stability**
-   - `lake build` keeps theorem entrypoints compiling.
+   - `lake build` keeps theorem entrypoints compiling and emits no unresolved Lean warnings in required Tier 1 checks.
    - No committed `axiom`, `sorry`, or unresolved work markers in core scope.
 
 2. **Executable behavior stability**
@@ -48,7 +48,7 @@ The framework is successful only if all of the following remain true.
 ### 3.1 Active required tiers
 
 - **Tier 0** hygiene check (`scripts/test_tier0_hygiene.sh`)
-- **Tier 1** build/theorem check (`scripts/test_tier1_build.sh`)
+- **Tier 1** build/theorem check (`scripts/test_tier1_build.sh`, including warning-free `lake build` enforcement)
 - **Tier 2** fixture-backed executable smoke (`scripts/test_tier2_trace.sh`)
 
 ### 3.2 Aggregated required entrypoints

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.4.0"
+version = "0.4.3"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.4.3"
+version = "0.4.4"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier1_build.sh
+++ b/scripts/test_tier1_build.sh
@@ -17,6 +17,6 @@ cleanup() {
 trap cleanup EXIT
 
 run_check "BUILD" bash -lc "set -o pipefail; lake build 2>&1 | tee '${build_log}'"
-run_check "BUILD" bash -lc "if rg -n '^warning:' '${build_log}'; then echo 'Lean build emitted warnings; resolve warnings before merge.' >&2; exit 1; fi"
+run_check "BUILD" bash -lc "rg -n '^warning:' '${build_log}'; status=\$?; if [ \$status -eq 0 ]; then echo 'Lean build emitted warnings; resolve warnings before merge.' >&2; exit 1; elif [ \$status -eq 1 ]; then exit 0; else echo 'Warning scan failed (rg error); cannot validate warning-free build.' >&2; exit \$status; fi"
 
 finalize_report

--- a/scripts/test_tier1_build.sh
+++ b/scripts/test_tier1_build.sh
@@ -10,6 +10,13 @@ cd "${REPO_ROOT}"
 
 ensure_lake_available
 
-run_check "BUILD" lake build
+build_log="$(mktemp)"
+cleanup() {
+  rm -f "${build_log}"
+}
+trap cleanup EXIT
+
+run_check "BUILD" bash -lc "set -o pipefail; lake build 2>&1 | tee '${build_log}'"
+run_check "BUILD" bash -lc "if rg -n '^warning:' '${build_log}'; then echo 'Lean build emitted warnings; resolve warnings before merge.' >&2; exit 1; fi"
 
 finalize_report

--- a/scripts/test_tier1_build.sh
+++ b/scripts/test_tier1_build.sh
@@ -17,6 +17,6 @@ cleanup() {
 trap cleanup EXIT
 
 run_check "BUILD" bash -lc "set -o pipefail; lake build 2>&1 | tee '${build_log}'"
-run_check "BUILD" bash -lc "rg -n '^warning:' '${build_log}'; status=\$?; if [ \$status -eq 0 ]; then echo 'Lean build emitted warnings; resolve warnings before merge.' >&2; exit 1; elif [ \$status -eq 1 ]; then exit 0; else echo 'Warning scan failed (rg error); cannot validate warning-free build.' >&2; exit \$status; fi"
+run_check "BUILD" bash -lc "if ! command -v rg >/dev/null 2>&1; then echo 'Warning scan failed: rg not found on PATH.' >&2; exit 127; fi; rg -n '^warning:' '${build_log}'; status=\$?; if [ \"\$status\" -eq 0 ]; then echo 'Lean build emitted warnings; resolve warnings before merge.' >&2; exit 1; elif [ \"\$status\" -eq 1 ]; then exit 0; else echo 'Warning scan failed (rg error); cannot validate warning-free build.' >&2; exit \"\$status\"; fi"
 
 finalize_report

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -30,6 +30,14 @@ run_check "INVARIANT" rg -n '^\s*ipcState\s*:\s*ThreadIpcState' SeLe4n/Model/Obj
 run_check "INVARIANT" rg -n '^\s*waitingReceiver\s*:\s*Option SeLe4n\.ThreadId' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^def endpointQueueWellFormed' SeLe4n/Kernel/IPC/Invariant.lean
 run_check "INVARIANT" rg -n '^def endpointObjectValid' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def blockedOnSendNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def blockedOnReceiveNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def runnableThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def currentThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def schedulerIpcCoherencePredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_schedulerIpcCoherencePredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_schedulerIpcCoherencePredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_schedulerIpcCoherencePredicates' SeLe4n/Kernel/IPC/Invariant.lean
 
 # Active milestone docs should stay synchronized for both current and next slices.
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md


### PR DESCRIPTION
### Motivation

- Close the remaining gap in the M3.5 step-3 work by proving scheduler↔IPC coherence predicates are preserved across endpoint transitions and by hardening the local CI gate to prevent Lean warning regressions.
- Ensure the code, documentation, and testing surface are internally consistent for the current M3.5 slice and that no unresolved Lean warnings are introduced at Tier 1.
- Re-audit the implementation surface to resolve warnings, add small stability lemmas, and make invariant anchors findable by the full-suite checks.

### Description

- Added four targeted scheduler↔IPC coherence predicates and a grouped entrypoint in `SeLe4n/Kernel/IPC/Invariant.lean`: `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`, `runnableThreadIpcReady`, `currentThreadIpcReady`, and `schedulerIpcCoherencePredicates`.
- Introduced tcb lookup stability lemmas for endpoint transitions (`endpointSend_tcb_lookup_iff`, `endpointAwaitReceive_tcb_lookup_iff`, `endpointReceive_tcb_lookup_iff`) and machine-checked preservation theorem entrypoints for these predicates (`endpointSend_preserves_schedulerIpcCoherencePredicates`, `endpointAwaitReceive_preserves_schedulerIpcCoherencePredicates`, `endpointReceive_preserves_schedulerIpcCoherencePredicates`) together with small simp/linter-friendly cleanups.
- Hardened the test gate and docs: updated `scripts/test_tier1_build.sh` to capture `lake build` output and fail if any `warning:` lines appear, bumped project version to `0.4.3` in `lakefile.toml`, and synchronized `README.md`, `docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`, and `docs/TESTING_FRAMEWORK_PLAN.md` to reflect the M3.5 progress and the warning-free Tier 1 requirement.
- Extended Tier-3 invariant surface script (`scripts/test_tier3_invariant_surface.sh`) to anchor the new predicates and preservation theorem names so the full-suite checks detect the step-3 artifacts.

### Testing

- Ran `lake clean && lake build` successfully and verified no `warning:` lines are emitted by the Lean build in the new Tier 1 gate.
- Executed the local validation matrix `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh` and observed all automated checks (Tier 0–3 anchors, fixture trace matches, and doc-surface checks) pass.
- Ran `./scripts/audit_testing_framework.sh` to validate the testing framework and invariant anchors, and the audit completed with expected behavior and no unresolved failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699189db7dec832bab540ec9b21d0b75)