### PR TITLE
Implement Workstream E and update documentation to finish slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.lake
+/tests/artifacts

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A Lean 4 formalization project for building an executable and machine-checked mo
 
 ## Project status snapshot
 
-seLe4n is currently in **M4-B lifecycle-capability composition hardening (Workstreams A+B+C+D complete)** after
-completing M4-A lifecycle/retype foundations.
+seLe4n is currently in **M4-B lifecycle-capability composition hardening (Workstreams A+B+C+D+E complete)** with slice
+closeout complete and M5 preparation now active.
 
 ### Milestone board
 
@@ -19,8 +19,7 @@ completing M4-A lifecycle/retype foundations.
   waiting-to-delivery trace evidence.
 - ✅ **M4-A current slice complete**: object lifecycle/retype foundations now include local lifecycle
   preservation entrypoints and composed scheduler/capability/IPC + lifecycle bundle theorem entrypoints.
-- 🚧 **M4-B current slice active**: Workstreams A+B+C+D (transition composition + invariant hardening + preservation theorem expansion + executable/fixture evidence) are
-  complete; executable/testing growth and closeout docs remain in progress.
+- ✅ **M4-B current slice complete**: Workstreams A+B+C+D+E (transition composition + invariant hardening + preservation theorem expansion + executable/fixture evidence + testing/CI growth) are complete, including Tier 3 M4-B anchors and staged Tier 4 nightly candidates.
 
 ## Documentation hub (GitBook-ready)
 
@@ -68,7 +67,8 @@ unauthorized branch, illegal-state branch, and success-path object-kind confirma
    (Workstream B complete).
 3. ✅ Add composed preservation theorems spanning lifecycle + capability bundles (Workstream C complete).
 4. ✅ Expand scenario coverage to include lifecycle rollback/error branches (Workstream D complete).
-5. Deepen Tier 3 checks for lifecycle-specific theorem/bundle surfaces.
+5. ✅ Deepen Tier 3 checks for lifecycle-specific theorem/bundle surfaces and stage Tier 4 nightly extension candidates
+   (Workstream E complete).
 
 Next-slice (M5 preview) direction: service-graph semantics, policy-oriented authority constraints,
 and architecture-binding interfaces that preserve reusable core proofs while M4-B lands.
@@ -76,14 +76,14 @@ and architecture-binding interfaces that preserve reusable core proofs while M4-
 
 ## Current slice execution plan (M4-B)
 
-To move M4-B toward closeout, work should progress in this order:
+M4-B closeout sequence executed in this order:
 
 1. compose lifecycle transitions with revoke/delete semantics,
 2. formalize stale-reference exclusion invariant components ✅ completed,
 3. prove local then composed preservation including failure paths ✅ completed,
 4. extend executable scenarios + fixture anchors ✅ completed,
-5. add Tier 3 anchors for new theorem/bundle surfaces,
-6. close out docs with explicit M5 deferrals.
+5. add Tier 3 anchors for new theorem/bundle surfaces ✅ completed,
+6. close out docs with explicit M5 deferrals ✅ completed.
 
 ## Next-slice readiness goals (M5 preview)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,8 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M4-B lifecycle-capability composition hardening (Workstreams A+B+C+D complete)**.
+Current stage: **M4-B lifecycle-capability composition hardening (Workstreams A+B+C+D+E complete)**;
+M5 preparation is now active.
 
 Primary goals for contributors:
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **active M4-B lifecycle-capability composition hardening (Workstreams A+B+C+D complete)**.
+Current stage: **M4-B lifecycle-capability composition hardening complete (Workstreams A+B+C+D+E complete)**.
 
 ---
 
@@ -184,8 +184,8 @@ For review clarity, M4-B evidence should map to these five workstreams:
    proven without placeholder debt.
 4. **WS-D executable evidence** ✅ **completed**: `Main.lean` includes composition success/failure scenarios and Tier
    2 fixture anchors capture stable semantics.
-5. **WS-E testing anchors**: Tier 3 includes M4-B theorem/bundle symbols so milestone claims remain
-   continuously checkable.
+5. **WS-E testing anchors** ✅ **completed**: Tier 3 includes M4-B theorem/bundle symbols, nightly extension
+   candidates are staged in Tier 4 entrypoints, and failure triage references exact script commands.
 
 ### 5.6 M4-B completion evidence checklist
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M4 stage.
 
-Current stage context: **M4-B lifecycle-capability composition hardening active (M4-A + WS-A + WS-B + WS-C + WS-D complete)**.
+Current stage context: **M4-B lifecycle-capability composition hardening complete (M4-A + WS-A + WS-B + WS-C + WS-D + WS-E complete)**.
 
 ## 2. Current enforced tiers
 
@@ -13,7 +13,7 @@ Current stage context: **M4-B lifecycle-capability composition hardening active 
 - **Tier 2** fixture-backed executable smoke (`scripts/test_tier2_trace.sh`)
 - **Tier 3** invariant/doc-surface checks (`scripts/test_tier3_invariant_surface.sh`, via full suite),
   including M4-A executable-anchor checks for lifecycle unauthorized/illegal-state/success trace fragments.
-- **Tier 4** extension hook (nightly wrapper currently documents expansion point)
+- **Tier 4** staged nightly candidates (`scripts/test_tier4_nightly_candidates.sh` via `scripts/test_nightly.sh`; explicit opt-in extension point)
 
 ## 3. Required entrypoints and CI contract
 
@@ -114,6 +114,7 @@ Primary risks to target next:
 3. **Phase T3 — Tier 3 anchor expansion**
    - add symbol anchors for M4-B invariant and preservation theorem surfaces,
    - keep anchors grouped by milestone objective for triage clarity.
-4. **Phase T4 — nightly evolution**
-   - preserve current Tier 4 extension hook behavior,
-   - stage repeat-run determinism checks as follow-on without destabilizing mainline gates.
+4. **Phase T4 — nightly evolution** ✅ completed
+   - preserve explicit Tier 4 extension-point behavior by default in `./scripts/test_nightly.sh`,
+   - stage repeat-run determinism + full-suite replay candidates in `./scripts/test_tier4_nightly_candidates.sh`,
+   - keep candidate execution opt-in (`NIGHTLY_ENABLE_EXPERIMENTAL=1`) so required mainline gates remain stable.

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -12,8 +12,9 @@
 - **Tier 3 (invariant and documentation anchor surface)**
   - validates critical theorem/bundle/doc anchors expected for active milestone slices,
   - includes executable-trace anchor checks for milestone-critical lifecycle fragments.
-- **Tier 4 (nightly extension point)**
-  - explicitly reserved for heavier future checks.
+- **Tier 4 (nightly staged extension candidates)**
+  - `./scripts/test_tier4_nightly_candidates.sh` stages repeat-run determinism + full-suite replay candidates,
+  - default remains explicit extension-point behavior unless `NIGHTLY_ENABLE_EXPERIMENTAL=1` is set.
 
 ## Entrypoints and intent
 
@@ -24,7 +25,7 @@
 - `./scripts/test_full.sh`
   - broader local verification (smoke + Tier 3 anchor coverage).
 - `./scripts/test_nightly.sh`
-  - full + nightly extension placeholder.
+  - full + Tier 4 staged-candidate wrapper (explicit opt-in by environment flag).
 
 CI should execute these repository scripts directly to avoid local/CI drift.
 
@@ -56,7 +57,7 @@ stories remain visible and intentional, especially for milestone claims tied to 
 ## M4 testing trajectory
 
 - **M4-A:** lifecycle semantic trace fragments are now landed and fixture-backed in Tier 2 smoke coverage.
-- **M4-B:** WS-A/WS-B/WS-C/WS-D semantic and proof-evidence anchors are landed; continue expanding WS-E theorem-surface and CI-growth anchors.
+- **M4-B:** WS-A/WS-B/WS-C/WS-D/WS-E are complete, including Tier 3 M4-B symbol anchors and staged Tier 4 nightly candidates.
 
 ## Practical failure triage
 
@@ -64,4 +65,5 @@ stories remain visible and intentional, especially for milestone claims tied to 
 - **Tier 1 fails:** resolve first Lean compile/proof failure before chasing downstream errors.
 - **Tier 2 fails:** inspect missing fixture lines and decide if behavior change was accidental or
   intentional.
-- **Tier 3 fails:** verify theorem/bundle/doc anchor names are still present after refactor.
+- **Tier 3 fails (`./scripts/test_tier3_invariant_surface.sh`):** verify theorem/bundle/doc anchor names are still present after refactor, then repair the exact missing anchor in the referenced file.
+- **Tier 4 fails (`./scripts/test_nightly.sh` / `./scripts/test_tier4_nightly_candidates.sh`):** inspect `tests/artifacts/nightly/` traces + determinism diff and decide whether the drift is semantic regression or an intentional behavior change that needs fixture/doc updates.

--- a/docs/gitbook/09-next-slice-m4b.md
+++ b/docs/gitbook/09-next-slice-m4b.md
@@ -41,10 +41,11 @@ when they interact with authority-changing capability operations in realistic wo
 - extend Tier 3 anchors to include M4-B theorem surfaces,
 - keep fixture updates minimal and intentional.
 
-### Phase 5: documentation closeout
+### Phase 5: documentation closeout ✅ completed
 
 - update spec/development guide/GitBook pages,
-- publish explicit note on what is deferred to M5.
+- publish explicit note on what is deferred to M5,
+- align Tier 3/Tier 4 testing notes and triage entrypoints with script-level checks.
 
 ## Exit signals for M4-B
 

--- a/docs/gitbook/14-m4b-execution-playbook.md
+++ b/docs/gitbook/14-m4b-execution-playbook.md
@@ -81,7 +81,7 @@ Definition of done:
 - fragments are stable semantic signals (not formatting noise),
 - scenario coverage maps back to M4-B target outcomes.
 
-### Workstream E — Testing and CI growth
+### Workstream E — Testing and CI growth ✅ completed
 
 Goal: ensure M4-B regression detection is reliable.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.5.15"
+version = "0.5.16"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_nightly.sh
+++ b/scripts/test_nightly.sh
@@ -13,6 +13,7 @@ if [[ "${CONTINUE_MODE}" -eq 1 ]]; then
 fi
 
 run_check "META" "${SCRIPT_DIR}/test_full.sh" "${sub_args[@]}"
-log_section "INVARIANT" "Tier 4 nightly extensions are not yet wired; this is an explicit extension point."
+run_check "META" "${SCRIPT_DIR}/test_tier4_nightly_candidates.sh" "${sub_args[@]}"
+log_section "INVARIANT" "Tier 4 keeps an explicit extension-point default; set NIGHTLY_ENABLE_EXPERIMENTAL=1 to run staged candidates."
 
 finalize_report

--- a/scripts/test_tier0_hygiene.sh
+++ b/scripts/test_tier0_hygiene.sh
@@ -18,7 +18,7 @@ fi
 if command -v shellcheck >/dev/null 2>&1; then
   run_check "HYGIENE" shellcheck scripts/*.sh
 else
-  log_section "HYGIENE" "shellcheck not installed; skipping optional lint."
+  log_section "HYGIENE" "shellcheck unavailable; optional shell lint not executed in this environment."
 fi
 
 finalize_report

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -183,7 +183,9 @@ run_check "DOC" rg -n 'Workstream C — Preservation theorem expansion ✅ compl
 run_check "DOC" rg -n 'Workstream D — Executable and fixture evidence ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'Workstream E — Testing and CI growth ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'test_tier4_nightly_candidates\.sh' docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md scripts/test_nightly.sh
+# shellcheck disable=SC2016
 run_check "DOC" rg -n 'Tier 3 fails \(`\./scripts/test_tier3_invariant_surface\.sh`\)' docs/gitbook/07-testing-and-ci.md
+# shellcheck disable=SC2016
 run_check "DOC" rg -n 'Tier 4 fails \(`\./scripts/test_nightly\.sh` / `\./scripts/test_tier4_nightly_candidates\.sh`\)' docs/gitbook/07-testing-and-ci.md
 
 # Full-suite contract should continue to include Tier 3.

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -175,11 +175,16 @@ run_check "TRACE" rg -n 'post-delete lookup \(expected error\): SeLe4n.Model.Ker
 # Active milestone docs should stay synchronized for both current and next slices.
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
-run_check "DOC" rg -n 'Workstreams A\+B\+C\+D complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
+run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'Phase 3: theorem expansion ✅ completed' docs/gitbook/09-next-slice-m4b.md
+run_check "DOC" rg -n 'Phase 5: documentation closeout ✅ completed' docs/gitbook/09-next-slice-m4b.md
 run_check "DOC" rg -n 'Workstream B — Invariant hardening ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'Workstream C — Preservation theorem expansion ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'Workstream D — Executable and fixture evidence ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
+run_check "DOC" rg -n 'Workstream E — Testing and CI growth ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
+run_check "DOC" rg -n 'test_tier4_nightly_candidates\.sh' docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md scripts/test_nightly.sh
+run_check "DOC" rg -n 'Tier 3 fails \(`\./scripts/test_tier3_invariant_surface\.sh`\)' docs/gitbook/07-testing-and-ci.md
+run_check "DOC" rg -n 'Tier 4 fails \(`\./scripts/test_nightly\.sh` / `\./scripts/test_tier4_nightly_candidates\.sh`\)' docs/gitbook/07-testing-and-ci.md
 
 # Full-suite contract should continue to include Tier 3.
 run_check "DOC" rg -n 'test_tier3_invariant_surface\.sh' scripts/test_full.sh

--- a/scripts/test_tier4_nightly_candidates.sh
+++ b/scripts/test_tier4_nightly_candidates.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_lib.sh"
+
+parse_common_args "$@"
+cd "${REPO_ROOT}"
+
+if [[ "${NIGHTLY_ENABLE_EXPERIMENTAL:-0}" != "1" ]]; then
+  log_section "META" "Tier 4 candidates staged but not enabled (set NIGHTLY_ENABLE_EXPERIMENTAL=1 to run)."
+  log_section "META" "Staged candidates: repeat-run trace determinism + full suite replay."
+  finalize_report
+fi
+
+ensure_lake_available
+
+ARTIFACT_DIR="tests/artifacts/nightly"
+mkdir -p "${ARTIFACT_DIR}"
+
+run_check "TRACE" bash -lc 'lake exe sele4n > tests/artifacts/nightly/sele4n_run1.trace'
+run_check "TRACE" bash -lc 'lake exe sele4n > tests/artifacts/nightly/sele4n_run2.trace'
+run_check "TRACE" bash -lc 'diff -u tests/artifacts/nightly/sele4n_run1.trace tests/artifacts/nightly/sele4n_run2.trace > tests/artifacts/nightly/sele4n_determinism.diff'
+run_check "META" "${SCRIPT_DIR}/test_full.sh"
+
+finalize_report


### PR DESCRIPTION
Completed Workstream E implementation by tightening Tier 3 CI/doc anchors to require M4-B WS-E + Phase 5 completion markers and explicit failure-triage entrypoint references, so regression detection now checks both theorem/doc surfaces and operational triage guidance. 

Added a staged Tier 4 nightly candidate runner (scripts/test_tier4_nightly_candidates.sh) with explicit opt-in behavior (NIGHTLY_ENABLE_EXPERIMENTAL=1), including repeat-run executable determinism checks and full-suite replay for deeper nightly confidence without destabilizing default gates. 

Updated nightly orchestration so test_nightly.sh now invokes the staged Tier 4 candidate script while still documenting explicit extension-point behavior. 

Synchronized project status/docs to mark M4-B Workstreams A+B+C+D+E complete and closeout complete across README, development guide, spec, testing plan, and GitBook pages (including Workstream E and Phase 5 completion indicators plus triage guidance updates)
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928de3024c832b8f01f742dda75670)