### PR TITLE
Prune unused IPC preservation helper and add local-first preservation theorems for M3.5 step-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
+seLe4n is currently in a **post-M3 IPC seed / mid-M3.5 handshake** stage.
 
 ### Milestone board (authoritative)
 
@@ -13,7 +13,7 @@ seLe4n is currently in a **post-M3 IPC seed / pre-M3.5 handshake** stage.
 - ✅ **M1 complete**: scheduler integrity invariants and preservation entrypoints.
 - ✅ **M2 complete**: capability + CSpace operations, attenuation/lifecycle rules, composed invariants.
 - ✅ **M3 complete**: endpoint IPC seed (`endpointSend`/`endpointReceive`) plus preservation theorem surface.
-- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-5 complete: endpoint/thread handshake fields, explicit handshake transition branches, targeted scheduler blocked-vs-runnable contract predicates, composed IPC+scheduler bundle layering over `m3IpcSeedInvariantBundle`, and local endpoint-store helper lemmas used by transition-preservation proofs).
+- 🚧 **M3.5 in progress target**: typed waiting/handshake behavior with scheduler coherence obligations (steps 1-6 complete: endpoint/thread handshake fields, explicit handshake transition branches, targeted scheduler blocked-vs-runnable contract predicates, composed IPC+scheduler bundle layering over `m3IpcSeedInvariantBundle`, local endpoint-store helper lemmas, and local-first preservation theorem layering with `<transition>_preserves_<invariant>` naming).
 - 📌 **Next slice after M3.5 (planned M4)**: object lifecycle/retype safety and capability-object interaction invariants.
 
 Testing framework status:

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -287,33 +287,48 @@ def ipcSchedulerContractPredicates (st : SystemState) : Prop :=
   blockedOnSendNotRunnable st ∧
   blockedOnReceiveNotRunnable st
 
-/-- Shared local proof core: any successful endpoint-object store preserves
-M3.5 scheduler-contract predicates. -/
-theorem endpointStore_preserves_ipcSchedulerContractPredicates
+theorem endpointSend_preserves_runnableThreadIpcReady
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
-    (ep' : Endpoint)
-    (hInv : ipcSchedulerContractPredicates st)
-    (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st')) :
-    ipcSchedulerContractPredicates st' := by
-  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
-  refine ⟨?_, ?_, ?_⟩
-  · intro tid tcb hObj hRun
-    have hObjOrig : st.objects tid = some (.tcb tcb) :=
-      tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
-    have hRunOrig : tid ∈ st.scheduler.runnable :=
-      runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
-    exact hReady tid tcb hObjOrig hRunOrig
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) :=
-      tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedSend tid tcb endpoint hObjOrig hBlocked
-    exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
-  · intro tid tcb endpoint hObj hBlocked
-    have hObjOrig : st.objects tid = some (.tcb tcb) :=
-      tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
-    have hNotRun : tid ∉ st.scheduler.runnable := hBlockedReceive tid tcb endpoint hObjOrig hBlocked
-    exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
+    (sender : SeLe4n.ThreadId)
+    (hInv : runnableThreadIpcReady st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    runnableThreadIpcReady st' := by
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  intro tid tcb hObj hRun
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hRunOrig : tid ∈ st.scheduler.runnable :=
+    runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
+  exact hInv tid tcb hObjOrig hRunOrig
+
+theorem endpointSend_preserves_blockedOnSendNotRunnable
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : blockedOnSendNotRunnable st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    blockedOnSendNotRunnable st' := by
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  intro tid tcb endpoint hObj hBlocked
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
+  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
+
+theorem endpointSend_preserves_blockedOnReceiveNotRunnable
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    blockedOnReceiveNotRunnable st' := by
+  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  intro tid tcb endpoint hObj hBlocked
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
+  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
 theorem endpointSend_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState)
@@ -322,8 +337,54 @@ theorem endpointSend_preserves_ipcSchedulerContractPredicates
     (hInv : ipcSchedulerContractPredicates st)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
     ipcSchedulerContractPredicates st' := by
-  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  exact endpointStore_preserves_ipcSchedulerContractPredicates st st' endpointId ep' hInv hStore
+  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
+  refine ⟨?_, ?_, ?_⟩
+  · exact endpointSend_preserves_runnableThreadIpcReady st st' endpointId sender hReady hStep
+  · exact endpointSend_preserves_blockedOnSendNotRunnable st st' endpointId sender hBlockedSend hStep
+  · exact endpointSend_preserves_blockedOnReceiveNotRunnable st st' endpointId sender hBlockedReceive hStep
+
+theorem endpointAwaitReceive_preserves_runnableThreadIpcReady
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId)
+    (hInv : runnableThreadIpcReady st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    runnableThreadIpcReady st' := by
+  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
+  intro tid tcb hObj hRun
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hRunOrig : tid ∈ st.scheduler.runnable :=
+    runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
+  exact hInv tid tcb hObjOrig hRunOrig
+
+theorem endpointAwaitReceive_preserves_blockedOnSendNotRunnable
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId)
+    (hInv : blockedOnSendNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    blockedOnSendNotRunnable st' := by
+  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
+  intro tid tcb endpoint hObj hBlocked
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
+  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
+
+theorem endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId)
+    (hInv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    blockedOnReceiveNotRunnable st' := by
+  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
+  intro tid tcb endpoint hObj hBlocked
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
+  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
 theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState)
@@ -332,8 +393,54 @@ theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
     (hInv : ipcSchedulerContractPredicates st)
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
     ipcSchedulerContractPredicates st' := by
-  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
-  exact endpointStore_preserves_ipcSchedulerContractPredicates st st' endpointId ep' hInv hStore
+  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
+  refine ⟨?_, ?_, ?_⟩
+  · exact endpointAwaitReceive_preserves_runnableThreadIpcReady st st' endpointId receiver hReady hStep
+  · exact endpointAwaitReceive_preserves_blockedOnSendNotRunnable st st' endpointId receiver hBlockedSend hStep
+  · exact endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable st st' endpointId receiver hBlockedReceive hStep
+
+theorem endpointReceive_preserves_runnableThreadIpcReady
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : runnableThreadIpcReady st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    runnableThreadIpcReady st' := by
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  intro tid tcb hObj hRun
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hRunOrig : tid ∈ st.scheduler.runnable :=
+    runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
+  exact hInv tid tcb hObjOrig hRunOrig
+
+theorem endpointReceive_preserves_blockedOnSendNotRunnable
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : blockedOnSendNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    blockedOnSendNotRunnable st' := by
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  intro tid tcb endpoint hObj hBlocked
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
+  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
+
+theorem endpointReceive_preserves_blockedOnReceiveNotRunnable
+    (st st' : SystemState)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId)
+    (hInv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    blockedOnReceiveNotRunnable st' := by
+  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
+  intro tid tcb endpoint hObj hBlocked
+  have hObjOrig : st.objects tid = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
+  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
 theorem endpointReceive_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState)
@@ -342,8 +449,11 @@ theorem endpointReceive_preserves_ipcSchedulerContractPredicates
     (hInv : ipcSchedulerContractPredicates st)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
     ipcSchedulerContractPredicates st' := by
-  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  exact endpointStore_preserves_ipcSchedulerContractPredicates st st' endpointId ep' hInv hStore
+  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
+  refine ⟨?_, ?_, ?_⟩
+  · exact endpointReceive_preserves_runnableThreadIpcReady st st' endpointId sender hReady hStep
+  · exact endpointReceive_preserves_blockedOnSendNotRunnable st st' endpointId sender hBlockedSend hStep
+  · exact endpointReceive_preserves_blockedOnReceiveNotRunnable st st' endpointId sender hBlockedReceive hStep
 
 theorem endpointObjectValid_of_queueWellFormed
     (ep : Endpoint)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines the expected engineering workflow for seLe4n contributors.
 
-Current project stage: **post-M3 seed / pre-M3.5 handshake completion**.
+Current project stage: **post-M3 seed / mid-M3.5 handshake completion**.
 
 Primary contributor goals:
 
@@ -79,9 +79,10 @@ Use this order unless a concrete dependency forces adjustment.
    - added local endpoint-store lookup helpers near IPC transitions (`tcb_lookup_of_endpoint_store`, runnable/non-runnable scheduler membership transport lemmas),
    - preservation proofs now consume these small lemmas directly to discharge concrete object-lookup and runnable-set obligations without duplicated case analysis.
 
-6. **Preservation theorems sixth**
-   - prove local invariants first, composed bundles second,
-   - use `<transition>_preserves_<invariant>` naming.
+6. **Preservation theorems sixth** ✅ **completed**
+   - endpoint transitions now prove local scheduler-contract components first (`runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`),
+   - composed preservation (`ipcSchedulerContractPredicates`, `m35IpcSchedulerInvariantBundle`) is layered after those local theorems,
+   - new theorem entrypoints follow `<transition>_preserves_<invariant>` naming throughout step-6 additions.
 
 7. **Executable demonstration last**
    - extend `Main.lean` with a concrete M3.5 story,

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -12,8 +12,8 @@ It has five jobs:
 4. Declare what is out of scope so review stays focused.
 5. Provide acceptance gates that can be validated locally.
 
-The project is currently in a **post-M3-seed / pre-M3.5** stage: M1 scheduler invariants, M2
-capability semantics, and M3 endpoint send/receive seed semantics are complete and executable.
+The project is currently in a **post-M3-seed / mid-M3.5** stage: M1 scheduler invariants, M2
+capability semantics, and M3 endpoint send/receive seed semantics are complete and executable, while M3.5 step 7 remains open.
 
 Testing baseline status: Tier 0 hygiene checks, Tier 1 build checks, and Tier 2 fixture-backed
 executable smoke checks are implemented under `scripts/test_*.sh` and enforced in pull-request CI.
@@ -160,8 +160,11 @@ A change set claiming M3.5 completion must satisfy all outcomes below.
 - ✅ **Step 5 complete (helper lemmas)**
   - added local endpoint-store lookup helpers near transitions (`tcb_lookup_of_endpoint_store`, `runnable_membership_of_endpoint_store`, `not_runnable_membership_of_endpoint_store`),
   - send/await-receive/receive scheduler-contract preservation proofs now discharge concrete lookup/runnable obligations via these small local lemmas rather than repeated ad hoc case splits.
+- ✅ **Step 6 complete (preservation-theorem hardening)**
+  - endpoint transitions now expose local-first preservation theorems for scheduler-contract components (`<transition>_preserves_runnableThreadIpcReady`, `<transition>_preserves_blockedOnSendNotRunnable`, `<transition>_preserves_blockedOnReceiveNotRunnable`),
+  - composed scheduler-contract and M3.5 bundle preservation theorems are layered second and continue to compile machine-checked.
 - ⏳ **Remaining M3.5 steps**
-  - preservation-theorem hardening and executable-demonstration extension (steps 6-7) remain in progress.
+  - executable-demonstration extension (step 7) remains in progress.
 
 ---
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -14,7 +14,7 @@ Current repository status:
 - ✅ Work package B (fixture-backed executable smoke baseline) implemented.
 - ✅ Work package C (CI wiring to script entrypoints) implemented.
 - ✅ Work package D (docs integration) implemented.
-- ✅ Work package E (Tier 3 invariant/doc-surface checks) implemented, including M3.5 step-1 through step-5 theorem/lemma surface anchors.
+- ✅ Work package E (Tier 3 invariant/doc-surface checks) implemented, including M3.5 step-1 through step-6 theorem/lemma surface anchors.
 
 ---
 
@@ -63,7 +63,7 @@ Both are required pull-request CI jobs.
 - `./scripts/test_full.sh` runs Tier 3 invariant/doc-surface checks.
 - `./scripts/test_nightly.sh` runs full plus Tier 4 extension notice.
 
-Tier 3 is now active in the full suite and includes milestone-surface anchors through current M3.5 step-5 helper lemmas; Tier 4 remains the next expansion hook.
+Tier 3 is now active in the full suite and includes milestone-surface anchors through current M3.5 step-6 local-first preservation theorem layer; Tier 4 remains the next expansion hook.
 
 ---
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.4.5"
+version = "0.4.6"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -41,6 +41,17 @@ run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m35IpcSchedulerInva
 run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
+# M3.5 step-6 local-first preservation-theorem anchors must remain present.
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_runnableThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_blockedOnSendNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_blockedOnReceiveNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_runnableThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_blockedOnSendNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_runnableThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_blockedOnSendNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_blockedOnReceiveNotRunnable' SeLe4n/Kernel/IPC/Invariant.lean
+
 # M3.5 step-5 helper-lemma anchors must remain present.
 run_check "INVARIANT" rg -n '^theorem tcb_lookup_of_endpoint_store' SeLe4n/Kernel/IPC/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem runnable_membership_of_endpoint_store' SeLe4n/Kernel/IPC/Invariant.lean


### PR DESCRIPTION
### Motivation
- Remove dead proof surface that was no longer referenced after factoring local endpoint-store lemmas to reduce maintenance burden and API surface. 
- Make preservation-theorem layering explicit and local-first so each transition proves the three scheduler-contract components separately before composing them. 
- Keep project docs, testing anchors, and version metadata synchronized with the active M3.5 step-6 development slice.

### Description
- Deleted the unused helper theorem `endpointStore_preserves_ipcSchedulerContractPredicates` and expanded the IPC preservation surface to expose local-first theorems per transition (`runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`) for `endpointSend`, `endpointAwaitReceive`, and `endpointReceive` in `SeLe4n/Kernel/IPC/Invariant.lean`.
- Updated composed preservation theorems (`*_preserves_ipcSchedulerContractPredicates`) to invoke the new local component theorems instead of the removed helper.
- Added Tier-3 invariant anchors to `scripts/test_tier3_invariant_surface.sh` to require the new local-first preservation-theorem names, and bumped package `version` in `lakefile.toml`.
- Synchronized documentation to reflect the M3.5 step-6 completion by updating `README.md`, `docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`, and `docs/TESTING_FRAMEWORK_PLAN.md`.

### Testing
- Ran `lake build` which completed successfully and kept the theorem surface compiling. 
- Executed `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh`, all of which passed under the revalidated suite. 
- Ran the test-audit `./scripts/audit_testing_framework.sh` which completed successfully; the framework reported a controlled Tier-2 trace mismatch (missing expected `[CONTROL] impossible expected line`) as an intentional negative test and the audit script handled it as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922a01bdc8832bb51abb89d4e6af5a)