### PR TITLE
Implement WS-M5-A service graph model and mark WS-M5-A complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M5 service-graph + policy surfaces.
+- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model completed).
 - **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
 
 For normative milestones, acceptance criteria, and scope decisions, use

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -2,6 +2,32 @@ import SeLe4n.Prelude
 
 namespace SeLe4n.Model
 
+/-- Identifier for modeled services in the M5 service graph layer. -/
+abbrev ServiceId := Nat
+
+/-- High-level service runtime status for orchestration-level reasoning. -/
+inductive ServiceStatus where
+  | stopped
+  | running
+  | failed
+  | isolated
+  deriving Repr, DecidableEq
+
+/-- Stable service identity metadata for graph-level orchestration. -/
+structure ServiceIdentity where
+  sid : ServiceId
+  backingObject : SeLe4n.ObjId
+  owner : SeLe4n.ObjId
+  deriving Repr, DecidableEq
+
+/-- Declared service dependencies and isolation edges. -/
+structure ServiceGraphEntry where
+  identity : ServiceIdentity
+  status : ServiceStatus
+  dependencies : List ServiceId
+  isolatedFrom : List ServiceId
+  deriving Repr, DecidableEq
+
 inductive AccessRight where
   | read
   | write

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -36,6 +36,7 @@ structure LifecycleMetadata where
 structure SystemState where
   machine : SeLe4n.MachineState
   objects : SeLe4n.ObjId → Option KernelObject
+  services : ServiceId → Option ServiceGraphEntry
   scheduler : SchedulerState
   irqHandlers : SeLe4n.Irq → Option SeLe4n.ObjId
   lifecycle : LifecycleMetadata
@@ -50,6 +51,7 @@ instance : Inhabited SystemState where
   default := {
     machine := default
     objects := fun _ => none
+    services := fun _ => none
     scheduler := default
     irqHandlers := fun _ => none
     lifecycle := {
@@ -115,6 +117,77 @@ def setCurrentThread (tid : Option SeLe4n.ThreadId) : Kernel Unit :=
   fun st =>
     let sched := { st.scheduler with current := tid }
     .ok ((), { st with scheduler := sched })
+
+/-- Read one service graph entry. -/
+def lookupService (st : SystemState) (sid : ServiceId) : Option ServiceGraphEntry :=
+  st.services sid
+
+/-- Determine whether `sid` lists `dependency` as a declared dependency edge. -/
+def hasServiceDependency (st : SystemState) (sid dependency : ServiceId) : Bool :=
+  match lookupService st sid with
+  | some svc => dependency ∈ svc.dependencies
+  | none => false
+
+/-- Determine whether two services are explicitly isolated from one another. -/
+def hasIsolationEdge (st : SystemState) (lhs rhs : ServiceId) : Bool :=
+  match lookupService st lhs, lookupService st rhs with
+  | some lhsSvc, some rhsSvc => rhs ∈ lhsSvc.isolatedFrom || lhs ∈ rhsSvc.isolatedFrom
+  | _, _ => false
+
+/-- A service is runnable only when all declared dependencies are currently `running`. -/
+def dependenciesSatisfied (st : SystemState) (sid : ServiceId) : Bool :=
+  match lookupService st sid with
+  | none => false
+  | some svc =>
+      svc.dependencies.all (fun dep =>
+        match lookupService st dep with
+        | some depSvc => depSvc.status = .running
+        | none => false)
+
+/-- Deterministic pure state helper: replace one service graph entry. -/
+def storeServiceState (sid : ServiceId) (entry : ServiceGraphEntry) (st : SystemState) : SystemState :=
+  {
+    st with
+      services := fun sid' => if sid' = sid then some entry else st.services sid'
+  }
+
+/-- Deterministic pure state helper: update only the status of an existing service. -/
+def setServiceStatusState (sid : ServiceId) (status : ServiceStatus) (st : SystemState) : SystemState :=
+  match lookupService st sid with
+  | none => st
+  | some svc => storeServiceState sid { svc with status := status } st
+
+theorem storeServiceState_lookup_eq
+    (st : SystemState)
+    (sid : ServiceId)
+    (entry : ServiceGraphEntry) :
+    lookupService (storeServiceState sid entry st) sid = some entry := by
+  simp [lookupService, storeServiceState]
+
+theorem storeServiceState_lookup_ne
+    (st : SystemState)
+    (sid sid' : ServiceId)
+    (entry : ServiceGraphEntry)
+    (hNe : sid' ≠ sid) :
+    lookupService (storeServiceState sid entry st) sid' = lookupService st sid' := by
+  simp [lookupService, storeServiceState, hNe]
+
+theorem setServiceStatusState_lookup_eq
+    (st : SystemState)
+    (sid : ServiceId)
+    (status : ServiceStatus)
+    (svc : ServiceGraphEntry)
+    (hSvc : lookupService st sid = some svc) :
+    lookupService (setServiceStatusState sid status st) sid = some { svc with status := status } := by
+  simp [setServiceStatusState, hSvc, storeServiceState_lookup_eq]
+
+theorem setServiceStatusState_preserves_objects
+    (st : SystemState)
+    (sid : ServiceId)
+    (status : ServiceStatus) :
+    (setServiceStatusState sid status st).objects = st.objects := by
+  unfold setServiceStatusState lookupService
+  cases hSvc : st.services sid <;> simp [storeServiceState]
 
 theorem storeCapabilityRef_preserves_objects
     (st st' : SystemState)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M5 service-graph + policy surface delivery (active implementation)**.
+Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A complete)**.
 M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
 baseline.
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **M5 service-graph semantics and policy-oriented authority layering (active)**.
+Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A complete)**.
 
 ---
 
@@ -220,8 +220,9 @@ The active milestone family (M5) targets operational realism while preserving th
 
 ### 6.3 M5 execution tracks (active)
 
-1. **Service-graph modeling track**
-   - define minimal restart/isolation scenarios that reuse M4-B composition surfaces.
+1. **Service-graph modeling track** ✅ **completed baseline**
+   - service identity/status/dependency/isolation model and deterministic state helpers are implemented,
+   - next work now consumes this stable surface for orchestration transitions and policy proofs.
 2. **Policy decomposition track**
    - outline authority predicates that can layer over M4 bundles without reshaping closed theorem
      interfaces.

--- a/docs/gitbook/09-current-slice-m5.md
+++ b/docs/gitbook/09-current-slice-m5.md
@@ -7,7 +7,7 @@ foundation.
 
 ## Current status
 
-- **Slice state:** active planning + incremental implementation.
+- **Slice state:** active implementation (WS-M5-A completed; WS-M5-B onward in progress).
 - **Baseline assumption:** M4-B theorem and invariant surfaces are stable and should be consumed as
   dependency contracts.
 
@@ -21,9 +21,9 @@ foundation.
 
 ## Workstream map
 
-### WS-M5-A — service graph model
+### WS-M5-A — service graph model ✅ **completed**
 
-Define service identity, status, dependencies, and deterministic lifecycle helpers.
+Service identity, status, dependency, isolation, and deterministic state helpers are now implemented in the model layer.
 
 ### WS-M5-B — policy and authority layer
 

--- a/docs/gitbook/15-m5-development-blueprint.md
+++ b/docs/gitbook/15-m5-development-blueprint.md
@@ -29,12 +29,17 @@ failure paths).
 
 ## 3. Workstreams, deliverables, and file touch map
 
-### WS-M5-A — Service graph model
+### WS-M5-A — Service graph model ✅ **completed**
 
 **Deliverables**
 - service identity/status/dependency types,
 - helper queries for dependency and isolation checks,
 - deterministic state-update helpers.
+
+**Completion status**
+- implemented in `SeLe4n/Model/Object.lean` and `SeLe4n/Model/State.lean`,
+- deterministic service graph read/write helper theorems are machine-checked,
+- remaining M5 workstreams now build on this stabilized state-model surface.
 
 **Expected file touch areas**
 - `SeLe4n/Model/Object.lean`

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.6.0"
+version = "0.7.0"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Provide the M5 workstream a stable, machine-checked service-graph surface (service identity, status, dependency/isolation metadata and deterministic helpers) so orchestration transitions and policy proofs can be built on a well-defined model layer.
- Ensure the change is traceable in the milestone docs and versioned so downstream PRs (WS-M5-B/C/D) can rely on the new surface.

### Description
- Add M5 model primitives in `SeLe4n/Model/Object.lean`: `ServiceId`, `ServiceStatus`, `ServiceIdentity`, and `ServiceGraphEntry`.
- Extend `SystemState` in `SeLe4n/Model/State.lean` with a `services : ServiceId → Option ServiceGraphEntry` store and default initialization, and add query/update helpers: `lookupService`, `hasServiceDependency`, `hasIsolationEdge`, `dependenciesSatisfied`, `storeServiceState`, and `setServiceStatusState`.
- Add machine-checked helper theorems for deterministic service read/write behavior and object-store preservation: `storeServiceState_lookup_eq`, `storeServiceState_lookup_ne`, `setServiceStatusState_lookup_eq`, and `setServiceStatusState_preserves_objects`.
- Bump project version from `0.6.0` to `0.7.0` in `lakefile.toml`.
- Update documentation to reflect WS-M5-A completion while keeping M5 active: `README.md`, `docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`, `docs/gitbook/09-current-slice-m5.md`, and `docs/gitbook/15-m5-development-blueprint.md`.

### Testing
- Ran `source /root/.elan/env && lake build && lake exe sele4n` which completed successfully and produced executable output used by trace tests (build succeeded).
- Ran `source /root/.elan/env && ./scripts/test_fast.sh` and `./scripts/test_smoke.sh` and both passed their hygiene and build gates.
- Ran `source /root/.elan/env && ./scripts/test_full.sh` which ran Tier 0–3 checks (including invariant surface scans) and the trace fixture comparison, with fixtures matching expected output (fixture comparison passed 17/17).
- Ran `source /root/.elan/env && ./scripts/test_nightly.sh` which completed the full nightly sequence (no failing gates reported), and an `rg -n "axiom|sorry|TODO" SeLe4n Main.lean` hygiene scan returned clean results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b2eed72c832ba9a510f15d69991f)