### PR TITLE
chore: set project version to 0.6.1

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.7.0"
+version = "0.6.1"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Align the project metadata with the requested release version by updating the project version to `0.6.1` in the build manifest.

### Description
- Updated the `version` field in `lakefile.toml` from `"0.7.0"` to `"0.6.1"` and committed the change with message `chore: set project version to 0.6.1`.

### Testing
- Verified the change by running `git diff -- lakefile.toml`, `rg -n "version" lakefile.toml`, and printing the file head with `nl -ba lakefile.toml | sed -n '1,20p'`, all showing the updated `version = "0.6.1"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992bb5db1f0832ba79a1d85661473af)