### PR TITLE
Factor IPC scheduler-contract preservation core and tighten step-5 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
 - ✅ **M1 complete**: scheduler integrity invariants and preservation entrypoints.
 - ✅ **M2 complete**: capability + CSpace operations, attenuation/lifecycle rules, composed invariants.
 - ✅ **M3 complete**: endpoint IPC seed (`endpointSend`/`endpointReceive`) plus preservation theorem surface.
-- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-4 complete: endpoint/thread handshake fields, explicit handshake transition branches, targeted scheduler blocked-vs-runnable contract predicates, and composed IPC+scheduler bundle layering over `m3IpcSeedInvariantBundle`).
+- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-5 complete: endpoint/thread handshake fields, explicit handshake transition branches, targeted scheduler blocked-vs-runnable contract predicates, composed IPC+scheduler bundle layering over `m3IpcSeedInvariantBundle`, and local endpoint-store helper lemmas used by transition-preservation proofs).
 - 📌 **Next slice after M3.5 (planned M4)**: object lifecycle/retype safety and capability-object interaction invariants.
 
 Testing framework status:

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -59,6 +59,9 @@ def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
     | some _ => .error .invalidCapability
     | none => .error .objectNotFound
 
+/- Local store/lookup transport lemmas (M3.5 step-5).
+These lemmas keep endpoint-transition preservation proofs concrete and non-duplicative. -/
+
 /-- Generic object-store update lemma: writing at `id` makes that slot resolve to `obj`. -/
 theorem storeObject_objects_eq
     (st st' : SystemState)
@@ -91,6 +94,51 @@ theorem storeObject_scheduler_eq
   unfold storeObject at hStore
   cases hStore
   rfl
+
+/-- Local lookup helper for endpoint transitions:
+if an endpoint-object store succeeds, any TCB lookup in the post-state
+comes from the pre-state. -/
+theorem tcb_lookup_of_endpoint_store
+    (st st' : SystemState)
+    (endpointId tid : SeLe4n.ObjId)
+    (tcb : TCB)
+    (ep' : Endpoint)
+    (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
+    (hObj : st'.objects tid = some (.tcb tcb)) :
+    st.objects tid = some (.tcb tcb) := by
+  by_cases hEq : tid = endpointId
+  · have hObjAtEndpoint : st'.objects endpointId = some (.tcb tcb) := by
+      simpa [hEq] using hObj
+    rw [storeObject_objects_eq st st' endpointId (.endpoint ep') hStore] at hObjAtEndpoint
+    cases hObjAtEndpoint
+  · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
+    exact hObj
+
+/-- Scheduler-local helper for endpoint transitions:
+endpoint-object stores do not alter runnable-set membership goals. -/
+theorem runnable_membership_of_endpoint_store
+    (st st' : SystemState)
+    (endpointId tid : SeLe4n.ObjId)
+    (ep' : Endpoint)
+    (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
+    (hRun : tid ∈ st'.scheduler.runnable) :
+    tid ∈ st.scheduler.runnable := by
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  simpa [hSchedEq] using hRun
+
+/-- Scheduler-local helper for endpoint transitions:
+endpoint-object stores do not alter non-runnable goals. -/
+theorem not_runnable_membership_of_endpoint_store
+    (st st' : SystemState)
+    (endpointId tid : SeLe4n.ObjId)
+    (ep' : Endpoint)
+    (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
+    (hNotRun : tid ∉ st.scheduler.runnable) :
+    tid ∉ st'.scheduler.runnable := by
+  have hSchedEq : st'.scheduler = st.scheduler :=
+    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
+  simpa [hSchedEq] using hNotRun
 
 
 /-- Local transition helper: successful send is exactly one endpoint-object update. -/
@@ -239,6 +287,34 @@ def ipcSchedulerContractPredicates (st : SystemState) : Prop :=
   blockedOnSendNotRunnable st ∧
   blockedOnReceiveNotRunnable st
 
+/-- Shared local proof core: any successful endpoint-object store preserves
+M3.5 scheduler-contract predicates. -/
+theorem endpointStore_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (ep' : Endpoint)
+    (hInv : ipcSchedulerContractPredicates st)
+    (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
+  refine ⟨?_, ?_, ?_⟩
+  · intro tid tcb hObj hRun
+    have hObjOrig : st.objects tid = some (.tcb tcb) :=
+      tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+    have hRunOrig : tid ∈ st.scheduler.runnable :=
+      runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
+    exact hReady tid tcb hObjOrig hRunOrig
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) :=
+      tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
+    exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
+  · intro tid tcb endpoint hObj hBlocked
+    have hObjOrig : st.objects tid = some (.tcb tcb) :=
+      tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
+    exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
+
 theorem endpointSend_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
@@ -246,40 +322,8 @@ theorem endpointSend_preserves_ipcSchedulerContractPredicates
     (hInv : ipcSchedulerContractPredicates st)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
     ipcSchedulerContractPredicates st' := by
-  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
   rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  have hSchedEq : st'.scheduler = st.scheduler :=
-    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
-  refine ⟨?_, ?_, ?_⟩
-  · intro tid tcb hObj hRun
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    exact hReady tid tcb hObjOrig (by simpa [hSchedEq] using hRun)
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
-    simpa [hSchedEq] using hNotRun
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
-    simpa [hSchedEq] using hNotRun
+  exact endpointStore_preserves_ipcSchedulerContractPredicates st st' endpointId ep' hInv hStore
 
 theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState)
@@ -288,40 +332,8 @@ theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
     (hInv : ipcSchedulerContractPredicates st)
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
     ipcSchedulerContractPredicates st' := by
-  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
   rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
-  have hSchedEq : st'.scheduler = st.scheduler :=
-    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
-  refine ⟨?_, ?_, ?_⟩
-  · intro tid tcb hObj hRun
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    exact hReady tid tcb hObjOrig (by simpa [hSchedEq] using hRun)
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
-    simpa [hSchedEq] using hNotRun
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
-    simpa [hSchedEq] using hNotRun
+  exact endpointStore_preserves_ipcSchedulerContractPredicates st st' endpointId ep' hInv hStore
 
 theorem endpointReceive_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState)
@@ -330,40 +342,8 @@ theorem endpointReceive_preserves_ipcSchedulerContractPredicates
     (hInv : ipcSchedulerContractPredicates st)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
     ipcSchedulerContractPredicates st' := by
-  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
   rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  have hSchedEq : st'.scheduler = st.scheduler :=
-    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
-  refine ⟨?_, ?_, ?_⟩
-  · intro tid tcb hObj hRun
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    exact hReady tid tcb hObjOrig (by simpa [hSchedEq] using hRun)
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
-    simpa [hSchedEq] using hNotRun
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) := by
-      by_cases hEq : tid = endpointId
-      · subst hEq
-        rw [storeObject_objects_eq st st' tid (.endpoint ep') hStore] at hObj
-        cases hObj
-      · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-        exact hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
-    simpa [hSchedEq] using hNotRun
+  exact endpointStore_preserves_ipcSchedulerContractPredicates st st' endpointId ep' hInv hStore
 
 theorem endpointObjectValid_of_queueWellFormed
     (ep : Endpoint)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,9 +75,9 @@ Use this order unless a concrete dependency forces adjustment.
    - add named IPC+scheduler coherence components,
    - layer over `m3IpcSeedInvariantBundle`.
 
-5. **Helper lemmas fifth**
-   - add local store/lookup lemmas near transitions,
-   - prefer small lemmas that discharge concrete proof obligations.
+5. **Helper lemmas fifth** ✅ **completed**
+   - added local endpoint-store lookup helpers near IPC transitions (`tcb_lookup_of_endpoint_store`, runnable/non-runnable scheduler membership transport lemmas),
+   - preservation proofs now consume these small lemmas directly to discharge concrete object-lookup and runnable-set obligations without duplicated case analysis.
 
 6. **Preservation theorems sixth**
    - prove local invariants first, composed bundles second,

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -20,7 +20,7 @@ Validation commands used in this audit:
 
 ## 2. Executive summary
 
-Overall project health is **strong** for its milestone stage (post-M3 seed / active M3.5 step-4 complete).
+Overall project health is **strong** for its milestone stage (post-M3 seed / active M3.5 step-5 complete).
 
 - The codebase exhibits a disciplined, executable-and-provable style.
 - Required quality gates (hygiene/build/smoke fixture) are effective and deterministic.
@@ -28,12 +28,12 @@ Overall project health is **strong** for its milestone stage (post-M3 seed / act
 
 Key advancement in this audit cycle:
 
-- M3.5 step-3 scheduler/IPC coherence predicates are implemented and now lifted into a named step-4 composed bundle (`m35IpcSchedulerInvariantBundle`) layered over `m3IpcSeedInvariantBundle` with explicit named coherence subcomponents, with machine-checked preservation entrypoints for send/await-receive/receive.
-- Tier 3 remains active and now includes anchor checks for the new step-3 predicate/theorem surface.
+- M3.5 step-3 scheduler/IPC coherence predicates and step-4 composed bundle layering (`m35IpcSchedulerInvariantBundle` over `m3IpcSeedInvariantBundle`) are in place, and step-5 local endpoint-store helper lemmas now discharge recurring lookup/runnable obligations in machine-checked send/await-receive/receive preservation proofs.
+- Tier 3 remains active and now includes anchor checks through the new step-5 helper-lemma surface.
 
 Primary remaining high-value path:
 
-- Complete M3.5 steps 5-7 (helper-lemma hardening, further composed preservation/theorem hardening, and expanded executable story), while continuing to deepen Tier 3 from surface checks toward milestone semantic group checks.
+- Complete M3.5 steps 6-7 (further composed preservation/theorem hardening and expanded executable story), while continuing to deepen Tier 3 from surface checks toward milestone semantic group checks.
 
 ---
 
@@ -82,7 +82,7 @@ Primary remaining high-value path:
 ### 4.3 Remaining testing roadmap
 
 1. Strengthen Tier 3 from static symbol-surface checks to grouped milestone semantic checks.
-2. Expand Tier 2 fixture scenarios as additional M3.5 blocked/wakeup stories (steps 4-7) land.
+2. Expand Tier 2 fixture scenarios as additional M3.5 blocked/wakeup stories (steps 5-7) land.
 3. Convert Tier 4 nightly note into repeat-run determinism and broader scenario sweeps.
 
 ---

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -157,8 +157,11 @@ A change set claiming M3.5 completion must satisfy all outcomes below.
   - added named IPC+scheduler coherence components (`ipcSchedulerRunnableReadyComponent`, `ipcSchedulerBlockedSendComponent`, `ipcSchedulerBlockedReceiveComponent`) and aggregated them under `ipcSchedulerCoherenceComponent`,
   - introduced composed `m35IpcSchedulerInvariantBundle` layered directly over `m3IpcSeedInvariantBundle`,
   - added machine-checked preservation entrypoints for send/await-receive/receive over the new composed M3.5 bundle.
+- ✅ **Step 5 complete (helper lemmas)**
+  - added local endpoint-store lookup helpers near transitions (`tcb_lookup_of_endpoint_store`, `runnable_membership_of_endpoint_store`, `not_runnable_membership_of_endpoint_store`),
+  - send/await-receive/receive scheduler-contract preservation proofs now discharge concrete lookup/runnable obligations via these small local lemmas rather than repeated ad hoc case splits.
 - ⏳ **Remaining M3.5 steps**
-  - helper lemmas onward (steps 5-7) remain in progress.
+  - preservation-theorem hardening and executable-demonstration extension (steps 6-7) remain in progress.
 
 ---
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -14,7 +14,7 @@ Current repository status:
 - ✅ Work package B (fixture-backed executable smoke baseline) implemented.
 - ✅ Work package C (CI wiring to script entrypoints) implemented.
 - ✅ Work package D (docs integration) implemented.
-- ✅ Work package E (Tier 3 invariant/doc-surface checks) implemented.
+- ✅ Work package E (Tier 3 invariant/doc-surface checks) implemented, including M3.5 step-1 through step-5 theorem/lemma surface anchors.
 
 ---
 
@@ -63,7 +63,7 @@ Both are required pull-request CI jobs.
 - `./scripts/test_full.sh` runs Tier 3 invariant/doc-surface checks.
 - `./scripts/test_nightly.sh` runs full plus Tier 4 extension notice.
 
-Tier 3 is now active in the full suite; Tier 4 remains the next expansion hook.
+Tier 3 is now active in the full suite and includes milestone-surface anchors through current M3.5 step-5 helper lemmas; Tier 4 remains the next expansion hook.
 
 ---
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.4.3"
+version = "0.4.5"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -41,6 +41,11 @@ run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m35IpcSchedulerInva
 run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
+# M3.5 step-5 helper-lemma anchors must remain present.
+run_check "INVARIANT" rg -n '^theorem tcb_lookup_of_endpoint_store' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem runnable_membership_of_endpoint_store' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem not_runnable_membership_of_endpoint_store' SeLe4n/Kernel/IPC/Invariant.lean
+
 # Bundle composition guard: M3 seed bundle must still compose scheduler + capability + IPC invariants.
 run_check "INVARIANT" rg -n '^\s*schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st' SeLe4n/Kernel/Capability/Invariant.lean
 


### PR DESCRIPTION
### Motivation
- Reduce duplicated case analysis in the IPC transition preservation proofs by introducing a shared local preservation core that reuses small, local endpoint-store transport lemmas. 
- Keep the M3.5 milestone surface, documentation, and Tier 3 invariant anchors synchronized with the new helper-lemma proof surface. 
- Make the proof surface easier to maintain while preserving explicit, concrete obligations needed for the current development slice. 

### Description
- Introduced a shared preservation core theorem `endpointStore_preserves_ipcSchedulerContractPredicates` in `SeLe4n/Kernel/IPC/Invariant.lean` to capture the common post-store reasoning for scheduler/IPC contract predicates. 
- Added and kept local endpoint-store transport lemmas: `tcb_lookup_of_endpoint_store`, `runnable_membership_of_endpoint_store`, and `not_runnable_membership_of_endpoint_store` and used them from the shared core. 
- Refactored `endpointSend_preserves_ipcSchedulerContractPredicates`, `endpointAwaitReceive_preserves_ipcSchedulerContractPredicates`, and `endpointReceive_preserves_ipcSchedulerContractPredicates` to extract their per-transition `..._ok_as_storeObject` witness and delegate the remainder to the new shared theorem. 
- Updated Tier 3 surface checks ordering and anchors in `scripts/test_tier3_invariant_surface.sh`, bumped the project version in `lakefile.toml` to `0.4.5`, and updated README/docs (`docs/DEVELOPMENT.md`, `docs/PROJECT_AUDIT.md`, `docs/SEL4_SPEC.md`, `docs/TESTING_FRAMEWORK_PLAN.md`) to reflect the step-5 proof surface. 

### Testing
- Ran `./scripts/test_fast.sh` (Tier 0 + Tier 1 build) and it completed successfully. 
- Ran `./scripts/test_smoke.sh` (Tier 0 + Tier 1 + Tier 2 fixtures) and `./scripts/test_full.sh` (full suite including Tier 3) and both completed successfully. 
- Ran the framework audit `./scripts/audit_testing_framework.sh` which executes the full validation pipeline and observed a passing audit run; optional `shellcheck` was installed so Tier 0 hygiene now includes shell linting during this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699224722d38832b95b3352b701e2dd4)