### PR TITLE
Ensure shellcheck is installed by setup_lean_env.sh

### DIFF
--- a/scripts/setup_lean_env.sh
+++ b/scripts/setup_lean_env.sh
@@ -6,6 +6,44 @@ ELAN_HOME_DEFAULT="${HOME}/.elan"
 ELAN_ENV_FILE="${ELAN_HOME:-$ELAN_HOME_DEFAULT}/env"
 LEAN_TOOLCHAIN_FILE="${ROOT_DIR}/lean-toolchain"
 
+ensure_shellcheck() {
+  if command -v shellcheck >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "[setup] shellcheck not found; attempting to install"
+
+  run_pkg_install() {
+    if command -v sudo >/dev/null 2>&1; then
+      sudo "$@"
+    else
+      "$@"
+    fi
+  }
+
+  if command -v apt-get >/dev/null 2>&1; then
+    run_pkg_install apt-get update
+    run_pkg_install env DEBIAN_FRONTEND=noninteractive apt-get install -y shellcheck
+  elif command -v dnf >/dev/null 2>&1; then
+    run_pkg_install dnf install -y ShellCheck
+  elif command -v yum >/dev/null 2>&1; then
+    run_pkg_install yum install -y epel-release
+    run_pkg_install yum install -y ShellCheck
+  elif command -v pacman >/dev/null 2>&1; then
+    run_pkg_install pacman -Sy --noconfirm shellcheck
+  elif command -v brew >/dev/null 2>&1; then
+    brew install shellcheck
+  else
+    echo "error: shellcheck is required, but no supported package manager (apt, dnf, yum, pacman, brew) was found" >&2
+    exit 1
+  fi
+
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "error: shellcheck installation failed" >&2
+    exit 1
+  fi
+}
+
 if ! command -v curl >/dev/null 2>&1; then
   echo "error: curl is required to install elan" >&2
   exit 1
@@ -15,6 +53,8 @@ if [ ! -f "${LEAN_TOOLCHAIN_FILE}" ]; then
   echo "error: lean-toolchain not found at ${LEAN_TOOLCHAIN_FILE}" >&2
   exit 1
 fi
+
+ensure_shellcheck
 
 if ! command -v elan >/dev/null 2>&1; then
   echo "[setup] elan not found; installing to ${ELAN_HOME:-$ELAN_HOME_DEFAULT}"


### PR DESCRIPTION
### Motivation
- The repository runs optional shell hygiene checks with `shellcheck`, so the development environment setup should ensure `shellcheck` is available.
- Automatically installing `shellcheck` reduces friction for contributors and CI environments that expect shell linting to be present.

### Description
- Add an `ensure_shellcheck()` helper to `scripts/setup_lean_env.sh` that returns early if `shellcheck` is already present and attempts installation when missing.
- Implement package-manager-aware installation paths for `apt-get`, `dnf`, `yum` (with `epel-release`), `pacman`, and `brew`, and use `sudo` automatically when available via the helper `run_pkg_install`.
- Invoke `ensure_shellcheck` early in the setup flow before installing `elan` and the Lean toolchain so linting is available for subsequent scripts.
- Fail fast with clear error messages when no supported package manager is found or installation does not result in an available `shellcheck` binary.

### Testing
- Ran `bash -n scripts/setup_lean_env.sh` to validate the script syntax, which succeeded.
- Attempted `shellcheck scripts/setup_lean_env.sh` but `shellcheck` was not present in the runner prior to executing the setup script, so the lint run was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992955e77f4832b82d0231cde812613)