### PR TITLE
Audit follow-up: add illegal-state runtime evidence and tighten M4-A step-2 anchors

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -3,6 +3,7 @@ import SeLe4n
 open SeLe4n.Model
 
 def rootSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 0 }
+def lifecycleAuthSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 5 }
 def mintedSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 3 }
 def siblingSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 4 }
 def demoEndpoint : SeLe4n.ObjId := 30
@@ -33,7 +34,22 @@ def bootstrapState : SystemState :=
                 target := .object 1
                 rights := [.read, .write, .grant]
                 badge := none
+              }),
+              (5, {
+                target := .object 12
+                rights := [.read, .write]
+                badge := none
               }) ]
+        })
+      else if oid = 12 then
+        some (.tcb {
+          tid := 12
+          priority := 10
+          domain := 0
+          cspaceRoot := 10
+          vspaceRoot := 20
+          ipcBuffer := 8192
+          ipcState := .ready
         })
       else if oid = 11 then
         some (.cnode CNode.empty)
@@ -46,11 +62,13 @@ def bootstrapState : SystemState :=
       objectTypes := fun oid =>
         if oid = 1 then some .tcb
         else if oid = 10 then some .cnode
+        else if oid = 12 then some .tcb
         else if oid = 11 then some .cnode
         else if oid = demoEndpoint then some .endpoint
         else none
       capabilityRefs := fun ref =>
         if ref = rootSlot then some (.object 1)
+        else if ref = lifecycleAuthSlot then some (.object 12)
         else none
     }
   }
@@ -64,6 +82,30 @@ def main : IO Unit := do
       | .error err => IO.println s!"source lookup error: {reprStr err}"
       | .ok (srcCap, _) =>
           IO.println s!"source cap rights before mint: {reprStr srcCap.rights}"
+      match SeLe4n.Kernel.lifecycleRetypeObject rootSlot 12
+          (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st1 with
+      | .error err =>
+          IO.println s!"lifecycle retype unauthorized branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected lifecycle retype success with wrong authority"
+      let stIllegalState : SystemState :=
+        { st1 with
+          lifecycle := {
+            st1.lifecycle with
+              objectTypes := fun oid =>
+                if oid = 12 then some .endpoint else st1.lifecycle.objectTypes oid
+          }
+        }
+      match SeLe4n.Kernel.lifecycleRetypeObject lifecycleAuthSlot 12
+          (.endpoint { state := .idle, queue := [], waitingReceiver := none }) stIllegalState with
+      | .error err => IO.println s!"lifecycle retype illegal-state branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected lifecycle retype success under stale metadata"
+      match SeLe4n.Kernel.lifecycleRetypeObject lifecycleAuthSlot 12
+          (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st1 with
+      | .error err => IO.println s!"lifecycle retype error: {reprStr err}"
+      | .ok (_, stLifecycle) =>
+          IO.println s!"lifecycle retype success object kind: {reprStr <| (stLifecycle.objects 12).map KernelObject.objectType}"
       match SeLe4n.Kernel.cspaceMint rootSlot mintedSlot [.read] none st1 with
       | .error err => IO.println s!"cspace mint error: {reprStr err}"
       | .ok (_, st2) =>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in **M4-A lifecycle/retype foundations (step 1 complete)** after completing M3.5
+seLe4n is currently in **M4-A lifecycle/retype foundations (steps 1-2 complete)** after completing M3.5
 IPC handshake + scheduler coherence.
 
 ### Milestone board
@@ -18,7 +18,7 @@ IPC handshake + scheduler coherence.
   composed IPC+scheduler invariant bundle, local-first preservation theorem layering, executable
   waiting-to-delivery trace evidence.
 - 🚧 **M4 current slice in progress**: object lifecycle/retype foundations and capability-object
-  coupling safety (with state-model preparation completed).
+  coupling safety (with state-model preparation and deterministic lifecycle transition branching completed).
 - 📍 **M4 next slice planned**: lifecycle + revocation composition, richer invariants, and expanded
   executable scenarios.
 
@@ -48,14 +48,16 @@ Deep technical chapters for implementation work:
 
 ## Current slice target outcomes (M4-A)
 
-1. Introduce typed lifecycle transition surface (at minimum one deterministic retype/create path).
+1. Introduce typed lifecycle transition surface (deterministic retype branch now implemented).
 2. Define object identity and aliasing invariants for newly created/retyped objects.
 3. Establish capability-reference coherence invariants over lifecycle updates.
 4. Add preservation theorem entrypoints for each lifecycle transition.
 5. Extend executable evidence (`Main.lean`) and Tier 2 trace fixtures for lifecycle behavior.
 
-Step-1 progress note: lifecycle metadata now explicitly tracks object-store type identity and slot-to-target
-capability references, and CSpace insert/delete/revoke transitions keep those references synchronized.
+Progress note (steps 1-2): lifecycle metadata now explicitly tracks object-store type identity and slot-to-target
+capability references, CSpace insert/delete/revoke transitions keep those references synchronized, and
+`lifecycleRetypeObject` provides deterministic success/error branching with explicit illegal-state and
+illegal-authority outcomes, and the executable trace now exercises both failure branches plus a success path.
 
 ## Next slice target outcomes (M4-B)
 

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -3,3 +3,4 @@ import SeLe4n.Machine
 import SeLe4n.Model.Object
 import SeLe4n.Model.State
 import SeLe4n.Kernel.API
+

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -3,3 +3,5 @@ import SeLe4n.Kernel.Capability.Operations
 import SeLe4n.Kernel.IPC.Invariant
 import SeLe4n.Kernel.Capability.Invariant
 import SeLe4n.Kernel.Scheduler.Operations
+
+import SeLe4n.Kernel.Lifecycle.Operations

--- a/SeLe4n/Kernel/Lifecycle/Operations.lean
+++ b/SeLe4n/Kernel/Lifecycle/Operations.lean
@@ -1,0 +1,82 @@
+import SeLe4n.Kernel.Capability.Operations
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+/-- Lifecycle authority required to retype an object identity in this slice.
+
+The authority capability must target the object directly and include `write` rights. -/
+def lifecycleRetypeAuthority (cap : Capability) (target : SeLe4n.ObjId) : Bool :=
+  decide (cap.target = .object target) && Capability.hasRight cap .write
+
+/-- Retype an existing object id to a new typed object value.
+
+Deterministic branch contract for M4-A step 2:
+1. target object must exist,
+2. lifecycle metadata for the target id must agree with object-store type (`illegalState` otherwise),
+3. authority slot lookup must succeed,
+4. authority must satisfy `lifecycleRetypeAuthority` (`illegalAuthority` otherwise),
+5. object store + lifecycle object-type metadata are updated atomically on success. -/
+def lifecycleRetypeObject
+    (authority : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj : KernelObject) : Kernel Unit :=
+  fun st =>
+    match st.objects target with
+    | none => .error .objectNotFound
+    | some currentObj =>
+        if st.lifecycle.objectTypes target = some currentObj.objectType then
+          match cspaceLookupSlot authority st with
+          | .error e => .error e
+          | .ok (authCap, st') =>
+              if lifecycleRetypeAuthority authCap target then
+                storeObject target newObj st'
+              else
+                .error .illegalAuthority
+        else
+          .error .illegalState
+
+theorem lifecycleRetypeObject_error_illegalState
+    (st : SystemState)
+    (authority : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj currentObj : KernelObject)
+    (hObj : st.objects target = some currentObj)
+    (hMetaMismatch : st.lifecycle.objectTypes target ≠ some currentObj.objectType) :
+    lifecycleRetypeObject authority target newObj st = .error .illegalState := by
+  unfold lifecycleRetypeObject
+  simp [hObj, hMetaMismatch]
+
+theorem lifecycleRetypeObject_error_illegalAuthority
+    (st : SystemState)
+    (authority : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj currentObj : KernelObject)
+    (cap : Capability)
+    (hObj : st.objects target = some currentObj)
+    (hMeta : st.lifecycle.objectTypes target = some currentObj.objectType)
+    (hLookup : cspaceLookupSlot authority st = .ok (cap, st))
+    (hAuthFail : lifecycleRetypeAuthority cap target = false) :
+    lifecycleRetypeObject authority target newObj st = .error .illegalAuthority := by
+  unfold lifecycleRetypeObject
+  simp [hObj, hMeta, hLookup, hAuthFail]
+
+theorem lifecycleRetypeObject_success_updates_object
+    (st st' : SystemState)
+    (authority : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj currentObj : KernelObject)
+    (cap : Capability)
+    (hObj : st.objects target = some currentObj)
+    (hMeta : st.lifecycle.objectTypes target = some currentObj.objectType)
+    (hLookup : cspaceLookupSlot authority st = .ok (cap, st))
+    (hAuth : lifecycleRetypeAuthority cap target = true)
+    (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
+    st'.objects target = some newObj := by
+  unfold lifecycleRetypeObject at hStep
+  simp [hObj, hMeta, hLookup, hAuth] at hStep
+  cases hStep
+  simp
+
+end SeLe4n.Kernel

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -6,6 +6,8 @@ namespace SeLe4n.Model
 inductive KernelError where
   | invalidCapability
   | objectNotFound
+  | illegalState
+  | illegalAuthority
   | schedulerInvariantViolation
   | endpointStateMismatch
   | endpointQueueEmpty

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M4-A lifecycle/retype foundations (active, step 1 completed)**.
+Current stage: **M4-A lifecycle/retype foundations (active, steps 1-2 completed)**.
 
 Primary goals for contributors:
 
@@ -43,9 +43,9 @@ Unless intentionally redesigned and documented, preserve:
    - lifecycle metadata introduced for first transition story only,
    - ownership remains explicit via object-store identity metadata and capability reference mapping.
 
-2. **Lifecycle transition(s)**
-   - implement deterministic success/error branching,
-   - keep illegal-state and illegal-authority branches explicit via `KernelError`.
+2. **Lifecycle transition(s)** ✅ **completed**
+   - deterministic success/error branching implemented via `lifecycleRetypeObject`,
+   - illegal-state and illegal-authority branches are explicit via `KernelError.illegalState` and `KernelError.illegalAuthority`.
 
 3. **Invariant definitions**
    - define narrow, named lifecycle invariants first,

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -12,7 +12,7 @@ It defines:
 4. Acceptance criteria and non-goals for focused, reviewable implementation.
 5. Change-control expectations for code, proofs, executable traces, and docs.
 
-Current stage: **active M4-A lifecycle/retype foundations (step 1 complete)**.
+Current stage: **active M4-A lifecycle/retype foundations (steps 1-2 complete)**.
 
 ---
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M4 stage.
 
-Current stage context: **M4-A lifecycle/retype foundations in progress (step 1 completed)**.
+Current stage context: **M4-A lifecycle/retype foundations in progress (steps 1-2 completed)**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -11,9 +11,9 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 2. **Typed object/state model (`Model/Object`, `Model/State`)**
    - kernel object universe and lifecycle-relevant object fields,
    - global object store, scheduler state, typed lookup/store helpers,
-   - shared error taxonomy (`KernelError`).
+   - shared error taxonomy (`KernelError`, including explicit illegal-state/authority lifecycle branches).
 
-3. **Kernel transition subsystems (`Kernel/Scheduler`, `Kernel/Capability`, `Kernel/IPC`)**
+3. **Kernel transition subsystems (`Kernel/Scheduler`, `Kernel/Capability`, `Kernel/IPC`, `Kernel/Lifecycle`)**
    - executable transition definitions,
    - local invariants and transition-preservation theorem entrypoints.
 
@@ -67,6 +67,12 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
   - endpoint + IPC invariants,
   - scheduler-coherence contract predicates,
   - preservation theorem entrypoints.
+
+### Lifecycle subsystem
+
+- `SeLe4n/Kernel/Lifecycle/Operations.lean`
+  - deterministic lifecycle retype transition (`lifecycleRetypeObject`),
+  - explicit illegal-state / illegal-authority error branching and local theorem entrypoints.
 
 ### API + executable
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -4,7 +4,7 @@ This handbook chapter complements `docs/SEL4_SPEC.md`.
 
 ## Current slice: M4-A
 
-M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces (with step 1 state-model preparation completed):
+M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces (with steps 1-2 (state-model preparation + deterministic lifecycle transition branching) completed):
 
 1. lifecycle transition API,
 2. identity/aliasing invariants,

--- a/docs/gitbook/08-current-slice-m4a.md
+++ b/docs/gitbook/08-current-slice-m4a.md
@@ -11,8 +11,10 @@ relationships remain coherent through those updates.
 
 - ✅ Step 1 complete: state-model lifecycle metadata is now explicit for object identity and
   capability reference ownership mapping (including revoke-path sibling cleanup).
-- 🚧 Remaining M4-A work: transition expansion, invariant layering, and composed preservation
-  theorem growth.
+- ✅ Step 2 complete: `lifecycleRetypeObject` adds deterministic success/error branching with
+  explicit `KernelError.illegalState` and `KernelError.illegalAuthority` branches, and executable
+  traces now cover both failure branches plus success.
+- 🚧 Remaining M4-A work: invariant layering and composed preservation theorem growth.
 
 
 1. **Transition surface**

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -86,7 +86,7 @@ Key design choices:
 
 Primary contents:
 
-- `KernelError`, `SchedulerState`, `SystemState`, `SlotRef`,
+- `KernelError` (including `illegalState`/`illegalAuthority` lifecycle errors), `SchedulerState`, `SystemState`, `SlotRef`,
 - global lookup/store transitions (`lookupObject`, `storeObject`, `setCurrentThread`),
 - typed CSpace helpers (`lookupCNode`, `lookupSlotCap`, `ownsSlot`, `ownedSlots`),
 - small support lemmas that simplify subsystem-level invariants.
@@ -159,6 +159,24 @@ Design details that matter:
    - failure path is explicit via `invalidCapability`.
 3. **Revoke is local by design**
    - aligns with the current CNode-local revoke helper in object model.
+
+### `SeLe4n/Kernel/Lifecycle/Operations.lean`
+
+Primary semantics:
+
+- lifecycle retype authority predicate (`lifecycleRetypeAuthority`),
+- deterministic retype transition (`lifecycleRetypeObject`),
+- explicit branch theorems for illegal-state and illegal-authority outcomes.
+
+Design details that matter:
+
+1. **Metadata coherence gate before mutation**
+   - retype fails with `illegalState` when object-store type and lifecycle metadata diverge.
+2. **Authority is explicit and narrow**
+   - retype authority requires direct-object target and `write` rights; violations return
+     `illegalAuthority`.
+3. **Successful path reuses `storeObject`**
+   - object store and lifecycle object-type metadata are updated atomically.
 
 ### `SeLe4n/Kernel/Capability/Invariant.lean`
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.5.0"
+version = "0.5.1"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -74,10 +74,20 @@ run_check "INVARIANT" rg -n '^def lifecycleMetadataConsistent' SeLe4n/Model/Stat
 run_check "INVARIANT" rg -n '^def cspaceRevoke' SeLe4n/Kernel/Capability/Operations.lean
 run_check "INVARIANT" rg -n '^theorem cspaceRevoke_local_target_reduction' SeLe4n/Kernel/Capability/Invariant.lean
 
+# M4-A step-2 lifecycle transition anchors must remain present.
+run_check "INVARIANT" rg -n '^\s*\| illegalState' SeLe4n/Model/State.lean
+run_check "INVARIANT" rg -n '^\s*\| illegalAuthority' SeLe4n/Model/State.lean
+run_check "INVARIANT" rg -n '^def lifecycleRetypeObject' SeLe4n/Kernel/Lifecycle/Operations.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_error_illegalState' SeLe4n/Kernel/Lifecycle/Operations.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_error_illegalAuthority' SeLe4n/Kernel/Lifecycle/Operations.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_success_updates_object' SeLe4n/Kernel/Lifecycle/Operations.lean
+
 # M3.5 step-7 executable demonstration closure anchors.
 run_check "TRACE" rg -n 'endpointAwaitReceive demoEndpoint 2' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'lifecycle retype illegal-state branch' Main.lean
+run_check "TRACE" rg -n 'lifecycle retype illegal-state branch' tests/fixtures/main_trace_smoke.expected
 
 # Active milestone docs should stay synchronized for both current and next slices.
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -1,5 +1,8 @@
 scheduled thread: some 1
 source cap rights before mint:
+lifecycle retype unauthorized branch: SeLe4n.Model.KernelError.illegalAuthority
+lifecycle retype illegal-state branch: SeLe4n.Model.KernelError.illegalState
+lifecycle retype success object kind: some (SeLe4n.Model.KernelObjectType.endpoint)
 created sibling cap with the same target
 post-revoke sibling lookup: SeLe4n.Model.KernelError.invalidCapability
 post-delete lookup (expected error): SeLe4n.Model.KernelError.invalidCapability


### PR DESCRIPTION
### Motivation

- Ensure the M4-A lifecycle/retype delivery genuinely exercises all deterministic transition outcomes (illegal-authority, illegal-state, and success) in the executable trace and that Tier-3 invariant anchors reflect the surface implemented.
- Tighten test/fixture/Docs alignment so regressions against the new lifecycle surface are detected by existing CI/Tier scripts.

### Description

- Added a lifecycle subsystem with `lifecycleRetypeAuthority` and `lifecycleRetypeObject` plus theorem anchors for `illegalState`, `illegalAuthority`, and successful update in `SeLe4n/Kernel/Lifecycle/Operations.lean` and wired it into the public API via `SeLe4n/Kernel/API.lean`.
- Extended the executable scenario in `Main.lean` to exercise three runtime branches in order: illegal-authority, illegal-state (using a stale metadata view), and a successful retype, and added an auth slot plus test object entries to `bootstrapState` to support those paths.
- Updated `tests/fixtures/main_trace_smoke.expected` to include the new lifecycle trace lines and strengthened `scripts/test_tier3_invariant_surface.sh` anchors to require the lifecycle theorems and the illegal-state trace fragment to remain present.
- Synchronized documentation and project metadata by updating `README.md`, several `docs/*` GitBook pages to state steps 1–2 complete and by bumping `lakefile.toml` to `0.5.1`.

### Testing

- Ran the Lean build with `source /root/.elan/env && lake build` which completed successfully.
- Executed the repository test scripts `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh`, and all reported passing status for `HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, and `META` checks.
- Fixture comparison for the executable trace (`tests/fixtures/main_trace_smoke.expected`) matched the runtime output during Tier-2 trace checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699252ef7eb8832bb27c61bec0aa3ced)