### PR TITLE
Audit & harden M4‑A: add lifecycle invariants, strengthen Tier‑3 anchors, docs sync, and hygiene fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in **M4-A lifecycle/retype foundations (steps 1-2 complete)** after completing M3.5
+seLe4n is currently in **M4-A lifecycle/retype foundations (steps 1-3 complete)** after completing M3.5
 IPC handshake + scheduler coherence.
 
 ### Milestone board
@@ -18,7 +18,8 @@ IPC handshake + scheduler coherence.
   composed IPC+scheduler invariant bundle, local-first preservation theorem layering, executable
   waiting-to-delivery trace evidence.
 - 🚧 **M4 current slice in progress**: object lifecycle/retype foundations and capability-object
-  coupling safety (with state-model preparation and deterministic lifecycle transition branching completed).
+  coupling safety (with state-model preparation, deterministic lifecycle transition branching, and
+  lifecycle invariant definitions completed).
 - 📍 **M4 next slice planned**: lifecycle + revocation composition, richer invariants, and expanded
   executable scenarios.
 
@@ -54,10 +55,12 @@ Deep technical chapters for implementation work:
 4. Add preservation theorem entrypoints for each lifecycle transition.
 5. Extend executable evidence (`Main.lean`) and Tier 2 trace fixtures for lifecycle behavior.
 
-Progress note (steps 1-2): lifecycle metadata now explicitly tracks object-store type identity and slot-to-target
-capability references, CSpace insert/delete/revoke transitions keep those references synchronized, and
+Progress note (steps 1-3): lifecycle metadata now explicitly tracks object-store type identity and slot-to-target
+capability references, CSpace insert/delete/revoke transitions keep those references synchronized,
 `lifecycleRetypeObject` provides deterministic success/error branching with explicit illegal-state and
-illegal-authority outcomes, and the executable trace now exercises both failure branches plus a success path.
+illegal-authority outcomes, and step-3 now defines narrow lifecycle invariants with explicit separation
+between identity/aliasing constraints (`lifecycleIdentityAliasingInvariant`) and capability-reference
+constraints (`lifecycleCapabilityReferenceInvariant`).
 
 ## Next slice target outcomes (M4-B)
 

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -5,3 +5,4 @@ import SeLe4n.Kernel.Capability.Invariant
 import SeLe4n.Kernel.Scheduler.Operations
 
 import SeLe4n.Kernel.Lifecycle.Operations
+import SeLe4n.Kernel.Lifecycle.Invariant

--- a/SeLe4n/Kernel/Lifecycle/Invariant.lean
+++ b/SeLe4n/Kernel/Lifecycle/Invariant.lean
@@ -1,0 +1,87 @@
+import SeLe4n.Kernel.Lifecycle.Operations
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+/-- M4-A step-3 identity invariant: lifecycle object-type metadata exactly tracks
+object-store identity typing for each object id. -/
+def lifecycleIdentityTypeExact (st : SystemState) : Prop :=
+  SystemState.objectTypeMetadataConsistent st
+
+/-- M4-A step-3 aliasing invariant: one object identity cannot carry conflicting lifecycle
+object-type aliases. -/
+def lifecycleIdentityNoTypeAliasConflict (st : SystemState) : Prop :=
+  ∀ oid ty₁ ty₂,
+    SystemState.lookupObjectTypeMeta st oid = some ty₁ →
+    SystemState.lookupObjectTypeMeta st oid = some ty₂ →
+    ty₁ = ty₂
+
+/-- Identity/aliasing bundle used by lifecycle proofs before capability-reference composition. -/
+def lifecycleIdentityAliasingInvariant (st : SystemState) : Prop :=
+  lifecycleIdentityTypeExact st ∧ lifecycleIdentityNoTypeAliasConflict st
+
+/-- M4-A step-3 capability-reference invariant: lifecycle slot-reference metadata exactly tracks
+concrete capability-slot targets. -/
+def lifecycleCapabilityRefExact (st : SystemState) : Prop :=
+  SystemState.capabilityRefMetadataConsistent st
+
+/-- M4-A step-3 capability-reference invariant: every metadata object-target reference is backed by
+an actual slot capability carrying that same object target. -/
+def lifecycleCapabilityRefObjectTargetBacked (st : SystemState) : Prop :=
+  ∀ ref oid,
+    SystemState.lookupCapabilityRefMeta st ref = some (.object oid) →
+    ∃ cap, SystemState.lookupSlotCap st ref = some cap ∧ cap.target = .object oid
+
+/-- Lifecycle capability-reference constraint bundle (separate from identity/aliasing constraints). -/
+def lifecycleCapabilityReferenceInvariant (st : SystemState) : Prop :=
+  lifecycleCapabilityRefExact st ∧ lifecycleCapabilityRefObjectTargetBacked st
+
+/-- Full lifecycle invariant bundle for M4-A step-3 with explicit layering separation. -/
+def lifecycleInvariantBundle (st : SystemState) : Prop :=
+  lifecycleIdentityAliasingInvariant st ∧ lifecycleCapabilityReferenceInvariant st
+
+theorem lifecycleIdentityNoTypeAliasConflict_of_exact
+    (st : SystemState)
+    (hExact : lifecycleIdentityTypeExact st) :
+    lifecycleIdentityNoTypeAliasConflict st := by
+  intro oid ty₁ ty₂ hTy₁ hTy₂
+  cases hObj : st.objects oid with
+  | none =>
+      have hNone : SystemState.lookupObjectTypeMeta st oid = none := by
+        simpa [lifecycleIdentityTypeExact, SystemState.objectTypeMetadataConsistent,
+          SystemState.lookupObjectTypeMeta, hObj] using hExact oid
+      rw [hNone] at hTy₁
+      contradiction
+  | some obj =>
+      have hMeta : SystemState.lookupObjectTypeMeta st oid = some obj.objectType := by
+        simpa [lifecycleIdentityTypeExact, SystemState.objectTypeMetadataConsistent,
+          SystemState.lookupObjectTypeMeta, hObj] using hExact oid
+      rw [hMeta] at hTy₁ hTy₂
+      cases hTy₁
+      cases hTy₂
+      rfl
+
+theorem lifecycleCapabilityRefObjectTargetBacked_of_exact
+    (st : SystemState)
+    (hExact : lifecycleCapabilityRefExact st) :
+    lifecycleCapabilityRefObjectTargetBacked st := by
+  intro ref oid hMeta
+  rw [hExact ref] at hMeta
+  cases hLookup : SystemState.lookupSlotCap st ref with
+  | none => simp [hLookup] at hMeta
+  | some cap =>
+      have hTarget : cap.target = .object oid := by
+        simpa [hLookup] using hMeta
+      exact ⟨cap, rfl, hTarget⟩
+
+theorem lifecycleInvariantBundle_of_metadata_consistent
+    (st : SystemState)
+    (hMeta : SystemState.lifecycleMetadataConsistent st) :
+    lifecycleInvariantBundle st := by
+  rcases hMeta with ⟨hObjType, hCapRef⟩
+  refine ⟨?_, ?_⟩
+  · exact ⟨hObjType, lifecycleIdentityNoTypeAliasConflict_of_exact st hObjType⟩
+  · exact ⟨hCapRef, lifecycleCapabilityRefObjectTargetBacked_of_exact st hCapRef⟩
+
+end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M4-A lifecycle/retype foundations (active, steps 1-2 completed)**.
+Current stage: **M4-A lifecycle/retype foundations (active, steps 1-3 completed)**.
 
 Primary goals for contributors:
 
@@ -47,9 +47,10 @@ Unless intentionally redesigned and documented, preserve:
    - deterministic success/error branching implemented via `lifecycleRetypeObject`,
    - illegal-state and illegal-authority branches are explicit via `KernelError.illegalState` and `KernelError.illegalAuthority`.
 
-3. **Invariant definitions**
-   - define narrow, named lifecycle invariants first,
-   - separate identity/aliasing constraints from capability-reference constraints.
+3. **Invariant definitions** ✅ **completed**
+   - narrow, named lifecycle invariants are defined in `SeLe4n/Kernel/Lifecycle/Invariant.lean`,
+   - identity/aliasing constraints are separated from capability-reference constraints via
+     `lifecycleIdentityAliasingInvariant` and `lifecycleCapabilityReferenceInvariant`.
 
 4. **Local helper lemmas**
    - add transition-local lookup/membership lemmas near lifecycle code,

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -24,8 +24,8 @@ What is strong today:
 
 ## 3. Key risks and next mitigations
 
-1. **Lifecycle semantics not yet fully landed**
-   - mitigation: keep M4-A narrow and theorem-first with explicit transition APIs.
+1. **Lifecycle semantics currently partial (M4-A steps 1-3 landed; preservation composition remains)**
+   - mitigation: continue M4-A with local helper lemmas and composed preservation entrypoints before broadening scope.
 2. **Potential invariant growth complexity**
    - mitigation: enforce component naming and layered composition from the start.
 3. **Fixture drift during lifecycle rollout**
@@ -35,7 +35,8 @@ What is strong today:
 
 - Required gates (`test_fast`, `test_smoke`) are correctly scoped.
 - Full/nightly tiers provide extension headroom for M4-specific hardening.
-- Next high-value test work: lifecycle fixture lines + Tier 3 lifecycle-capability grouped anchors.
+- Step-3 lifecycle invariant layering anchors are now enforced in Tier 3.
+- Next high-value test work: lifecycle-preservation theorem anchors as M4-A steps 4-5 land.
 
 ## 5. Documentation posture summary
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -12,7 +12,7 @@ It defines:
 4. Acceptance criteria and non-goals for focused, reviewable implementation.
 5. Change-control expectations for code, proofs, executable traces, and docs.
 
-Current stage: **active M4-A lifecycle/retype foundations (steps 1-2 complete)**.
+Current stage: **active M4-A lifecycle/retype foundations (steps 1-3 complete)**.
 
 ---
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M4 stage.
 
-Current stage context: **M4-A lifecycle/retype foundations in progress (steps 1-2 completed)**.
+Current stage context: **M4-A lifecycle/retype foundations in progress (steps 1-3 completed)**.
 
 ## 2. Current enforced tiers
 
@@ -28,7 +28,8 @@ PR CI must call repository scripts directly and keep workflow logic thin.
 1. Keep baseline M1-M3.5 behavior stable.
 2. Add fixture fragments for lifecycle output once lifecycle scenarios become executable.
 3. Keep Tier 3 anchors for lifecycle transition/invariant theorem surfaces (including metadata-coherence anchors).
-4. Preserve category-labeled failure output (`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`).
+4. Keep Tier 3 milestone-closure anchors for M1 scheduler and M2 capability transition/preservation surfaces so completed milestones remain continuously verified.
+5. Preserve category-labeled failure output (`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`).
 
 ## 5. M4-B testing expansion targets
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -73,6 +73,9 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 - `SeLe4n/Kernel/Lifecycle/Operations.lean`
   - deterministic lifecycle retype transition (`lifecycleRetypeObject`),
   - explicit illegal-state / illegal-authority error branching and local theorem entrypoints.
+- `SeLe4n/Kernel/Lifecycle/Invariant.lean`
+  - step-3 lifecycle invariant components and bundle layering,
+  - explicit split between identity/aliasing and capability-reference constraints.
 
 ### API + executable
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -4,7 +4,7 @@ This handbook chapter complements `docs/SEL4_SPEC.md`.
 
 ## Current slice: M4-A
 
-M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces (with steps 1-2 (state-model preparation + deterministic lifecycle transition branching) completed):
+M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces (with steps 1-3 (state-model preparation + deterministic lifecycle transition branching + invariant definitions) completed):
 
 1. lifecycle transition API,
 2. identity/aliasing invariants,

--- a/docs/gitbook/08-current-slice-m4a.md
+++ b/docs/gitbook/08-current-slice-m4a.md
@@ -14,7 +14,10 @@ relationships remain coherent through those updates.
 - ✅ Step 2 complete: `lifecycleRetypeObject` adds deterministic success/error branching with
   explicit `KernelError.illegalState` and `KernelError.illegalAuthority` branches, and executable
   traces now cover both failure branches plus success.
-- 🚧 Remaining M4-A work: invariant layering and composed preservation theorem growth.
+- ✅ Step 3 complete: lifecycle invariants are now defined as narrow named components with explicit
+  separation between identity/aliasing (`lifecycleIdentityAliasingInvariant`) and
+  capability-reference (`lifecycleCapabilityReferenceInvariant`) constraints.
+- 🚧 Remaining M4-A work: local helper lemmas and composed preservation theorem growth.
 
 
 1. **Transition surface**

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -178,6 +178,23 @@ Design details that matter:
 3. **Successful path reuses `storeObject`**
    - object store and lifecycle object-type metadata are updated atomically.
 
+### `SeLe4n/Kernel/Lifecycle/Invariant.lean`
+
+Primary semantics:
+
+- identity/aliasing lifecycle invariants (`lifecycleIdentityAliasingInvariant`),
+- capability-reference lifecycle invariants (`lifecycleCapabilityReferenceInvariant`),
+- composed lifecycle invariant bundle (`lifecycleInvariantBundle`).
+
+Design details that matter:
+
+1. **Invariant layering is explicit**
+   - identity/aliasing constraints are defined and reviewed independently from capability-reference constraints.
+2. **Naming is milestone-oriented**
+   - definitions are narrow and named so later preservation theorems can compose cleanly.
+3. **Metadata-to-bundle bridge is explicit**
+   - `lifecycleInvariantBundle_of_metadata_consistent` connects model-level consistency assumptions to the new lifecycle bundle surface.
+
 ### `SeLe4n/Kernel/Capability/Invariant.lean`
 
 Core components:

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -91,14 +91,14 @@ Why:
 - stable doc/test anchors,
 - predictable maintainability under milestone growth.
 
-## 7. How M4 should extend this map
+## 7. M4-A lifecycle invariant layering (step-3 completed)
 
-M4 additions should follow existing style:
+Current M4-A lifecycle invariant structure now follows the existing layered style:
 
-1. lifecycle component invariants,
-2. lifecycle subsystem bundle,
-3. lifecycle+capability composed bundle integration,
-4. transition-level local preservation,
-5. bundle-level preservation entrypoints.
+1. identity/aliasing components (`lifecycleIdentityTypeExact`, `lifecycleIdentityNoTypeAliasConflict`),
+2. identity bundle (`lifecycleIdentityAliasingInvariant`),
+3. capability-reference components (`lifecycleCapabilityRefExact`, `lifecycleCapabilityRefObjectTargetBacked`),
+4. capability-reference bundle (`lifecycleCapabilityReferenceInvariant`),
+5. composed lifecycle bundle (`lifecycleInvariantBundle`).
 
-Avoid adding broad invariants that bypass this layering.
+This explicit split keeps proof and review scope narrow as M4-A moves to helper lemmas and preservation composition.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.5.1"
+version = "0.5.2"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -13,6 +13,25 @@ run_check "INVARIANT" rg -n '^(def|abbrev) schedulerInvariantBundle' SeLe4n/Kern
 run_check "INVARIANT" rg -n '^def capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^def m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
+# M1 closure anchors: scheduler transition APIs + preservation theorem entrypoints.
+run_check "INVARIANT" rg -n '^def chooseThread' SeLe4n/Kernel/Scheduler/Operations.lean
+run_check "INVARIANT" rg -n '^def schedule' SeLe4n/Kernel/Scheduler/Operations.lean
+run_check "INVARIANT" rg -n '^def handleYield' SeLe4n/Kernel/Scheduler/Operations.lean
+run_check "INVARIANT" rg -n '^theorem chooseThread_preserves_schedulerInvariantBundle' SeLe4n/Kernel/Scheduler/Operations.lean
+run_check "INVARIANT" rg -n '^theorem schedule_preserves_schedulerInvariantBundle' SeLe4n/Kernel/Scheduler/Operations.lean
+run_check "INVARIANT" rg -n '^theorem handleYield_preserves_schedulerInvariantBundle' SeLe4n/Kernel/Scheduler/Operations.lean
+
+# M2 closure anchors: CSpace transition APIs + capability-bundle preservation theorem entrypoints.
+run_check "INVARIANT" rg -n '^def cspaceLookupSlot' SeLe4n/Kernel/Capability/Operations.lean
+run_check "INVARIANT" rg -n '^def cspaceInsertSlot' SeLe4n/Kernel/Capability/Operations.lean
+run_check "INVARIANT" rg -n '^def cspaceMint' SeLe4n/Kernel/Capability/Operations.lean
+run_check "INVARIANT" rg -n '^def cspaceDeleteSlot' SeLe4n/Kernel/Capability/Operations.lean
+run_check "INVARIANT" rg -n '^def cspaceRevoke' SeLe4n/Kernel/Capability/Operations.lean
+run_check "INVARIANT" rg -n '^theorem cspaceInsertSlot_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem cspaceMint_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem cspaceDeleteSlot_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem cspaceRevoke_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+
 # M3 seed IPC preservation theorem anchors.
 run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
@@ -73,6 +92,14 @@ run_check "INVARIANT" rg -n '^structure LifecycleMetadata' SeLe4n/Model/State.le
 run_check "INVARIANT" rg -n '^def lifecycleMetadataConsistent' SeLe4n/Model/State.lean
 run_check "INVARIANT" rg -n '^def cspaceRevoke' SeLe4n/Kernel/Capability/Operations.lean
 run_check "INVARIANT" rg -n '^theorem cspaceRevoke_local_target_reduction' SeLe4n/Kernel/Capability/Invariant.lean
+
+# M4-A step-3 lifecycle invariant layering anchors must remain present.
+run_check "INVARIANT" rg -n '^def lifecycleIdentityAliasingInvariant' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleCapabilityReferenceInvariant' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleCapabilityRefObjectTargetBacked' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleInvariantBundle' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleCapabilityRefObjectTargetBacked_of_exact' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleInvariantBundle_of_metadata_consistent' SeLe4n/Kernel/Lifecycle/Invariant.lean
 
 # M4-A step-2 lifecycle transition anchors must remain present.
 run_check "INVARIANT" rg -n '^\s*\| illegalState' SeLe4n/Model/State.lean


### PR DESCRIPTION
### Motivation

- Formalize M4‑A step‑3 by introducing narrow, reviewable lifecycle invariant components so preservation composition can proceed safely. 
- Harden continuous verification by ensuring milestones already claimed complete (M1/M2/M3/M3.5) remain present and automatically detected. 
- Remove avoidable hygiene noise and enable local linting so Tier‑0 hygiene checks exercise their intended path. 

### Description

- Added lifecycle invariant definitions in `SeLe4n/Kernel/Lifecycle/Invariant.lean`, including `lifecycleIdentityAliasingInvariant`, `lifecycleCapabilityReferenceInvariant`, `lifecycleCapabilityRefObjectTargetBacked`, `lifecycleInvariantBundle`, and bridging the model-level metadata consistency to the invariant bundle with `lifecycleInvariantBundle_of_metadata_consistent`. 
- Wired the new invariant module into the public surface by importing `SeLe4n.Kernel.Lifecycle.Invariant` from `SeLe4n/Kernel/API.lean`. 
- Strengthened Tier‑3 invariant anchors by expanding `scripts/test_tier3_invariant_surface.sh` to explicitly check M1 scheduler transition/preservation anchors (`chooseThread`, `schedule`, `handleYield` and their `*_preserves_schedulerInvariantBundle` theorems) and M2 CSpace/capability transition/preservation anchors (`cspaceLookupSlot`, `cspaceInsertSlot`, `cspaceMint`, `cspaceDeleteSlot`, `cspaceRevoke` and their `*_preserves_capabilityInvariantBundle` theorems). 
- Synchronized documentation and bookkeeping: updated `README.md`, `docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`, `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/PROJECT_AUDIT.md`, `docs/gitbook/*` to reflect M4‑A step‑3 completion and the new invariant surfaces, and bumped package `version` to `0.5.2` in `lakefile.toml`. 
- Restored Tier‑0 hygiene behavior by ensuring the shell lint path is exercised (`shellcheck` available), which allows `scripts/test_tier0_hygiene.sh` to run the optional lint step instead of skipping it. 

### Testing

- Ran the full scripted test stack: `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh`, and observed all checks pass. 
- Executed the expanded `scripts/test_tier3_invariant_surface.sh` and verified the new M1/M2 anchors and the new lifecycle invariant anchors are present and pass. 
- Confirmed `lake build` completes successfully as part of the Tier‑1 build gate and `lake exe sele4n` plus fixture comparison succeed in Tier‑2 smoke runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992583da66c832baa41f86b2782c21b)