### PR TITLE
Refine M3.5 step-4 coherence components and strengthen full-project audit coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
 - ✅ **M1 complete**: scheduler integrity invariants and preservation entrypoints.
 - ✅ **M2 complete**: capability + CSpace operations, attenuation/lifecycle rules, composed invariants.
 - ✅ **M3 complete**: endpoint IPC seed (`endpointSend`/`endpointReceive`) plus preservation theorem surface.
-- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-3 complete: endpoint/thread handshake fields, explicit handshake transition branches, and targeted scheduler blocked-vs-runnable contract predicates landed).
+- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-4 complete: endpoint/thread handshake fields, explicit handshake transition branches, targeted scheduler blocked-vs-runnable contract predicates, and composed IPC+scheduler bundle layering over `m3IpcSeedInvariantBundle`).
 - 📌 **Next slice after M3.5 (planned M4)**: object lifecycle/retype safety and capability-object interaction invariants.
 
 Testing framework status:

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -384,6 +384,34 @@ theorem cspaceRevoke_preserves_capabilityInvariantBundle
 def m3IpcSeedInvariantBundle (st : SystemState) : Prop :=
   schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st
 
+/-- Named M3.5 coherence component: runnable threads stay IPC-ready. -/
+def ipcSchedulerRunnableReadyComponent (st : SystemState) : Prop :=
+  runnableThreadIpcReady st
+
+/-- Named M3.5 coherence component: send-blocked threads are not runnable. -/
+def ipcSchedulerBlockedSendComponent (st : SystemState) : Prop :=
+  blockedOnSendNotRunnable st
+
+/-- Named M3.5 coherence component: receive-blocked threads are not runnable. -/
+def ipcSchedulerBlockedReceiveComponent (st : SystemState) : Prop :=
+  blockedOnReceiveNotRunnable st
+
+/-- Named M3.5 aggregate coherence component for IPC+scheduler interaction. -/
+def ipcSchedulerCoherenceComponent (st : SystemState) : Prop :=
+  ipcSchedulerRunnableReadyComponent st ∧
+  ipcSchedulerBlockedSendComponent st ∧
+  ipcSchedulerBlockedReceiveComponent st
+
+theorem ipcSchedulerCoherenceComponent_iff_contractPredicates (st : SystemState) :
+    ipcSchedulerCoherenceComponent st ↔ ipcSchedulerContractPredicates st := by
+  rfl
+
+/-- M3.5 composed bundle entrypoint layered over the M3 IPC seed bundle.
+
+This is the step-4 composition target for active-slice endpoint/scheduler coupling. -/
+def m35IpcSchedulerInvariantBundle (st : SystemState) : Prop :=
+  m3IpcSeedInvariantBundle st ∧ ipcSchedulerCoherenceComponent st
+
 theorem endpointSend_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
@@ -455,5 +483,50 @@ theorem endpointReceive_preserves_m3IpcSeedInvariantBundle
   · exact endpointReceive_preserves_schedulerInvariantBundle st st' endpointId sender hSched hStep
   · exact endpointReceive_preserves_capabilityInvariantBundle st st' endpointId sender hCap hStep
   · exact endpointReceive_preserves_ipcInvariant st st' endpointId sender hIpc hStep
+
+theorem endpointSend_preserves_m35IpcSchedulerInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : m35IpcSchedulerInvariantBundle st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    m35IpcSchedulerInvariantBundle st' := by
+  rcases hInv with ⟨hM3Seed, hIpcSched⟩
+  have hContract : ipcSchedulerContractPredicates st :=
+    (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
+  refine ⟨?_, ?_⟩
+  · exact endpointSend_preserves_m3IpcSeedInvariantBundle st st' endpointId sender hM3Seed hStep
+  · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
+      (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender hContract hStep)
+
+theorem endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId)
+    (hInv : m35IpcSchedulerInvariantBundle st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    m35IpcSchedulerInvariantBundle st' := by
+  rcases hInv with ⟨hM3Seed, hIpcSched⟩
+  have hContract : ipcSchedulerContractPredicates st :=
+    (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
+  refine ⟨?_, ?_⟩
+  · exact endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId receiver hM3Seed hStep
+  · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
+      (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver hContract hStep)
+
+theorem endpointReceive_preserves_m35IpcSchedulerInvariantBundle
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : m35IpcSchedulerInvariantBundle st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    m35IpcSchedulerInvariantBundle st' := by
+  rcases hInv with ⟨hM3Seed, hIpcSched⟩
+  have hContract : ipcSchedulerContractPredicates st :=
+    (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
+  refine ⟨?_, ?_⟩
+  · exact endpointReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId sender hM3Seed hStep
+  · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
+      (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender hContract hStep)
 
 end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -71,7 +71,7 @@ Use this order unless a concrete dependency forces adjustment.
    - define targeted blocked-vs-runnable coherence predicates,
    - avoid over-generalized abstraction.
 
-4. **Invariant bundle composition fourth**
+4. **Invariant bundle composition fourth** ✅ **completed**
    - add named IPC+scheduler coherence components,
    - layer over `m3IpcSeedInvariantBundle`.
 

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -20,7 +20,7 @@ Validation commands used in this audit:
 
 ## 2. Executive summary
 
-Overall project health is **strong** for its milestone stage (post-M3 seed / active M3.5 step-3 complete).
+Overall project health is **strong** for its milestone stage (post-M3 seed / active M3.5 step-4 complete).
 
 - The codebase exhibits a disciplined, executable-and-provable style.
 - Required quality gates (hygiene/build/smoke fixture) are effective and deterministic.
@@ -28,12 +28,12 @@ Overall project health is **strong** for its milestone stage (post-M3 seed / act
 
 Key advancement in this audit cycle:
 
-- M3.5 step-3 scheduler/IPC coherence predicates are now implemented and machine-checked preservation entrypoints exist for send/await-receive/receive.
+- M3.5 step-3 scheduler/IPC coherence predicates are implemented and now lifted into a named step-4 composed bundle (`m35IpcSchedulerInvariantBundle`) layered over `m3IpcSeedInvariantBundle` with explicit named coherence subcomponents, with machine-checked preservation entrypoints for send/await-receive/receive.
 - Tier 3 remains active and now includes anchor checks for the new step-3 predicate/theorem surface.
 
 Primary remaining high-value path:
 
-- Complete M3.5 steps 4-7 (bundle composition, helper-lemma hardening, composed preservation entrypoints, and expanded executable story), while continuing to deepen Tier 3 from surface checks toward milestone semantic group checks.
+- Complete M3.5 steps 5-7 (helper-lemma hardening, further composed preservation/theorem hardening, and expanded executable story), while continuing to deepen Tier 3 from surface checks toward milestone semantic group checks.
 
 ---
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -153,8 +153,12 @@ A change set claiming M3.5 completion must satisfy all outcomes below.
   - added explicit scheduler/IPC coherence predicates for the active slice (`runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`),
   - composed the targeted trio under `ipcSchedulerContractPredicates` with intentionally narrow (non-over-generalized) scope,
   - added machine-checked preservation entrypoints for send/await-receive/receive under the new scheduler-contract predicate set.
+- ✅ **Step 4 complete (invariant bundle composition)**
+  - added named IPC+scheduler coherence components (`ipcSchedulerRunnableReadyComponent`, `ipcSchedulerBlockedSendComponent`, `ipcSchedulerBlockedReceiveComponent`) and aggregated them under `ipcSchedulerCoherenceComponent`,
+  - introduced composed `m35IpcSchedulerInvariantBundle` layered directly over `m3IpcSeedInvariantBundle`,
+  - added machine-checked preservation entrypoints for send/await-receive/receive over the new composed M3.5 bundle.
 - ⏳ **Remaining M3.5 steps**
-  - invariant bundle composition onward (steps 4-7) remain in progress.
+  - helper lemmas onward (steps 5-7) remain in progress.
 
 ---
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.4.1"
+version = "0.4.3"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -30,6 +30,17 @@ run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_ipcSchedulerContrac
 run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
 
+# M3.5 step-4 composed bundle anchors must remain present.
+run_check "INVARIANT" rg -n '^def ipcSchedulerRunnableReadyComponent' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^def ipcSchedulerBlockedSendComponent' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^def ipcSchedulerBlockedReceiveComponent' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^def ipcSchedulerCoherenceComponent' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem ipcSchedulerCoherenceComponent_iff_contractPredicates' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^def m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+
 # Bundle composition guard: M3 seed bundle must still compose scheduler + capability + IPC invariants.
 run_check "INVARIANT" rg -n '^\s*schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st' SeLe4n/Kernel/Capability/Invariant.lean
 


### PR DESCRIPTION
### Motivation

- Clarify and harden the M3.5 IPC↔scheduler composition by making the scheduler-facing coherence obligations explicit and modular so downstream helper lemmas and composed preservation work can land without changing M1–M3 contracts.
- Ensure the repository-level invariant surface and milestone docs accurately reflect the implemented composition so CI anchors, docs, and proofs stay synchronized.

### Description

- Factor the prior single `ipcSchedulerCoherenceComponent` into three named subcomponents `ipcSchedulerRunnableReadyComponent`, `ipcSchedulerBlockedSendComponent`, and `ipcSchedulerBlockedReceiveComponent`, and recompose them under `ipcSchedulerCoherenceComponent` in `SeLe4n/Kernel/Capability/Invariant.lean`.
- Add a bridge theorem `ipcSchedulerCoherenceComponent_iff_contractPredicates` and update the M3.5 composed preservation entrypoints (`endpointSend_preserves_m35IpcSchedulerInvariantBundle`, `endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle`, `endpointReceive_preserves_m35IpcSchedulerInvariantBundle`) to convert between the contract-level predicates and the bundle-level component during proofs.
- Extend Tier-3 invariant surface checks (`scripts/test_tier3_invariant_surface.sh`) to anchor the new subcomponents and the bridge theorem, and update `docs/SEL4_SPEC.md`, `docs/PROJECT_AUDIT.md`, and `docs/DEVELOPMENT.md` to describe the plural components and step-4 completion.
- Bump project version to `0.4.3` in `lakefile.toml` and install `shellcheck` to enable real Tier-0 shell linting during the audit.

### Testing

- Ran `./scripts/test_fast.sh` and it completed successfully (hygiene + build checks passed).
- Ran `./scripts/test_smoke.sh` and `./scripts/test_full.sh` and both completed successfully including build, smoke fixtures, and Tier-3 invariant surface anchors.
- Ran `./scripts/test_nightly.sh` and `./scripts/audit_testing_framework.sh` as part of the audit sweep; the audit harness executed fully and flagged an expected Tier-2 control-data trace mismatch (the harness intentionally detects this scenario), otherwise audit checks passed.
- `shellcheck` installation completed successfully (an unrelated external apt source emitted a non-blocking 403 warning but did not affect the installation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69921f4a4cc0832ba18bf256952c9908)