### PR TITLE
Strengthen Tier-3 trace regression guard to require both files

### DIFF
--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -70,7 +70,8 @@ run_check "INVARIANT" rg -n '^def endpointObjectValid' SeLe4n/Kernel/IPC/Invaria
 
 # M3.5 step-7 executable demonstration closure anchors.
 run_check "TRACE" rg -n 'endpointAwaitReceive demoEndpoint 2' Main.lean
-run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean
+run_check "TRACE" rg -n 'handshake send matched waiting receiver' tests/fixtures/main_trace_smoke.expected
 
 # Active milestone docs should stay synchronized for both current and next slices.
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md


### PR DESCRIPTION
### Motivation
- A single `rg` invocation previously searched both `Main.lean` and `tests/fixtures/main_trace_smoke.expected` at once, which could succeed if the pattern appeared in only one file and thus allow fixture drift to go undetected.

### Description
- Split the combined check into two `run_check "TRACE"` calls so the pattern `'handshake send matched waiting receiver'` is verified independently in `Main.lean` and in `tests/fixtures/main_trace_smoke.expected` by updating `scripts/test_tier3_invariant_surface.sh`.

### Testing
- Ran `bash scripts/test_tier3_invariant_surface.sh`, and the script completed with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699236b762d0832b9b6539fff44a7b59)