### PR TITLE
Tighten M4-B milestone audit anchors and bump release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in **M4-B lifecycle-capability composition hardening (Workstream A complete)** after
+seLe4n is currently in **M4-B lifecycle-capability composition hardening (Workstreams A+B complete)** after
 completing M4-A lifecycle/retype foundations.
 
 ### Milestone board
@@ -19,8 +19,8 @@ completing M4-A lifecycle/retype foundations.
   waiting-to-delivery trace evidence.
 - ✅ **M4-A current slice complete**: object lifecycle/retype foundations now include local lifecycle
   preservation entrypoints and composed scheduler/capability/IPC + lifecycle bundle theorem entrypoints.
-- 🚧 **M4-B current slice active**: Workstream A transition composition semantics complete; stale-reference
-  exclusion, preservation expansion, and broader testing anchors remain in progress.
+- 🚧 **M4-B current slice active**: Workstreams A+B (transition composition + invariant hardening) are
+  complete; preservation expansion, executable/testing growth, and closeout docs remain in progress.
 
 ## Documentation hub (GitBook-ready)
 
@@ -64,7 +64,8 @@ unauthorized branch, illegal-state branch, and success-path object-kind confirma
 ## Current slice target outcomes (M4-B)
 
 1. ✅ Compose lifecycle transitions with revoke/delete authority paths (Workstream A complete).
-2. Strengthen invariants for stale-reference exclusion and authority monotonicity across retype chains.
+2. ✅ Strengthen invariants for stale-reference exclusion and authority monotonicity across retype chains
+   (Workstream B complete).
 3. Add composed preservation theorems spanning lifecycle + capability bundles.
 4. Expand scenario coverage to include lifecycle rollback/error branches.
 5. Deepen Tier 3 checks for lifecycle-specific theorem/bundle surfaces.
@@ -78,7 +79,7 @@ and architecture-binding interfaces that preserve reusable core proofs while M4-
 To move M4-B toward closeout, work should progress in this order:
 
 1. compose lifecycle transitions with revoke/delete semantics,
-2. formalize stale-reference exclusion invariant components,
+2. formalize stale-reference exclusion invariant components ✅ completed,
 3. prove local then composed preservation including failure paths,
 4. extend executable scenarios + fixture anchors,
 5. add Tier 3 anchors for new theorem/bundle surfaces,

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -53,6 +53,19 @@ def capabilityInvariantBundle (st : SystemState) : Prop :=
   cspaceSlotUnique st ∧ cspaceLookupSound st ∧ cspaceAttenuationRule ∧
     lifecycleAuthorityMonotonicity st
 
+/-- M4-B bridge bundle: ties stale-reference exclusion to lifecycle transition authority
+monotonicity so composition proofs can depend on a single named assumption. -/
+def lifecycleCapabilityStaleAuthorityInvariant (st : SystemState) : Prop :=
+  lifecycleStaleReferenceExclusionInvariant st ∧ lifecycleAuthorityMonotonicity st
+
+theorem lifecycleCapabilityStaleAuthorityInvariant_of_bundles
+    (st : SystemState)
+    (hLifecycle : lifecycleInvariantBundle st)
+    (hCap : capabilityInvariantBundle st) :
+    lifecycleCapabilityStaleAuthorityInvariant st := by
+  refine ⟨lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle st hLifecycle, ?_⟩
+  exact hCap.2.2.2
+
 /-- Delete transition authority reduction clause. -/
 theorem cspaceDeleteSlot_authority_reduction
     (st st' : SystemState)

--- a/SeLe4n/Kernel/Lifecycle/Invariant.lean
+++ b/SeLe4n/Kernel/Lifecycle/Invariant.lean
@@ -37,6 +37,34 @@ def lifecycleCapabilityRefObjectTargetBacked (st : SystemState) : Prop :=
 def lifecycleCapabilityReferenceInvariant (st : SystemState) : Prop :=
   lifecycleCapabilityRefExact st ∧ lifecycleCapabilityRefObjectTargetBacked st
 
+/-- M4-B stale-reference exclusion component: any object-target capability reference agrees with
+object-type metadata whenever that object identity is present. -/
+def lifecycleCapabilityRefObjectTargetTypeAligned (st : SystemState) : Prop :=
+  ∀ ref oid obj,
+    SystemState.lookupCapabilityRefMeta st ref = some (.object oid) →
+    st.objects oid = some obj →
+    SystemState.lookupObjectTypeMeta st oid = some obj.objectType
+
+/-- M4-B stale-reference exclusion component: capability-object references inherit the same
+identity non-aliasing guarantee used by lifecycle identity metadata. -/
+def lifecycleCapabilityRefNoTypeAliasConflict (st : SystemState) : Prop :=
+  ∀ ref oid ty₁ ty₂,
+    SystemState.lookupCapabilityRefMeta st ref = some (.object oid) →
+    SystemState.lookupObjectTypeMeta st oid = some ty₁ →
+    SystemState.lookupObjectTypeMeta st oid = some ty₂ →
+    ty₁ = ty₂
+
+/-- M4-B stale-reference exclusion family built from narrow, composable components. -/
+def lifecycleStaleReferenceExclusionInvariant (st : SystemState) : Prop :=
+  lifecycleCapabilityRefObjectTargetBacked st ∧
+    lifecycleCapabilityRefObjectTargetTypeAligned st ∧
+    lifecycleCapabilityRefNoTypeAliasConflict st
+
+/-- M4-B link point: stale-reference exclusion explicitly depends on identity/aliasing constraints
+rather than replacing them with a monolithic definition. -/
+def lifecycleIdentityStaleReferenceInvariant (st : SystemState) : Prop :=
+  lifecycleIdentityAliasingInvariant st ∧ lifecycleStaleReferenceExclusionInvariant st
+
 /-- Full lifecycle invariant bundle for M4-A step-3 with explicit layering separation. -/
 def lifecycleInvariantBundle (st : SystemState) : Prop :=
   lifecycleIdentityAliasingInvariant st ∧ lifecycleCapabilityReferenceInvariant st
@@ -93,6 +121,38 @@ theorem lifecycleMetadataConsistent_of_lifecycleInvariantBundle
   rcases hCapRef with ⟨hCapRefExact, _hBacked⟩
   exact ⟨hObjType, hCapRefExact⟩
 
+theorem lifecycleCapabilityRefObjectTargetTypeAligned_of_exact
+    (st : SystemState)
+    (hObjType : lifecycleIdentityTypeExact st) :
+    lifecycleCapabilityRefObjectTargetTypeAligned st := by
+  intro ref oid obj _hMeta hObj
+  simpa [lifecycleIdentityTypeExact, SystemState.objectTypeMetadataConsistent,
+    SystemState.lookupObjectTypeMeta, hObj] using hObjType oid
+
+theorem lifecycleCapabilityRefNoTypeAliasConflict_of_identity
+    (st : SystemState)
+    (hAlias : lifecycleIdentityNoTypeAliasConflict st) :
+    lifecycleCapabilityRefNoTypeAliasConflict st := by
+  intro _ref oid ty₁ ty₂ _hMeta hTy₁ hTy₂
+  exact hAlias oid ty₁ ty₂ hTy₁ hTy₂
+
+theorem lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle
+    (st : SystemState)
+    (hInv : lifecycleInvariantBundle st) :
+    lifecycleStaleReferenceExclusionInvariant st := by
+  rcases hInv with ⟨hIdAlias, hCapRef⟩
+  rcases hIdAlias with ⟨hObjType, hAlias⟩
+  rcases hCapRef with ⟨_hCapRefExact, hBacked⟩
+  refine ⟨hBacked, ?_, ?_⟩
+  · exact lifecycleCapabilityRefObjectTargetTypeAligned_of_exact st hObjType
+  · exact lifecycleCapabilityRefNoTypeAliasConflict_of_identity st hAlias
+
+theorem lifecycleIdentityStaleReferenceInvariant_of_lifecycleInvariantBundle
+    (st : SystemState)
+    (hInv : lifecycleInvariantBundle st) :
+    lifecycleIdentityStaleReferenceInvariant st := by
+  refine ⟨hInv.1, lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle st hInv⟩
+
 theorem lifecycleRetypeObject_preserves_lifecycleInvariantBundle
     (st st' : SystemState)
     (authority : CSpaceAddr)
@@ -108,5 +168,29 @@ theorem lifecycleRetypeObject_preserves_lifecycleInvariantBundle
   have hMeta' : SystemState.lifecycleMetadataConsistent st' :=
     storeObject_preserves_lifecycleMetadataConsistent st st' target newObj hMeta hStore
   exact lifecycleInvariantBundle_of_metadata_consistent st' hMeta'
+
+theorem lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant
+    (st st' : SystemState)
+    (authority : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj : KernelObject)
+    (hInv : lifecycleInvariantBundle st)
+    (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
+    lifecycleStaleReferenceExclusionInvariant st' := by
+  have hBundle' : lifecycleInvariantBundle st' :=
+    lifecycleRetypeObject_preserves_lifecycleInvariantBundle st st' authority target newObj hInv hStep
+  exact lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle st' hBundle'
+
+theorem lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant
+    (st st' : SystemState)
+    (authority : CSpaceAddr)
+    (target : SeLe4n.ObjId)
+    (newObj : KernelObject)
+    (hInv : lifecycleInvariantBundle st)
+    (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
+    lifecycleIdentityStaleReferenceInvariant st' := by
+  have hBundle' : lifecycleInvariantBundle st' :=
+    lifecycleRetypeObject_preserves_lifecycleInvariantBundle st st' authority target newObj hInv hStep
+  exact lifecycleIdentityStaleReferenceInvariant_of_lifecycleInvariantBundle st' hBundle'
 
 end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M4-B lifecycle-capability composition hardening (Workstream A complete)**.
+Current stage: **M4-B lifecycle-capability composition hardening (Workstreams A+B complete)**.
 
 Primary goals for contributors:
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **active M4-B lifecycle-capability composition hardening (Workstream A complete)**.
+Current stage: **active M4-B lifecycle-capability composition hardening (Workstreams A+B complete)**.
 
 ---
 
@@ -178,8 +178,8 @@ For review clarity, M4-B evidence should map to these five workstreams:
 
 1. **WS-A semantics** ✅ **completed**: lifecycle-capability composed transition behavior is deterministic and
    includes explicit failure branches.
-2. **WS-B invariants**: stale-reference exclusion is formalized as named components and linked to
-   identity/authority assumptions.
+2. **WS-B invariants** ✅ **completed**: stale-reference exclusion is formalized as named components
+   and linked to identity/authority assumptions.
 3. **WS-C proofs**: local-first preservation is complete, then composed cross-bundle preservation is
    proven without placeholder debt.
 4. **WS-D executable evidence**: `Main.lean` includes composition success/failure scenarios and Tier

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M4 stage.
 
-Current stage context: **M4-B lifecycle-capability composition hardening active (M4-A + WS-A complete)**.
+Current stage context: **M4-B lifecycle-capability composition hardening active (M4-A + WS-A + WS-B complete)**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -93,7 +93,7 @@ To keep reviews crisp, each M4-B target should be tied to concrete evidence:
 Suggested checkpoint structure:
 
 - **Checkpoint B1 (semantics ready)**: composed transition APIs merged and deterministic.
-- **Checkpoint B2 (invariants ready)**: stale-reference components + local helpers merged.
+- **Checkpoint B2 (invariants ready)** ✅ completed: stale-reference components + local helpers merged.
 - **Checkpoint B3 (proof-ready)**: local and composed preservation theorem surfaces merged.
 - **Checkpoint B4 (evidence-ready)**: executable/fixture/Tier 3 updates merged.
 - **Checkpoint B5 (closeout-ready)**: docs synchronized and M5 deferrals explicitly listed.

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -56,7 +56,7 @@ stories remain visible and intentional, especially for milestone claims tied to 
 ## M4 testing trajectory
 
 - **M4-A:** lifecycle semantic trace fragments are now landed and fixture-backed in Tier 2 smoke coverage.
-- **M4-B:** add lifecycle-capability composition success/failure traces and stronger Tier 3 anchors.
+- **M4-B:** WS-A/WS-B traces and invariant anchors are landed; continue expanding WS-C/WS-D/WS-E theorem and scenario anchors.
 
 ## Practical failure triage
 

--- a/docs/gitbook/09-next-slice-m4b.md
+++ b/docs/gitbook/09-next-slice-m4b.md
@@ -25,7 +25,7 @@ when they interact with authority-changing capability operations in realistic wo
 - codified a deterministic transition story spanning lifecycle and revoke/delete behavior,
 - made ordering assumptions explicit in transition API and theorem statements.
 
-### Phase 2: invariant hardening
+### Phase 2: invariant hardening ✅ completed
 
 - define stale-reference exclusion invariants,
 - tie those invariants to existing identity/aliasing and authority components.

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -184,7 +184,9 @@ Primary semantics:
 
 - identity/aliasing lifecycle invariants (`lifecycleIdentityAliasingInvariant`),
 - capability-reference lifecycle invariants (`lifecycleCapabilityReferenceInvariant`),
-- composed lifecycle invariant bundle (`lifecycleInvariantBundle`).
+- composed lifecycle invariant bundle (`lifecycleInvariantBundle`),
+- M4-B stale-reference hardening surfaces (`lifecycleStaleReferenceExclusionInvariant`,
+  `lifecycleIdentityStaleReferenceInvariant`).
 
 Design details that matter:
 
@@ -193,7 +195,9 @@ Design details that matter:
 2. **Naming is milestone-oriented**
    - definitions are narrow and named so later preservation theorems can compose cleanly.
 3. **Metadata-to-bundle bridge is explicit**
-   - `lifecycleInvariantBundle_of_metadata_consistent` connects model-level consistency assumptions to the new lifecycle bundle surface.
+   - `lifecycleInvariantBundle_of_metadata_consistent` connects model-level consistency assumptions to the lifecycle bundle surface.
+4. **WS-B stale-reference hardening is explicit**
+   - theorems lift stale-reference components from lifecycle bundle assumptions and preserve them across `lifecycleRetypeObject`.
 
 ### `SeLe4n/Kernel/Capability/Invariant.lean`
 
@@ -207,6 +211,7 @@ Core components:
 Composition surfaces:
 
 - `capabilityInvariantBundle`
+- `lifecycleCapabilityStaleAuthorityInvariant`
 - `m3IpcSeedInvariantBundle`
 - `m35IpcSchedulerInvariantBundle`
 
@@ -260,11 +265,13 @@ Proof organization:
 
 1. scheduler step (`schedule`),
 2. root capability lookup,
-3. mint + sibling mint,
-4. revoke + delete checks,
-5. waiting-receiver handshake send,
-6. queued senders + receives,
-7. expected error on extra receive.
+3. lifecycle retype unauthorized + illegal-state + success branches,
+4. mint + sibling mint,
+5. composed revoke/delete/retype alias-guard failure and success path,
+6. post-revoke/post-delete lookup checks,
+7. waiting-receiver handshake send,
+8. queued senders + receives,
+9. expected error on extra receive.
 
 Why this matters:
 

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -91,7 +91,7 @@ Why:
 - stable doc/test anchors,
 - predictable maintainability under milestone growth.
 
-## 7. M4-A lifecycle invariant layering (steps 3-6 completed)
+## 7. M4 lifecycle invariant layering (M4-A complete, M4-B WS-B complete)
 
 Current M4-A lifecycle invariant structure now follows the existing layered style:
 
@@ -99,10 +99,14 @@ Current M4-A lifecycle invariant structure now follows the existing layered styl
 2. identity bundle (`lifecycleIdentityAliasingInvariant`),
 3. capability-reference components (`lifecycleCapabilityRefExact`, `lifecycleCapabilityRefObjectTargetBacked`),
 4. capability-reference bundle (`lifecycleCapabilityReferenceInvariant`),
-5. composed lifecycle bundle (`lifecycleInvariantBundle`).
+5. composed lifecycle bundle (`lifecycleInvariantBundle`),
+6. stale-reference hardening family (`lifecycleStaleReferenceExclusionInvariant`),
+7. lifecycle+stale bridge (`lifecycleIdentityStaleReferenceInvariant`).
 
 This explicit split now includes transition-local lifecycle helper lemmas in `Lifecycle/Operations`,
 local and composed lifecycle preservation entrypoints (`lifecycleRetypeObject_preserves_lifecycleInvariantBundle`,
+`lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant`,
+`lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant`,
 `lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle`, and
 `lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle`), and fixture-backed executable trace evidence
-for unauthorized/illegal-state/success lifecycle retype outcomes.
+for unauthorized/illegal-state/success lifecycle retype outcomes plus composed lifecycle+capability behavior.

--- a/docs/gitbook/14-m4b-execution-playbook.md
+++ b/docs/gitbook/14-m4b-execution-playbook.md
@@ -33,7 +33,7 @@ Definition of done:
 - error variants are explicit,
 - behavior is observable from executable scenarios.
 
-### Workstream B — Invariant hardening
+### Workstream B — Invariant hardening ✅ completed
 
 Goal: eliminate stale-reference ambiguity across lifecycle operations.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.5.8"
+version = "0.5.11"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -101,6 +101,19 @@ run_check "INVARIANT" rg -n '^def lifecycleInvariantBundle' SeLe4n/Kernel/Lifecy
 run_check "INVARIANT" rg -n '^theorem lifecycleCapabilityRefObjectTargetBacked_of_exact' SeLe4n/Kernel/Lifecycle/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleInvariantBundle_of_metadata_consistent' SeLe4n/Kernel/Lifecycle/Invariant.lean
 
+# M4-B WS-B invariant hardening anchors must remain present.
+run_check "INVARIANT" rg -n '^def lifecycleCapabilityRefObjectTargetTypeAligned' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleCapabilityRefNoTypeAliasConflict' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleStaleReferenceExclusionInvariant' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleIdentityStaleReferenceInvariant' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleCapabilityRefObjectTargetTypeAligned_of_exact' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleCapabilityRefNoTypeAliasConflict_of_identity' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleCapabilityStaleAuthorityInvariant' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleCapabilityStaleAuthorityInvariant_of_bundles' SeLe4n/Kernel/Capability/Invariant.lean
+
 # M4-A step-5 lifecycle preservation entrypoint anchors must remain present.
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_lifecycleInvariantBundle' SeLe4n/Kernel/Lifecycle/Invariant.lean
 run_check "INVARIANT" rg -n '^def m4aLifecycleInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
@@ -109,6 +122,11 @@ run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_capability
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_ipcInvariant' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+
+# M4-B WS-A composition transition anchors must remain present.
+run_check "INVARIANT" rg -n '^def lifecycleRevokeDeleteRetype' SeLe4n/Kernel/Lifecycle/Operations.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRevokeDeleteRetype_error_authority_cleanup_alias' SeLe4n/Kernel/Lifecycle/Operations.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRevokeDeleteRetype_ok_implies_authority_ne_cleanup' SeLe4n/Kernel/Lifecycle/Operations.lean
 
 # M4-A step-4 lifecycle local-helper anchors must remain present.
 run_check "INVARIANT" rg -n '^theorem lifecycle_storeObject_objects_eq' SeLe4n/Kernel/Lifecycle/Operations.lean
@@ -134,13 +152,24 @@ run_check "TRACE" rg -n 'handshake send matched waiting receiver' tests/fixtures
 run_check "TRACE" rg -n 'lifecycle retype unauthorized branch' Main.lean
 run_check "TRACE" rg -n 'lifecycle retype illegal-state branch' Main.lean
 run_check "TRACE" rg -n 'lifecycle retype success object kind' Main.lean
+run_check "TRACE" rg -n 'composed transition alias guard \(expected error\)' Main.lean
+run_check "TRACE" rg -n 'composed revoke/delete/retype success' Main.lean
+run_check "TRACE" rg -n 'post-revoke sibling lookup' Main.lean
+run_check "TRACE" rg -n 'post-delete lookup \(expected error\)' Main.lean
 run_check "TRACE" rg -n 'lifecycle retype unauthorized branch: SeLe4n.Model.KernelError.illegalAuthority' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'lifecycle retype illegal-state branch: SeLe4n.Model.KernelError.illegalState' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'lifecycle retype success object kind: some \(SeLe4n.Model.KernelObjectType.endpoint\)' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'composed transition alias guard \(expected error\): SeLe4n.Model.KernelError.illegalState' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'composed revoke/delete/retype success' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'post-revoke sibling lookup: SeLe4n.Model.KernelError.invalidCapability' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'post-delete lookup \(expected error\): SeLe4n.Model.KernelError.invalidCapability' tests/fixtures/main_trace_smoke.expected
 
 # Active milestone docs should stay synchronized for both current and next slices.
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
+run_check "DOC" rg -n 'Workstreams A\+B complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
+run_check "DOC" rg -n 'Phase 2: invariant hardening ✅ completed' docs/gitbook/09-next-slice-m4b.md
+run_check "DOC" rg -n 'Workstream B — Invariant hardening ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
 
 # Full-suite contract should continue to include Tier 3.
 run_check "DOC" rg -n 'test_tier3_invariant_surface\.sh' scripts/test_full.sh


### PR DESCRIPTION
### Motivation

- Ensure the repository truly enforces the M4-B milestone claims by making Tier 3 invariant/trace/doc anchors fail-fast on regressions. 
- Prevent documentation and fixture drift so milestone-complete signals remain continuously checked by the testing framework.

### Description

- Strengthen `scripts/test_tier3_invariant_surface.sh` by adding INVARIANT anchors for the M4-B WS-B stale-reference components and helper theorems and for WS-A composition transition symbols (e.g. `lifecycleRevokeDeleteRetype` and its authority/alias helper theorems). 
- Add TRACE anchors that verify composed revoke/delete/retype behavior appears in `Main.lean` output and extend fixture checks in `tests/fixtures/main_trace_smoke.expected` for alias-guard error, composed success, and post-revoke/post-delete invalid-capability outcomes. 
- Add DOC anchors to ensure the repository content contains the expected “Workstreams A+B complete” and WS-B completion markers in README/spec/development and the relevant GitBook pages. 
- Bump project release version in `lakefile.toml` to `0.5.11` to reflect this audit/hardening pass.

### Testing

- Ran the repository audit entrypoint `./scripts/audit_testing_framework.sh`, which completed successfully and reported Tier 0/1/2/3 checks passing. 
- Built the project with `lake build` and ran `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh`, and all entrypoints passed in this environment. 
- Tier 2 fixture/tracing checks matched expected fragments (fixture comparisons passed) and the enhanced Tier 3 anchor checks validated presence of the new theorem/doc/trace anchors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927a2c0df0832b8123b795119d1cdb)