### PR TITLE
Verify exit readiness signals for M4-B and update slice to M5

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,8 +4,9 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M4-B lifecycle-capability composition hardening (Workstreams A+B+C+D+E complete)**;
-M5 preparation is now active.
+Current stage: **M5 service-graph + policy surface delivery (active implementation)**.
+M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
+baseline.
 
 Primary goals for contributors:
 
@@ -13,7 +14,8 @@ Primary goals for contributors:
 - preserve theorem-entrypoint continuity across milestones,
 - ship narrow, reviewable slices,
 - keep docs synchronized with active and next slice plans,
-- deliver M4-B composition hardening with clear handoff toward M5.
+- deliver M5 service-level semantics and policy layering without regressing closed M1–M4-B
+  contracts.
 
 ---
 
@@ -87,9 +89,9 @@ Do not include in this slice unless explicitly approved:
 
 ---
 
-## 4. Current slice implementation plan: M4-B
+## 4. Completed predecessor slice baseline: M4-B
 
-### 4.1 M4-B target outcomes
+### 4.1 M4-B target outcomes (all complete)
 
 1. Compose lifecycle with revoke/delete semantics.
 2. Add stale-reference exclusion invariants.
@@ -97,7 +99,7 @@ Do not include in this slice unless explicitly approved:
 4. Add failure-path theorem coverage for lifecycle-capability interactions.
 5. Expand Tier 3 checks and scenario coverage for lifecycle composition.
 
-### 4.2 Delivery sequence for M4-B
+### 4.2 Delivery sequence used for M4-B closeout
 
 1. **Transition composition pass**
    - introduce helper transitions and theorem statements for lifecycle+capability interactions.
@@ -110,7 +112,7 @@ Do not include in this slice unless explicitly approved:
 5. **Documentation pass**
    - update spec, development guide, and GitBook slices with exact outcome/deferred mapping.
 
-### 4.3 Design guardrails for M4-B readiness
+### 4.3 Design guardrails retained from M4-B closeout
 
 - preserve clean invariant layering;
 - keep lifecycle assumptions out of unrelated IPC predicates;
@@ -118,7 +120,7 @@ Do not include in this slice unless explicitly approved:
 - keep theorem names searchable with `<transition>_preserves_<target>` style.
 
 
-### 4.4 Suggested M4-B work packages
+### 4.4 M4-B work package archive
 
 Use narrow PR-sized work packages to reduce review risk:
 
@@ -137,7 +139,7 @@ Use narrow PR-sized work packages to reduce review risk:
 7. **WP-7 doc closeout**
    - sync README/spec/development/testing/GitBook and state M5 deferrals.
 
-### 4.5 Exit readiness signals for M4-B
+### 4.5 Exit readiness signals used for M4-B
 
 Before maintainers mark M4-B complete, verify:
 
@@ -149,9 +151,10 @@ Before maintainers mark M4-B complete, verify:
 
 ---
 
-## 5. Next slice planning discipline (M5 preview)
+## 5. Current slice planning discipline (M5)
 
-To reduce milestone thrash, each M4-B PR should state how it advances M4-B exit criteria and supports the likely M5 direction:
+To reduce milestone thrash, each M5 PR should state how it advances M5 outcomes while preserving
+closed milestone contracts:
 
 1. service-graph-oriented semantics,
 2. policy-oriented authority decomposition,
@@ -160,13 +163,13 @@ To reduce milestone thrash, each M4-B PR should state how it advances M4-B exit 
 A lightweight “what this unlocks next” paragraph is now expected in milestone-moving PRs.
 
 
-### 5.1 M4-B to M5 handoff narrative standard
+### 5.1 M5 narrative standard
 
 For each milestone-moving PR, include a short section that states:
 
-1. what concrete M4-B outcome moved,
+1. what concrete M5 outcome moved,
 2. what evidence command validates that movement,
-3. what dependency for M5 is now unblocked.
+3. what dependency for the next slice (M6) is now unblocked.
 
 ---
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -7,13 +7,13 @@ This document is the normative specification baseline for seLe4n.
 It defines:
 
 1. What milestone behavior is already closed and considered stable.
-2. The **current delivery slice** (M4-B) with concrete target outcomes.
-3. The **next delivery slice** (M5-preview) so work continues without roadmap drift.
+2. The **current delivery slice** (M5) with concrete target outcomes.
+3. The **next delivery slice** preview (M6-directional) so work continues without roadmap drift.
 4. Acceptance criteria and non-goals for focused, reviewable implementation.
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **M4-B lifecycle-capability composition hardening complete (Workstreams A+B+C+D+E complete)**.
+Current stage: **M5 service-graph semantics and policy-oriented authority layering (active)**.
 
 ---
 
@@ -25,14 +25,15 @@ Current stage: **M4-B lifecycle-capability composition hardening complete (Works
 - **M3 (complete)**: endpoint send/receive seed semantics + IPC invariant seed bundle.
 - **M3.5 (complete)**: waiting/handshake IPC semantics + scheduler coherence contract.
 - **M4-A (complete)**: lifecycle/retype transition foundations + initial lifecycle invariants.
-- **M4-B (current slice)**: lifecycle-capability composition hardening and richer scenario coverage.
-- **M5 (next slice preview)**: service-graph semantics and policy-oriented authority constraints.
+- **M4-B (complete)**: lifecycle-capability composition hardening and richer scenario coverage.
+- **M5 (current slice)**: service-graph semantics and policy-oriented authority constraints.
+- **M6 (next slice preview)**: architecture-binding interfaces and hardware-facing assumption hardening.
 
 ---
 
 ## 3. Stable baseline contracts (must not regress)
 
-The following contracts are considered stable and preserved while M4 evolves:
+The following contracts are considered stable and preserved while M5 evolves:
 
 1. M1 scheduler invariant bundle and entrypoint preservation theorems.
 2. M2 capability/CSpace transition APIs (`lookup`, `insert`, `mint`, `delete`, `revoke`) and
@@ -120,7 +121,7 @@ A change is M4-A complete only when all of the following are true:
 
 ---
 
-## 5. Current slice: M4-B lifecycle-capability composition hardening
+## 5. Completed predecessor slice: M4-B lifecycle-capability composition hardening
 
 ### 5.1 Objective
 
@@ -200,24 +201,24 @@ A PR series claiming M4-B completion should include all of:
 
 ---
 
-## 6. Next slice preview (M5 and beyond)
+## 6. Current slice: M5 service graph + policy surfaces
 
 ### 6.1 M5 target direction: service graph + policy surfaces
 
-The next milestone family (M5) targets operational realism while preserving theorem layering:
+The active milestone family (M5) targets operational realism while preserving theorem layering:
 
 1. model service restart/isolation stories that exercise lifecycle+IPC+capability composition,
 2. introduce policy-friendly authority constraints without replacing existing invariants,
 3. prepare architecture-binding interfaces as explicit assumptions rather than implicit behavior.
 
-### 6.2 Required outcomes before entering M5
+### 6.2 M5 entry requirements (already satisfied)
 
 - M4-B stale-reference properties are merged and stable,
 - lifecycle-capability composition traces are fixture-backed,
 - invariant bundles expose reusable theorem surfaces for policy composition.
 
 
-### 6.3 M5 preparation tracks (to stage during late M4-B)
+### 6.3 M5 execution tracks (active)
 
 1. **Service-graph modeling track**
    - define minimal restart/isolation scenarios that reuse M4-B composition surfaces.

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -2,9 +2,9 @@
 
 ## 1. Purpose
 
-This document defines the active testing baseline and near-term expansion path for the M4 stage.
+This document defines the active testing baseline and near-term expansion path for the M5 stage.
 
-Current stage context: **M4-B lifecycle-capability composition hardening complete (M4-A + WS-A + WS-B + WS-C + WS-D + WS-E complete)**.
+Current stage context: **M5 service-graph + policy surface delivery active (with M4-B fully closed)**.
 
 ## 2. Current enforced tiers
 
@@ -36,12 +36,12 @@ PR CI must call repository scripts directly and keep workflow logic thin.
 4. Keep Tier 3 milestone-closure anchors for M1 scheduler and M2 capability transition/preservation surfaces so completed milestones remain continuously verified.
 5. Preserve category-labeled failure output (`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`).
 
-## 5. Active M4-B testing expansion targets
+## 5. Active M5 testing expansion targets
 
-1. Add success + failure lifecycle scenario fixtures.
-2. Add grouped Tier 3 checks for lifecycle-capability composition symbols.
+1. Add service-graph restart/isolation/dependency-failure scenario fixtures.
+2. Add grouped Tier 3 checks for M5 service/policy theorem and bundle symbols.
 3. Expand nightly checks toward repeat-run determinism and broader scenario sweeps.
-4. Standardize new artifact names for debugging lifecycle regression failures.
+4. Standardize new artifact names for debugging service/policy regression failures.
 
 ## 6. Fixture policy
 
@@ -99,26 +99,26 @@ Primary risks to target next:
 - scenario breadth gaps,
 - long-horizon confidence blind spots.
 
-## 9. M4-specific testing growth plan
+## 9. M5-specific testing growth plan
 
-1. add lifecycle scenario fixture fragments that remain stable across formatting changes,
-2. add grouped lifecycle theorem anchor checks in Tier 3,
-3. add at least one failure-path scenario for lifecycle invalid-object/invalid-authority behavior,
+1. add service-orchestration fixture fragments that remain stable across formatting changes,
+2. add grouped service/policy theorem anchor checks in Tier 3,
+3. add failure-path scenarios for dependency violation and policy denial behavior,
 4. record any new artifact outputs with consistent naming for CI triage.
 
 
-## 10. M4-B test implementation plan (detailed)
+## 10. M5 test implementation plan (detailed)
 
-1. **Phase T1 — composition scenario seeds**
-   - add at least one composed lifecycle+capability success trace,
-   - add at least one composed failure trace (stale or authority failure).
+1. **Phase T1 — service scenario seeds**
+   - add at least one service start/restart success trace,
+   - add at least one policy/dependency failure trace.
 2. **Phase T2 — fixture hardening**
    - capture stable semantic fragments only,
    - avoid transient formatting-dependent assertions.
 3. **Phase T3 — Tier 3 anchor expansion**
-   - add symbol anchors for M4-B invariant and preservation theorem surfaces,
+   - add symbol anchors for M5 invariant and preservation theorem surfaces,
    - keep anchors grouped by milestone objective for triage clarity.
-4. **Phase T4 — nightly evolution** ✅ completed
+4. **Phase T4 — nightly evolution**
    - preserve explicit Tier 4 extension-point behavior by default in `./scripts/test_nightly.sh`,
    - stage repeat-run determinism + full-suite replay candidates in `./scripts/test_tier4_nightly_candidates.sh`,
    - keep candidate execution opt-in (`NIGHTLY_ENABLE_EXPERIMENTAL=1`) so required mainline gates remain stable.

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -54,10 +54,11 @@ Type-checking alone can miss semantic regressions. Tier 2 fixture checks ensure 
 stories remain visible and intentional, especially for milestone claims tied to executable behavior
 (e.g., mint/revoke/delete and IPC handshake flows).
 
-## M4 testing trajectory
+## M4 closeout + M5 testing trajectory
 
-- **M4-A:** lifecycle semantic trace fragments are now landed and fixture-backed in Tier 2 smoke coverage.
+- **M4-A:** lifecycle semantic trace fragments are landed and fixture-backed in Tier 2 smoke coverage.
 - **M4-B:** WS-A/WS-B/WS-C/WS-D/WS-E are complete, including Tier 3 M4-B symbol anchors and staged Tier 4 nightly candidates.
+- **M5 (active):** expand Tier 2/Tier 3 coverage to service-graph transitions, policy-denial branches, and composed service+lifecycle+capability preservation theorem anchors.
 
 ## Practical failure triage
 

--- a/docs/gitbook/09-current-slice-m5.md
+++ b/docs/gitbook/09-current-slice-m5.md
@@ -59,3 +59,24 @@ Before landing M5 PRs, verify:
 - immediate predecessor contracts: [Completed Slice: M4-B](16-completed-slice-m4b.md)
 - normative scope and acceptance criteria: [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md)
 - broader roadmap: [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
+
+
+## M5 execution dashboard (optimized handoff)
+
+Use this compact checklist at the top of every M5 PR:
+
+- **Model surface (WS-M5-A/B):** service graph state + deterministic transition branch shape.
+- **Policy surface (WS-M5-C):** policy predicates are explicit, named, and separable from mutation.
+- **Proof surface (WS-M5-D):** local + composed preservation theorem entrypoints include failure paths.
+- **Evidence surface (WS-M5-E):** `Main.lean` traces and `tests/fixtures/main_trace_smoke.expected` anchors updated intentionally.
+- **Validation surface:** Tier 0/1/2 required gates pass; Tier 3 anchor additions reflect every new theorem/invariant claim.
+
+## M5 exit-readiness signals
+
+M5 should be marked complete only when all are true:
+
+1. service orchestration transitions are deterministic and expose denial/error branches,
+2. policy predicates bridge cleanly to lifecycle/capability invariants,
+3. local and composed theorem surfaces are machine-checked and discoverable,
+4. fixture-backed traces cover success and failure operational stories,
+5. Tier 3 includes all M5 symbol anchors and docs state M6 deferrals explicitly.

--- a/docs/gitbook/15-m5-development-blueprint.md
+++ b/docs/gitbook/15-m5-development-blueprint.md
@@ -132,3 +132,28 @@ Copy this into M5 PR descriptions:
 - Historical predecessor: [Completed Slice: M4-B](16-completed-slice-m4b.md)
 - Development workflow standards: [Development Workflow](06-development-workflow.md)
 - Testing contract: [Testing & CI](07-testing-and-ci.md)
+
+
+## 8. Fast-start command bundle (recommended per PR)
+
+```bash
+./scripts/test_fast.sh
+./scripts/test_smoke.sh
+./scripts/test_tier3_invariant_surface.sh
+./scripts/audit_testing_framework.sh
+```
+
+Use this sequence whenever an M5 PR adds or changes theorem/invariant claims so exit-readiness
+signals remain continuously provable.
+
+## 9. Coverage obligations matrix for M5
+
+Treat “full coverage” in this project as obligation coverage across these layers:
+
+1. **Build/proof closure:** `lake build` through Tier 1.
+2. **Executable semantic closure:** Tier 2 fixture anchors covering M5 stories.
+3. **Surface-anchor closure:** Tier 3 symbol checks for every new theorem/bundle/predicate claim.
+4. **Nightly confidence closure:** Tier 4 candidate replay/determinism checks during audits.
+5. **Negative-control closure:** audit script verifies Tier 2 fails on impossible expectations.
+
+A milestone claim is incomplete if any one obligation is missing, even if other layers pass.

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -175,13 +175,14 @@ run_check "TRACE" rg -n 'post-delete lookup \(expected error\): SeLe4n.Model.Ker
 # Active milestone docs should stay synchronized for both current and next slices.
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
-run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
-run_check "DOC" rg -n 'Phase 3: theorem expansion ✅ completed' docs/gitbook/09-next-slice-m4b.md
-run_check "DOC" rg -n 'Phase 5: documentation closeout ✅ completed' docs/gitbook/09-next-slice-m4b.md
-run_check "DOC" rg -n 'Workstream B — Invariant hardening ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
-run_check "DOC" rg -n 'Workstream C — Preservation theorem expansion ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
-run_check "DOC" rg -n 'Workstream D — Executable and fixture evidence ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
-run_check "DOC" rg -n 'Workstream E — Testing and CI growth ✅ completed' docs/gitbook/14-m4b-execution-playbook.md
+run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete|WS-A \+ WS-B \+ WS-C \+ WS-D \+ WS-E complete|WS-A/WS-B/WS-C/WS-D/WS-E are complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md
+run_check "DOC" rg -n 'Active slice:|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-current-slice-m5.md
+run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md
+run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-current-slice-m5.md
+run_check "DOC" rg -n 'Workstream B — invariant hardening ✅' docs/gitbook/14-m4b-execution-playbook.md
+run_check "DOC" rg -n 'Workstream C — preservation theorem expansion ✅' docs/gitbook/14-m4b-execution-playbook.md
+run_check "DOC" rg -n 'Workstream D — executable \+ fixture evidence ✅' docs/gitbook/14-m4b-execution-playbook.md
+run_check "DOC" rg -n 'Workstream E — testing and CI growth ✅' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'test_tier4_nightly_candidates\.sh' docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md scripts/test_nightly.sh
 # shellcheck disable=SC2016
 run_check "DOC" rg -n 'Tier 3 fails \(`\./scripts/test_tier3_invariant_surface\.sh`\)' docs/gitbook/07-testing-and-ci.md

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -6,8 +6,8 @@ This directory tracks fixture-backed executable trace checks used by
 ## Stage alignment
 
 - Closed baseline: M1-M3.5 (scheduler, capability, IPC handshake coherence).
-- Active stage: M4-B lifecycle-capability composition hardening (Workstream D complete).
-- Next stage: M4-B Workstream E testing-anchor expansion and M5 preparation.
+- Active stage: M5 service-graph + policy surface development.
+- Previous stage (closed): M4-B lifecycle-capability composition hardening (WS-A..WS-E complete).
 
 ## Fixture source
 
@@ -28,10 +28,10 @@ This directory tracks fixture-backed executable trace checks used by
    ./scripts/test_tier2_trace.sh
    ./scripts/test_smoke.sh
    ```
-4. Document why fixture changes are expected and which slice they support (M4-A or M4-B).
+4. Document why fixture changes are expected and which slice they support (M4-B closeout or M5 execution).
 
 
-## Current fixture rationale notes (M4-B Workstream D)
+## Current fixture rationale notes (M4-B closeout baseline)
 
 The smoke fixture captures stable semantic anchors rather than formatting-dependent text:
 


### PR DESCRIPTION
Updated the project’s core milestone docs to treat M4-B as a completed predecessor slice, mark M5 as the active delivery slice, and introduce M6 as the forward preview direction in the normative spec/development guidance. 

Updated testing and scenario documentation so the active test-planning language now targets M5 (service-graph/policy outcomes), while preserving M4-B closure context and obligation-based “full coverage” framing. 

Optimized the GitBook for M5 execution by adding an explicit M5 execution dashboard, M5 exit-readiness signals, a fast-start command bundle, and a coverage-obligations matrix for slice-close confidence. 

Updated Tier 3 invariant/doc-surface checks to validate current M5 GitBook/doc anchors and remove stale references to deleted pages, ensuring readiness checks are aligned with today’s documentation topology. 


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a9799914832b8d2639a2e7153799)