### PR TITLE
Expand and refine project documentation after M4-B completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ M5 kickoff goals are now documented around three readiness tracks:
 
 See `docs/gitbook/14-m4b-execution-playbook.md` for detailed workstream guidance and exit checklists.
 
+## How teams can use seLe4n today
+
+1. **Semantics prototyping** — model and evaluate transition changes before implementation lock-in.
+2. **Proof-backed regression control** — tie theorem surfaces and executable traces to test tiers.
+3. **Authority/policy design analysis** — reason about lifecycle-capability behavior under constraints.
+4. **Formal-methods onboarding** — use milestone slices as a practical Lean learning progression.
+5. **Pre-hardware assurance planning** — validate assumptions in architecture-neutral form first.
+
+For expanded adoption guidance, see `docs/gitbook/15-m5-blueprint-and-project-usage.md`.
+
 ## Codebase reasoning quick map
 
 For developers trying to understand where logic lives today:

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -2,66 +2,101 @@
 
 ## 1. Motivation
 
-seLe4n aims to make high-assurance kernel reasoning more usable for developers by combining three
-properties in one workflow:
+seLe4n is a Lean 4 formalization effort for building an executable, machine-checked model of core
+seL4-style microkernel behavior. The project exists to make three concerns evolve together in one
+engineering loop:
 
-1. executable transition semantics,
+1. deterministic transition semantics,
 2. machine-checked invariant preservation,
-3. milestone-scoped change management.
+3. milestone-oriented delivery with explicit acceptance criteria.
 
-Many projects optimize for only one or two of these at a time. seLe4n intentionally treats all
-three as first-class engineering constraints.
+This combination is deliberate: high-assurance work is most useful when it remains operationally
+iterable by contributors who are not formal-methods specialists.
 
-## 2. Why this project exists now
+## 2. Why this project matters
 
-The practical gap addressed by seLe4n:
+seLe4n addresses a common reliability gap in systems work:
 
-- formal methods can be hard to iterate on in day-to-day engineering,
-- executable prototypes can drift from proof claims,
-- subsystem interactions (scheduler/capability/IPC/lifecycle) are often documented inconsistently.
+- architecture docs can drift from what code actually does,
+- prototype code can drift from proof claims,
+- milestone goals can drift from test and CI gates.
 
-seLe4n closes this gap by making transition/proof/executable/docs/test gates move together.
+The repository structure and documentation strategy are designed to prevent that drift by coupling
+semantics, proofs, executable traces, and milestone docs.
 
-## 3. What is already implemented
+## 3. What is implemented today
 
-Closed milestone surface today:
+Closed baseline slices:
 
-- Bootstrap: model skeleton,
-- M1: scheduler invariants and preservation,
-- M2: capability/CSpace semantics and authority invariants,
-- M3: endpoint IPC seed semantics,
-- M3.5: typed waiting handshake + scheduler coherence contract.
+- Bootstrap: initial Lean project + model scaffolding,
+- M1: scheduler semantics and preservation surfaces,
+- M2: CSpace/capability operations + authority invariants,
+- M3: IPC seed semantics,
+- M3.5: waiting handshake + scheduler coherence predicates,
+- M4-A: lifecycle/retype foundations,
+- M4-B: lifecycle-capability hardening with stale-reference safety.
 
-Current active milestone:
+Current planning focus:
 
-- M4-A lifecycle/retype foundations.
+- M5 kickoff preparation: service graph semantics and policy-oriented authority modeling.
 
-Planned immediate follow-on:
+## 4. How to think about the architecture
 
-- M4-B lifecycle-capability hardening.
+The codebase is organized as layered contracts:
 
-## 4. Project design in one page
+- **Model layer** (`SeLe4n/Model/*`): object/state representation and typed lookup/update helpers.
+- **Subsystem transitions** (`SeLe4n/Kernel/*/Operations.lean`): executable behavior with explicit
+  error paths.
+- **Invariant layer** (`SeLe4n/Kernel/*/Invariant.lean`): named safety predicates and composed
+  bundles.
+- **Executable evidence** (`Main.lean`): scenario traces used by Tier 2 fixture checks.
+- **Validation scripts** (`scripts/test_*.sh`): tiered CI contract from hygiene to nightly lanes.
 
-- transitions are executable and explicit,
-- errors are first-class (`KernelError`) outcomes,
-- invariants are named components before bundle composition,
-- theorem entrypoints are transition-oriented and searchable,
-- integration evidence is executable (`Main.lean`) and fixture-guarded.
+## 5. Contributor mental model (definition-of-done loop)
 
-## 5. How contributors should think about the codebase
+For milestone-moving changes, contributors should follow this sequence:
 
-When touching any subsystem:
+1. update transition semantics first,
+2. add or refine narrow invariant components,
+3. prove local preservation,
+4. prove composed preservation,
+5. expose behavior in executable traces where relevant,
+6. wire proof/trace symbols into test tiers,
+7. update spec + README + GitBook in the same PR.
 
-1. identify state-model assumptions in `Model/*`,
-2. update transition semantics in subsystem module,
-3. add/refine local invariant components,
-4. prove local preservation first,
-5. prove composed preservation next,
-6. update executable trace and fixtures if semantic output changed,
-7. synchronize docs in canonical + GitBook layers.
+## 6. Target outcomes for the next slice (M5)
 
-## 6. Long-horizon objective
+M5 is intended to convert the M4 lifecycle-capability foundation into service-oriented system
+reasoning.
 
-seLe4n is not only a proof exercise; it is a staged path toward deployment-relevant reasoning,
-including mobile-first hardware considerations. The roadmap chapter details how to bridge from
-architecture-neutral model semantics to architecture binding and prototype integration constraints.
+Primary target outcomes:
+
+1. **Service graph model**
+   - represent service instances and restart/isolation relationships in a theorem-friendly form.
+2. **Policy surfaces**
+   - encode policy constraints over capability authority without breaking existing bundle layering.
+3. **Failure semantics for orchestration stories**
+   - ensure restart/recovery paths are explicit and theorem-covered, not only success paths.
+4. **Architecture-binding assumptions**
+   - make platform assumptions first-class interfaces so core proofs remain reusable.
+
+## 7. Project technical value for developers
+
+seLe4n can be used today as:
+
+1. a **reference microkernel semantics lab** for experimenting with state-machine changes safely,
+2. a **proof-aware regression framework** where theorem symbols and executable traces guard claims,
+3. an **onboarding corpus** for learning practical Lean theorem-proving in systems contexts,
+4. a **design review artifact** for discussing authority and lifecycle edge cases with precision,
+5. a **staging ground for hardware-bound assurance plans** before architecture-specific lock-in.
+
+## 8. Long-horizon direction
+
+The long-horizon objective remains mobile-first hardware relevance through staged refinement:
+
+1. architecture-neutral semantic hardening,
+2. explicit architecture binding interfaces,
+3. subsystem trust-boundary mapping,
+4. integration with platform and test evidence.
+
+See the roadmap and delivery-plan chapters for execution-level details.

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -1,107 +1,144 @@
 # Specification and Roadmap
 
-This chapter complements `docs/SEL4_SPEC.md` and provides the contributor-facing interpretation
-of current/next milestones.
+This chapter translates the normative spec (`docs/SEL4_SPEC.md`) into contributor-oriented
+planning and delivery guidance.
 
-## Completed slice baseline: M4-A
+## 1. Baseline status
 
-M4-A focuses on introducing lifecycle/retype semantics with clear theorem and executable surfaces.
-All six planned implementation steps are complete, so this chapter now acts as the baseline for
-follow-on work.
+M4 foundation status for planning purposes:
 
-### M4-A target outcomes (what must already be true)
+- **M4-A complete**: lifecycle/retype semantics, lifecycle invariants, and baseline preservation.
+- **M4-B complete**: lifecycle-capability composition hardening and stale-reference safety.
 
-1. lifecycle transition API with deterministic success/error branching,
-2. identity/aliasing invariants for lifecycle transitions,
-3. capability-object coherence invariants,
-4. lifecycle preservation theorem entrypoints and composed bundle entrypoints,
-5. executable trace evidence with fixture-backed semantic anchors.
+That means M5 planning should build on existing transition and theorem surfaces rather than
+restructuring them.
 
-### M4-A closeout outcomes
+## 2. M4 outcomes that are now assumed stable
 
-At this point, contributors should treat M4-A as the “stable foundation” layer:
+Contributors should treat these as established contracts:
 
-- new work should build on lifecycle theorem surfaces instead of replacing them,
-- failure branches should remain explicit and regression-testable,
-- docs should reference M4-A as complete and avoid re-opening its non-goals.
+1. deterministic lifecycle transition/error behavior,
+2. lifecycle identity/aliasing and capability-reference invariant components,
+3. lifecycle + capability composed preservation entrypoints,
+4. executable trace anchors for lifecycle and composition stories,
+5. Tier 3 symbol checks for critical theorem/bundle surfaces.
 
-## Current slice: M4-B
+## 3. Next slice definition: M5
 
-M4-B hardens lifecycle semantics through capability-lifecycle composition.
+M5 scope is to model **service-level operational stories** on top of M4 semantics.
 
-### M4-B target outcomes
+### M5 target outcomes
 
-1. lifecycle + revoke/delete interaction stories,
-2. stale-reference exclusion invariants,
-3. cross-bundle preservation theorems,
-4. explicit failure-path theorem coverage,
-5. expanded scenario/Tier 3 checks.
+1. **Service-graph semantics**
+   - model services, dependencies, and restart/isolation boundaries.
+2. **Policy-oriented authority constraints**
+   - represent policy checks as reusable theorem-facing predicates.
+3. **Composed preservation over orchestration paths**
+   - prove safety across start/stop/restart and dependency transitions.
+4. **Failure-path completeness**
+   - include denied-policy, missing-dependency, and stale-reference-style failures.
+5. **Executable scenario coverage**
+   - add `Main.lean` stories showing service lifecycle success and failure.
 
-### M4-B implementation sequencing
+### Non-goals for M5 (to prevent scope drift)
 
-1. define transition composition helpers,
-2. encode stale-reference properties,
-3. prove local then composed preservation,
-4. extend executable stories ✅ completed,
-5. lock fixture intent and update docs.
+- no architecture-specific memory-model lock-in,
+- no full seL4 boot pipeline modeling,
+- no replacement of M1-M4 theorem interfaces unless required for soundness.
 
-## Delivery model for upcoming slices
+## 4. Workstreams for completing M5
 
-The project now follows a predictable slice template:
+### Workstream A — Service graph model and transition API
 
-1. **Semantics first**: add deterministic transition behavior.
-2. **Invariants second**: codify named safety components.
-3. **Proofs third**: prove local, then composed preservation.
-4. **Executable evidence fourth**: extend `Main.lean` and fixtures.
-5. **Docs and roadmap finalization**: update spec + development guide + GitBook.
+Deliver:
 
-This keeps the codebase reviewable while preserving clear milestone boundaries.
+- service node/state representation,
+- dependency edges and restart policy shape,
+- deterministic transition helpers for activation/deactivation/restart.
 
-## Next-slice direction (M5 preview)
+Exit signal:
 
-After M4-A/M4-B, likely focus areas include:
+- transitions compile and return explicit `KernelError`-compatible failures.
 
-- service-graph and restart-oriented semantics,
-- policy and authority decomposition hardening,
-- architecture binding strategy with explicit assumptions,
-- and pre-deployment constraints for hardware execution paths.
+### Workstream B — Policy surfaces and authority decomposition
 
-See also:
+Deliver:
 
-- [Completed Slice: M4-A](08-current-slice-m4a.md)
+- policy predicates that constrain capability actions in service context,
+- theorem-friendly decomposition (small components, then bundle),
+- bridge lemmas connecting policy predicates to existing capability invariants.
+
+Exit signal:
+
+- policy logic can be reused without importing unrelated service internals.
+
+### Workstream C — Proof layering for service operations
+
+Deliver:
+
+- local preservation per service transition,
+- composed preservation across service + lifecycle + capability bundles,
+- failure-path preservation theorems.
+
+Exit signal:
+
+- proof naming and locality follow existing conventions; no `sorry`/`axiom` debt.
+
+### Workstream D — Trace/test expansion
+
+Deliver:
+
+- executable service scenarios (good and bad paths),
+- fixture anchors with semantic intent notes,
+- Tier 3 symbol anchors for new theorem surfaces.
+
+Exit signal:
+
+- `test_smoke` + `test_full` remain green with stable, intentional fixture deltas.
+
+### Workstream E — Documentation + milestone closeout
+
+Deliver:
+
+- synchronized updates across spec, README, GitBook,
+- explicit M6 deferrals and assumptions,
+- short risk log for unresolved architectural unknowns.
+
+Exit signal:
+
+- docs consistently describe active/next slice and accepted deferrals.
+
+## 5. Evidence map (what reviewers should require)
+
+For each M5 target outcome, require concrete evidence:
+
+1. transition code + theorem entrypoint,
+2. executable trace or symbol anchor,
+3. test command output in PR notes,
+4. explicit deferred items.
+
+## 6. Suggested checkpoint cadence
+
+- **M5-C1**: service graph definitions + initial transitions,
+- **M5-C2**: policy predicate set + bridge lemmas,
+- **M5-C3**: local preservation completion,
+- **M5-C4**: composed/failure-path preservation,
+- **M5-C5**: trace/fixture/Tier 3 completion,
+- **M5-C6**: docs and closeout memo.
+
+## 7. Delivery model (kept from prior slices)
+
+1. semantics first,
+2. invariants second,
+3. proofs third,
+4. executable evidence fourth,
+5. docs and acceptance closeout final.
+
+This sequencing minimizes churn and keeps proof updates aligned with behavior changes.
+
+## 8. Cross-reference index
+
 - [Current Slice: M4-B](09-next-slice-m4b.md)
 - [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
-
-
-## Detailed M4-B outcome framing
-
-To keep reviews crisp, each M4-B target should be tied to concrete evidence:
-
-1. **Transition composition**
-   - Evidence: deterministic lifecycle+capability transition(s) with explicit errors.
-2. **Stale-reference exclusion**
-   - Evidence: named invariants + helper lemmas showing exclusion properties.
-3. **Cross-bundle preservation**
-   - Evidence: local-first then composed theorem entrypoints in compile-checked modules.
-4. **Failure-path completeness**
-   - Evidence: theorem statements covering invalid authority/state/reference outcomes.
-5. **Executable and testing growth**
-   - Evidence: trace scenario + fixture anchor + Tier 3 symbol checks.
-
-## Near-term roadmap checkpoints (M4-B)
-
-Suggested checkpoint structure:
-
-- **Checkpoint B1 (semantics ready)**: composed transition APIs merged and deterministic.
-- **Checkpoint B2 (invariants ready)** ✅ completed: stale-reference components + local helpers merged.
-- **Checkpoint B3 (proof-ready)**: local and composed preservation theorem surfaces merged.
-- **Checkpoint B4 (evidence-ready)**: executable/fixture/Tier 3 updates merged.
-- **Checkpoint B5 (closeout-ready)**: docs synchronized and M5 deferrals explicitly listed.
-
-## M5 preview: what “ready to start” should mean
-
-M5 should not start because of calendar pressure; it should start when:
-
-1. M4-B composed behavior is regression-protected by tests and fixture anchors,
-2. theorem surfaces are reusable without significant refactoring,
-3. roadmap docs list concrete M5 assumptions and constraints.
+- [M4-B Execution Playbook](14-m4b-execution-playbook.md)
+- [M5 Blueprint and Usage Value](15-m5-blueprint-and-project-usage.md)

--- a/docs/gitbook/09-next-slice-m4b.md
+++ b/docs/gitbook/09-next-slice-m4b.md
@@ -2,112 +2,76 @@
 
 ## Objective
 
-Move from foundational lifecycle semantics to stronger composition with capability deletion/revocation
-and stale-reference safety.
+M4-B moved lifecycle semantics from standalone correctness to robust composition with capability
+revocation/deletion paths and stale-reference safety.
 
-## Why M4-B matters
+## Why M4-B mattered
 
-M4-A made lifecycle transitions explicit and provable. M4-B ensures those transitions remain safe
-when they interact with authority-changing capability operations in realistic workflows.
+M4-A established lifecycle transitions. M4-B ensured those transitions remain safe under realistic
+authority-changing operations.
 
-## Detailed target outcomes
+## Delivered outcomes
 
-1. lifecycle + capability lifecycle interaction semantics,
-2. stale-reference exclusion invariants,
-3. cross-bundle preservation theorems,
+1. lifecycle + capability interaction semantics,
+2. stale-reference exclusion invariant components,
+3. composed preservation across lifecycle/capability bundles,
 4. failure-path theorem coverage,
-5. expanded executable/test anchors.
+5. expanded trace/test anchors.
 
-## Proposed execution plan
+## Workstream closeout summary
 
-### Phase 1: semantic composition ✅ completed
+### Workstream A — semantic composition ✅
 
-- codified a deterministic transition story spanning lifecycle and revoke/delete behavior,
-- made ordering assumptions explicit in transition API and theorem statements.
+- codified deterministic transition order across lifecycle + revoke/delete behavior,
+- documented authority/state validation assumptions in theorem-facing form.
 
-### Phase 2: invariant hardening ✅ completed
+### Workstream B — invariant hardening ✅
 
-- define stale-reference exclusion invariants,
-- tie those invariants to existing identity/aliasing and authority components.
+- added stale-reference exclusion components,
+- linked lifecycle identity/aliasing and capability authority assumptions.
 
-### Phase 3: theorem expansion ✅ completed
+### Workstream C — theorem expansion ✅
 
-- prove local preservation for new composition helpers,
-- prove composed preservation across lifecycle + capability bundles.
+- proved local preservation for composition helpers,
+- proved composed preservation including failure-path branches.
 
-### Phase 4: executable + testing growth ✅ completed
+### Workstream D — executable + fixture evidence ✅
 
-- add M4-B success/failure traces in `Main.lean`,
-- extend Tier 3 anchors to include M4-B theorem surfaces,
-- keep fixture updates minimal and intentional.
+- extended `Main.lean` with composed success/failure scenarios,
+- maintained fixture updates as intentional semantic anchors.
 
-### Phase 5: documentation closeout ✅ completed
+### Workstream E — test/doc synchronization ✅
 
-- update spec/development guide/GitBook pages,
-- publish explicit note on what is deferred to M5,
-- align Tier 3/Tier 4 testing notes and triage entrypoints with script-level checks.
+- expanded Tier 3 symbol anchors,
+- aligned roadmap and planning docs for next-slice kickoff.
 
-## Exit signals for M4-B
+## Exit signals satisfied
 
-- required gates remain green,
-- lifecycle-capability composition theorem surfaces compile,
-- fixture updates are intentional and explained,
-- docs include post-M4 direction and M5 preparation notes.
+- composition theorem surfaces compile,
+- stale-reference safety is explicit and machine-checked,
+- fixtures and Tier 3 anchors track claimed behavior,
+- documentation now includes concrete M5 planning details.
 
-## M4-B success outcomes for the broader roadmap
+## Handoff to M5 (next-slice implications)
 
-When M4-B exits successfully, the project should be ready to:
+M4-B reduces expected M5 churn by providing:
 
-1. model service restart/isolation workflows with stronger safety assumptions,
-2. introduce policy-facing authority constraints with less theorem churn,
-3. move architecture-binding work into explicit interfaces rather than hidden assumptions.
+1. deterministic lifecycle-capability base transitions,
+2. reusable stale-reference vocabulary for service-level policy checks,
+3. precedent for proving failure paths as first-class outcomes,
+4. stable executable evidence patterns for orchestration scenarios.
 
+## M5 readiness checklist
 
-## Detailed deliverable map
+Before opening M5 implementation PRs, contributors should verify:
 
-### D1. Composition transition API surface
+1. target transition can be expressed using existing lifecycle/capability helpers,
+2. new invariants are introduced as narrow components (not monolithic bundles),
+3. local-preservation theorem names follow repository conventions,
+4. intended trace outputs are represented in fixture strategy,
+5. docs identify which M5 target outcome the change advances.
 
-Expected characteristics:
+## Developer takeaway
 
-- explicit authority/state/reference validation order,
-- deterministic result shape for success and each failure case,
-- helper theorems that make result-case proof scripts concise.
-
-### D2. Stale-reference exclusion invariant family
-
-Expected characteristics:
-
-- narrow invariant components instead of one mega definition,
-- explicit dependency links to lifecycle identity/aliasing and capability authority invariants,
-- theorem assumptions phrased for reuse in M5 policy layering.
-
-### D3. Proof surface completion
-
-Expected characteristics:
-
-- local preservation theorem per transition,
-- composed preservation theorem(s) over lifecycle + capability bundles,
-- explicit failure-path preservation statements.
-
-### D4. Evidence and regression guardrails
-
-Expected characteristics:
-
-- executable scenarios for composed success/failure behavior,
-- fixture anchors for stable semantic fragments,
-- Tier 3 symbol anchors for new M4-B theorem surfaces.
-
-## Dependencies and critical path
-
-1. D1 must land before D3 can stabilize.
-2. D2 should land before final composed theorem statements are frozen.
-3. D4 should land after D1/D3 behavior settles to minimize fixture churn.
-
-## Exit review questions
-
-Maintainers should be able to answer “yes” to all:
-
-1. Are stale references excluded after lifecycle+capability composition transitions?
-2. Are failure paths as rigorously preserved as success paths?
-3. Does executable evidence clearly represent composed behavior?
-4. Are M4-B claims continuously protected by Tier 3 anchors?
+M4-B is now a completed hardening slice. New work should consume M4-B surfaces as dependency
+contracts, not reopen them unless a soundness bug is identified.

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -1,101 +1,116 @@
 # Future Slices and Delivery Plan
 
-This chapter describes where the project is heading beyond the immediate M4-A/M4-B pair and how to
-get there without roadmap drift.
+This chapter describes the forward path beyond M4 closeout and provides execution structure to keep
+implementation, proofs, tests, and docs aligned.
 
-## Planning principles
+## 1. Planning principles
 
-1. keep slices narrow enough for one coherent review thread,
+1. keep each slice reviewable in one coherent thread,
 2. preserve theorem layering (local first, composed second),
-3. treat executable traces as contract evidence, not demo-only output,
-4. require docs to state both achieved outcomes and explicit deferrals.
+3. treat executable traces as contract evidence,
+4. ship docs and deferrals with each milestone change,
+5. preserve deterministic semantics before broadening scope.
 
-## Near-term path (M4 completion)
+## 2. Immediate next slice (M5)
 
-### M4-A (complete foundation)
+M5 theme: **service-oriented semantics built on M4 lifecycle-capability hardening**.
 
-Delivered:
+### M5 target outcomes
 
-- lifecycle/retype transition baseline,
-- identity/aliasing + capability-reference invariant seeds,
-- local/composed preservation entrypoints,
-- executable lifecycle traces.
+1. service dependency graph representation and transition semantics,
+2. policy-aware authority constraints integrated with capability surfaces,
+3. preservation theorems for restart/isolation and failure paths,
+4. executable scenario evidence for orchestration behaviors,
+5. Tier 3 anchors for M5 theorem/bundle surfaces.
 
-### M4-B (active next target)
+### M5 implementation workstreams
 
-To deliver:
+#### WS-M5-A — Service graph model
 
-- lifecycle + revoke/delete composed semantics,
-- stale-reference exclusion properties,
-- cross-bundle preservation and failure-path theorem coverage,
-- expanded Tier 3 and scenario anchors.
+- define service identity, status, and dependency structure,
+- model restart intent and isolation boundaries,
+- expose deterministic helper transitions.
 
-## Mid-term path (M5 preview)
+#### WS-M5-B — Policy and authority layer
 
-M5 is expected to focus on service-graph semantics and policy-friendly authority constraints.
+- encode policy predicates over capability/lifecycle operations,
+- bridge policy checks to existing invariant bundles,
+- ensure policy denial paths are explicit and testable.
+
+#### WS-M5-C — Proof completion
+
+- local preservation for each service transition,
+- composed preservation across service + lifecycle + capability bundles,
+- failure-path theorem completion.
+
+#### WS-M5-D — Evidence and testing
+
+- add scenario traces for restart and dependency failures,
+- add/adjust fixtures with rationale notes,
+- add Tier 3 anchors and nightly candidates.
+
+#### WS-M5-E — Documentation and closeout
+
+- align spec/README/GitBook with shipped behavior,
+- record M6 assumptions and deferred items,
+- publish slice closeout summary and risk notes.
+
+## 3. Mid-term slice preview (M6)
+
+M6 theme: **architecture binding interface preparation**.
+
 Indicative outcomes:
 
-1. model service restart and isolation semantics using M4 composition surfaces,
-2. refine authority decomposition for realistic multi-service topologies,
-3. prepare architecture-binding interfaces as explicit assumptions.
+1. explicit architecture assumptions represented as stable interfaces,
+2. proof-carrying adapters from architecture-neutral semantics,
+3. platform contract checklist for boot/runtime boundary expectations.
 
-## Long-term path (hardware relevance)
+## 4. Long-horizon trajectory (mobile-first relevance)
 
-The hardware trajectory (mobile-first) stays staged:
+1. architecture-neutral semantic hardening (M1-M5),
+2. architecture-binding interface stabilization (M6+),
+3. subsystem trust-boundary mapping,
+4. prototype integration with traceability back to theorem claims,
+5. hardware-oriented validation strategy alignment.
 
-1. semantic hardening in architecture-neutral model,
-2. architecture binding interfaces,
-3. boot/platform contract alignment,
-4. subsystem decomposition and trust-boundary mapping,
-5. prototype integration and traceability to system tests.
+See [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first.md).
 
-See [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first.md) for details.
+## 5. Transition gates
 
-## How contributors should use this plan
+### Gate: M4 → M5
 
-When opening milestone-moving PRs, include a short note answering:
+Require all:
 
-1. What slice outcome does this PR land now?
-2. What next-slice outcome does it unlock?
-3. What remains deferred and why?
+1. M4-B semantics/theorems merged and fixture-backed,
+2. stale-reference and failure-path coverage in place,
+3. Tier 3 anchors cover M4-B claims,
+4. docs explicitly describe M5 assumptions.
 
-That discipline keeps implementation, proofs, tests, and documentation aligned over time.
+### Gate: M5 → M6
 
+Require all:
 
-
-## Milestone transition criteria (quality gates)
-
-### M4-B → M5 transition gate
-
-Only transition once all are true:
-
-1. M4-B composition semantics are merged and fixture-backed.
-2. Stale-reference exclusion is theorem-backed with failure-path coverage.
-3. Tier 3 anchors cover newly claimed M4-B theorem surfaces.
-4. Docs explicitly list M5 assumptions and deferred risk items.
-
-### M5 → hardware-alignment transition gate (preview)
-
-Only transition once all are true:
-
-1. service-graph semantics support realistic restart/isolation stories,
-2. policy decomposition surfaces are stable enough for reuse,
+1. service graph semantics cover realistic restart/isolation stories,
+2. policy surfaces prove reusable across multiple service scenarios,
 3. architecture-binding assumptions are explicit and reviewable.
 
-## Suggested planning cadence
+## 6. Risk register (active)
 
-1. **Per PR**: state current-slice movement + next-slice unlock.
-2. **Per week**: publish checkpoint status against active slice outcomes.
-3. **Per milestone**: publish closeout summary including deferred items and rationale.
+1. **Semantic/proof skew**
+   - risk: transitions evolve without theorem updates.
+   - mitigation: enforce transition + theorem pairing in PR checklist.
+2. **Trace/fixture fragility**
+   - risk: fixtures reflect formatting noise instead of semantics.
+   - mitigation: document semantic intent per fixture delta.
+3. **Roadmap drift**
+   - risk: docs describe different active slices.
+   - mitigation: synchronize README/spec/GitBook in same PR.
+4. **Policy overcoupling**
+   - risk: policy model entangles service internals and capability internals.
+   - mitigation: require bridge lemmas and module boundary review.
 
-## Roadmap risk register (lightweight)
+## 7. Contributor operating cadence
 
-1. **Semantic/proof skew risk**
-   - symptom: theorem surfaces diverge from executable traces.
-   - mitigation: require fixture evidence with semantic transitions.
-2. **Documentation drift risk**
-   - symptom: README/spec/gitbook describe different active slices.
-   - mitigation: enforce same-PR status marker synchronization.
-3. **Test blind-spot risk**
-   - symptom: new theorem surfaces lack Tier 3 anchors.
-   - mitigation: treat anchor addition as part of definition-of-done.
+1. **Per PR**: state current-slice outcome moved + next-slice unlock.
+2. **Per checkpoint**: map progress to M5 workstreams A-E.
+3. **Per milestone closeout**: publish delivered outcomes, deferrals, and risk notes.

--- a/docs/gitbook/14-m4b-execution-playbook.md
+++ b/docs/gitbook/14-m4b-execution-playbook.md
@@ -1,138 +1,89 @@
 # M4-B Execution Playbook
 
-This chapter translates M4-B goals into concrete execution tracks so contributors can pick work that
-moves milestone outcomes forward without reopening M4-A contracts.
+This chapter records how M4-B was executed and captures handoff guidance so contributors can reuse
+a proven delivery pattern for M5.
 
 ## 1. Scope of this playbook
 
-M4-B is about **composition hardening**. The milestone is not complete by adding isolated new defs;
-it is complete when lifecycle and capability operations are integrated, proven, and evidenced in
-runnable traces.
+M4-B was a composition-hardening slice. Completion required integrated semantics, invariant
+hardening, theorem expansion, executable evidence, and test/doc synchronization.
 
-Use this playbook together with:
+Use this with:
 
-- `docs/SEL4_SPEC.md` (normative scope + acceptance),
-- `docs/DEVELOPMENT.md` (workflow + proof standards),
-- `docs/TESTING_FRAMEWORK_PLAN.md` (test expansion contract).
+- `docs/SEL4_SPEC.md` for normative scope,
+- `docs/DEVELOPMENT.md` for proof and workflow standards,
+- `docs/TESTING_FRAMEWORK_PLAN.md` for tiered validation contracts.
 
-## 2. Workstream map
+## 2. Workstream summary (completed)
 
-### Workstream A — Transition composition semantics ✅ completed
+### Workstream A — transition composition semantics ✅
 
-Goal: establish deterministic lifecycle+revoke/delete interaction behavior.
+Goal: deterministic lifecycle + revoke/delete behavior with explicit errors.
 
-Deliverables:
+### Workstream B — invariant hardening ✅
 
-1. one or more composition helper transitions with explicit error branches,
-2. theorem-visible ordering assumptions (e.g., delete-before-reuse),
-3. API comments documenting authority and state preconditions.
+Goal: stale-reference exclusion components tied to lifecycle/capability assumptions.
 
-Definition of done:
+### Workstream C — preservation theorem expansion ✅
 
-- transitions compile,
-- error variants are explicit,
-- behavior is observable from executable scenarios.
+Goal: local then composed proofs including failure paths.
 
-### Workstream B — Invariant hardening ✅ completed
+### Workstream D — executable + fixture evidence ✅
 
-Goal: eliminate stale-reference ambiguity across lifecycle operations.
+Goal: observable composed behavior guarded by fixture anchors.
 
-Deliverables:
+### Workstream E — testing and CI growth ✅
 
-1. stale-reference exclusion components,
-2. links to identity/aliasing and capability-authority components,
-3. reusable helper lemmas for local proof ergonomics.
+Goal: Tier 3 theorem anchors and stable full-suite behavior.
 
-Definition of done:
+## 3. What made execution effective
 
-- invariants are named and narrowly scoped,
-- helper lemmas are transition-local,
-- no monolithic mega-invariant introduced.
+1. semantics landed before fixture growth,
+2. local proofs landed before composed theorems,
+3. failure paths were treated as required proof surfaces,
+4. docs were closed out in the same phase as tests.
 
-### Workstream C — Preservation theorem expansion ✅ completed
+## 4. Reusable PR template (for future slices)
 
-Goal: keep proofs layered while broadening composition guarantees.
+Each milestone-moving PR should include:
 
-Deliverables:
+1. workstream(s) advanced,
+2. target outcome(s) moved,
+3. evidence commands and results,
+4. explicit deferrals,
+5. next-slice unlock statement.
 
-1. local preservation theorem entrypoints for each new operation,
-2. composed preservation theorem(s) spanning lifecycle + capability bundles,
-3. failure-path preservation statements (not just success-path proofs).
+## 5. M5 kickoff playbook (new)
 
-Definition of done:
+To start M5 cleanly, run this sequence:
 
-- theorem naming follows `<transition>_preserves_<target>`,
-- local-first structure is visible in code organization,
-- no `axiom`/`sorry` placeholders.
+1. **M5-K1: service graph definitions**
+   - add minimal service state model and dependency representation.
+2. **M5-K2: transition helpers**
+   - add deterministic start/stop/restart helpers with explicit failures.
+3. **M5-K3: policy predicates**
+   - add policy-oriented authority constraints as narrow components.
+4. **M5-K4: local proofs**
+   - prove each transition preserves relevant components.
+5. **M5-K5: composed proofs**
+   - prove service + lifecycle + capability bundle preservation.
+6. **M5-K6: traces/tests/docs**
+   - expose scenarios in `Main.lean`, update fixtures/Tier 3, sync docs.
 
-### Workstream D — Executable and fixture evidence ✅ completed
+## 6. Common pitfalls to avoid
 
-Goal: prove milestone behavior is externally visible and regression-testable.
+1. proof-first without stable semantics,
+2. monolithic invariants that block reuse,
+3. fixture updates without semantic intent notes,
+4. M5 policy logic coupled too tightly to one service story,
+5. documentation updates deferred to "later".
 
-Deliverables:
+## 7. Exit checklist for maintainers
 
-1. success/failure M4-B scenarios in `Main.lean`,
-2. stable fixture anchors for new semantic fragments,
-3. rationale notes for each fixture update.
+Before declaring a slice complete:
 
-Definition of done:
-
-- `test_tier2_trace` and `test_smoke` pass,
-- fragments are stable semantic signals (not formatting noise),
-- scenario coverage maps back to M4-B target outcomes.
-
-### Workstream E — Testing and CI growth ✅ completed
-
-Goal: ensure M4-B regression detection is reliable.
-
-Deliverables:
-
-1. Tier 3 symbol anchors for new composition theorem surfaces,
-2. nightly extension candidates documented and staged,
-3. failure triage notes linked to exact script entrypoints.
-
-Definition of done:
-
-- `test_full` remains green,
-- M4-B anchors are present and discoverable,
-- nightly is still explicit about extension-point status.
-
-## 3. Recommended sequencing
-
-1. Land semantics + local helpers.
-2. Land local invariants + local preservation.
-3. Land composed preservation + failure-path proofs.
-4. Land scenario/fixture expansion.
-5. Land Tier 3/CI anchor expansion.
-6. Land docs closeout + deferred M5 notes.
-
-This order minimizes churn and avoids fixture drift before semantics stabilize.
-
-## 4. PR template for M4-B work
-
-Each M4-B PR should answer:
-
-1. Which workstream(s) does this PR advance?
-2. Which target outcome(s) from the spec are moved?
-3. What command evidence validates the claim?
-4. What remains deferred in M4-B after this PR?
-5. What M5 direction does this work unlock?
-
-## 5. Common pitfalls to avoid
-
-1. **Proof-first without semantic anchors** — causes theorem churn when behavior changes.
-2. **Fixture-first without deterministic behavior** — causes fragile trace expectations.
-3. **Composed proof before local proof maturity** — hides root-cause failures.
-4. **Untracked deferred work** — creates milestone ambiguity and roadmap drift.
-5. **Undocumented failure paths** — reduces confidence in authority/lifecycle safety claims.
-
-## 6. Exit checklist for M4-B maintainers
-
-Before declaring M4-B complete, verify:
-
-- composed lifecycle+capability transition story exists and is deterministic,
-- stale-reference exclusion is explicit and machine-checked,
-- failure-path preservation is implemented and documented,
-- executable traces cover both success and failure composition stories,
-- Tier 3 contains M4-B theorem/bundle anchors,
-- docs across README/spec/development/gitbook/testing are synchronized.
+- transition and failure behavior are deterministic and explicit,
+- local + composed theorem surfaces compile,
+- executable evidence covers success and failure stories,
+- Tier 3 anchors include new theorem surfaces,
+- docs and roadmap state delivered outcomes plus deferrals.

--- a/docs/gitbook/15-m5-blueprint-and-project-usage.md
+++ b/docs/gitbook/15-m5-blueprint-and-project-usage.md
@@ -1,0 +1,127 @@
+# M5 Blueprint and Project Usage Value
+
+This chapter explains two things:
+
+1. a practical blueprint for the next slice (M5),
+2. how developers and teams can use seLe4n today for technical value.
+
+## 1. M5 blueprint at a glance
+
+### Desired slice outcome
+
+By M5 closeout, contributors should be able to reason about service-level operations (including
+restart and isolation scenarios) using the same semantics → invariants → proofs → traces workflow
+established by earlier slices.
+
+### Target outcomes
+
+1. service dependency graph semantics,
+2. policy-constrained capability/lifecycle orchestration,
+3. local and composed preservation theorems for orchestration paths,
+4. failure-path theorem coverage for policy/ordering/dependency issues,
+5. executable evidence and tiered test anchors.
+
+## 2. Concrete workstreams and deliverables
+
+### WS1 — Service graph representation
+
+Deliverables:
+
+- service identity and status model,
+- dependency-edge representation,
+- helper queries for dependency soundness checks.
+
+### WS2 — Orchestration transitions
+
+Deliverables:
+
+- start/stop/restart transition helpers,
+- explicit errors for policy denial and missing dependency states,
+- deterministic ordering assumptions captured in comments/theorems.
+
+### WS3 — Policy surfaces
+
+Deliverables:
+
+- policy predicates reusable across multiple service stories,
+- bridge lemmas to capability/lifecycle invariant surfaces,
+- clear separation between policy checks and low-level state mutation.
+
+### WS4 — Proof package
+
+Deliverables:
+
+- local preservation theorem entrypoint per transition,
+- composed preservation over service+lifecycle+capability bundles,
+- explicit failure-path preservation theorems.
+
+### WS5 — Evidence and validation
+
+Deliverables:
+
+- executable service scenarios in `Main.lean`,
+- stable fixture anchors for important semantic fragments,
+- Tier 3 symbol checks for new theorem/bundle names.
+
+### WS6 — Documentation closeout
+
+Deliverables:
+
+- updated spec roadmap status,
+- updated README usage notes,
+- updated GitBook planning and architecture chapters.
+
+## 3. Definition of done for M5
+
+M5 should be considered complete only when:
+
+1. all declared transitions and theorem entrypoints compile,
+2. success and failure stories are both executable and documented,
+3. test tiers cover newly claimed theorem surfaces,
+4. docs list both achieved outcomes and M6 deferrals.
+
+## 4. How developers can use seLe4n today
+
+### Use case A — Prototype kernel semantics safely
+
+Teams can model transition changes, observe behavior through executable traces, and prevent
+regressions with theorem and fixture checks.
+
+### Use case B — Evaluate authority and policy design
+
+Developers can formalize authority assumptions as predicates and test whether planned policy rules
+compose safely with lifecycle and capability behavior.
+
+### Use case C — Teach and onboard formal systems engineers
+
+The repository offers a realistic progression from core state models to subsystem proofs and
+cross-bundle theorem composition.
+
+### Use case D — Support design reviews with precise artifacts
+
+Instead of informal prose-only discussions, teams can point to concrete transition definitions,
+invariant statements, and proof obligations.
+
+### Use case E — Stage hardware-bound assurance planning
+
+Before architecture lock-in, teams can validate semantic assumptions and identify where
+architecture-binding interfaces are needed.
+
+## 5. Practical adoption paths
+
+1. **Research/architecture teams**
+   - use chapters 11/12 + proof surfaces to evaluate semantics alternatives.
+2. **Platform teams**
+   - use traces and test tiers to track semantic drift during implementation.
+3. **Verification teams**
+   - extend invariants and theorem bundles for product-specific risk areas.
+4. **Security teams**
+   - model authority constraints and failure paths for policy hardening.
+
+## 6. Suggested next PR themes
+
+1. M5 service model skeleton,
+2. first orchestration transition with local preservation,
+3. policy predicate bundle and bridge lemma set,
+4. first composed service+lifecycle+capability theorem,
+5. executable restart-failure scenario + fixture anchor.

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -13,14 +13,13 @@ This handbook is the long-form documentation set for:
 
 ## Why this handbook exists
 
-The repository docs (`README.md`, spec, development guide, testing plan) are intentionally concise.
-This GitBook layer provides deeper explanations so contributors can understand **why** the project
-is shaped this way, not only **what** commands to run.
+Repository-level docs are intentionally concise. The GitBook layer expands the "why" and "how" so
+contributors can understand current contracts and next-slice execution paths.
 
 ## Current stage
 
-- Active slice: **M4-B lifecycle-capability composition hardening**.
-- Next slice preview: **M5 service-graph + policy surfaces**.
+- Recently completed slice: **M4-B lifecycle-capability composition hardening**.
+- Next slice target: **M5 service-graph + policy surfaces**.
 
 ## Suggested reading order
 
@@ -38,17 +37,12 @@ is shaped this way, not only **what** commands to run.
 12. [Proof and Invariant Map](12-proof-and-invariant-map.md)
 13. [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
 14. [M4-B Execution Playbook](14-m4b-execution-playbook.md)
+15. [M5 Blueprint and Project Usage Value](15-m5-blueprint-and-project-usage.md)
 
 For normative acceptance criteria, treat `docs/SEL4_SPEC.md` as canonical.
 
 ## What changed in this edition
 
-- Expanded deep-reference material in **Codebase Reference** with transition-level semantics,
-  proof-organization guidance, and practical debug playbooks.
-- Expanded **Testing & CI** chapter with tier-by-tier intent, entrypoint behavior, and
-  color-coded test logging conventions for local runs.
-
-- Added **Future Slices and Delivery Plan** chapter to make post-M4 direction and milestone
-  handoff expectations explicit for contributors.
-
-- Added **M4-B Execution Playbook** chapter to turn roadmap targets into concrete workstreams, sequencing, and PR-level delivery checklists.
+- Expanded roadmap chapters to include explicit M5 target outcomes and workstreams.
+- Expanded M4-B closeout material to provide concrete handoff guidance.
+- Added a dedicated chapter on developer/team usage modes and technical project value.

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -15,3 +15,4 @@
 - [Proof and Invariant Map](12-proof-and-invariant-map.md)
 - [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
 - [M4-B Execution Playbook](14-m4b-execution-playbook.md)
+- [M5 Blueprint and Project Usage Value](15-m5-blueprint-and-project-usage.md)


### PR DESCRIPTION
Expanded the GitBook framing docs to reflect the current state (M4-B complete) and to provide a clearer M5-oriented planning narrative, including refreshed handbook navigation and a new reading path entry for the added chapter.

Reworked the high-level project and roadmap chapters with detailed next-slice outcomes, explicit M5 workstreams, non-goals, checkpoint cadence, and evidence expectations to make “next steps” actionable for contributors.

Refined M4-B documentation into a closeout + handoff format, including delivered outcomes, readiness checks, and a reusable execution pattern that now includes an M5 kickoff sequence.

Expanded future planning detail with M5/M6 direction, transition gates, risk register, and operating cadence so roadmap progression is explicit and reviewable.

Added a new GitBook chapter dedicated to M5 blueprinting plus practical “how to use this project” guidance for different developer/team personas, and linked that usage-oriented guidance from the root README as well.
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69929b086390832bafcadd58730c6189)