### PR TITLE
Refine and expand project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,87 +5,86 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in a **post-M3.5 handshake / pre-M4 lifecycle** stage.
+seLe4n is currently in **M4 kickoff (object lifecycle/retype safety)** after completing M3.5 IPC
+handshake + scheduler coherence.
 
-### Milestone board (authoritative)
+### Milestone board
 
 - ✅ **Bootstrap complete**: executable kernel monad, core object/state model, transition scaffolding.
 - ✅ **M1 complete**: scheduler integrity invariants and preservation entrypoints.
 - ✅ **M2 complete**: capability + CSpace operations, attenuation/lifecycle rules, composed invariants.
 - ✅ **M3 complete**: endpoint IPC seed (`endpointSend`/`endpointReceive`) plus preservation theorem surface.
-- ✅ **M3.5 complete**: typed waiting/handshake behavior, scheduler coherence contract predicates, composed IPC+scheduler invariant bundle, local-first preservation theorem layering, and executable waiting-to-delivery demonstration in `Main.lean`.
-- 📌 **Current active slice (M4)**: object lifecycle/retype safety and capability-object interaction invariants.
+- ✅ **M3.5 complete**: typed waiting/handshake behavior, scheduler coherence contract predicates,
+  composed IPC+scheduler invariant bundle, local-first preservation theorem layering, executable
+  waiting-to-delivery trace evidence.
+- 🚧 **M4 current slice in progress**: object lifecycle/retype foundations and capability-object
+  coupling safety.
+- 📍 **M4 next slice planned**: lifecycle + revocation composition, richer invariants, and expanded
+  executable scenarios.
 
-Testing framework status:
+## Documentation hub (GitBook-ready)
 
-- ✅ Tier 0 hygiene gate (`axiom|sorry|TODO` scan).
-- ✅ Tier 1 build/theorem gate (`lake build`).
-- ✅ Tier 2 fixture-backed executable smoke regression gate.
-- ✅ Tier 3 invariant/doc-surface checks are wired via `test_full.sh`.
-- 🧩 Tier 4 nightly extension point remains documented for broader confidence checks.
+Project documentation has been reorganized into a GitBook-compatible structure at:
 
-CI status:
+- `docs/gitbook/README.md` (book introduction + navigation)
+- `docs/gitbook/SUMMARY.md` (book table of contents)
+- `docs/gitbook/02-microkernel-and-sel4-primer.md` (microkernel + seL4 concepts)
+- `docs/gitbook/10-path-to-real-hardware-mobile-first.md` (mobile-first hardware roadmap)
 
-- Required pull-request jobs call repository script entrypoints directly via
-  `.github/workflows/lean_action_ci.yml`.
-- Required jobs today: `./scripts/test_fast.sh` and `./scripts/test_smoke.sh`.
+Core references remain:
 
----
+- `docs/SEL4_SPEC.md` — normative milestone spec, current/next slice targets, acceptance criteria.
+- `docs/DEVELOPMENT.md` — contributor workflow, proof standards, implementation sequence.
+- `docs/TESTING_FRAMEWORK_PLAN.md` — active test tiers and CI contract.
+- `docs/PROJECT_AUDIT.md` — audit snapshot and recommendations.
 
-## What is now closed (M3.5)
+## Current slice target outcomes (M4-A)
 
-The active engineering objective is **IPC handshake + scheduler interaction** with minimal, explicit
-state changes that can be proved and executed.
+1. Introduce typed lifecycle transition surface (at minimum one deterministic retype/create path).
+2. Define object identity and aliasing invariants for newly created/retyped objects.
+3. Establish capability-reference coherence invariants over lifecycle updates.
+4. Add preservation theorem entrypoints for each lifecycle transition.
+5. Extend executable evidence (`Main.lean`) and Tier 2 trace fixtures for lifecycle behavior.
 
-### Current-slice target outcomes (must all land for M3.5 close)
+## Next slice target outcomes (M4-B)
 
-1. Endpoint protocol-state refinement with explicit waiting direction(s).
-2. Narrow blocking/wakeup transition behavior in IPC send/receive paths.
-3. Scheduler-facing coherence predicate(s) for runnable-vs-blocked IPC thread state.
-4. Invariant bundle extension layered on top of M3 seed IPC invariants.
-5. Preservation theorem entrypoints for each changed/new transition.
-6. `Main.lean` evidence path showing at least one waiting-to-delivery story.
+1. Compose lifecycle transitions with revoke/delete authority paths.
+2. Strengthen invariants for stale-reference exclusion and authority monotonicity across retype chains.
+3. Add composed preservation theorems spanning lifecycle + capability bundles.
+4. Expand scenario coverage to include lifecycle rollback/error branches.
+5. Deepen Tier 3 checks for lifecycle-specific theorem/bundle surfaces.
 
-### Current-slice constraints
 
-- Keep changes architecture-neutral.
-- Preserve M1/M2/M3 theorem surfaces unless intentionally revised and documented.
-- Avoid reply-cap protocol completeness and policy redesign in this slice.
+## Codebase reasoning quick map
 
----
+For developers trying to understand where logic lives today:
 
-## What comes immediately after (next slice: M4)
+1. **Foundations**
+   - `SeLe4n/Prelude.lean` (core IDs + kernel monad)
+   - `SeLe4n/Machine.lean` (machine state + primitive updates)
 
-After M3.5 closure, the planned next delivery slice is **M4 object lifecycle / retype safety**.
+2. **Object/state model**
+   - `SeLe4n/Model/Object.lean` (typed objects, capabilities, TCB/endpoint/CNode)
+   - `SeLe4n/Model/State.lean` (global system state, typed lookups, store/update helpers)
 
-### Next-slice target outcomes (planning baseline)
+3. **Kernel semantics + proofs**
+   - scheduler: `SeLe4n/Kernel/Scheduler/*.lean`
+   - capability/CSpace: `SeLe4n/Kernel/Capability/*.lean`
+   - IPC + handshake/scheduler coherence: `SeLe4n/Kernel/IPC/*.lean`
 
-1. Typed object creation/retype transition model.
-2. Object identity and aliasing constraints suitable for machine proofs.
-3. Capability/object lifecycle coupling invariants.
-4. Preservation entrypoints for retype lifecycle transitions.
-5. Executable scenario coverage showing safe object lifecycle evolution.
+4. **Integration surface**
+   - `SeLe4n/Kernel/API.lean` (barrel)
+   - `Main.lean` (executable scenario trace)
 
-M4 planning is intentionally bounded so we can preserve the same incremental proof style used in
-M1-M3.5.
-
----
+If you need deeper module-level rationale, use `docs/gitbook/11-codebase-reference.md` and
+`docs/gitbook/12-proof-and-invariant-map.md`.
 
 ## Quick start
 
 ### 1) Install Lean tooling
 
-Use the repository bootstrap script (recommended):
-
 ```bash
 ./scripts/setup_lean_env.sh
-```
-
-Or install manually:
-
-```bash
-curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-source "$HOME/.elan/env"
 ```
 
 ### 2) Build and run
@@ -95,7 +94,14 @@ lake build
 lake exe sele4n
 ```
 
----
+## Validation commands
+
+```bash
+./scripts/test_fast.sh
+./scripts/test_smoke.sh
+./scripts/test_full.sh
+./scripts/test_nightly.sh
+```
 
 ## Repository layout
 
@@ -105,126 +111,12 @@ lake exe sele4n
 - `SeLe4n/Model/Object.lean` — kernel object types (`TCB`, `Endpoint`, `CNode`, `Capability`).
 - `SeLe4n/Model/State.lean` — global system state and typed lookup helpers.
 - `SeLe4n/Kernel/API.lean` — compatibility barrel that re-exports the kernel surface.
-- `SeLe4n/Kernel/Scheduler/Invariant.lean` — scheduler invariant definitions and base lemmas.
-- `SeLe4n/Kernel/Scheduler/Operations.lean` — scheduler transitions and preservation theorems.
-- `SeLe4n/Kernel/Capability/Operations.lean` — CSpace/capability executable operations.
-- `SeLe4n/Kernel/Capability/Invariant.lean` — capability invariant bundles and M3 composition proofs.
-- `SeLe4n/Kernel/IPC/Invariant.lean` — endpoint IPC transitions and IPC invariant preservation.
+- `SeLe4n/Kernel/Scheduler/*.lean` — scheduler operations, invariants, and preservation theorems.
+- `SeLe4n/Kernel/Capability/*.lean` — capability operations, invariants, composition with IPC layer.
+- `SeLe4n/Kernel/IPC/*.lean` — endpoint transitions and IPC invariants.
 - `Main.lean` — runnable integration trace.
-- `docs/SEL4_SPEC.md` — normative milestone spec and acceptance criteria.
-- `docs/DEVELOPMENT.md` — implementation workflow, proof standards, PR checklist.
-- `docs/TESTING_FRAMEWORK_PLAN.md` — testing tiers, CI strategy, and expansion path.
-- `docs/PROJECT_AUDIT.md` — current deep audit of code, tests, documentation, and roadmap.
-- `tests/scenarios/README.md` — fixture maintenance and trace regression workflow.
-
----
-
-## Milestone detail
-
-### Completed milestones
-
-1. **Bootstrap**
-   - state/object model,
-   - executable kernel monad shape,
-   - base transition/error scaffolding.
-
-2. **M1 Scheduler Integrity Bundle v1**
-   - queue uniqueness,
-   - current-thread validity,
-   - queue/current consistency,
-   - preservation through core scheduler transitions.
-
-3. **M2 Capability & CSpace Semantics**
-   - typed slot addressing and lookup,
-   - insert/mint/delete/revoke transitions,
-   - rights attenuation and lifecycle authority monotonicity,
-   - composed capability invariant bundle preservation.
-
-4. **M3 IPC seed**
-   - minimal endpoint state model,
-   - `endpointSend` / `endpointReceive` transitions,
-   - endpoint/IPC invariant definitions,
-   - preservation theorems including composed `m3IpcSeedInvariantBundle`.
-
-### Completed milestone (M3.5)
-
-Delivered: queue-only seed semantics were extended to an explicit waiting/handshake contract
-between endpoint behavior and scheduler-visible thread coherence, with machine-checked
-preservation theorem entrypoints and executable trace evidence.
-
-### Active milestone (M4)
-
-Focus: introduce object lifecycle/retype transitions and prove capability/object lifecycle safety
-properties without destabilizing existing scheduler/capability/IPC theorem bundles.
-
----
-
-## Testing quick reference
-
-Use the tiered test entrypoints for local validation:
-
-```bash
-./scripts/test_fast.sh      # Tier 0 + Tier 1
-./scripts/test_smoke.sh     # Tier 0 + Tier 1 + Tier 2 (fixture-backed trace gate)
-./scripts/test_full.sh      # smoke + Tier 3 invariant/doc-surface gate
-./scripts/test_nightly.sh   # full + explicit Tier 4 extension-point notice
-./scripts/audit_testing_framework.sh
-```
-
-The test scripts auto-source `$HOME/.elan/env` when present so `lake` is available in fresh shells
-after `./scripts/setup_lean_env.sh`.
-
----
-
-## CI gates (pull requests)
-
-Pull requests must pass both required CI jobs:
-
-```bash
-./scripts/test_fast.sh
-./scripts/test_smoke.sh
-```
-
-On smoke-trace failures, CI uploads diagnostics:
-
-- `main_trace_smoke.actual.log`
-- `main_trace_smoke.missing.txt`
-- `tests/fixtures/main_trace_smoke.expected`
-
----
+- `docs/gitbook/*` — in-depth project handbook for GitBook.
 
 ## License
 
 This project is licensed under the MIT License. See [`LICENSE`](./LICENSE).
-
-### Provenance policy
-
-- Do not copy third-party code or text into this repository without explicit attribution.
-- Confirm incoming third-party material is license-compatible with MIT before committing it.
-
----
-
-## Daily contributor verification loop
-
-Run this minimum loop before opening a PR:
-
-```bash
-./scripts/test_fast.sh
-./scripts/test_smoke.sh
-```
-
-Useful direct commands for local debugging:
-
-```bash
-lake build
-lake exe sele4n
-rg -n "axiom|sorry|TODO" SeLe4n Main.lean
-```
-
----
-
-## Where to look next
-
-- Normative scope and acceptance gates: `docs/SEL4_SPEC.md`
-- Implementation workflow and review checklist: `docs/DEVELOPMENT.md`
-- Testing framework roadmap and ownership guidance: `docs/TESTING_FRAMEWORK_PLAN.md`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,156 +2,134 @@
 
 ## 1. Purpose
 
-This guide defines the expected engineering workflow for seLe4n contributors.
+This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current project stage: **post-M3.5 handshake closure / pre-M4 lifecycle kickoff**.
+Current stage: **M4-A lifecycle/retype foundations (active)**.
 
-Primary contributor goals:
+Primary goals for contributors:
 
-- keep executable semantics readable and testable,
-- preserve milestone theorem entrypoints,
-- land changes in narrow, reviewable slices,
-- keep docs synchronized with implementation stage and next-slice planning.
-
----
-
-## 2. Stage contract and baseline stability
-
-The following behavior is stable and must not regress unless intentionally redesigned and documented.
-
-1. M1 scheduler invariant bundle (`schedulerInvariantBundle`) and preservation theorem entrypoints.
-2. M2 CSpace transition APIs (`lookup`, `insert`, `mint`, `delete`, `revoke`) and capability bundle
-   preservation entrypoints.
-3. M3 endpoint seed APIs (`endpointSend`, `endpointReceive`) and IPC invariant bundle entrypoints.
-4. Runnable executable trace in `Main.lean` demonstrating scheduler + CSpace + IPC seed behavior.
-5. Tier 0/1/2 required gates and Tier 3 full-suite invariant/doc-surface checks.
-
-If a change intentionally adjusts one of these contracts, call it out in docs + PR notes.
+- keep semantics executable and understandable,
+- preserve theorem-entrypoint continuity across milestones,
+- ship narrow, reviewable slices,
+- keep docs synchronized with active and next slice plans.
 
 ---
 
-## 3. Recently closed slice: M3.5 IPC handshake + scheduler interaction
+## 2. Baseline contracts to preserve
 
-### 3.1 Current-slice target outcomes
+Unless intentionally redesigned and documented, preserve:
 
-Contributors should align M3.5 work to all outcomes below:
-
-1. Refine endpoint protocol state so waiting directions are explicit.
-2. Introduce minimal blocking/wakeup effects in endpoint transitions.
-3. Add scheduler-facing coherence predicates for IPC-blocked threads.
-4. Extend IPC invariant bundle with endpoint/scheduler coherence components.
-5. Prove preservation theorem entrypoints for new/changed transitions.
-6. Extend executable trace with one waiting-to-delivery scenario.
-
-### 3.2 Current-slice non-goals
-
-Do **not** include the following in M3.5 PRs unless explicitly approved:
-
-- full reply-cap protocol,
-- priority scheduling policy redesign,
-- architecture/MMU concerns,
-- object lifecycle/retype semantics (belongs to M4).
-
-### 3.3 M3.5 recommended implementation sequence
-
-Use this order unless a concrete dependency forces adjustment.
-
-1. **State-model refinement first** ✅ **completed**
-   - added only endpoint/thread fields needed for one deterministic handshake story (`Endpoint.waitingReceiver`, `TCB.ipcState`),
-   - state ownership remains explicit: endpoint-owned waiting counterpart identity + thread-owned IPC blocking status,
-   - endpoint local well-formedness now constrains queue shape and waiting-receiver ownership together for deterministic unfolding in later transition/proof work.
-
-2. **Transition updates second** ✅ **completed**
-   - added explicit waiting-receiver registration transition (`endpointAwaitReceive`) for idle endpoints,
-   - updated `endpointSend` with explicit handshake-success branch (`receive` + waiting receiver) and explicit mismatch errors for illegal receive-state shapes,
-   - updated `endpointReceive` branching to keep explicit error outcomes for impossible waiting-receiver combinations,
-   - preservation-entrypoint proofs for updated send/receive transitions remain unfold-friendly and machine-checked.
-
-3. **Scheduler contract predicates third** ✅ **completed**
-   - define targeted blocked-vs-runnable coherence predicates,
-   - avoid over-generalized abstraction.
-
-4. **Invariant bundle composition fourth** ✅ **completed**
-   - add named IPC+scheduler coherence components,
-   - layer over `m3IpcSeedInvariantBundle`.
-
-5. **Helper lemmas fifth** ✅ **completed**
-   - added local endpoint-store lookup helpers near IPC transitions (`tcb_lookup_of_endpoint_store`, runnable/non-runnable scheduler membership transport lemmas),
-   - preservation proofs now consume these small lemmas directly to discharge concrete object-lookup and runnable-set obligations without duplicated case analysis.
-
-6. **Preservation theorems sixth** ✅ **completed**
-   - endpoint transitions now prove local scheduler-contract components first (`runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`),
-   - composed preservation (`ipcSchedulerContractPredicates`, `m35IpcSchedulerInvariantBundle`) is layered after those local theorems,
-   - new theorem entrypoints follow `<transition>_preserves_<invariant>` naming throughout step-6 additions.
-
-7. **Executable demonstration last** ✅ **completed**
-   - `Main.lean` now includes a concrete M3.5 waiting-receiver handshake story (`endpointAwaitReceive` followed by handshake-success send),
-   - the prior scheduler/CSpace/M3 executable trace is preserved as a prefix and the existing queue-delivery sequence remains executable after the handshake path.
+1. M1 scheduler bundle + preservation theorem entrypoints.
+2. M2 capability/CSpace transition surfaces and capability invariant composition.
+3. M3 endpoint seed APIs and invariant entrypoints.
+4. M3.5 handshake/scheduler coherence predicates and composed bundle surfaces.
+5. Tier 0/1/2 required test gates and CI entrypoint parity.
 
 ---
 
-## 4. Next slice preparation (planned): M4 object lifecycle / retype safety
+## 3. Current slice implementation plan: M4-A
 
-With M3.5 closed, contributors should now implement M4 work while preserving the M1-M3.5 theorem and executable contracts.
+### 3.1 M4-A target outcomes (implementation contract)
 
-### 4.1 M4 target outcomes (planning baseline)
+1. Add typed lifecycle/retype transition API.
+2. Add object identity + aliasing lifecycle invariants.
+3. Add capability-object coherence invariants.
+4. Add preservation theorem entrypoints for new lifecycle transitions.
+5. Add executable evidence in `Main.lean` and fixture-backed smoke coverage.
 
-1. Executable lifecycle/retype transition surface.
-2. Object identity and aliasing invariants.
-3. Capability-object lifecycle coherence invariants.
-4. Preservation theorem entrypoints for lifecycle transitions.
-5. Executable + fixture evidence for lifecycle behavior.
+### 3.2 Recommended implementation sequence (M4-A)
 
-### 4.2 Pre-M4 design guardrails
+1. **State-model preparation**
+   - introduce only lifecycle metadata required for the first transition story,
+   - keep ownership explicit (object store identity, capability reference mapping).
 
-While working on M4:
+2. **Lifecycle transition(s)**
+   - implement deterministic success/error branching,
+   - keep illegal-state and illegal-authority branches explicit via `KernelError`.
 
-- keep transition APIs typed and explicit,
-- avoid embedding lifecycle assumptions into IPC-only predicates,
-- preserve compositional bundle structure so M4 can layer cleanly.
+3. **Invariant definitions**
+   - define narrow, named lifecycle invariants first,
+   - separate identity/aliasing constraints from capability-reference constraints.
+
+4. **Local helper lemmas**
+   - add transition-local lookup/membership lemmas near lifecycle code,
+   - avoid duplicated case-analysis across proof scripts.
+
+5. **Preservation theorem entrypoints**
+   - prove local component preservation first,
+   - then compose with existing capability/scheduler/IPC bundles.
+
+6. **Executable demonstration + fixture update**
+   - extend `Main.lean` for lifecycle success path,
+   - add fixture lines only for stable semantic output.
+
+### 3.3 M4-A non-goals
+
+Do not include in this slice unless explicitly approved:
+
+- full allocator internals,
+- architecture-specific memory internals,
+- broad policy redesign,
+- unrelated IPC protocol expansion.
+
+---
+
+## 4. Next slice preparation: M4-B
+
+### 4.1 M4-B target outcomes
+
+1. Compose lifecycle with revoke/delete semantics.
+2. Add stale-reference exclusion invariants.
+3. Prove cross-bundle preservation theorems.
+4. Add failure-path theorem coverage for lifecycle-capability interactions.
+5. Expand Tier 3 checks and scenario coverage for lifecycle composition.
+
+### 4.2 Design guardrails for M4-B readiness
+
+- preserve clean invariant layering;
+- keep lifecycle assumptions out of unrelated IPC predicates;
+- avoid monolithic “mega invariant” definitions that block review.
 
 ---
 
 ## 5. Proof engineering standards
 
-1. Prefer explicit theorem statements over brittle tactic cleverness.
+1. Prefer explicit theorem statements and local proof structure over brittle tactic compression.
 2. Keep conjunction-heavy invariants factored into named components.
-3. Avoid global `simp` side effects; use local simp blocks.
-4. Structure proofs in layers:
-   - unfold transition,
-   - split result cases,
-   - apply local helper lemmas,
-   - discharge invariant components.
-5. Keep helper lemmas near transitions they support.
+3. Use local simplification blocks; avoid global `simp` side effects.
+4. Structure proofs by:
+   - transition unfold,
+   - result-case split,
+   - local helper lemma application,
+   - invariant component discharge.
+5. Keep helper lemmas physically near transitions they support.
 6. Do not introduce `axiom` or `sorry` in core modules.
 
 ---
 
 ## 6. Documentation responsibilities
 
-Any PR changing transitions, invariants, or milestone boundaries must update docs in the same
+Any PR changing transitions, invariants, milestone scope, or tests must update docs in the same
 commit range:
 
-1. `docs/SEL4_SPEC.md`: current + next slice definitions, outcomes, acceptance criteria.
-2. `docs/DEVELOPMENT.md`: implementation sequence, workflow expectations, PR checklist.
-3. `README.md`: stage snapshot and contributor verification loop.
-4. `docs/TESTING_FRAMEWORK_PLAN.md` and/or `tests/scenarios/README.md` when testing workflow
-   expectations change.
-
-If docs are deferred, state why and when they will be updated.
+1. `docs/SEL4_SPEC.md`
+2. `docs/DEVELOPMENT.md`
+3. `README.md`
+4. `docs/TESTING_FRAMEWORK_PLAN.md` and/or `tests/scenarios/README.md` as needed
+5. `docs/gitbook/*` pages impacted by the change
 
 ---
 
-## 7. Contributor validation loop (required)
+## 7. Required contributor validation loop
 
-Run this minimum set before opening a PR:
+Run before opening a PR:
 
 ```bash
 ./scripts/test_fast.sh
 ./scripts/test_smoke.sh
 ```
 
-Direct checks for local debugging:
+Recommended additional checks:
 
 ```bash
 lake build
@@ -160,73 +138,112 @@ rg -n "axiom|sorry|TODO" SeLe4n Main.lean
 ./scripts/test_full.sh
 ```
 
-If any command cannot run due to environment limits, report the constraint and impact.
-
-Default shared ownership of test/CI gates applies to contributors touching:
-
-- `Main.lean`,
-- `SeLe4n/Kernel/API.lean` (barrel) and `SeLe4n/Kernel/**/*.lean`,
-- `scripts/test_*.sh`,
-- `tests/fixtures/*`.
-
-Pull-request CI enforces required gates through `.github/workflows/lean_action_ci.yml` by running
-`./scripts/test_fast.sh` and `./scripts/test_smoke.sh` as separate required jobs.
-
-For fresh environments, run `./scripts/setup_lean_env.sh` once. Test scripts auto-source
-`$HOME/.elan/env` when available.
+If a command is blocked by environment limitations, report the limitation and impact.
 
 ---
 
-## 8. PR checklist (required)
+## 8. PR checklist (copy into PR descriptions)
 
-Copy this checklist into PR descriptions:
-
-- [ ] Scope is one coherent milestone slice.
-- [ ] Transition APIs use explicit success/error branching.
-- [ ] New invariant components are named and documented.
+- [ ] Scope fits one coherent milestone slice.
+- [ ] Transition APIs expose explicit success/error branching.
+- [ ] New invariants are named and documented.
 - [ ] Preservation theorem entrypoints compile.
 - [ ] `lake build` executed.
 - [ ] `lake exe sele4n` executed.
-- [ ] Hygiene scan (`axiom|sorry|TODO`) executed.
-- [ ] Docs updated in the same commit range.
-- [ ] Remaining proof debt identified.
-- [ ] Current-slice and next-slice docs are synchronized.
-
-### 8.1 Fixture-backed smoke regression workflow (Tier 2)
-
-Tier 2 is active and required in `./scripts/test_smoke.sh`.
-
-- Expected trace fragments live in `tests/fixtures/main_trace_smoke.expected`.
-- `scripts/test_tier2_trace.sh` runs `lake exe sele4n` and enforces substring matching for each
-  non-empty fixture line.
-- On mismatch, failures are tagged with `[TRACE]` and list each missing expectation.
-
-Intentional behavior change workflow:
-
-1. Run `lake exe sele4n` and verify new behavior is expected.
-2. Update only stable semantic lines in fixture.
-3. Re-run `./scripts/test_tier2_trace.sh` and `./scripts/test_smoke.sh`.
-4. Explain fixture updates in PR description.
+- [ ] Hygiene scan executed.
+- [ ] `test_fast` and `test_smoke` executed.
+- [ ] Docs (including GitBook pages) updated in same commit range.
+- [ ] Remaining proof debt identified explicitly.
 
 ---
 
-## 9. Review heuristics for maintainers
+## 9. Codebase touch matrix (what to update when)
 
-Reviewers should verify:
+This section helps avoid partial updates when changing a subsystem.
 
-1. Transition semantics are understandable without tactic archaeology.
-2. Endpoint/scheduler coupling is minimal and justified.
-3. Helper lemmas are scoped to transition behavior.
-4. Invariant bundle growth remains incremental and compositional.
-5. Executable trace evidence matches milestone claims.
-6. Current-slice and next-slice planning text is consistent across docs.
+### 9.1 Scheduler behavior changes
+
+Touch at least:
+
+- `SeLe4n/Kernel/Scheduler/Operations.lean` (transition semantics),
+- `SeLe4n/Kernel/Scheduler/Invariant.lean` (component/bundle reasoning),
+- any composed bundle module that imports scheduler invariants,
+- docs (`README`, `SEL4_SPEC`, `DEVELOPMENT`, relevant GitBook chapters).
+
+Validation focus:
+
+- queue/current consistency remains explicit,
+- `*_preserves_schedulerInvariantBundle` theorem surfaces still compile,
+- executable trace remains coherent if scheduling output changed.
+
+### 9.2 Capability/CSpace changes
+
+Touch at least:
+
+- `SeLe4n/Kernel/Capability/Operations.lean`,
+- `SeLe4n/Kernel/Capability/Invariant.lean`,
+- fixture/docs if executable output semantics changed.
+
+Validation focus:
+
+- attenuation properties preserved,
+- lifecycle authority monotonicity still valid,
+- composed bundle aliases remain stable.
+
+### 9.3 IPC changes
+
+Touch at least:
+
+- `SeLe4n/Kernel/IPC/Invariant.lean` (transitions + invariants + proofs),
+- composed invariant/bundle module references,
+- `Main.lean` scenario if behavior surface changed,
+- Tier 2 fixture if output changed intentionally.
+
+Validation focus:
+
+- endpoint object validity + queue well-formedness,
+- scheduler coherence predicates,
+- local-first and composed preservation theorem layering.
+
+### 9.4 Lifecycle/retype (M4) changes
+
+Touch at least:
+
+- model files when object metadata evolves,
+- lifecycle transition implementation module(s),
+- lifecycle invariant components,
+- cross-bundle composition entrypoints,
+- milestone docs and GitBook M4 chapters.
+
+Validation focus:
+
+- identity/aliasing safety,
+- capability-object coherence,
+- deterministic error-path behavior,
+- fixture signal quality for lifecycle scenarios.
 
 ---
 
-## 10. Anti-patterns to avoid
+## 10. Proof review checklist (maintainers)
 
-- Bundling model redesign, protocol redesign, and major proof rewrites in one PR.
-- Adding non-essential architecture detail during IPC-slice work.
-- Hiding transition semantics behind abstractions that block direct unfolding.
-- Claiming slice completion without theorem + executable evidence.
-- Leaving milestone docs stale after API or theorem-surface changes.
+When reviewing theorem changes, verify:
+
+1. transition-level theorem statements still mirror executable semantics,
+2. helper lemmas are local and narrowly scoped,
+3. no hidden global simp behavior introduced,
+4. composed bundle theorem depends on named components (not ad hoc unfolding),
+5. theorem naming follows searchable `<transition>_preserves_<target>` pattern.
+
+---
+
+## 11. Documentation depth contract
+
+For any milestone movement, docs should answer all of:
+
+1. **What exists now?**
+2. **What is being added in this slice?**
+3. **What is intentionally deferred?**
+4. **Which commands validate the change?**
+5. **How does this affect composed invariant architecture?**
+
+If a doc update does not answer these five, it is incomplete.

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -1,113 +1,65 @@
-# seLe4n Project Audit (Code, Tests, Documentation, and Development Path)
+# seLe4n Project Audit (Code, Tests, Docs, and Near-Term Path)
 
-## 1. Scope and methodology
+## 1. Scope
 
-This audit evaluates:
+This audit summarizes:
 
-1. **Codebase quality and optimization posture** (clarity, compositionality, proof-surface maintainability).
-2. **Testing framework completeness and correctness** (tiered gates, signal quality, CI parity).
-3. **Documentation richness and stage coherence** (current status + credible near-term roadmap).
+1. codebase quality posture,
+2. testing-framework maturity,
+3. documentation completeness versus current milestone stage.
 
-Validation commands used in this audit:
+## 2. Current stage assessment
 
-- `./scripts/test_fast.sh`
-- `./scripts/test_smoke.sh`
-- `./scripts/test_full.sh`
-- `./scripts/test_nightly.sh`
-- `./scripts/audit_testing_framework.sh`
+Overall status: **healthy, with M4-A lifecycle/retype implementation as the active engineering
+frontier**.
 
----
+What is strong today:
 
-## 2. Executive summary
+- M1-M3.5 contracts are stable and reflected in executable + theorem surfaces.
+- Tiered testing entrypoints are structured and CI-aligned.
+- Documentation now includes a GitBook-compatible handbook structure plus refreshed spec and
+  development guidance for current/next slices.
+- The handbook now also includes conceptual onboarding (microkernel/seL4 primer) and a staged
+  mobile-first hardware path chapter to make long-horizon goals explicit.
 
-Overall project health is **strong** for its current milestone stage (**post-M3.5 closure / active M4 planning**).
+## 3. Key risks and next mitigations
 
-- The codebase keeps a disciplined executable-and-provable style.
-- Required quality gates (hygiene/build/smoke fixture) are deterministic and informative.
-- Documentation now reflects that M3.5 is fully closed and M4 is the active next slice.
+1. **Lifecycle semantics not yet fully landed**
+   - mitigation: keep M4-A narrow and theorem-first with explicit transition APIs.
+2. **Potential invariant growth complexity**
+   - mitigation: enforce component naming and layered composition from the start.
+3. **Fixture drift during lifecycle rollout**
+   - mitigation: keep fixture lines semantic and require rationale in PR notes.
 
-Key verified status in this cycle:
+## 4. Testing posture summary
 
-- M3.5 closure is complete across code + docs: waiting-receiver handshake transitions, scheduler coherence predicates, composed invariant bundle layering, local-first preservation theorem surfaces, and executable demonstration evidence are all present and validated.
-- Tier 3 invariant/doc-surface checks and Tier 2 fixture checks both pass and guard milestone-regression surfaces effectively.
-- Hygiene warnings about missing optional shell tooling were eliminated by installing `shellcheck`; Tier 0 now runs shell linting as part of normal checks.
+- Required gates (`test_fast`, `test_smoke`) are correctly scoped.
+- Full/nightly tiers provide extension headroom for M4-specific hardening.
+- Next high-value test work: lifecycle fixture lines + Tier 3 lifecycle-capability grouped anchors.
 
-Primary next high-value path:
+## 5. Documentation posture summary
 
-- Begin M4 lifecycle/retype semantics while preserving M1–M3.5 contracts and extending Tier 2/Tier 3 checks to cover new lifecycle surfaces.
+Documentation now reflects active stage and upcoming work in both canonical docs and GitBook pages.
+Immediate maintenance rule: any transition/invariant/milestone update must keep
+`README.md`, `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, and affected `docs/gitbook/*` pages in
+sync.
 
----
+## 6. Conclusion
 
-## 3. Codebase audit findings
+The repository is well positioned to execute M4-A and then M4-B without destabilizing M1-M3.5,
+provided lifecycle work remains incremental, theorem-backed, and documentation-synchronized.
 
-### 3.1 Strengths
+## 7. Documentation hardening status (latest pass)
 
-1. **Compositional invariant architecture**
-   - Scheduler, capability, and IPC invariants remain separated and recomposed through named bundle entrypoints.
-2. **Executable semantics + proof entrypoints**
-   - Transition functions remain executable while theorem surfaces preserve key safety properties.
-3. **Conservative milestone evolution style**
-   - Existing M1–M3.5 theorem contracts are preserved while milestone status transitions to M4 planning.
+This pass increased documentation depth in two important ways:
 
-### 3.2 Remaining optimization recommendations
+1. **Conceptual onboarding depth**
+   - added explicit microkernel/seL4 background and rationale pages so new contributors can align on
+     model intent before touching proof code.
 
-1. Add theorem-group index comments around large proof files (especially IPC/capability invariant modules) as M4 content lands.
-2. Keep transition-local helper lemmas physically close to transitions they support to reduce proof-maintenance drift.
-3. Add narrow fixture lines and invariant-surface anchors for each M4 transition as they are introduced.
+2. **Codebase reasoning depth**
+   - added module-by-module codebase reference and proof/invariant map pages so contributors can
+     trace semantics, theorem surfaces, and composition boundaries without reverse-engineering file
+     responsibilities from source alone.
 
----
-
-## 4. Testing framework audit findings
-
-### 4.1 Current quality of implemented tiers
-
-- **Tier 0 hygiene**: catches `axiom|sorry|TODO` markers and now executes `shellcheck` successfully.
-- **Tier 1 build**: validates full Lean compilation and executable artifact.
-- **Tier 2 smoke fixture**: protects stable executable trace semantics.
-- **Tier 3 invariant/doc surface**: validates milestone theorem/bundle/documentation anchors.
-
-### 4.2 Audit-cycle hardening applied
-
-1. **Shell hygiene upgrade**
-   - Optional-lint warning removed by installing `shellcheck`; hygiene scripts now run the lint path instead of skip path.
-2. **M3.5 closure consistency verification**
-   - Re-ran all repository tier entrypoints plus audit script to verify no drift across proof surface, trace fixtures, and docs.
-
-### 4.3 Next testing roadmap
-
-1. Strengthen Tier 3 from symbol-surface checks toward grouped semantic checks for M4 lifecycle bundles.
-2. Expand Tier 2 fixture scenarios once M4 transitions add user-visible executable behavior.
-3. Upgrade Tier 4 from extension notice to repeat-run determinism + broader scenario sweeps.
-
----
-
-## 5. Documentation audit findings
-
-### 5.1 Current strengths
-
-- Status, acceptance criteria, and non-goals are clearly separated by milestone.
-- Stage markers now consistently reflect post-M3.5 closure and M4 planning.
-
-### 5.2 Remaining recommendations
-
-1. Keep this audit refreshed at each milestone boundary (M4 kickoff, M4 closure, etc.).
-2. Add a short “since last audit” section in future updates for easier review diffs.
-3. Keep README, `SEL4_SPEC`, `DEVELOPMENT`, and testing-plan synchronization as a hard PR requirement when stage markers change.
-
----
-
-## 6. Known limitations and next hardening steps
-
-1. Tier 3 currently validates milestone surfaces, not full semantic equivalence.
-2. M4 has not yet introduced lifecycle/retype transition semantics; associated fixture/proof checks will be required as those APIs appear.
-3. Tier 4 remains intentionally lightweight until nightly determinism and multi-scenario coverage are specified.
-
----
-
-## 7. Conclusion
-
-The project is in a healthy state, with M3.5 closure now fully reflected in executable evidence,
-proof surfaces, testing gates, and documentation.
-
-The repository is well-positioned for M4 lifecycle/retype work without sacrificing the existing
-M1–M3.5 contract quality bar.
+These additions reduce review friction and lower onboarding risk for M4 and later slices.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -2,270 +2,207 @@
 
 ## 1. Purpose
 
-This document is the normative planning baseline for the seLe4n Lean model.
+This document is the normative specification baseline for seLe4n.
 
-It has five jobs:
+It defines:
 
-1. Capture what is implemented and trusted today.
-2. Define the exact **current delivery slice** and why it matters.
-3. Define the exact **next delivery slice** so implementation does not stall after current-slice closure.
-4. Declare what is out of scope so review stays focused.
-5. Provide acceptance gates that can be validated locally.
+1. What milestone behavior is already closed and considered stable.
+2. The **current delivery slice** (M4-A) with concrete target outcomes.
+3. The **next delivery slice** (M4-B) so work continues without roadmap drift.
+4. Acceptance criteria and non-goals for focused, reviewable implementation.
+5. Change-control expectations for code, proofs, executable traces, and docs.
 
-The project is currently in a **post-M3.5 / pre-M4** stage: M1 scheduler invariants, M2 capability semantics, M3 endpoint send/receive seed semantics, and the full M3.5 IPC handshake + scheduler-interaction closure are complete and executable.
-
-Testing baseline status: Tier 0 hygiene checks, Tier 1 build checks, and Tier 2 fixture-backed
-executable smoke checks are implemented under `scripts/test_*.sh` and enforced in pull-request CI.
+Current stage: **post-M3.5 closure / active M4 kickoff**.
 
 ---
 
-## 2. Milestone glossary and stage markers
+## 2. Milestone map
 
-- **Bootstrap (complete)**: executable model skeleton (state, objects, kernel monad, transition style).
+- **Bootstrap (complete)**: executable model skeleton and transition style.
 - **M1 (complete)**: scheduler integrity bundle and preservation.
-- **M2 (complete)**: typed CSpace operations and capability lifecycle invariants.
-- **M3 (complete)**: endpoint send/receive seed semantics with first IPC invariant bundle.
-- **M3.5 (complete)**: typed IPC handshake + scheduler interaction contract.
-- **M4 (current slice, planned/starting)**: object lifecycle/retype safety with capability-object coupling invariants.
+- **M2 (complete)**: typed CSpace operations + capability lifecycle authority invariants.
+- **M3 (complete)**: endpoint send/receive seed semantics + IPC invariant seed bundle.
+- **M3.5 (complete)**: waiting/handshake IPC semantics + scheduler coherence contract.
+- **M4-A (current slice)**: lifecycle/retype transition foundations + initial lifecycle invariants.
+- **M4-B (next slice)**: lifecycle-capability composition hardening and richer scenario coverage.
 
 ---
 
-## 3. Current status (implemented and expected stable)
+## 3. Stable baseline contracts (must not regress)
 
-### 3.1 Bootstrap (complete)
+The following contracts are considered stable and preserved while M4 evolves:
 
-Implemented baseline:
+1. M1 scheduler invariant bundle and entrypoint preservation theorems.
+2. M2 capability/CSpace transition APIs (`lookup`, `insert`, `mint`, `delete`, `revoke`) and
+   composed capability invariant bundle.
+3. M3 endpoint APIs (`endpointSend`, `endpointReceive`) and IPC seed invariant layering.
+4. M3.5 waiting-receiver handshake behavior and scheduler-contract predicate surfaces.
+5. Tier 0/1/2 required test gates and CI invocation through repository scripts.
 
-1. Core identifiers and `Kernel` monad flow.
-2. Machine model (`RegisterFile`, `MachineState`).
-3. Object universe (`TCB`, `Endpoint`, `CNode`, `Capability`).
-4. Global `SystemState` with object store and scheduler state.
-5. Executable transitions with explicit error handling.
-
-### 3.2 M1 Scheduler Integrity Bundle v1 (complete)
-
-Implemented and theorem-backed:
-
-1. `runQueueUnique`.
-2. `currentThreadValid`.
-3. `queueCurrentConsistent`.
-4. Composed `schedulerInvariantBundle` preservation for `chooseThread`, `schedule`, `handleYield`.
-
-### 3.3 M2 Capability & CSpace Semantics (complete)
-
-Implemented and theorem-backed:
-
-1. Addressing model: `SlotRef` and `CSpaceAddr`.
-2. Read/write transitions: `cspaceLookupSlot`, `cspaceInsertSlot`, `cspaceMint`.
-3. Lifecycle transitions: `cspaceDeleteSlot`, `cspaceRevoke`.
-4. Authority policy support: `capAttenuates`, rights subset/attenuation lemmas.
-5. Bundle: slot uniqueness, lookup soundness, attenuation rule, lifecycle authority monotonicity.
-6. Preservation entrypoints for lookup/insert/mint/delete/revoke.
-
-### 3.4 M3 IPC seed (complete)
-
-Implemented and theorem-backed:
-
-1. Endpoint model state (`EndpointState` + queue field on endpoint objects).
-2. IPC transitions: `endpointSend`, `endpointReceive`.
-3. Explicit mismatch/error branches and empty-queue receive failure path.
-4. IPC invariants:
-   - `endpointQueueWellFormed`,
-   - `endpointObjectValid`,
-   - `endpointInvariant`,
-   - `ipcInvariant`,
-   - composed `m3IpcSeedInvariantBundle`.
-5. Preservation entrypoints for both endpoint transitions over IPC, scheduler, capability, and
-   composed M3 seed bundle invariants.
+Any intentional baseline changes must be documented in this file, `docs/DEVELOPMENT.md`, and
+`README.md` in the same commit range.
 
 ---
 
-## 4. Current slice definition: M3.5 IPC handshake + scheduler interaction
+## 4. Current slice: M4-A lifecycle/retype foundations
 
-### 4.1 Slice objective
+### 4.1 Objective
 
-Move from queue-only endpoint seed semantics toward a typed handshake model that introduces the
-first blocking/wakeup contract between IPC transitions and scheduler-visible thread state, while
-keeping M1/M2/M3 guarantees intact.
+Introduce the first deterministic object lifecycle/retype transition surface and machine-checked
+safety scaffolding that connects object-store evolution with capability references.
 
-### 4.2 Why this slice is now
+### 4.2 Why now
 
-M3 established endpoint-local safety. The highest-value next step is to connect endpoint behavior
-to scheduling consequences in a narrow and provable way. This creates a clean bridge to richer IPC
-protocol semantics without a large proof reset.
+M3.5 established IPC-scheduler coherence. The next major safety risk is object lifecycle evolution:
+without typed lifecycle transitions and invariants, capability reasoning can drift away from object
+state evolution.
 
-### 4.3 Required target outcomes for M3.5 closure
+### 4.3 M4-A target outcomes (all required)
 
-A change set claiming M3.5 completion must satisfy all outcomes below.
+1. **Lifecycle transition API**
+   - add at least one executable lifecycle/retype operation with explicit success/error outcomes,
+   - ensure deterministic state updates and architecture-neutral semantics.
 
-1. **Endpoint protocol state refinement**
-   - represent waiting direction(s) explicitly (at least one waiting sender or waiting receiver form),
-   - maintain deterministic and architecture-neutral representation.
+2. **Object identity + aliasing invariants**
+   - define invariants preventing invalid object identity reuse in active scope,
+   - define invariants constraining aliasing after lifecycle transitions.
 
-2. **Typed blocking/wakeup transition surface**
-   - include at least one send path that can block or mark waiting state,
-   - include at least one receive path that can wake or deliver against waiting counterpart state,
-   - preserve explicit `KernelError` paths for illegal object/state combinations.
-
-3. **Scheduler interaction contract**
-   - define predicate(s) connecting runnable queue membership and IPC-blocked thread state,
-   - preserve or intentionally update those predicates in endpoint transitions.
-
-4. **Invariant bundle extension**
-   - add at least two invariant components covering:
-     - endpoint protocol-state coherence,
-     - thread blocked/runnable coherence,
-   - integrate those invariants into a composed bundle layered on `m3IpcSeedInvariantBundle`.
-
-5. **Preservation theorem entrypoints**
-   - provide machine-checked preservation theorem entrypoints for each new/changed endpoint transition,
-   - demonstrate compositional compatibility with existing scheduler and capability bundles.
-
-6. **Executable evidence path**
-   - extend `Main.lean` with at least one waiting-to-delivery (or waiting-to-ready) scenario,
-   - preserve prior scheduler/CSpace/M3-seed behavior as executable prefix.
-
-### 4.4 M3.5 acceptance criteria (all required)
-
-1. `./scripts/test_fast.sh` succeeds.
-2. `./scripts/test_smoke.sh` succeeds (including Tier 2 fixture checks).
-3. `lake build` succeeds.
-4. `lake exe sele4n` succeeds and exhibits IPC behavior beyond queue-only seed semantics.
-5. Hygiene scan is clean:
-   - `rg -n "axiom|sorry|TODO" SeLe4n Main.lean`.
-6. New endpoint/scheduler interaction invariants exist and are included in the active IPC bundle.
-7. New/updated endpoint transitions have machine-checked preservation theorem entrypoints.
-8. `README.md`, `docs/SEL4_SPEC.md`, and `docs/DEVELOPMENT.md` are internally stage-consistent.
-
-### 4.5 M3.5 implementation sequence progress
-
-- ✅ **Step 1 complete (state-model refinement)**
-  - endpoint model now includes explicit waiting-counterpart identity for deterministic handshake setup (`waitingReceiver`),
-  - TCB model now carries explicit IPC blocking status (`ready`, `blockedOnSend endpoint`, `blockedOnReceive endpoint`) to keep scheduler-facing ownership clear,
-  - endpoint well-formedness now captures ownership coupling between endpoint mode and waiting-receiver identity (non-receive states require `none`, receive requires `some`).
-- ✅ **Step 2 complete (transition updates)**
-  - added explicit receiver-wait registration transition (`endpointAwaitReceive`) for idle endpoints,
-  - `endpointSend` now has an explicit receive-handshake success path (`receive` + waiting receiver) and explicit state-mismatch error branches for illegal endpoint shapes,
-  - `endpointReceive` now keeps explicit success/error splits over queue + waiting-receiver combinations,
-  - send/receive preservation theorem entrypoints remain machine-checked after transition-surface updates.
-- ✅ **Step 3 complete (scheduler contract predicates)**
-  - added explicit scheduler/IPC coherence predicates for the active slice (`runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`),
-  - composed the targeted trio under `ipcSchedulerContractPredicates` with intentionally narrow (non-over-generalized) scope,
-  - added machine-checked preservation entrypoints for send/await-receive/receive under the new scheduler-contract predicate set.
-- ✅ **Step 4 complete (invariant bundle composition)**
-  - added named IPC+scheduler coherence components (`ipcSchedulerRunnableReadyComponent`, `ipcSchedulerBlockedSendComponent`, `ipcSchedulerBlockedReceiveComponent`) and aggregated them under `ipcSchedulerCoherenceComponent`,
-  - introduced composed `m35IpcSchedulerInvariantBundle` layered directly over `m3IpcSeedInvariantBundle`,
-  - added machine-checked preservation entrypoints for send/await-receive/receive over the new composed M3.5 bundle.
-- ✅ **Step 5 complete (helper lemmas)**
-  - added local endpoint-store lookup helpers near transitions (`tcb_lookup_of_endpoint_store`, `runnable_membership_of_endpoint_store`, `not_runnable_membership_of_endpoint_store`),
-  - send/await-receive/receive scheduler-contract preservation proofs now discharge concrete lookup/runnable obligations via these small local lemmas rather than repeated ad hoc case splits.
-- ✅ **Step 6 complete (preservation-theorem hardening)**
-  - endpoint transitions now expose local-first preservation theorems for scheduler-contract components (`<transition>_preserves_runnableThreadIpcReady`, `<transition>_preserves_blockedOnSendNotRunnable`, `<transition>_preserves_blockedOnReceiveNotRunnable`),
-  - composed scheduler-contract and M3.5 bundle preservation theorems are layered second and continue to compile machine-checked.
-- ✅ **Step 7 complete (executable demonstration closure)**
-  - `Main.lean` now includes an explicit waiting-receiver registration + handshake-send success path before the existing queued-sender receive sequence,
-  - prior demonstration behavior is preserved as an executable prefix and fixture-backed smoke expectations remain stable.
-
----
-
-### 4.6 Explicit non-goals for M3.5
-
-Out of scope for this slice:
-
-- Reply-cap transfer protocol completeness.
-- Priority donation and full scheduling policy reasoning.
-- Architecture/MMU/ASID details.
-- Retype/object-creation semantics (deferred to M4).
-- Full refinement correspondence to C-level seL4 implementation.
-
----
-
-## 5. Next slice definition (planned): M4 object lifecycle / retype safety
-
-### 5.1 M4 objective
-
-Introduce typed object lifecycle semantics (creation/retype-class operations) and prove that
-capability/object ownership relationships remain coherent under lifecycle changes.
-
-### 5.2 Why M4 follows M3.5
-
-After M3.5, endpoint/scheduler coupling gains a minimal protocol skeleton. The next structural
-safety risk is object lifecycle evolution; addressing it early prevents capability reasoning from
-splitting away from object-state reasoning.
-
-### 5.3 Planned M4 target outcomes
-
-1. **Retype/lifecycle transition surface**
-   - define executable transitions for at least one object lifecycle operation,
-   - keep operation typing explicit and failure branches deterministic.
-
-2. **Lifecycle coherence invariants**
-   - object identity/aliasing constraints,
-   - capability references remain valid and authority-consistent across lifecycle updates.
-
-3. **Composed bundle integration**
-   - compose M4 lifecycle invariants with existing scheduler/capability/IPC bundles,
-   - retain separable theorem surfaces for maintainable proof updates.
+3. **Capability-object coherence invariants**
+   - specify that capability references remain type-compatible and target-valid after lifecycle
+     updates,
+   - ensure lifecycle updates preserve authority monotonicity assumptions already used by M2.
 
 4. **Preservation theorem entrypoints**
-   - theorem entrypoints for lifecycle transitions,
-   - at least one compositional theorem touching both capability and lifecycle layers.
+   - provide machine-checked `<transition>_preserves_<invariant>` entrypoints for each new
+     lifecycle transition,
+   - include at least one composed theorem over lifecycle + existing capability invariant bundle.
 
-5. **Executable scenario evidence**
-   - `Main.lean` demonstration of lifecycle operation with stable expected trace semantics,
-   - fixture updates in `tests/fixtures/main_trace_smoke.expected` only when behavior change is intentional.
+5. **Executable + fixture evidence**
+   - extend `Main.lean` with at least one lifecycle scenario,
+   - update `tests/fixtures/main_trace_smoke.expected` with stable semantic fragments if behavior
+     output changes intentionally.
 
-### 5.4 M4 provisional acceptance criteria (planning baseline)
+### 4.4 M4-A acceptance criteria
 
-1. Current required gates continue to pass (`test_fast`, `test_smoke`, `lake build`, `lake exe`).
-2. Lifecycle transitions compile with explicit success/error branches.
-3. Lifecycle invariants are named and integrated into composed invariant bundle structure.
-4. Preservation theorem entrypoints compile without `axiom`/`sorry` additions.
-5. Documentation is updated to reflect M4 scope and post-M4 next-slice plan.
+1. `./scripts/test_fast.sh` succeeds.
+2. `./scripts/test_smoke.sh` succeeds.
+3. `lake build` succeeds.
+4. `lake exe sele4n` succeeds and includes lifecycle behavior evidence.
+5. Hygiene scan is clean:
+   - `rg -n "axiom|sorry|TODO" SeLe4n Main.lean`.
+6. Lifecycle invariants are named, documented, and composed with existing bundle structure.
+7. Preservation theorem entrypoints compile without introducing proof placeholders.
 
-### 5.5 Explicit non-goals for M4 (initial pass)
+### 4.5 Explicit non-goals (M4-A)
 
 - Full allocator/heap policy modeling.
-- Architecture-specific memory management internals.
-- End-to-end refinement proof to C implementation.
-- Full policy framework redesign.
+- Architecture-specific MMU/ASID internals.
+- Full reply-cap protocol redesign.
+- End-to-end C refinement correspondence.
+- General policy engine redesign.
+
+---
+
+## 5. Next slice: M4-B lifecycle-capability composition hardening
+
+### 5.1 Objective
+
+Strengthen lifecycle semantics by integrating lifecycle updates with capability revocation/deletion
+flows and proving stronger stale-reference exclusion properties.
+
+### 5.2 M4-B target outcomes
+
+1. **Lifecycle + revoke/delete composition**
+   - define at least one composed transition story where lifecycle and capability lifecycle
+     operations interact explicitly.
+
+2. **Stale reference exclusion invariants**
+   - add invariants ruling out stale capability references to retired/retyped object identities.
+
+3. **Cross-bundle preservation theorem surface**
+   - prove composed preservation covering lifecycle invariants plus capability lifecycle authority
+     invariants.
+
+4. **Error-path completeness**
+   - include explicit failure-path theorems (invalid type, stale object reference, illegal
+     authority).
+
+5. **Scenario + testing growth**
+   - expand executable scenarios to include success and failure lifecycle stories,
+   - extend Tier 3 checks with M4-specific theorem/bundle anchors.
+
+### 5.3 Provisional M4-B acceptance baseline
+
+1. Existing required gates remain green (`test_fast`, `test_smoke`).
+2. M4-A lifecycle contracts remain intact while M4-B features land.
+3. Tier 2 fixture remains stable and intentional.
+4. Tier 3 includes lifecycle-capability composition anchors.
+5. Documentation clearly updates post-M4 roadmap direction (M5 preview).
 
 ---
 
 ## 6. Change-control policy
 
-When milestone scope, transition APIs, or invariant composition changes:
+When milestone scope or theorem/API surfaces change:
 
-1. Update docs in the same commit range as code.
-2. Keep milestone status markers accurate (`complete`, `in progress`, `planned`).
-3. If scope is deferred, record reason and destination milestone.
-4. Do not claim milestone completion without executable + theorem evidence.
-5. Keep `README.md`, `docs/SEL4_SPEC.md`, and `docs/DEVELOPMENT.md` synchronized.
+1. Update docs in the same commit range.
+2. Keep stage markers synchronized across README, spec, and development guide.
+3. Record deferred work and destination milestone explicitly.
+4. Do not claim slice completion without executable + theorem evidence.
+5. Keep acceptance criteria actionable and command-verifiable.
 
 ---
 
-## 7. Milestone closure evidence checklist
+## 7. PR evidence checklist
 
-Include this checklist in PR descriptions:
-
-- [ ] New/updated transition definitions for claimed slice exist.
-- [ ] Invariant components are named, documented, and bundled.
+- [ ] New/updated transition definitions for claimed slice are present.
+- [ ] Invariant components are named and integrated into bundle structure.
 - [ ] Preservation theorem entrypoints compile.
 - [ ] `lake build` executed successfully.
 - [ ] `lake exe sele4n` executed successfully.
 - [ ] Hygiene scan (`axiom|sorry|TODO`) executed and clean.
-- [ ] Docs updated to match implementation and next slice.
-- [ ] Explicit statement of remaining proof debt (if any).
+- [ ] `./scripts/test_fast.sh` and `./scripts/test_smoke.sh` executed.
+- [ ] Docs updated to match current and next slice.
+- [ ] Remaining proof debt (if any) is explicitly stated.
 
 ---
 
-## 8. Roadmap horizon (after M4)
+## 8. Implementation surface inventory (for contributors)
 
-1. **M5 refinement bridge (incremental)**
-   - staged correspondence obligations between abstract Lean transitions and lower-level semantics.
-2. **M6 policy/protocol deepening**
-   - richer IPC/reply-capability protocol and stronger scheduler-policy obligations.
-3. **M7 assurance hardening**
-   - expanded integration checks and stronger compositional coverage across milestone bundles.
+The current milestone contract spans these concrete module families:
 
-The roadmap remains incremental so proof breakage and review complexity stay local and tractable.
+1. **Foundations**
+   - `Prelude` (IDs + kernel monad),
+   - `Machine` (machine-state helpers),
+   - `Model/Object`, `Model/State` (typed object store and global system state).
+
+2. **Scheduler contract**
+   - scheduler transitions and M1 invariants/bundle surfaces.
+
+3. **Capability contract**
+   - CSpace lookup/insert/mint/delete/revoke,
+   - attenuation + lifecycle authority component invariants,
+   - capability bundle preservation entrypoints.
+
+4. **IPC contract**
+   - endpoint send/await-receive/receive transitions,
+   - endpoint/IPC invariants,
+   - M3.5 scheduler coherence predicates and bundle composition.
+
+5. **Executable evidence contract**
+   - `Main.lean` scenario path,
+   - Tier 2 fixture-backed semantic fragment checks.
+
+M4 work must extend this surface without regressing any closed milestone contract.
+
+---
+
+## 9. M4 documentation acceptance expectations
+
+A PR claiming meaningful M4 progress must include:
+
+1. updates to normative docs (`README`, spec, development guide),
+2. updates to GitBook deep-dive pages affected by the semantic change,
+3. explicit mention of whether fixture changes were required,
+4. explicit mention of which invariant bundles were touched and why,
+5. explicit statement of remaining proof debt, if any.

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -1,176 +1,101 @@
-# seLe4n Testing Framework Implementation Plan (Current Baseline + Next Expansion)
+# seLe4n Testing Framework Plan
 
 ## 1. Purpose
 
-This document is the testing framework baseline for seLe4n. It captures what is already enforced,
-what remains intentionally optional, and what next expansion steps should be taken as the project
-moves through the post-M3.5 / active-M4 stage.
+This document defines the active testing baseline and near-term expansion path for the M4 stage.
 
-### 1.1 Implementation status snapshot
+Current stage context: **M4-A lifecycle/retype foundations in progress**.
 
-Current repository status:
+## 2. Current enforced tiers
 
-- ✅ Work package A (script scaffold) implemented.
-- ✅ Work package B (fixture-backed executable smoke baseline) implemented.
-- ✅ Work package C (CI wiring to script entrypoints) implemented.
-- ✅ Work package D (docs integration) implemented.
-- ✅ Work package E (Tier 3 invariant/doc-surface checks) implemented, including M3.5 step-1 through step-7 closure anchors (transition/preservation anchors plus executable demonstration evidence anchors).
-
----
-
-## 2. Quality bar and outcomes
-
-The framework is successful only if all of the following remain true.
-
-1. **Proof-surface stability**
-   - `lake build` keeps theorem entrypoints compiling.
-   - No committed `axiom`, `sorry`, or unresolved work markers in core scope.
-
-2. **Executable behavior stability**
-   - `lake exe sele4n` remains operational.
-   - Stable output fragments are guarded by fixture checks.
-
-3. **Milestone regression resistance**
-   - M1/M2/M3/M3.5 guarantees remain protected while M4 evolves.
-   - Future milestone additions can be integrated without replacing baseline tiers.
-
-4. **Fast local loop + deterministic CI gates**
-   - contributors can run required checks quickly,
-   - CI runs the same repository entrypoints used locally.
-
-5. **Actionable failures**
-   - failures identify category (`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`) and likely next action.
-
----
-
-## 3. Current enforced scope
-
-### 3.1 Active required tiers
-
-- **Tier 0** hygiene check (`scripts/test_tier0_hygiene.sh`)
-- **Tier 1** build/theorem check (`scripts/test_tier1_build.sh`)
+- **Tier 0** hygiene (`scripts/test_tier0_hygiene.sh`)
+- **Tier 1** build/theorem compile (`scripts/test_tier1_build.sh`)
 - **Tier 2** fixture-backed executable smoke (`scripts/test_tier2_trace.sh`)
+- **Tier 3** invariant/doc-surface checks (`scripts/test_tier3_invariants.sh`, via full suite)
+- **Tier 4** extension hook (nightly wrapper currently documents expansion point)
 
-### 3.2 Aggregated required entrypoints
+## 3. Required entrypoints and CI contract
 
-- `./scripts/test_fast.sh` = Tier 0 + Tier 1
-- `./scripts/test_smoke.sh` = Tier 0 + Tier 1 + Tier 2
+Required local/CI entrypoints:
 
-Both are required pull-request CI jobs.
+- `./scripts/test_fast.sh` (Tier 0 + Tier 1)
+- `./scripts/test_smoke.sh` (Tier 0 + Tier 1 + Tier 2)
 
-### 3.3 Full/nightly tiers
+PR CI must call repository scripts directly and keep workflow logic thin.
 
-- `./scripts/test_full.sh` runs Tier 3 invariant/doc-surface checks.
-- `./scripts/test_nightly.sh` runs full plus Tier 4 extension notice.
+## 4. M4-A testing objectives
 
-Tier 3 is active in the full suite and includes milestone-surface anchors for M3.5 closure,
-including step-7 executable-demonstration closure guards; Tier 4 remains the next expansion hook.
+1. Keep baseline M1-M3.5 behavior stable.
+2. Add fixture fragments for lifecycle output once lifecycle scenarios become executable.
+3. Add Tier 3 anchors for lifecycle transition/invariant theorem surfaces.
+4. Preserve category-labeled failure output (`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`).
 
----
+## 5. M4-B testing expansion targets
 
-## 4. Script contract (implemented baseline)
+1. Add success + failure lifecycle scenario fixtures.
+2. Add grouped Tier 3 checks for lifecycle-capability composition symbols.
+3. Expand nightly checks toward repeat-run determinism and broader scenario sweeps.
+4. Standardize new artifact names for debugging lifecycle regression failures.
 
-All test scripts should continue to:
+## 6. Fixture policy
 
-- use `set -euo pipefail`,
-- resolve repository root robustly,
-- auto-source `$HOME/.elan/env` when available,
-- emit section-prefixed logs,
-- fail deterministically with clear category messages.
+Source of truth: `tests/fixtures/main_trace_smoke.expected`.
 
-Shared helper behaviors are centralized in `scripts/test_lib.sh` to avoid drift.
+Rules:
 
----
+1. Assert stable semantic substrings only.
+2. Update fixture only when executable behavior intentionally changes.
+3. Re-run `./scripts/test_tier2_trace.sh` and `./scripts/test_smoke.sh` after fixture edits.
+4. Explain fixture changes in PR notes.
 
-## 5. Fixture regression policy
+## 7. Operational checklist for contributors
 
-### 5.1 Fixture source of truth
+- [ ] Ran `./scripts/test_fast.sh`.
+- [ ] Ran `./scripts/test_smoke.sh`.
+- [ ] Ran `lake build` and `lake exe sele4n` when transition semantics changed.
+- [ ] Updated fixture intentionally (if needed) with rationale.
+- [ ] Updated docs when testing expectations changed.
 
-- Expected trace fragments: `tests/fixtures/main_trace_smoke.expected`.
-- Comparison mode: line-oriented substring matching for each non-empty fixture line.
+## 8. Signal map: what each tier protects
 
-### 5.2 Intentional behavior change workflow
+### Tier 0 (hygiene)
 
-1. Run `lake exe sele4n` and validate behavior change intent.
-2. Update only stable semantic fixture lines.
-3. Re-run `./scripts/test_tier2_trace.sh` and `./scripts/test_smoke.sh`.
-4. Explain fixture updates in PR notes.
+Primary risk protected:
 
-### 5.3 Failure diagnostics
+- accidental introduction of unresolved proof placeholders or hygiene debt in tracked proof surface.
 
-On mismatch, Tier 2 reports missing fragments on `[TRACE]` lines. CI can additionally archive:
+### Tier 1 (build/theorem compile)
 
-- `main_trace_smoke.actual.log`,
-- `main_trace_smoke.missing.txt`,
-- expected fixture file.
+Primary risks protected:
 
----
+- transition API drift,
+- theorem-entrypoint breakage,
+- bundle composition breakage across modules.
 
-## 6. CI contract
+### Tier 2 (trace fixture)
 
-Required PR jobs execute:
+Primary risks protected:
 
-1. `./scripts/test_fast.sh`
-2. `./scripts/test_smoke.sh`
+- executable semantic drift in integration scenarios,
+- stale milestone claims not reflected in runtime evidence.
 
-CI must continue calling repository scripts directly; avoid duplicating gate logic in workflow YAML.
+### Tier 3 (invariant/doc-surface anchors)
 
----
+Primary risks protected:
 
-## 7. Next expansion steps (active M4 readiness)
+- silent loss of required theorem/bundle/doc symbols used as milestone acceptance anchors.
 
-1. **Tier 2 fixture growth for M4 stories**
-   - add stable trace fragments once lifecycle/retype transitions become executable.
+### Tier 4 (nightly extension)
 
-2. **Tier 3 invariant-group deepening**
-   - extend current invariant/doc-surface checks into richer milestone-bundle grouped checks.
+Primary risks to target next:
 
-3. **Artifact ergonomics**
-   - standardize artifact naming for any new tier scripts.
+- determinism regressions,
+- scenario breadth gaps,
+- long-horizon confidence blind spots.
 
-4. **Nightly confidence checks (Tier 4)**
-   - add repeat-run determinism and broader scenario sweeps.
+## 9. M4-specific testing growth plan
 
-5. **Contributor guidance hardening**
-   - keep README + DEVELOPMENT + scenarios docs synchronized with any new tier requirements.
-
----
-
-## 8. Definition of done for current framework stage
-
-Current stage is healthy when all conditions below hold:
-
-1. `test_fast` and `test_smoke` remain stable and required.
-2. Tier 0/1/2 checks are enforced in PR CI.
-3. Fixture-backed trace regression check remains active and reviewable.
-4. Contributor docs explain run/debug/update workflow consistently.
-5. Failure output remains category-labeled and actionable.
-
----
-
-## 9. Operational checklist (for PR authors touching tests/docs)
-
-- [ ] Updated relevant docs when changing test behavior or tier requirements.
-- [ ] Verified `./scripts/test_fast.sh`.
-- [ ] Verified `./scripts/test_smoke.sh`.
-- [ ] Verified direct `lake build` and `lake exe sele4n` as needed.
-- [ ] Documented fixture intent when expected trace fragments changed.
-
----
-
-## 10. Risks and mitigations
-
-1. **Fixture brittleness**
-   - Mitigation: assert stable semantic fragments, not volatile formatting.
-
-2. **Script drift across tiers**
-   - Mitigation: continue shared helper usage in `test_lib.sh`.
-
-3. **CI/local divergence**
-   - Mitigation: CI must invoke repository scripts directly.
-
-4. **Runtime inflation**
-   - Mitigation: keep required loop minimal; push heavier checks to full/nightly.
-
-5. **Unclear maintenance ownership**
-   - Mitigation: maintain shared ownership expectations in `docs/DEVELOPMENT.md`.
+1. add lifecycle scenario fixture fragments that remain stable across formatting changes,
+2. add grouped lifecycle theorem anchor checks in Tier 3,
+3. add at least one failure-path scenario for lifecycle invalid-object/invalid-authority behavior,
+4. record any new artifact outputs with consistent naming for CI triage.

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -1,0 +1,67 @@
+# Project Overview
+
+## 1. Motivation
+
+seLe4n aims to make high-assurance kernel reasoning more usable for developers by combining three
+properties in one workflow:
+
+1. executable transition semantics,
+2. machine-checked invariant preservation,
+3. milestone-scoped change management.
+
+Many projects optimize for only one or two of these at a time. seLe4n intentionally treats all
+three as first-class engineering constraints.
+
+## 2. Why this project exists now
+
+The practical gap addressed by seLe4n:
+
+- formal methods can be hard to iterate on in day-to-day engineering,
+- executable prototypes can drift from proof claims,
+- subsystem interactions (scheduler/capability/IPC/lifecycle) are often documented inconsistently.
+
+seLe4n closes this gap by making transition/proof/executable/docs/test gates move together.
+
+## 3. What is already implemented
+
+Closed milestone surface today:
+
+- Bootstrap: model skeleton,
+- M1: scheduler invariants and preservation,
+- M2: capability/CSpace semantics and authority invariants,
+- M3: endpoint IPC seed semantics,
+- M3.5: typed waiting handshake + scheduler coherence contract.
+
+Current active milestone:
+
+- M4-A lifecycle/retype foundations.
+
+Planned immediate follow-on:
+
+- M4-B lifecycle-capability hardening.
+
+## 4. Project design in one page
+
+- transitions are executable and explicit,
+- errors are first-class (`KernelError`) outcomes,
+- invariants are named components before bundle composition,
+- theorem entrypoints are transition-oriented and searchable,
+- integration evidence is executable (`Main.lean`) and fixture-guarded.
+
+## 5. How contributors should think about the codebase
+
+When touching any subsystem:
+
+1. identify state-model assumptions in `Model/*`,
+2. update transition semantics in subsystem module,
+3. add/refine local invariant components,
+4. prove local preservation first,
+5. prove composed preservation next,
+6. update executable trace and fixtures if semantic output changed,
+7. synchronize docs in canonical + GitBook layers.
+
+## 6. Long-horizon objective
+
+seLe4n is not only a proof exercise; it is a staged path toward deployment-relevant reasoning,
+including mobile-first hardware considerations. The roadmap chapter details how to bridge from
+architecture-neutral model semantics to architecture binding and prototype integration constraints.

--- a/docs/gitbook/02-microkernel-and-sel4-primer.md
+++ b/docs/gitbook/02-microkernel-and-sel4-primer.md
@@ -1,0 +1,47 @@
+# Microkernel and seL4 Primer
+
+## What is a microkernel?
+
+A microkernel keeps only minimal core mechanisms in kernel mode, typically:
+
+- address-space and thread management,
+- scheduling,
+- IPC primitives,
+- capability-based authority mediation.
+
+Most services (drivers, filesystems, networking stacks) run in user space as isolated components.
+
+### Why microkernels are compelling
+
+1. **Smaller trusted core**: fewer lines in privileged code reduce attack and bug surface.
+2. **Fault containment**: a failed service can often be restarted without crashing entire system.
+3. **Policy/mechanism separation**: kernel provides mechanisms, user-space components define policy.
+4. **Security posture**: strong compartmentalization supports least privilege and high assurance.
+
+### Trade-offs
+
+- IPC and context-switch costs can be higher than monolithic kernels if not carefully designed.
+- System composition is operationally complex (service graph, capability distribution, startup order).
+- Verification and maintenance require disciplined interfaces and tooling.
+
+## What is seL4?
+
+seL4 is a high-assurance microkernel developed with machine-checked verification goals as a first
+class design constraint. It is known for combining strong isolation with formal assurance claims.
+
+Core seL4 characteristics relevant to seLe4n:
+
+- capability-based access control,
+- explicit object management and retype operations,
+- endpoint-based IPC,
+- scheduler and thread-state discipline,
+- architecture-specific realizations grounded in architecture-neutral reasoning layers.
+
+## Why seLe4n models seL4 semantics
+
+seLe4n does not attempt to instantly replicate the full seL4 proof corpus. Instead, it incrementally
+formalizes key semantic surfaces (scheduler, capabilities, IPC, lifecycle) so contributors can:
+
+- understand the interactions in executable form,
+- prove safety properties at each step,
+- and avoid all-or-nothing proof resets.

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -1,0 +1,92 @@
+# Architecture and Module Map
+
+## 1. Layered model structure
+
+seLe4n uses a layered architecture so semantic changes can be reviewed and proved incrementally.
+
+1. **Foundations (`Prelude`, `Machine`)**
+   - core type aliases and error/state monad shape,
+   - abstract machine state helpers used by kernel transitions.
+
+2. **Typed object/state model (`Model/Object`, `Model/State`)**
+   - kernel object universe and lifecycle-relevant object fields,
+   - global object store, scheduler state, typed lookup/store helpers,
+   - shared error taxonomy (`KernelError`).
+
+3. **Kernel transition subsystems (`Kernel/Scheduler`, `Kernel/Capability`, `Kernel/IPC`)**
+   - executable transition definitions,
+   - local invariants and transition-preservation theorem entrypoints.
+
+4. **Cross-subsystem composition (`Kernel/Capability/Invariant` + IPC links)**
+   - milestone bundles and composed preservation theorem surfaces.
+
+5. **Executable integration (`Main.lean`)**
+   - scenario trace demonstrating composed behavior under current milestone stage.
+
+## 2. Module responsibilities by file
+
+### Foundations
+
+- `SeLe4n/Prelude.lean`
+  - object/thread IDs and kernel monad contract used globally.
+- `SeLe4n/Machine.lean`
+  - machine registers, memory abstraction, and pure update/read helpers.
+
+### Model
+
+- `SeLe4n/Model/Object.lean`
+  - capability rights/targets,
+  - TCB structure + IPC state,
+  - endpoint protocol fields,
+  - CNode slot store and local revoke helper,
+  - `KernelObject` discriminated union.
+
+- `SeLe4n/Model/State.lean`
+  - `SystemState` (machine + object store + scheduler + IRQ handlers),
+  - `lookupObject` / `storeObject` / `setCurrentThread`,
+  - typed CSpace lookup/ownership helpers and supporting lemmas.
+
+### Scheduler subsystem
+
+- `SeLe4n/Kernel/Scheduler/Invariant.lean`
+  - M1 component invariants and scheduler bundle alias.
+- `SeLe4n/Kernel/Scheduler/Operations.lean`
+  - scheduling transitions + preservation theorem families.
+
+### Capability subsystem
+
+- `SeLe4n/Kernel/Capability/Operations.lean`
+  - CSpace transitions (`lookup`, `insert`, `mint`, `delete`, `revoke`).
+- `SeLe4n/Kernel/Capability/Invariant.lean`
+  - capability invariants + composed milestone bundles + IPC/scheduler composition links.
+
+### IPC subsystem
+
+- `SeLe4n/Kernel/IPC/Invariant.lean`
+  - endpoint transitions (`send`, `awaitReceive`, `receive`),
+  - endpoint + IPC invariants,
+  - scheduler-coherence contract predicates,
+  - preservation theorem entrypoints.
+
+### API + executable
+
+- `SeLe4n/Kernel/API.lean`
+  - compatibility barrel import surface for clients.
+- `Main.lean`
+  - concrete scenario execution and trace output validated by fixture checks.
+
+## 3. Dependency flow
+
+Conceptual dependency direction:
+
+`Prelude/Machine` → `Model` → `Scheduler/Capability/IPC transitions` → `Invariant composition` → `Main trace`
+
+This direction should be preserved to prevent proof cycles and maintain module readability.
+
+## 4. Cross-cutting architectural rules
+
+1. transition behavior must be deterministic and explicit,
+2. invariant components should be named and localized,
+3. bundle composition should remain additive,
+4. theorem naming should remain discoverable,
+5. docs and fixtures should evolve with semantics in the same change set.

--- a/docs/gitbook/04-project-design-deep-dive.md
+++ b/docs/gitbook/04-project-design-deep-dive.md
@@ -1,0 +1,46 @@
+# Project Design Deep Dive
+
+## Core design principles
+
+### 1) Deterministic transition semantics
+
+Every operation should expose clear success/error branching. Illegal object-state combinations must
+fail explicitly rather than being hidden behind partial definitions.
+
+### 2) Local-first theorem layering
+
+For a transition `t`, prove local invariant component preservation first, then prove composed-bundle
+preservation from those local facts. This keeps proof maintenance manageable across milestones.
+
+### 3) Compositional invariant architecture
+
+Avoid mega-invariants that become brittle. Instead:
+
+- define meaningful components,
+- name them clearly,
+- compose them into milestone bundles,
+- and preserve the bundle surface for downstream users/tests.
+
+### 4) Executable evidence as a contract
+
+`Main.lean` is not demo-only: it is part of the regression surface. Tier 2 fixture checks protect
+semantic breadcrumbs in executable traces so docs/claims stay grounded.
+
+## Why milestone slicing works here
+
+Milestone slicing (M1→M4) reduces risk by avoiding simultaneous redesign of:
+
+- object model,
+- transition APIs,
+- invariant architecture,
+- theorem strategy,
+- executable scenarios,
+- and testing gates.
+
+The slice approach allows each layer to harden before broader composition.
+
+## Design pressure at M4
+
+M4 is where object lifecycle semantics become central. This is a high-leverage layer because it
+connects capability references with the evolving object store. Done well, it sets up later stages
+for stronger stale-reference and authority proofs.

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -1,0 +1,32 @@
+# Specification and Roadmap
+
+This handbook chapter complements `docs/SEL4_SPEC.md`.
+
+## Current slice: M4-A
+
+M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces:
+
+1. lifecycle transition API,
+2. identity/aliasing invariants,
+3. capability-object coherence invariants,
+4. preservation theorem entrypoints,
+5. executable + fixture evidence.
+
+## Next slice: M4-B
+
+M4-B hardens lifecycle semantics through capability-lifecycle composition:
+
+1. lifecycle + revoke/delete interaction stories,
+2. stale-reference exclusion invariants,
+3. cross-bundle preservation,
+4. explicit failure-path theorem coverage,
+5. expanded scenario/Tier 3 checks.
+
+## Longer-term direction
+
+After M4-A/M4-B, likely focus areas include:
+
+- richer object lifecycle families,
+- policy and authority decomposition hardening,
+- architecture binding strategy,
+- and pre-deployment constraints for hardware execution paths.

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -1,0 +1,37 @@
+# Development Workflow
+
+## Daily contributor loop
+
+```bash
+./scripts/test_fast.sh
+./scripts/test_smoke.sh
+```
+
+Recommended deeper checks:
+
+```bash
+lake build
+lake exe sele4n
+rg -n "axiom|sorry|TODO" SeLe4n Main.lean
+./scripts/test_full.sh
+```
+
+## Implementation pattern
+
+1. update/introduce transition,
+2. define/refine local invariant components,
+3. add helper lemmas near transition,
+4. prove local preservation,
+5. prove composed preservation,
+6. update executable scenario/fixture,
+7. update docs in same commit range.
+
+## Documentation synchronization rule
+
+When semantics or milestone boundaries change, keep these in sync:
+
+- `README.md`,
+- `docs/SEL4_SPEC.md`,
+- `docs/DEVELOPMENT.md`,
+- `docs/TESTING_FRAMEWORK_PLAN.md`,
+- related `docs/gitbook/*` pages.

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -1,0 +1,26 @@
+# Testing and CI
+
+## Tier model
+
+- Tier 0: hygiene markers and shell-quality checks.
+- Tier 1: full Lean build/theorem compile.
+- Tier 2: fixture-backed executable smoke trace.
+- Tier 3: invariant/doc-surface anchors (full suite).
+- Tier 4: nightly extension point.
+
+## Required gates
+
+- `./scripts/test_fast.sh`
+- `./scripts/test_smoke.sh`
+
+CI should execute repository scripts directly to avoid local/CI divergence.
+
+## Why fixture checks matter
+
+The fixture check ensures that executable behavior supporting milestone claims remains visible and
+reviewable. It catches semantic drift that pure type-checking may miss.
+
+## M4 testing trajectory
+
+- M4-A: add lifecycle semantic trace fragments once lifecycle scenarios land.
+- M4-B: add success/failure lifecycle composition traces and stronger Tier 3 anchors.

--- a/docs/gitbook/08-current-slice-m4a.md
+++ b/docs/gitbook/08-current-slice-m4a.md
@@ -1,0 +1,26 @@
+# Current Slice: M4-A Lifecycle/Retype Foundations
+
+## Objective
+
+Add first-class lifecycle/retype semantics to the executable model and prove that capability/object
+relationships remain coherent through those updates.
+
+## Detailed target outcomes
+
+1. **Transition surface**
+   - at least one lifecycle operation with explicit success/error outcomes.
+2. **Identity discipline**
+   - invariants preventing illegal identity reuse and invalid aliasing.
+3. **Capability coherence**
+   - invariants ensuring capabilities remain target-valid/type-compatible after transitions.
+4. **Proof surface**
+   - transition-level preservation theorem entrypoints.
+5. **Executable evidence**
+   - scenario extension in `Main.lean` and fixture updates where behavior changes intentionally.
+
+## Review heuristics
+
+- are failure branches explicit and deterministic?
+- are invariants narrow and named?
+- are preservation proofs layered local-first?
+- is executable output still meaningful and stable?

--- a/docs/gitbook/09-next-slice-m4b.md
+++ b/docs/gitbook/09-next-slice-m4b.md
@@ -1,0 +1,21 @@
+# Next Slice: M4-B Lifecycle-Capability Hardening
+
+## Objective
+
+Move from foundational lifecycle semantics to stronger composition with capability deletion/revocation
+and stale-reference safety.
+
+## Detailed target outcomes
+
+1. lifecycle + capability lifecycle interaction semantics,
+2. stale-reference exclusion invariants,
+3. cross-bundle preservation theorems,
+4. failure-path theorem coverage,
+5. expanded executable/test anchors.
+
+## Exit signals for M4-B
+
+- required gates remain green,
+- lifecycle-capability composition theorem surfaces compile,
+- fixture updates are intentional and explained,
+- docs include post-M4 direction.

--- a/docs/gitbook/10-path-to-real-hardware-mobile-first.md
+++ b/docs/gitbook/10-path-to-real-hardware-mobile-first.md
@@ -1,0 +1,80 @@
+# Path to Real Hardware (Mobile-First)
+
+## Why mobile-first
+
+Mobile devices are an important practical target for high-assurance compartmentalization:
+
+- they run heterogeneous, privilege-sensitive workloads,
+- they are exposed to hostile networks and app ecosystems,
+- and they require strong isolation with tight performance/power constraints.
+
+A mobile-first strategy gives seLe4n a realistic deployment pressure profile early.
+
+## Reality check: model-to-hardware is a multi-stage bridge
+
+seLe4n today is a formal/executable model project, not a drop-in deployable kernel. A credible
+hardware path requires staged convergence across semantics, tooling, architecture binding, and
+system integration.
+
+## Staged roadmap toward hardware relevance
+
+### Stage H0: Semantic completeness in architecture-neutral model
+
+- complete lifecycle/capability/IPC/scheduler interactions,
+- harden invariant composition and error-path coverage,
+- strengthen executable scenarios to represent realistic subsystem choreography.
+
+### Stage H1: Architecture-binding interface plan
+
+- identify architecture-dependent assumptions currently abstracted,
+- define explicit interfaces for CPU mode transitions, interrupt surfaces, and memory mappings,
+- keep architecture-neutral theorems reusable where possible.
+
+### Stage H2: Boot and platform model alignment
+
+- model assumptions required at early boot (object initialization, capability roots, thread startup),
+- encode minimal platform contracts needed before user-space service graph starts.
+
+### Stage H3: Mobile-oriented subsystem decomposition
+
+- define trusted/less-trusted component boundaries for mobile use-cases,
+- map expected services (UI, radio, storage, sensor brokering) to capability/IPC patterns,
+- prioritize least-privilege capability distribution strategies.
+
+### Stage H4: Performance and predictability envelope
+
+- identify IPC and scheduling hot paths that matter on mobile SoCs,
+- introduce scenario-driven performance hypotheses (without prematurely overfitting),
+- track proof-friendly simplifications versus deployment realism trade-offs.
+
+### Stage H5: Prototype integration path
+
+- produce a small demonstrator topology that mirrors a realistic mobile security partition,
+- connect formal model assumptions to implementation obligations,
+- establish traceability from theorem claims to system-level tests.
+
+## Mobile-first target outcomes (long horizon)
+
+1. clear trust-boundary documentation for mobile service partitions,
+2. lifecycle/capability semantics robust enough for dynamic service management,
+3. explicit failure semantics for compromised/restarted services,
+4. architecture-binding strategy that does not invalidate core proofs,
+5. incremental evidence chain from model behavior to deployment constraints.
+
+## Risks and mitigations
+
+1. **Risk: overcommitting to hardware details too early**
+   - mitigation: preserve architecture-neutral core while isolating binding interfaces.
+2. **Risk: proof complexity explosion during architecture binding**
+   - mitigation: keep theorem layering compositional and interface-driven.
+3. **Risk: performance surprises on mobile IPC/scheduling paths**
+   - mitigation: add scenario-guided profiling hypotheses early in H4 planning.
+4. **Risk: docs drift between formal model and integration assumptions**
+   - mitigation: treat roadmap and assumption docs as versioned artifacts with PR gating.
+
+## What contributors can do now
+
+- keep M4 work crisp and deterministic,
+- document assumptions where lifecycle semantics intersect capability authority,
+- add executable scenarios that resemble real compartment orchestration,
+- and keep spec/development/testing/gitbook docs synchronized as the roadmap evolves.

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -1,0 +1,208 @@
+# Codebase Reference (Developer-Facing)
+
+This chapter is a practical map of the current Lean codebase so developers can reason about where
+semantics live, where proofs live, and how to evolve modules without breaking milestone contracts.
+
+## 1. Repository-level structure
+
+- `SeLe4n.lean`
+  - package export root; re-exports the public model + kernel API surface.
+- `Main.lean`
+  - executable scenario integration trace used in Tier 2 smoke checks.
+- `SeLe4n/`
+  - foundational model, transition, and proof modules.
+
+## 2. Foundation layer
+
+### `SeLe4n/Prelude.lean`
+
+Purpose:
+
+- defines core ID aliases (`ObjId`, `ThreadId`, `CPtr`, etc.),
+- defines `KernelM`, a small state+error monad for executable transitions.
+
+Why it matters:
+
+- all kernel operations and proof statements ultimately rely on these type aliases and monadic
+  conventions.
+
+Design notes:
+
+- aliases remain architecture-neutral (`Nat`) intentionally to keep early slices focused on
+  semantic correctness over representation detail.
+
+### `SeLe4n/Machine.lean`
+
+Purpose:
+
+- defines abstract machine state (`RegisterFile`, `MachineState`),
+- provides pure primitive update/read helpers (`readReg`, `writeReg`, `readMem`, `writeMem`, etc.).
+
+Why it matters:
+
+- allows transitions to carry machine context while keeping proof effort concentrated on kernel
+  object semantics.
+
+## 3. Object/state modeling layer
+
+### `SeLe4n/Model/Object.lean`
+
+Primary contents:
+
+- capability rights + capability target model,
+- TCB model with M3.5 IPC-visible thread state (`ready`, `blockedOnSend`, `blockedOnReceive`),
+- endpoint model (`state`, queue, optional waiting receiver),
+- CNode structure and slot operations (`lookup`, `insert`, `remove`, local revoke helper),
+- `KernelObject` sum type (`tcb`, `endpoint`, `cnode`).
+
+Reasoning value:
+
+- central place where object semantics are typed and constrained before transition code applies
+  updates.
+
+### `SeLe4n/Model/State.lean`
+
+Primary contents:
+
+- `KernelError`, `SchedulerState`, `SystemState`, `SlotRef`.
+- global object lookup/store transitions (`lookupObject`, `storeObject`, `setCurrentThread`).
+- typed CSpace helpers (`lookupCNode`, `lookupSlotCap`, `ownsSlot`, `ownedSlots`) + local lemmas.
+
+Reasoning value:
+
+- provides reusable typed access patterns; reduces repeated object-store pattern matching in kernel
+  transitions and theorem scripts.
+
+## 4. Scheduler layer (M1)
+
+### `SeLe4n/Kernel/Scheduler/Invariant.lean`
+
+Core invariants:
+
+1. `runQueueUnique`
+2. `currentThreadValid`
+3. `queueCurrentConsistent`
+4. composed alias bundle `schedulerInvariantBundle`
+
+Design intent:
+
+- strict queue/current consistency policy today (current must appear in runnable list).
+- aliases are used so milestone naming can evolve without breaking theorem call sites.
+
+### `SeLe4n/Kernel/Scheduler/Operations.lean`
+
+Primary transitions:
+
+- `chooseThread`
+- `schedule`
+- `handleYield`
+
+Proof style:
+
+- case-split over runnable queue and object lookup shape,
+- preserve each invariant component,
+- compose component proofs into bundle-level preservation entrypoints.
+
+## 5. Capability layer (M2)
+
+### `SeLe4n/Kernel/Capability/Operations.lean`
+
+Primary semantics:
+
+- slot lookup/insert (`cspaceLookupSlot`, `cspaceInsertSlot`),
+- minting with rights attenuation (`cspaceMint`, `rightsSubset`, `mintDerivedCap`),
+- lifecycle transitions (`cspaceDeleteSlot`, `cspaceRevoke`).
+
+Authority modeling:
+
+- attenuation + local revoke semantics intentionally scoped to current slice constraints.
+
+### `SeLe4n/Kernel/Capability/Invariant.lean`
+
+Core invariant components:
+
+1. `cspaceSlotUnique`
+2. `cspaceLookupSound`
+3. `cspaceAttenuationRule`
+4. `lifecycleAuthorityMonotonicity`
+
+Composition surfaces:
+
+- `capabilityInvariantBundle`
+- `m3IpcSeedInvariantBundle`
+- `m35IpcSchedulerInvariantBundle`
+
+Cross-layer role:
+
+- composes scheduler + capability + IPC invariants while preserving milestone-wise theorem naming
+  conventions.
+
+## 6. IPC layer (M3/M3.5)
+
+### `SeLe4n/Kernel/IPC/Invariant.lean`
+
+Primary transitions:
+
+- `endpointSend`
+- `endpointAwaitReceive`
+- `endpointReceive`
+
+Core invariant surfaces:
+
+- endpoint-local validity (`endpointQueueWellFormed`, `endpointObjectValid`, `endpointInvariant`),
+- system-level IPC validity (`ipcInvariant`),
+- scheduler coherence predicates for M3.5 handshake contract:
+  - `runnableThreadIpcReady`,
+  - `blockedOnSendNotRunnable`,
+  - `blockedOnReceiveNotRunnable`,
+  - composed `ipcSchedulerContractPredicates`.
+
+Proof organization:
+
+- local helper lemmas for `storeObject` effects,
+- transition-specific preservation theorems,
+- bundle-level preservation theorems reusing local components.
+
+## 7. API and executable integration
+
+### `SeLe4n/Kernel/API.lean`
+
+Purpose:
+
+- compatibility barrel re-exporting kernel surfaces for client imports.
+
+### `Main.lean`
+
+Purpose:
+
+- constructs bootstrap object graph,
+- executes scheduler/capability/IPC scenario chain,
+- emits trace lines validated by Tier 2 fixture checks.
+
+## 8. How to reason about changes safely
+
+When editing a module, apply this map:
+
+1. identify which milestone contract the file owns,
+2. identify which composed bundle references that contract,
+3. add/adjust local helper lemmas near transition changes,
+4. preserve theorem-entrypoint naming shape,
+5. update docs + fixture/test anchors in same commit range.
+
+## 9. Typical developer navigation patterns
+
+- **Need to add a new transition?**
+  - start in `Model/Object` or `Model/State` for data model updates,
+  - implement transition in the relevant kernel subsystem,
+  - add invariant component + preservation theorem,
+  - update composed bundle if needed.
+
+- **Need to understand an existing proof failure?**
+  - inspect transition-local helper lemmas first,
+  - then invariant component theorem,
+  - then composed bundle theorem that imports those components.
+
+- **Need to adjust executable scenario behavior?**
+  - update `Main.lean`,
+  - run Tier 2 trace check,
+  - update fixture lines intentionally and document rationale.

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -1,0 +1,104 @@
+# Proof and Invariant Map
+
+This chapter summarizes how theorem surfaces are organized and how they compose across milestones.
+
+## 1. Layered invariant philosophy
+
+seLe4n invariants are intentionally layered:
+
+1. **component invariants** describe one focused safety condition,
+2. **subsystem bundles** combine related components,
+3. **cross-subsystem bundles** compose milestone contracts.
+
+This keeps proof scripts reviewable and reduces blast radius when adding new transitions.
+
+## 2. Scheduler invariants (M1)
+
+Component level:
+
+- `runQueueUnique`
+- `currentThreadValid`
+- `queueCurrentConsistent`
+
+Bundle level:
+
+- `schedulerInvariantBundle` (alias over `kernelInvariant`)
+
+Preservation shape:
+
+- `chooseThread_preserves_*`
+- `schedule_preserves_*`
+- `handleYield_preserves_*`
+
+## 3. Capability invariants (M2)
+
+Component level:
+
+- uniqueness of slots,
+- lookup soundness,
+- attenuation rule,
+- lifecycle authority monotonicity.
+
+Bundle level:
+
+- `capabilityInvariantBundle`
+
+Preservation shape:
+
+- operation-level `*_preserves_capabilityInvariantBundle` for lookup/insert/mint/delete/revoke.
+
+## 4. IPC invariants (M3)
+
+Component level:
+
+- endpoint queue/object validity,
+- endpoint invariant,
+- `ipcInvariant` across object store.
+
+Preservation shape:
+
+- transition-level `endpointSend_preserves_ipcInvariant`, etc.
+
+## 5. IPC-scheduler coherence (M3.5)
+
+Component level:
+
+- runnable threads should be IPC-ready,
+- blocked-on-send threads should not remain runnable,
+- blocked-on-receive threads should not remain runnable.
+
+Bundle level:
+
+- `ipcSchedulerContractPredicates`
+- `ipcSchedulerCoherenceComponent`
+- `m35IpcSchedulerInvariantBundle`
+
+Preservation shape:
+
+- local component preservation theorem per transition,
+- composed contract preservation theorem per transition,
+- bundle preservation theorem per transition.
+
+## 6. Naming conventions and why they matter
+
+Preferred shape:
+
+- `<transition>_preserves_<componentOrBundle>`
+
+Why:
+
+- searchable theorem entrypoints,
+- stable doc/test anchors,
+- predictable maintainability under milestone growth.
+
+## 7. How M4 should extend this map
+
+M4 additions should follow existing style:
+
+1. lifecycle component invariants,
+2. lifecycle subsystem bundle,
+3. lifecycle+capability composed bundle integration,
+4. transition-level local preservation,
+5. bundle-level preservation entrypoints.
+
+Avoid adding broad invariants that bypass this layering.

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -1,0 +1,40 @@
+# seLe4n Handbook
+
+seLe4n is a Lean 4 formalization effort to build an executable, machine-checked model of core
+[seL4](https://sel4.systems) microkernel semantics.
+
+This handbook is the long-form documentation set for:
+
+- project motivation and design rationale,
+- milestone planning and delivery slices,
+- proof + implementation workflow,
+- testing/CI policy,
+- and the roadmap toward running verified components on real hardware (mobile-first).
+
+## Why this handbook exists
+
+The repository docs (`README.md`, spec, development guide, testing plan) are intentionally concise.
+This GitBook layer provides deeper explanations so contributors can understand **why** the project
+is shaped this way, not only **what** commands to run.
+
+## Current stage
+
+- Active slice: **M4-A lifecycle/retype foundations**.
+- Next slice: **M4-B lifecycle-capability composition hardening**.
+
+## Suggested reading order
+
+1. [Project Overview](01-project-overview.md)
+2. [Microkernel and seL4 Primer](02-microkernel-and-sel4-primer.md)
+3. [Architecture & Module Map](03-architecture-and-module-map.md)
+4. [Project Design Deep Dive](04-project-design-deep-dive.md)
+5. [Specification & Roadmap](05-specification-and-roadmap.md)
+6. [Development Workflow](06-development-workflow.md)
+7. [Testing & CI](07-testing-and-ci.md)
+8. [Current Slice: M4-A](08-current-slice-m4a.md)
+9. [Next Slice: M4-B](09-next-slice-m4b.md)
+10. [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first.md)
+11. [Codebase Reference](11-codebase-reference.md)
+12. [Proof and Invariant Map](12-proof-and-invariant-map.md)
+
+For normative acceptance criteria, treat `docs/SEL4_SPEC.md` as canonical.

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -1,0 +1,15 @@
+# Summary
+
+- [seLe4n Handbook](README.md)
+- [Project Overview](01-project-overview.md)
+- [Microkernel and seL4 Primer](02-microkernel-and-sel4-primer.md)
+- [Architecture & Module Map](03-architecture-and-module-map.md)
+- [Project Design Deep Dive](04-project-design-deep-dive.md)
+- [Specification & Roadmap](05-specification-and-roadmap.md)
+- [Development Workflow](06-development-workflow.md)
+- [Testing & CI](07-testing-and-ci.md)
+- [Current Slice: M4-A](08-current-slice-m4a.md)
+- [Next Slice: M4-B](09-next-slice-m4b.md)
+- [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first.md)
+- [Codebase Reference](11-codebase-reference.md)
+- [Proof and Invariant Map](12-proof-and-invariant-map.md)

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -1,68 +1,44 @@
 # Test scenarios and fixture maintenance
 
-This directory documents fixture-backed trace checks for `scripts/test_tier2_trace.sh` and how to
-keep them aligned with the active milestone stage.
+This directory tracks fixture-backed executable trace checks used by
+`scripts/test_tier2_trace.sh`.
 
-## Current stage alignment
+## Stage alignment
 
-- Most recently closed slice: **M3.5 IPC handshake + scheduler interaction**.
-- Fixture expectations preserve stable M1/M2/M3 behavior while capturing intentional M3.5
-  executable semantics (including waiting-receiver handshake evidence).
+- Closed baseline: M1-M3.5 (scheduler, capability, IPC handshake coherence).
+- Active stage: M4-A lifecycle/retype foundations.
+- Next stage: M4-B lifecycle-capability composition hardening.
 
-## Current fixture
+## Fixture source
 
 - `tests/fixtures/main_trace_smoke.expected`
-  - line-oriented expected *substrings* for `lake exe sele4n` smoke trace,
-  - each non-empty line must appear somewhere in actual output.
+  - each non-empty line is a required output substring,
+  - matching is line-oriented and order-agnostic.
 
-## Intentional fixture update workflow
+## Intentional update workflow
 
-When executable behavior changes intentionally:
-
-1. Run executable and inspect output:
+1. Run executable:
    ```bash
    source "$HOME/.elan/env"
    lake exe sele4n
    ```
-2. Update `tests/fixtures/main_trace_smoke.expected` with stable semantic lines only
-   (avoid timestamps/ordering-noise-sensitive strings).
+2. Update fixture with stable semantic fragments only.
 3. Re-run:
    ```bash
    ./scripts/test_tier2_trace.sh
    ./scripts/test_smoke.sh
    ```
-4. In PR description, explain why fixture changes are expected and which milestone slice they
-   correspond to (current slice vs next slice prep).
+4. Document why fixture changes are expected and which slice they support (M4-A or M4-B).
 
-## Control-data audit tip
+## Diagnostics behavior
 
-Use an intentionally bad fixture line to verify deterministic failure behavior:
+On mismatch, Tier 2 reports:
 
-```bash
-TMP_FIXTURE="$(mktemp)"
-cp tests/fixtures/main_trace_smoke.expected "$TMP_FIXTURE"
-echo "this line should never match" >> "$TMP_FIXTURE"
-TRACE_FIXTURE_PATH="$TMP_FIXTURE" ./scripts/test_tier2_trace.sh
-```
+- expected vs matched fragment counts,
+- missing lines with `[TRACE]` prefixes,
+- reminder to update fixture intentionally when behavior changed by design.
 
-The command should fail and report the missing expected line.
+When `TRACE_ARTIFACT_DIR` is set, diagnostics files are written:
 
-## Failure diagnostics contract
-
-`./scripts/test_tier2_trace.sh` reports:
-
-- total matched vs expected fragment count,
-- each missing expected fragment on its own `[TRACE]` line,
-- reminder to update fixture + PR rationale when drift is intentional.
-
-This keeps smoke regressions deterministic and reviewable in local runs and CI logs.
-
-## CI trace artifacts
-
-CI can set `TRACE_ARTIFACT_DIR` when running `./scripts/test_tier2_trace.sh`. When set, the script
-writes:
-
-- `main_trace_smoke.actual.log` (captured executable output),
-- `main_trace_smoke.missing.txt` (one missing expectation per line).
-
-PR workflow uploads those files plus expected fixture on failure.
+- `main_trace_smoke.actual.log`
+- `main_trace_smoke.missing.txt`


### PR DESCRIPTION
Expanded the GitBook navigation and handbook framing to include a much richer reading path for contributors, including new deep-reference chapters for codebase and proof-map reasoning. 

Significantly deepened high-level project explanation and contributor guidance in the GitBook overview and architecture chapters, including milestone context, workflow intent, dependency flow, and module responsibilities. 

Added a new Codebase Reference chapter that documents each major Lean module family (foundation, model, scheduler, capability, IPC, API, executable trace) and gives concrete change-navigation guidance for developers. 

Added a new Proof and Invariant Map chapter that explains layered invariant composition, theorem naming conventions, milestone bundle structure, and how M4 should extend the proof architecture safely. 

Expanded core repository docs to better support whole-codebase reasoning: README now includes a codebase reasoning quick map; the development guide adds a subsystem touch matrix and proof-review checklist; the spec adds implementation-surface inventory and M4 doc-acceptance expectations; the testing plan adds a tier signal map and M4 test-growth plan; the audit now records this documentation hardening pass. 
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699238077a8c832ba5710750dde387de)