### PR TITLE
Re-audit milestones, expand M4‑A Tier 3 anchors, and bump to 0.5.0

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -42,6 +42,17 @@ def bootstrapState : SystemState :=
       else
         none
     scheduler := { runnable := [1, 2], current := none }
+    lifecycle := {
+      objectTypes := fun oid =>
+        if oid = 1 then some .tcb
+        else if oid = 10 then some .cnode
+        else if oid = 11 then some .cnode
+        else if oid = demoEndpoint then some .endpoint
+        else none
+      capabilityRefs := fun ref =>
+        if ref = rootSlot then some (.object 1)
+        else none
+    }
   }
 
 def main : IO Unit := do

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in **M4 kickoff (object lifecycle/retype safety)** after completing M3.5 IPC
-handshake + scheduler coherence.
+seLe4n is currently in **M4-A lifecycle/retype foundations (step 1 complete)** after completing M3.5
+IPC handshake + scheduler coherence.
 
 ### Milestone board
 
@@ -18,7 +18,7 @@ handshake + scheduler coherence.
   composed IPC+scheduler invariant bundle, local-first preservation theorem layering, executable
   waiting-to-delivery trace evidence.
 - 🚧 **M4 current slice in progress**: object lifecycle/retype foundations and capability-object
-  coupling safety.
+  coupling safety (with state-model preparation completed).
 - 📍 **M4 next slice planned**: lifecycle + revocation composition, richer invariants, and expanded
   executable scenarios.
 
@@ -53,6 +53,9 @@ Deep technical chapters for implementation work:
 3. Establish capability-reference coherence invariants over lifecycle updates.
 4. Add preservation theorem entrypoints for each lifecycle transition.
 5. Extend executable evidence (`Main.lean`) and Tier 2 trace fixtures for lifecycle behavior.
+
+Step-1 progress note: lifecycle metadata now explicitly tracks object-store type identity and slot-to-target
+capability references, and CSpace insert/delete/revoke transitions keep those references synchronized.
 
 ## Next slice target outcomes (M4-B)
 

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -92,10 +92,40 @@ theorem cspaceRevoke_local_target_reduction
       | tcb tcb => simp [hObj] at hStep
       | endpoint ep => simp [hObj] at hStep
       | cnode cn =>
-          simp [hObj] at hStep
-          cases hStep
-          simp [SystemState.lookupSlotCap, SystemState.lookupCNode, CNode.lookup, CNode.revokeTargetLocal] at hLookup
-          rcases hLookup with ⟨slot', hFind⟩
+          let revokedRefs : List SlotRef :=
+            (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
+              (fun entry => { cnode := addr.cnode, slot := entry.fst })
+          let storedState : SystemState :=
+            { st with
+              objects :=
+                fun oid =>
+                  if oid = addr.cnode then
+                    some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target))
+                  else
+                    st.objects oid,
+              lifecycle :=
+                {
+                  st.lifecycle with
+                    objectTypes :=
+                      fun oid =>
+                        if oid = addr.cnode then
+                          some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)).objectType
+                        else
+                          st.lifecycle.objectTypes oid
+                }
+            }
+          have hStepClear : clearCapabilityRefs revokedRefs storedState = .ok ((), st') := by
+            simpa [revokedRefs, storedState, storeObject, hObj] using hStep
+          have hObjEq : st'.objects = storedState.objects :=
+            clearCapabilityRefs_preserves_objects storedState st' revokedRefs hStepClear
+          have hLookupStored :
+              SystemState.lookupSlotCap storedState { cnode := addr.cnode, slot := slot } = some cap := by
+            have hEq := SystemState.lookupSlotCap_eq_of_objects_eq st' storedState
+              { cnode := addr.cnode, slot := slot } hObjEq
+            simpa [hEq] using hLookup
+          simp [storedState, SystemState.lookupSlotCap, SystemState.lookupCNode,
+            CNode.lookup, CNode.revokeTargetLocal] at hLookupStored
+          rcases hLookupStored with ⟨slot', hFind⟩
           have hPred :
               ((decide (slot' = addr.slot) || !decide (cap.target = parent.target)) &&
                 decide (slot' = slot)) = true := by
@@ -204,22 +234,42 @@ theorem cspaceRevoke_preserves_source
           | tcb tcb => simp [hLookup, hObj] at hStep
           | endpoint ep => simp [hLookup, hObj] at hStep
           | cnode cn =>
-              simp [hLookup, hObj] at hStep
-              cases hStep
-              have hCap : SystemState.lookupSlotCap st addr = some parent :=
-                (cspaceLookupSlot_ok_iff_lookupSlotCap st addr parent).1 hLookup
-              refine ⟨parent, ?_⟩
-              apply (cspaceLookupSlot_ok_iff_lookupSlotCap
+              let revokedRefs : List SlotRef :=
+                (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
+                  (fun entry => { cnode := addr.cnode, slot := entry.fst })
+              let storedState : SystemState :=
                 { st with
                   objects :=
                     fun oid =>
                       if oid = addr.cnode then
-                        some (.cnode (cn.revokeTargetLocal addr.slot parent.target))
+                        some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target))
                       else
-                        st.objects oid }
-                addr parent).2
-              simpa [SystemState.lookupSlotCap, SystemState.lookupCNode,
-                CNode.lookup_revokeTargetLocal_source_eq_lookup, hObj] using hCap
+                        st.objects oid,
+                  lifecycle :=
+                    {
+                      st.lifecycle with
+                        objectTypes :=
+                          fun oid =>
+                            if oid = addr.cnode then
+                              some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)).objectType
+                            else
+                              st.lifecycle.objectTypes oid
+                    }
+                }
+              have hStepClear : clearCapabilityRefs revokedRefs storedState = .ok ((), st') := by
+                simpa [revokedRefs, storedState, storeObject, hLookup, hObj] using hStep
+              have hObjEq : st'.objects = storedState.objects :=
+                clearCapabilityRefs_preserves_objects storedState st' revokedRefs hStepClear
+              have hCap : SystemState.lookupSlotCap st addr = some parent :=
+                (cspaceLookupSlot_ok_iff_lookupSlotCap st addr parent).1 hLookup
+              have hCapStored : SystemState.lookupSlotCap storedState addr = some parent := by
+                simpa [storedState, SystemState.lookupSlotCap, SystemState.lookupCNode,
+                  CNode.lookup_revokeTargetLocal_source_eq_lookup, hObj] using hCap
+              have hCapFinal : SystemState.lookupSlotCap st' addr = some parent := by
+                have hEq := SystemState.lookupSlotCap_eq_of_objects_eq st' storedState addr hObjEq
+                simpa [hEq] using hCapStored
+              refine ⟨parent, ?_⟩
+              exact (cspaceLookupSlot_ok_iff_lookupSlotCap st' addr parent).2 hCapFinal
 
 theorem mintDerivedCap_attenuates
     (parent child : Capability)

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -30,7 +30,9 @@ def cspaceInsertSlot (addr : CSpaceAddr) (cap : Capability) : Kernel Unit :=
     match st.objects addr.cnode with
     | some (.cnode cn) =>
         let cn' := cn.insert addr.slot cap
-        storeObject addr.cnode (.cnode cn') st
+        match storeObject addr.cnode (.cnode cn') st with
+        | .error e => .error e
+        | .ok (_, st') => storeCapabilityRef addr (some cap.target) st'
     | _ => .error .objectNotFound
 
 theorem cspaceLookupSlot_ok_iff_lookupSlotCap
@@ -107,7 +109,9 @@ def cspaceDeleteSlot (addr : CSpaceAddr) : Kernel Unit :=
     match st.objects addr.cnode with
     | some (.cnode cn) =>
         let cn' := cn.remove addr.slot
-        storeObject addr.cnode (.cnode cn') st
+        match storeObject addr.cnode (.cnode cn') st with
+        | .error e => .error e
+        | .ok (_, st') => storeCapabilityRef addr none st'
     | _ => .error .objectNotFound
 
 /-- Revoke capabilities with the same target as the source in the containing CNode.
@@ -123,7 +127,12 @@ def cspaceRevoke (addr : CSpaceAddr) : Kernel Unit :=
         match st'.objects addr.cnode with
         | some (.cnode cn) =>
             let cn' := cn.revokeTargetLocal addr.slot parent.target
-            storeObject addr.cnode (.cnode cn') st'
+            let revokedRefs : List SlotRef :=
+              (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
+                (fun entry => { cnode := addr.cnode, slot := entry.fst })
+            match storeObject addr.cnode (.cnode cn') st' with
+            | .error e => .error e
+            | .ok (_, st'') => clearCapabilityRefs revokedRefs st''
         | _ => .error .objectNotFound
 
 

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -17,17 +17,26 @@ structure SchedulerState where
   current : Option SeLe4n.ThreadId
   deriving Repr, DecidableEq
 
-structure SystemState where
-  machine : SeLe4n.MachineState
-  objects : SeLe4n.ObjId → Option KernelObject
-  scheduler : SchedulerState
-  irqHandlers : SeLe4n.Irq → Option SeLe4n.ObjId
-
 /-- Architecture-neutral address of a capability slot inside a CNode object. -/
 structure SlotRef where
   cnode : SeLe4n.ObjId
   slot : SeLe4n.Slot
   deriving Repr, DecidableEq
+
+/-- Lifecycle metadata required by the first M4-A transition story.
+
+`objectTypes` keeps object-store identity explicit, while `capabilityRefs` records the target
+named by each populated capability slot reference. -/
+structure LifecycleMetadata where
+  objectTypes : SeLe4n.ObjId → Option KernelObjectType
+  capabilityRefs : SlotRef → Option CapTarget
+
+structure SystemState where
+  machine : SeLe4n.MachineState
+  objects : SeLe4n.ObjId → Option KernelObject
+  scheduler : SchedulerState
+  irqHandlers : SeLe4n.Irq → Option SeLe4n.ObjId
+  lifecycle : LifecycleMetadata
 
 /-- Abstract owner identity for a slot in this model: the containing CNode object id. -/
 abbrev CSpaceOwner := SeLe4n.ObjId
@@ -41,6 +50,10 @@ instance : Inhabited SystemState where
     objects := fun _ => none
     scheduler := default
     irqHandlers := fun _ => none
+    lifecycle := {
+      objectTypes := fun _ => none
+      capabilityRefs := fun _ => none
+    }
   }
 
 abbrev Kernel := SeLe4n.KernelM SystemState KernelError
@@ -56,12 +69,101 @@ def storeObject (id : SeLe4n.ObjId) (obj : KernelObject) : Kernel Unit :=
   fun st =>
     let objects' : SeLe4n.ObjId → Option KernelObject :=
       fun oid => if oid = id then some obj else st.objects oid
-    .ok ((), { st with objects := objects' })
+    let lifecycle' : LifecycleMetadata :=
+      {
+        st.lifecycle with
+          objectTypes := fun oid => if oid = id then some obj.objectType else st.lifecycle.objectTypes oid
+      }
+    .ok ((), { st with objects := objects', lifecycle := lifecycle' })
+
+/-- Record or clear a slot-to-target lifecycle reference mapping. -/
+def storeCapabilityRef (ref : SlotRef) (target : Option CapTarget) : Kernel Unit :=
+  fun st =>
+    let lifecycle' : LifecycleMetadata :=
+      {
+        st.lifecycle with
+          capabilityRefs := fun ref' => if ref' = ref then target else st.lifecycle.capabilityRefs ref'
+      }
+    .ok ((), { st with lifecycle := lifecycle' })
+
+/-- Pure state update that clears a finite list of slot-reference mappings. -/
+def clearCapabilityRefsState : List SlotRef → SystemState → SystemState
+  | [], st => st
+  | ref :: refs, st =>
+      clearCapabilityRefsState refs {
+        st with
+          lifecycle := {
+            st.lifecycle with
+              capabilityRefs := fun ref' => if ref' = ref then none else st.lifecycle.capabilityRefs ref'
+          }
+      }
+
+/-- Clear a finite list of slot-reference mappings. -/
+def clearCapabilityRefs (refs : List SlotRef) : Kernel Unit :=
+  fun st => .ok ((), clearCapabilityRefsState refs st)
 
 def setCurrentThread (tid : Option SeLe4n.ThreadId) : Kernel Unit :=
   fun st =>
     let sched := { st.scheduler with current := tid }
     .ok ((), { st with scheduler := sched })
+
+theorem storeCapabilityRef_preserves_objects
+    (st st' : SystemState)
+    (ref : SlotRef)
+    (target : Option CapTarget)
+    (hStep : storeCapabilityRef ref target st = .ok ((), st')) :
+    st'.objects = st.objects := by
+  unfold storeCapabilityRef at hStep
+  simp at hStep
+  cases hStep
+  rfl
+
+theorem clearCapabilityRefsState_preserves_objects
+    (refs : List SlotRef)
+    (st : SystemState) :
+    (clearCapabilityRefsState refs st).objects = st.objects := by
+  induction refs generalizing st with
+  | nil => rfl
+  | cons ref refs ih =>
+      simpa [clearCapabilityRefsState] using
+        ih {
+          st with
+            lifecycle := {
+              st.lifecycle with
+                capabilityRefs := fun ref' => if ref' = ref then none else st.lifecycle.capabilityRefs ref'
+            }
+        }
+
+theorem clearCapabilityRefs_preserves_objects
+    (st st' : SystemState)
+    (refs : List SlotRef)
+    (hStep : clearCapabilityRefs refs st = .ok ((), st')) :
+    st'.objects = st.objects := by
+  unfold clearCapabilityRefs at hStep
+  cases hStep
+  simpa using clearCapabilityRefsState_preserves_objects refs st
+
+theorem storeCapabilityRef_lookup_eq
+    (st st' : SystemState)
+    (ref : SlotRef)
+    (target : Option CapTarget)
+    (hStep : storeCapabilityRef ref target st = .ok ((), st')) :
+    st'.lifecycle.capabilityRefs ref = target := by
+  unfold storeCapabilityRef at hStep
+  simp at hStep
+  cases hStep
+  simp
+
+theorem storeObject_updates_objectTypeMeta
+    (st st' : SystemState)
+    (oid : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hStep : storeObject oid obj st = .ok ((), st')) :
+    st'.lifecycle.objectTypes oid = some obj.objectType := by
+  unfold storeObject at hStep
+  simp at hStep
+  cases hStep
+  simp
 
 namespace SystemState
 
@@ -90,6 +192,34 @@ def ownedSlots (st : SystemState) (owner : CSpaceOwner) : List (SeLe4n.Slot × C
   match lookupCNode st owner with
   | some cn => cn.slots
   | none => []
+
+/-- Lifecycle metadata view of object identity typing. -/
+def lookupObjectTypeMeta (st : SystemState) (id : SeLe4n.ObjId) : Option KernelObjectType :=
+  st.lifecycle.objectTypes id
+
+/-- Lifecycle metadata view of capability slot reference mapping. -/
+def lookupCapabilityRefMeta (st : SystemState) (ref : SlotRef) : Option CapTarget :=
+  st.lifecycle.capabilityRefs ref
+
+/-- `lookupSlotCap` is determined entirely by the object store. -/
+theorem lookupSlotCap_eq_of_objects_eq
+    (st₁ st₂ : SystemState)
+    (ref : SlotRef)
+    (hObj : st₁.objects = st₂.objects) :
+    lookupSlotCap st₁ ref = lookupSlotCap st₂ ref := by
+  simp [lookupSlotCap, lookupCNode, hObj]
+
+/-- Object-type lifecycle metadata is exact for every object-store id. -/
+def objectTypeMetadataConsistent (st : SystemState) : Prop :=
+  ∀ oid, lookupObjectTypeMeta st oid = (st.objects oid).map KernelObject.objectType
+
+/-- Capability-reference lifecycle metadata is exact for every slot reference. -/
+def capabilityRefMetadataConsistent (st : SystemState) : Prop :=
+  ∀ ref, lookupCapabilityRefMeta st ref = (lookupSlotCap st ref).map Capability.target
+
+/-- M4-A state-model metadata consistency bundle. -/
+def lifecycleMetadataConsistent (st : SystemState) : Prop :=
+  objectTypeMetadataConsistent st ∧ capabilityRefMetadataConsistent st
 
 theorem lookupSlotCap_eq_none_of_lookupCNode_eq_none
     (st : SystemState)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M4-A lifecycle/retype foundations (active)**.
+Current stage: **M4-A lifecycle/retype foundations (active, step 1 completed)**.
 
 Primary goals for contributors:
 
@@ -39,9 +39,9 @@ Unless intentionally redesigned and documented, preserve:
 
 ### 3.2 Recommended implementation sequence (M4-A)
 
-1. **State-model preparation**
-   - introduce only lifecycle metadata required for the first transition story,
-   - keep ownership explicit (object store identity, capability reference mapping).
+1. **State-model preparation** ✅ **completed**
+   - lifecycle metadata introduced for first transition story only,
+   - ownership remains explicit via object-store identity metadata and capability reference mapping.
 
 2. **Lifecycle transition(s)**
    - implement deterministic success/error branching,

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -63,3 +63,20 @@ This pass increased documentation depth in two important ways:
      responsibilities from source alone.
 
 These additions reduce review friction and lower onboarding risk for M4 and later slices.
+
+## 8. Milestone completion verification (latest re-audit)
+
+This re-audit re-validated milestones currently marked complete in repository docs:
+
+- **Bootstrap**: executable monad/model skeleton still builds and runs via `lake build` +
+  `lake exe sele4n`.
+- **M1**: scheduler invariant bundle symbols and theorem entrypoints verified by Tier 3 anchors.
+- **M2**: capability invariant bundle and preservation entrypoints verified by Tier 3 anchors and
+  full build.
+- **M3**: IPC seed bundle and endpoint send/receive preservation entrypoints verified by Tier 3.
+- **M3.5**: handshake/scheduler coherence predicates, composed bundle surfaces, and executable trace
+  evidence verified by Tier 2 fixture checks and Tier 3 anchor scans.
+
+No failing tests were observed in the full scripted stack (`test_fast`, `test_smoke`,
+`test_full`, `test_nightly`). The nightly Tier 4 message remains an explicit documented extension
+point, not a runtime warning/failure condition.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -12,7 +12,7 @@ It defines:
 4. Acceptance criteria and non-goals for focused, reviewable implementation.
 5. Change-control expectations for code, proofs, executable traces, and docs.
 
-Current stage: **post-M3.5 closure / active M4 kickoff**.
+Current stage: **active M4-A lifecycle/retype foundations (step 1 complete)**.
 
 ---
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,14 +4,14 @@
 
 This document defines the active testing baseline and near-term expansion path for the M4 stage.
 
-Current stage context: **M4-A lifecycle/retype foundations in progress**.
+Current stage context: **M4-A lifecycle/retype foundations in progress (step 1 completed)**.
 
 ## 2. Current enforced tiers
 
 - **Tier 0** hygiene (`scripts/test_tier0_hygiene.sh`)
 - **Tier 1** build/theorem compile (`scripts/test_tier1_build.sh`)
 - **Tier 2** fixture-backed executable smoke (`scripts/test_tier2_trace.sh`)
-- **Tier 3** invariant/doc-surface checks (`scripts/test_tier3_invariants.sh`, via full suite)
+- **Tier 3** invariant/doc-surface checks (`scripts/test_tier3_invariant_surface.sh`, via full suite)
 - **Tier 4** extension hook (nightly wrapper currently documents expansion point)
 
 ## 3. Required entrypoints and CI contract
@@ -27,7 +27,7 @@ PR CI must call repository scripts directly and keep workflow logic thin.
 
 1. Keep baseline M1-M3.5 behavior stable.
 2. Add fixture fragments for lifecycle output once lifecycle scenarios become executable.
-3. Add Tier 3 anchors for lifecycle transition/invariant theorem surfaces.
+3. Keep Tier 3 anchors for lifecycle transition/invariant theorem surfaces (including metadata-coherence anchors).
 4. Preserve category-labeled failure output (`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`).
 
 ## 5. M4-B testing expansion targets

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -4,7 +4,7 @@ This handbook chapter complements `docs/SEL4_SPEC.md`.
 
 ## Current slice: M4-A
 
-M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces:
+M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces (with step 1 state-model preparation completed):
 
 1. lifecycle transition API,
 2. identity/aliasing invariants,

--- a/docs/gitbook/08-current-slice-m4a.md
+++ b/docs/gitbook/08-current-slice-m4a.md
@@ -7,6 +7,14 @@ relationships remain coherent through those updates.
 
 ## Detailed target outcomes
 
+## Implementation status
+
+- ✅ Step 1 complete: state-model lifecycle metadata is now explicit for object identity and
+  capability reference ownership mapping (including revoke-path sibling cleanup).
+- 🚧 Remaining M4-A work: transition expansion, invariant layering, and composed preservation
+  theorem growth.
+
+
 1. **Transition surface**
    - at least one lifecycle operation with explicit success/error outcomes.
 2. **Identity discipline**

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.4.8"
+version = "0.5.0"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -68,6 +68,12 @@ run_check "INVARIANT" rg -n '^def endpointQueueWellFormed' SeLe4n/Kernel/IPC/Inv
 run_check "INVARIANT" rg -n '^def endpointObjectValid' SeLe4n/Kernel/IPC/Invariant.lean
 
 
+# M4-A step-1 lifecycle metadata anchors must remain present.
+run_check "INVARIANT" rg -n '^structure LifecycleMetadata' SeLe4n/Model/State.lean
+run_check "INVARIANT" rg -n '^def lifecycleMetadataConsistent' SeLe4n/Model/State.lean
+run_check "INVARIANT" rg -n '^def cspaceRevoke' SeLe4n/Kernel/Capability/Operations.lean
+run_check "INVARIANT" rg -n '^theorem cspaceRevoke_local_target_reduction' SeLe4n/Kernel/Capability/Invariant.lean
+
 # M3.5 step-7 executable demonstration closure anchors.
 run_check "TRACE" rg -n 'endpointAwaitReceive demoEndpoint 2' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean


### PR DESCRIPTION
### Motivation

- Ensure that the repository milestone claims, documentation, and test surface remain synchronized after the M4‑A lifecycle metadata rollout. 
- Harden Tier‑3 invariant anchors so M4‑A lifecycle metadata/coherence symbols are protected by automated checks. 
- Bump the project version to reflect the audited slice baseline.

### Description

- Introduced lifecycle metadata into the state model via `structure LifecycleMetadata` and added `lifecycle` to `SystemState`, plus pure helpers `storeCapabilityRef`, `clearCapabilityRefsState`, and `clearCapabilityRefs` in `SeLe4n/Model/State.lean` to track slot→target mappings and object‑type identity. 
- Synchronized CSpace transitions to atomically update lifecycle metadata: `cspaceInsertSlot`, `cspaceDeleteSlot`, and `cspaceRevoke` now update `capabilityRefs` and use `storeObject`/`clearCapabilityRefs` where appropriate in `SeLe4n/Kernel/Capability/Operations.lean`. 
- Adjusted proof obligations in `SeLe4n/Kernel/Capability/Invariant.lean` to account for lifecycle metadata cleanup (e.g. `cspaceRevoke_local_target_reduction`, `cspaceRevoke_preserves_source`) using small state lemmas such as `lookupSlotCap_eq_of_objects_eq` and `clearCapabilityRefs_preserves_objects`. 
- Made the demo bootstrap coherent with the new model by initializing `lifecycle` metadata in `Main.lean`. 
- Documentation and testing framework updates: bumped `lakefile.toml` version to `0.5.0`, added M4‑A lifecycle anchors to `scripts/test_tier3_invariant_surface.sh`, updated `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/PROJECT_AUDIT.md`, `docs/DEVELOPMENT.md`, and `README.md` to reflect `M4‑A (step 1 completed)` and the metadata‑coherence testing expectations.

### Testing

- Ran `./scripts/test_fast.sh` (Tier 0 + Tier 1) and the build/theorem-compile checks completed successfully. (PASS)
- Ran `./scripts/test_smoke.sh` (Tier 0 + Tier 1 + Tier 2) and fixture trace comparisons matched the expected smoke output. (PASS)
- Ran `./scripts/test_full.sh` and `./scripts/test_nightly.sh` including Tier 3 invariant-surface anchors and all anchored symbol checks passed. (PASS)
- Ran the audit harness `./scripts/audit_testing_framework.sh` which exercised the control-data failure path; the audit intentionally triggers a control mismatch to validate detection and handled it as expected (the injected Tier‑2 mismatch is intentional and treated as a pass for the audit). (PASS as intended)
- Executed `lake build` and `lake exe sele4n` and observed successful build and expected demo trace output. (PASS)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924c242f64832b9d6f7845118bbc19)