### PR TITLE
Refresh audit and M3.5 step-3 scheduler/IPC predicates; sync docs & Tier‑3 checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
 - ✅ **M1 complete**: scheduler integrity invariants and preservation entrypoints.
 - ✅ **M2 complete**: capability + CSpace operations, attenuation/lifecycle rules, composed invariants.
 - ✅ **M3 complete**: endpoint IPC seed (`endpointSend`/`endpointReceive`) plus preservation theorem surface.
-- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-2 complete: endpoint/thread handshake fields plus explicit handshake transition branches landed).
+- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-3 complete: endpoint/thread handshake fields, explicit handshake transition branches, and targeted scheduler blocked-vs-runnable contract predicates landed).
 - 📌 **Next slice after M3.5 (planned M4)**: object lifecycle/retype safety and capability-object interaction invariants.
 
 Testing framework status:

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -209,6 +209,162 @@ def ipcInvariant (st : SystemState) : Prop :=
     st.objects oid = some (.endpoint ep) →
     endpointInvariant ep
 
+/-- Scheduler contract predicate #1 for M3.5: runnable threads are explicitly IPC-ready. -/
+def runnableThreadIpcReady (st : SystemState) : Prop :=
+  ∀ tid tcb,
+    st.objects tid = some (.tcb tcb) →
+    tid ∈ st.scheduler.runnable →
+    tcb.ipcState = .ready
+
+/-- Scheduler contract predicate #2 for M3.5: send-blocked threads are not runnable. -/
+def blockedOnSendNotRunnable (st : SystemState) : Prop :=
+  ∀ tid tcb endpointId,
+    st.objects tid = some (.tcb tcb) →
+    tcb.ipcState = .blockedOnSend endpointId →
+    tid ∉ st.scheduler.runnable
+
+/-- Scheduler contract predicate #3 for M3.5: receive-blocked threads are not runnable. -/
+def blockedOnReceiveNotRunnable (st : SystemState) : Prop :=
+  ∀ tid tcb endpointId,
+    st.objects tid = some (.tcb tcb) →
+    tcb.ipcState = .blockedOnReceive endpointId →
+    tid ∉ st.scheduler.runnable
+
+/-- Targeted scheduler/IPC coherence contract for the M3.5 step-3 slice.
+
+This intentionally avoids over-generalized abstraction: it names exactly the three obligations
+needed by current endpoint-waiting semantics. -/
+def ipcSchedulerContractPredicates (st : SystemState) : Prop :=
+  runnableThreadIpcReady st ∧
+  blockedOnSendNotRunnable st ∧
+  blockedOnReceiveNotRunnable st
+
+theorem endpointSend_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : ipcSchedulerContractPredicates st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  refine ⟨?_, ?_, ?_⟩
+  · intro tid tcb hObj hRun
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    exact hReady tid tcb hObjOrig (by simpa [hSchedEq] using hRun)
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
+    simpa [hSchedEq] using hNotRun
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
+    simpa [hSchedEq] using hNotRun
+
+theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId)
+    (hInv : ipcSchedulerContractPredicates st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
+  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  refine ⟨?_, ?_, ?_⟩
+  · intro tid tcb hObj hRun
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    exact hReady tid tcb hObjOrig (by simpa [hSchedEq] using hRun)
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
+    simpa [hSchedEq] using hNotRun
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
+    simpa [hSchedEq] using hNotRun
+
+theorem endpointReceive_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : ipcSchedulerContractPredicates st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  refine ⟨?_, ?_, ?_⟩
+  · intro tid tcb hObj hRun
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    exact hReady tid tcb hObjOrig (by simpa [hSchedEq] using hRun)
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
+    simpa [hSchedEq] using hNotRun
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) := by
+      by_cases hEq : tid = endpointId
+      · subst hEq
+        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
+        cases hObj
+      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+        exact hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
+    simpa [hSchedEq] using hNotRun
+
 theorem endpointObjectValid_of_queueWellFormed
     (ep : Endpoint)
     (hWf : endpointQueueWellFormed ep) :

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -67,7 +67,7 @@ Use this order unless a concrete dependency forces adjustment.
    - updated `endpointReceive` branching to keep explicit error outcomes for impossible waiting-receiver combinations,
    - preservation-entrypoint proofs for updated send/receive transitions remain unfold-friendly and machine-checked.
 
-3. **Scheduler contract predicates third**
+3. **Scheduler contract predicates third** ✅ **completed**
    - define targeted blocked-vs-runnable coherence predicates,
    - avoid over-generalized abstraction.
 

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -20,7 +20,7 @@ Validation commands used in this audit:
 
 ## 2. Executive summary
 
-Overall project health is **strong** for its milestone stage (post-M3 seed / pre-M3.5 handshake).
+Overall project health is **strong** for its milestone stage (post-M3 seed / active M3.5 step-3 complete).
 
 - The codebase exhibits a disciplined, executable-and-provable style.
 - Required quality gates (hygiene/build/smoke fixture) are effective and deterministic.
@@ -28,11 +28,12 @@ Overall project health is **strong** for its milestone stage (post-M3 seed / pre
 
 Key advancement in this audit cycle:
 
-- Tier 3 was moved from placeholder to an active full-suite gate (`test_tier3_invariant_surface.sh`) that checks critical invariant theorem surface anchors and doc stage markers.
+- M3.5 step-3 scheduler/IPC coherence predicates are now implemented and machine-checked preservation entrypoints exist for send/await-receive/receive.
+- Tier 3 remains active and now includes anchor checks for the new step-3 predicate/theorem surface.
 
 Primary remaining high-value path:
 
-- Develop M3.5 handshake semantics with scheduler-blocked/runnable coherence and strengthen Tier 3 from static surface checks toward semantic grouped invariant checks.
+- Complete M3.5 steps 4-7 (bundle composition, helper-lemma hardening, composed preservation entrypoints, and expanded executable story), while continuing to deepen Tier 3 from surface checks toward milestone semantic group checks.
 
 ---
 
@@ -55,7 +56,7 @@ Primary remaining high-value path:
 ### 3.3 Remaining optimization recommendations
 
 1. Introduce a small proof-style guide section for preferred lemma naming patterns by milestone bundle.
-2. Add focused theorem-group index comments around M3.5 additions to keep API discoverability high as file size grows.
+2. Add focused theorem-group index comments around M3.5 additions to keep API discoverability high as `SeLe4n/Kernel/IPC/Invariant.lean` grows.
 3. Keep transition-local helper theorems near transition definitions to maintain unfolding ergonomics.
 
 ---
@@ -81,7 +82,7 @@ Primary remaining high-value path:
 ### 4.3 Remaining testing roadmap
 
 1. Strengthen Tier 3 from static symbol-surface checks to grouped milestone semantic checks.
-2. Expand Tier 2 fixture scenarios once M3.5 waiting/handshake behavior lands.
+2. Expand Tier 2 fixture scenarios as additional M3.5 blocked/wakeup stories (steps 4-7) land.
 3. Convert Tier 4 nightly note into repeat-run determinism and broader scenario sweeps.
 
 ---
@@ -140,6 +141,6 @@ Primary remaining high-value path:
 
 ## 8. Conclusion
 
-The project is in a healthy state and technically well-positioned for M3.5 handshake work.
+The project is in a healthy state and technically well-positioned to finish the remaining M3.5 closure steps.
 
 This audit cycle improved maintainability (predicate aliasing), strengthened confidence gates (Tier 3 activation), and expanded project-level status reporting (new audit document).

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -149,8 +149,12 @@ A change set claiming M3.5 completion must satisfy all outcomes below.
   - `endpointSend` now has an explicit receive-handshake success path (`receive` + waiting receiver) and explicit state-mismatch error branches for illegal endpoint shapes,
   - `endpointReceive` now keeps explicit success/error splits over queue + waiting-receiver combinations,
   - send/receive preservation theorem entrypoints remain machine-checked after transition-surface updates.
+- ✅ **Step 3 complete (scheduler contract predicates)**
+  - added explicit scheduler/IPC coherence predicates for the active slice (`runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`),
+  - composed the targeted trio under `ipcSchedulerContractPredicates` with intentionally narrow (non-over-generalized) scope,
+  - added machine-checked preservation entrypoints for send/await-receive/receive under the new scheduler-contract predicate set.
 - ⏳ **Remaining M3.5 steps**
-  - scheduler contract predicates onward (steps 3-7) remain in progress.
+  - invariant bundle composition onward (steps 4-7) remain in progress.
 
 ---
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.4.0"
+version = "0.4.1"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -21,6 +21,15 @@ run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m3IpcSeedInvaria
 run_check "INVARIANT" rg -n '^def endpointAwaitReceive' SeLe4n/Kernel/IPC/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
+# M3.5 step-3 scheduler-contract predicate anchors must remain present.
+run_check "INVARIANT" rg -n '^def runnableThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def blockedOnSendNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def blockedOnReceiveNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+
 # Bundle composition guard: M3 seed bundle must still compose scheduler + capability + IPC invariants.
 run_check "INVARIANT" rg -n '^\s*schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st' SeLe4n/Kernel/Capability/Invariant.lean
 


### PR DESCRIPTION
### Motivation

- Capture and document the recent M3.5 step-3 work (scheduler/IPC coherence predicates) and align repository audit/status with the implemented code surface. 
- Ensure Tier‑3 invariant surface checks and documentation reflect the new scheduler/IPC obligations so milestone gating remains deterministic.

### Description

- Added targeted scheduler/IPC coherence predicates and preservation theorems in `SeLe4n/Kernel/IPC/Invariant.lean`: `runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`, `ipcSchedulerContractPredicates`, and `endpoint* _preserves_ipcSchedulerContractPredicates` theorems. 
- Extended the Tier‑3 surface test `scripts/test_tier3_invariant_surface.sh` to assert presence of the new predicates and preservation theorem anchors. 
- Updated documentation and project metadata: `docs/PROJECT_AUDIT.md`, `README.md`, `docs/DEVELOPMENT.md`, and `docs/SEL4_SPEC.md` to mark M3.5 step‑3 complete and to align roadmap wording, and bumped `lakefile.toml` `version` to `0.4.1`. 
- Small housekeeping: committed the audit narrative changes to reflect verification outcomes and tightened recommended next steps for M3.5 (steps 4–7).

### Testing

- Ran `source "$HOME/.elan/env" && ./scripts/test_fast.sh` and it passed. 
- Ran `source "$HOME/.elan/env" && ./scripts/test_smoke.sh` and it passed. 
- Ran `source "$HOME/.elan/env" && ./scripts/test_full.sh` and it passed (Tier‑3 checks included). 
- Ran `source "$HOME/.elan/env" && ./scripts/test_nightly.sh` and `./scripts/audit_testing_framework.sh` as part of the audit runs and they completed successfully. 
- Built and executed the artifact with `lake exe sele4n` and the smoke/trace fixtures matched expected outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699197fb34bc832ba1ff2e4aadad95c8)