### PR TITLE
Implement lifecycleRevokeDeleteRetype (Workstream A complete)

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -113,21 +113,26 @@ def main : IO Unit := do
           | .error err => IO.println s!"sibling mint error: {reprStr err}"
           | .ok (_, st3) =>
               IO.println "created sibling cap with the same target"
-              match SeLe4n.Kernel.cspaceRevoke mintedSlot st3 with
-              | .error err => IO.println s!"cspace revoke error: {reprStr err}"
-              | .ok (_, st4) =>
-                  match SeLe4n.Kernel.cspaceLookupSlot siblingSlot st4 with
+              match SeLe4n.Kernel.lifecycleRevokeDeleteRetype mintedSlot mintedSlot 12
+                  (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st3 with
+              | .error err =>
+                  IO.println s!"composed transition alias guard (expected error): {reprStr err}"
+              | .ok _ =>
+                  IO.println "unexpected composed transition success with aliased authority/cleanup"
+              match SeLe4n.Kernel.lifecycleRevokeDeleteRetype lifecycleAuthSlot mintedSlot 12
+                  (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st3 with
+              | .error err => IO.println s!"composed transition error: {reprStr err}"
+              | .ok (_, st5) =>
+                  IO.println "composed revoke/delete/retype success"
+                  match SeLe4n.Kernel.cspaceLookupSlot siblingSlot st5 with
                   | .error err => IO.println s!"post-revoke sibling lookup: {reprStr err}"
                   | .ok (cap, _) =>
                       IO.println s!"unexpected sibling cap after revoke: {reprStr cap}"
-                  match SeLe4n.Kernel.cspaceDeleteSlot mintedSlot st4 with
-                  | .error err => IO.println s!"cspace delete error: {reprStr err}"
-                  | .ok (_, st5) =>
-                      match SeLe4n.Kernel.cspaceLookupSlot mintedSlot st5 with
-                      | .error err => IO.println s!"post-delete lookup (expected error): {reprStr err}"
-                      | .ok (cap, _) =>
-                          IO.println s!"unexpected cap after delete: {reprStr cap}"
-                      match SeLe4n.Kernel.endpointAwaitReceive demoEndpoint 2 st5 with
+                  match SeLe4n.Kernel.cspaceLookupSlot mintedSlot st5 with
+                  | .error err => IO.println s!"post-delete lookup (expected error): {reprStr err}"
+                  | .ok (cap, _) =>
+                      IO.println s!"unexpected cap after delete: {reprStr cap}"
+                  match SeLe4n.Kernel.endpointAwaitReceive demoEndpoint 2 st5 with
                       | .error err => IO.println s!"endpoint await-receive error: {reprStr err}"
                       | .ok (_, st6) =>
                           match SeLe4n.Kernel.endpointSend demoEndpoint 1 st6 with

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in **M4-B lifecycle-capability composition hardening (active slice kickoff)** after
+seLe4n is currently in **M4-B lifecycle-capability composition hardening (Workstream A complete)** after
 completing M4-A lifecycle/retype foundations.
 
 ### Milestone board
@@ -19,8 +19,8 @@ completing M4-A lifecycle/retype foundations.
   waiting-to-delivery trace evidence.
 - ✅ **M4-A current slice complete**: object lifecycle/retype foundations now include local lifecycle
   preservation entrypoints and composed scheduler/capability/IPC + lifecycle bundle theorem entrypoints.
-- 🚧 **M4-B current slice active**: lifecycle + revocation composition hardening, stale-reference
-  exclusion, and expanded executable/testing coverage.
+- 🚧 **M4-B current slice active**: Workstream A transition composition semantics complete; stale-reference
+  exclusion, preservation expansion, and broader testing anchors remain in progress.
 
 ## Documentation hub (GitBook-ready)
 
@@ -63,7 +63,7 @@ unauthorized branch, illegal-state branch, and success-path object-kind confirma
 
 ## Current slice target outcomes (M4-B)
 
-1. Compose lifecycle transitions with revoke/delete authority paths.
+1. ✅ Compose lifecycle transitions with revoke/delete authority paths (Workstream A complete).
 2. Strengthen invariants for stale-reference exclusion and authority monotonicity across retype chains.
 3. Add composed preservation theorems spanning lifecycle + capability bundles.
 4. Expand scenario coverage to include lifecycle rollback/error branches.

--- a/SeLe4n/Kernel/Lifecycle/Operations.lean
+++ b/SeLe4n/Kernel/Lifecycle/Operations.lean
@@ -37,6 +37,39 @@ def lifecycleRetypeObject
         else
           .error .illegalState
 
+/-- Compose local revoke/delete cleanup with lifecycle retype.
+
+Authority and state preconditions for deterministic success:
+1. `authority ≠ cleanup` (delete-before-reuse ordering guard),
+2. `cleanup` must resolve to a capability so revoke/delete can execute,
+3. post-delete lookup of `cleanup` must return `invalidCapability`,
+4. lifecycle retype preconditions from `lifecycleRetypeObject` must hold.
+
+Failure branches remain explicit and ordered:
+- aliasing `authority = cleanup` is rejected as `illegalState`,
+- revoke/delete failures are propagated directly,
+- unexpected post-delete lookup success is rejected as `illegalState`,
+- final retype failures are propagated directly. -/
+def lifecycleRevokeDeleteRetype
+    (authority cleanup : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj : KernelObject) : Kernel Unit :=
+  fun st =>
+    if authority = cleanup then
+      .error .illegalState
+    else
+      match cspaceRevoke cleanup st with
+      | .error e => .error e
+      | .ok (_, stRevoked) =>
+          match cspaceDeleteSlot cleanup stRevoked with
+          | .error e => .error e
+          | .ok (_, stDeleted) =>
+              match cspaceLookupSlot cleanup stDeleted with
+              | .ok _ => .error .illegalState
+              | .error .invalidCapability =>
+                  lifecycleRetypeObject authority target newObj stDeleted
+              | .error e => .error e
+
 /- Local lifecycle transition helper lemmas (M4-A step 4).
 These theorems keep preservation scripts focused on invariant obligations rather than
 repeating transition case analysis. -/
@@ -216,5 +249,28 @@ theorem lifecycleRetypeObject_success_updates_object
   injection hCapLookup with hCapEq
   subst hCapEq
   exact lifecycle_storeObject_objects_eq st st' target newObj hStore
+
+theorem lifecycleRevokeDeleteRetype_error_authority_cleanup_alias
+    (st : SystemState)
+    (authority cleanup : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj : KernelObject)
+    (hAlias : authority = cleanup) :
+    lifecycleRevokeDeleteRetype authority cleanup target newObj st = .error .illegalState := by
+  unfold lifecycleRevokeDeleteRetype
+  simp [hAlias]
+
+theorem lifecycleRevokeDeleteRetype_ok_implies_authority_ne_cleanup
+    (st st' : SystemState)
+    (authority cleanup : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj : KernelObject)
+    (hStep : lifecycleRevokeDeleteRetype authority cleanup target newObj st = .ok ((), st')) :
+    authority ≠ cleanup := by
+  intro hAlias
+  have hErr := lifecycleRevokeDeleteRetype_error_authority_cleanup_alias
+    st authority cleanup target newObj hAlias
+  rw [hErr] at hStep
+  cases hStep
 
 end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M4-B lifecycle-capability composition hardening (active slice kickoff)**.
+Current stage: **M4-B lifecycle-capability composition hardening (Workstream A complete)**.
 
 Primary goals for contributors:
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **active M4-B lifecycle-capability composition hardening (kickoff underway)**.
+Current stage: **active M4-B lifecycle-capability composition hardening (Workstream A complete)**.
 
 ---
 
@@ -176,7 +176,7 @@ flows and proving stronger stale-reference exclusion properties.
 
 For review clarity, M4-B evidence should map to these five workstreams:
 
-1. **WS-A semantics**: lifecycle-capability composed transition behavior is deterministic and
+1. **WS-A semantics** ✅ **completed**: lifecycle-capability composed transition behavior is deterministic and
    includes explicit failure branches.
 2. **WS-B invariants**: stale-reference exclusion is formalized as named components and linked to
    identity/authority assumptions.

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M4 stage.
 
-Current stage context: **M4-B lifecycle-capability composition hardening active (M4-A complete)**.
+Current stage context: **M4-B lifecycle-capability composition hardening active (M4-A + WS-A complete)**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/09-next-slice-m4b.md
+++ b/docs/gitbook/09-next-slice-m4b.md
@@ -20,10 +20,10 @@ when they interact with authority-changing capability operations in realistic wo
 
 ## Proposed execution plan
 
-### Phase 1: semantic composition
+### Phase 1: semantic composition ✅ completed
 
-- codify at least one deterministic transition story spanning lifecycle and revoke/delete behavior,
-- make ordering assumptions explicit in transition API and theorem statements.
+- codified a deterministic transition story spanning lifecycle and revoke/delete behavior,
+- made ordering assumptions explicit in transition API and theorem statements.
 
 ### Phase 2: invariant hardening
 

--- a/docs/gitbook/14-m4b-execution-playbook.md
+++ b/docs/gitbook/14-m4b-execution-playbook.md
@@ -17,7 +17,7 @@ Use this playbook together with:
 
 ## 2. Workstream map
 
-### Workstream A — Transition composition semantics
+### Workstream A — Transition composition semantics ✅ completed
 
 Goal: establish deterministic lifecycle+revoke/delete interaction behavior.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.5.7"
+version = "0.5.8"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -4,6 +4,8 @@ lifecycle retype unauthorized branch: SeLe4n.Model.KernelError.illegalAuthority
 lifecycle retype illegal-state branch: SeLe4n.Model.KernelError.illegalState
 lifecycle retype success object kind: some (SeLe4n.Model.KernelObjectType.endpoint)
 created sibling cap with the same target
+composed transition alias guard (expected error): SeLe4n.Model.KernelError.illegalState
+composed revoke/delete/retype success
 post-revoke sibling lookup: SeLe4n.Model.KernelError.invalidCapability
 post-delete lookup (expected error): SeLe4n.Model.KernelError.invalidCapability
 handshake send matched waiting receiver


### PR DESCRIPTION
### Motivation

- Provide a deterministic composed transition that sequences capability revoke/delete with a lifecycle retype so lifecycle+capability composition semantics are explicit and testable.
- Surface ordering and aliasing assumptions in the API and theorem surface so downstream proofs and fixtures can rely on stable semantics.

### Description

- Added a new composed transition `lifecycleRevokeDeleteRetype` in `SeLe4n/Kernel/Lifecycle/Operations.lean` that sequences `cspaceRevoke` -> `cspaceDeleteSlot` -> post-delete validation -> `lifecycleRetypeObject` and documents ordered failure branches and preconditions.
- Added two theorem-visible lemmas: `lifecycleRevokeDeleteRetype_error_authority_cleanup_alias` (aliased authority/cleanup yields `illegalState`) and `lifecycleRevokeDeleteRetype_ok_implies_authority_ne_cleanup` (success implies distinct authority/cleanup slots).
- Extended `Main.lean` to exercise the new composed transition for both the aliased-authority failure case and a successful revoke/delete/retype path, and updated the Tier 2 trace fixture `tests/fixtures/main_trace_smoke.expected` accordingly.
- Synchronized documentation and project metadata to reflect Workstream A completion by updating `README.md`, `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/gitbook/09-next-slice-m4b.md`, and `docs/gitbook/14-m4b-execution-playbook.md`, and bumped the project version in `lakefile.toml` from `0.5.7` to `0.5.8`.

### Testing

- Ran `./scripts/test_fast.sh` which performed hygiene and `lake build` and passed successfully.
- Ran `./scripts/test_smoke.sh` which built the project, executed the binary, and compared the trace against the updated fixture and the test passed (fixture comparison passed).
- Ran `./scripts/test_full.sh` and `./scripts/test_nightly.sh` which exercise the full suite of invariant surface checks and nightly wrapper and both completed successfully.
- `lake build` and `lake exe sele4n` were executed during tests and completed with successful build and expected trace output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699273621e80832bad4ef3d92308fb3f)