### PR TITLE
Expand WS-M5-B evidence coverage, tighten Tier 3 anchors, and bump to 0.6.3

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -7,6 +7,12 @@ def lifecycleAuthSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 5 }
 def mintedSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 3 }
 def siblingSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 4 }
 def demoEndpoint : SeLe4n.ObjId := 30
+def svcDb : ServiceId := 100
+def svcApi : ServiceId := 101
+def svcDenied : ServiceId := 102
+def svcBroken : ServiceId := 103
+def svcRestart : ServiceId := 104
+def svcRestartBroken : ServiceId := 105
 
 /-- Demonstrate a tiny executable path through scheduler + CSpace + IPC transitions.
 
@@ -57,6 +63,51 @@ def bootstrapState : SystemState :=
         some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
       else
         none
+    services := fun sid =>
+      if sid = svcDb then
+        some {
+          identity := { sid := svcDb, backingObject := 12, owner := 10 }
+          status := .running
+          dependencies := []
+          isolatedFrom := []
+        }
+      else if sid = svcApi then
+        some {
+          identity := { sid := svcApi, backingObject := 1, owner := 10 }
+          status := .stopped
+          dependencies := [svcDb]
+          isolatedFrom := []
+        }
+      else if sid = svcDenied then
+        some {
+          identity := { sid := svcDenied, backingObject := 1, owner := 10 }
+          status := .stopped
+          dependencies := []
+          isolatedFrom := []
+        }
+      else if sid = svcBroken then
+        some {
+          identity := { sid := svcBroken, backingObject := 1, owner := 10 }
+          status := .stopped
+          dependencies := [999]
+          isolatedFrom := []
+        }
+      else if sid = svcRestart then
+        some {
+          identity := { sid := svcRestart, backingObject := 12, owner := 10 }
+          status := .running
+          dependencies := [svcDb]
+          isolatedFrom := []
+        }
+      else if sid = svcRestartBroken then
+        some {
+          identity := { sid := svcRestartBroken, backingObject := 12, owner := 10 }
+          status := .running
+          dependencies := [999]
+          isolatedFrom := []
+        }
+      else
+        none
     scheduler := { runnable := [1, 2], current := none }
     lifecycle := {
       objectTypes := fun oid =>
@@ -82,6 +133,41 @@ def main : IO Unit := do
       | .error err => IO.println s!"source lookup error: {reprStr err}"
       | .ok (srcCap, _) =>
           IO.println s!"source cap rights before mint: {reprStr srcCap.rights}"
+      let allowAll : SeLe4n.Kernel.ServicePolicy := fun _ => true
+      let denyAll : SeLe4n.Kernel.ServicePolicy := fun _ => false
+      match SeLe4n.Kernel.serviceStart svcApi allowAll st1 with
+      | .error err => IO.println s!"service start api error: {reprStr err}"
+      | .ok (_, stServiceStart) =>
+          IO.println s!"service start api status: {reprStr <| (SeLe4n.Model.lookupService stServiceStart svcApi).map ServiceGraphEntry.status}"
+      match SeLe4n.Kernel.serviceStart svcDenied denyAll st1 with
+      | .error err => IO.println s!"service start denied branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected service start success under denied policy"
+      match SeLe4n.Kernel.serviceStart svcBroken allowAll st1 with
+      | .error err => IO.println s!"service start dependency branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected service start success with unsatisfied dependencies"
+      match SeLe4n.Kernel.serviceRestart svcRestart allowAll allowAll st1 with
+      | .error err => IO.println s!"service restart error: {reprStr err}"
+      | .ok (_, stRestarted) =>
+          IO.println s!"service restart status: {reprStr <| (SeLe4n.Model.lookupService stRestarted svcRestart).map ServiceGraphEntry.status}"
+      match SeLe4n.Kernel.serviceStop svcRestart denyAll st1 with
+      | .error err => IO.println s!"service stop denied branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected service stop success under denied policy"
+      match SeLe4n.Kernel.serviceStop svcApi allowAll st1 with
+      | .error err => IO.println s!"service stop illegal-state branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected service stop success from stopped state"
+      match SeLe4n.Kernel.serviceRestart svcRestart denyAll allowAll st1 with
+      | .error err => IO.println s!"service restart stop-stage failure: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected service restart success when stop policy denies"
+      match SeLe4n.Kernel.serviceRestart svcRestartBroken allowAll allowAll st1 with
+      | .error err => IO.println s!"service restart start-stage failure: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected service restart success with broken dependencies"
+
       match SeLe4n.Kernel.lifecycleRetypeObject rootSlot 12
           (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st1 with
       | .error err =>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model completed).
+- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model and WS-M5-B orchestration transitions completed).
 - **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
 
 For normative milestones, acceptance criteria, and scope decisions, use
@@ -56,6 +56,7 @@ lake exe sele4n
 - `SeLe4n/Kernel/Capability/*.lean` — capability/CSpace operations and invariants.
 - `SeLe4n/Kernel/IPC/*.lean` — endpoint IPC semantics and invariants.
 - `SeLe4n/Kernel/Lifecycle/*.lean` — lifecycle/retype semantics and invariants.
+- `SeLe4n/Kernel/Service/*.lean` — service orchestration transitions for start/stop/restart.
 - `Main.lean` — executable scenario traces.
 
 ## License

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -6,3 +6,4 @@ import SeLe4n.Kernel.Scheduler.Operations
 
 import SeLe4n.Kernel.Lifecycle.Operations
 import SeLe4n.Kernel.Lifecycle.Invariant
+import SeLe4n.Kernel.Service.Operations

--- a/SeLe4n/Kernel/Service/Operations.lean
+++ b/SeLe4n/Kernel/Service/Operations.lean
@@ -1,0 +1,169 @@
+import SeLe4n.Model.State
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+/-- External policy gate used by M5 orchestration helpers. -/
+abbrev ServicePolicy := ServiceGraphEntry → Bool
+
+/-- Deterministic service update helper in kernel-monad form. -/
+def storeServiceEntry (sid : ServiceId) (entry : ServiceGraphEntry) : Kernel Unit :=
+  fun st => .ok ((), storeServiceState sid entry st)
+
+/-- Start a stopped service when policy allows and dependencies are running.
+
+Deterministic check ordering:
+1. service lookup (`objectNotFound`),
+2. service must be `stopped` (`illegalState`),
+3. policy predicate must allow start (`policyDenied`),
+4. dependencies must be running (`dependencyViolation`),
+5. status changes to `running` on success. -/
+def serviceStart
+    (sid : ServiceId)
+    (policyAllowsStart : ServicePolicy) : Kernel Unit :=
+  fun st =>
+    match lookupService st sid with
+    | none => .error .objectNotFound
+    | some svc =>
+        if svc.status = .stopped then
+          if policyAllowsStart svc then
+            if dependenciesSatisfied st sid then
+              storeServiceEntry sid { svc with status := .running } st
+            else
+              .error .dependencyViolation
+          else
+            .error .policyDenied
+        else
+          .error .illegalState
+
+/-- Stop a running service when policy allows.
+
+Deterministic check ordering:
+1. service lookup (`objectNotFound`),
+2. service must be `running` (`illegalState`),
+3. policy predicate must allow stop (`policyDenied`),
+4. status changes to `stopped` on success. -/
+def serviceStop
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy) : Kernel Unit :=
+  fun st =>
+    match lookupService st sid with
+    | none => .error .objectNotFound
+    | some svc =>
+        if svc.status = .running then
+          if policyAllowsStop svc then
+            storeServiceEntry sid { svc with status := .stopped } st
+          else
+            .error .policyDenied
+        else
+          .error .illegalState
+
+/-- Restart composes deterministic `stop` then `start` transition ordering.
+
+Failure ordering:
+1. any `serviceStop` failure is returned directly,
+2. if stop succeeds then `serviceStart` runs over the post-stop state,
+3. any start failure is returned directly,
+4. success requires both stages to succeed. -/
+def serviceRestart
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy) : Kernel Unit :=
+  fun st =>
+    match serviceStop sid policyAllowsStop st with
+    | .error e => .error e
+    | .ok (_, stStopped) => serviceStart sid policyAllowsStart stStopped
+
+theorem serviceStart_error_policyDenied
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStart : ServicePolicy)
+    (svc : ServiceGraphEntry)
+    (hSvc : lookupService st sid = some svc)
+    (hStopped : svc.status = .stopped)
+    (hPolicy : policyAllowsStart svc = false) :
+    serviceStart sid policyAllowsStart st = .error .policyDenied := by
+  unfold serviceStart
+  simp [hSvc, hStopped, hPolicy]
+
+theorem serviceStart_error_dependencyViolation
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStart : ServicePolicy)
+    (svc : ServiceGraphEntry)
+    (hSvc : lookupService st sid = some svc)
+    (hStopped : svc.status = .stopped)
+    (hPolicy : policyAllowsStart svc = true)
+    (hDeps : dependenciesSatisfied st sid = false) :
+    serviceStart sid policyAllowsStart st = .error .dependencyViolation := by
+  unfold serviceStart
+  simp [hSvc, hStopped, hPolicy, hDeps]
+
+theorem serviceStop_error_policyDenied
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (svc : ServiceGraphEntry)
+    (hSvc : lookupService st sid = some svc)
+    (hRunning : svc.status = .running)
+    (hPolicy : policyAllowsStop svc = false) :
+    serviceStop sid policyAllowsStop st = .error .policyDenied := by
+  unfold serviceStop
+  simp [hSvc, hRunning, hPolicy]
+
+theorem serviceStop_error_illegalState
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (svc : ServiceGraphEntry)
+    (hSvc : lookupService st sid = some svc)
+    (hNotRunning : svc.status ≠ .running) :
+    serviceStop sid policyAllowsStop st = .error .illegalState := by
+  unfold serviceStop
+  simp [hSvc, hNotRunning]
+
+theorem serviceRestart_error_of_stop_error
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy)
+    (e : KernelError)
+    (hStop : serviceStop sid policyAllowsStop st = .error e) :
+    serviceRestart sid policyAllowsStop policyAllowsStart st = .error e := by
+  unfold serviceRestart
+  simp [hStop]
+
+theorem serviceRestart_error_of_start_error
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy)
+    (stStopped : SystemState)
+    (e : KernelError)
+    (hStop : serviceStop sid policyAllowsStop st = .ok ((), stStopped))
+    (hStart : serviceStart sid policyAllowsStart stStopped = .error e) :
+    serviceRestart sid policyAllowsStop policyAllowsStart st = .error e := by
+  unfold serviceRestart
+  simp [hStop, hStart]
+
+theorem serviceRestart_ok_implies_staged_steps
+    (st st' : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy)
+    (hStep : serviceRestart sid policyAllowsStop policyAllowsStart st = .ok ((), st')) :
+    ∃ stStopped,
+      serviceStop sid policyAllowsStop st = .ok ((), stStopped) ∧
+      serviceStart sid policyAllowsStart stStopped = .ok ((), st') := by
+  unfold serviceRestart at hStep
+  cases hStop : serviceStop sid policyAllowsStop st with
+  | error e => simp [hStop] at hStep
+  | ok pair =>
+      rcases pair with ⟨u, stStopped⟩
+      cases u
+      refine ⟨stStopped, ?_, ?_⟩
+      · rfl
+      · simpa [hStop] using hStep
+
+end SeLe4n.Kernel

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -8,6 +8,8 @@ inductive KernelError where
   | objectNotFound
   | illegalState
   | illegalAuthority
+  | policyDenied
+  | dependencyViolation
   | schedulerInvariantViolation
   | endpointStateMismatch
   | endpointQueueEmpty

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A complete)**.
+Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A and WS-M5-B complete)**.
 M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
 baseline.
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A complete)**.
+Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A and WS-M5-B complete)**.
 
 ---
 
@@ -222,11 +222,15 @@ The active milestone family (M5) targets operational realism while preserving th
 
 1. **Service-graph modeling track** ✅ **completed baseline**
    - service identity/status/dependency/isolation model and deterministic state helpers are implemented,
-   - next work now consumes this stable surface for orchestration transitions and policy proofs.
-2. **Policy decomposition track**
-   - outline authority predicates that can layer over M4 bundles without reshaping closed theorem
+   - orchestration and policy work consume this stable surface.
+2. **Orchestration transition track** ✅ **completed baseline**
+   - deterministic `serviceStart`, `serviceStop`, and `serviceRestart` transitions are implemented,
+   - explicit `policyDenied`, `dependencyViolation`, and `illegalState` branches are executable,
+   - staged success/failure ordering helper theorems are available for restart composition.
+3. **Policy decomposition track**
+   - outline reusable authority predicates that can layer over M4 bundles without reshaping closed theorem
      interfaces.
-3. **Architecture-binding track**
+4. **Architecture-binding track**
    - catalog architecture assumptions currently abstracted and define interface surfaces for future
      binding work.
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M5 stage.
 
-Current stage context: **M5 service-graph + policy surface delivery active (with M4-B fully closed)**.
+Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A and WS-M5-B complete; M4-B fully closed)**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -13,7 +13,7 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
    - global object store, scheduler state, typed lookup/store helpers,
    - shared error taxonomy (`KernelError`, including explicit illegal-state/authority lifecycle branches).
 
-3. **Kernel transition subsystems (`Kernel/Scheduler`, `Kernel/Capability`, `Kernel/IPC`, `Kernel/Lifecycle`)**
+3. **Kernel transition subsystems (`Kernel/Scheduler`, `Kernel/Capability`, `Kernel/IPC`, `Kernel/Lifecycle`, `Kernel/Service`)**
    - executable transition definitions,
    - local invariants and transition-preservation theorem entrypoints.
 
@@ -76,6 +76,13 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 - `SeLe4n/Kernel/Lifecycle/Invariant.lean`
   - step-3 lifecycle invariant components and bundle layering,
   - explicit split between identity/aliasing and capability-reference constraints.
+
+### Service subsystem
+
+- `SeLe4n/Kernel/Service/Operations.lean`
+  - deterministic orchestration transitions (`serviceStart`, `serviceStop`, `serviceRestart`),
+  - explicit `policyDenied`, `dependencyViolation`, and `illegalState` branches,
+  - staged-order theorem surface for restart composition.
 
 ### API + executable
 

--- a/docs/gitbook/09-current-slice-m5.md
+++ b/docs/gitbook/09-current-slice-m5.md
@@ -7,7 +7,7 @@ foundation.
 
 ## Current status
 
-- **Slice state:** active implementation (WS-M5-A completed; WS-M5-B onward in progress).
+- **Slice state:** active implementation (WS-M5-A and WS-M5-B completed; WS-M5-C onward in progress).
 - **Baseline assumption:** M4-B theorem and invariant surfaces are stable and should be consumed as
   dependency contracts.
 
@@ -16,7 +16,7 @@ foundation.
 1. service dependency graph representation and deterministic transition helpers,
 2. policy-aware authority predicates connected to lifecycle/capability checks,
 3. local and composed preservation theorems (including failure-path branches),
-4. executable traces and fixture anchors for restart/isolation/dependency-failure stories,
+4. executable traces and fixture anchors for restart/stop-policy/isolation/dependency-failure stories,
 5. Tier 3 symbol anchors for M5 theorem and invariant surfaces.
 
 ## Workstream map
@@ -25,21 +25,25 @@ foundation.
 
 Service identity, status, dependency, isolation, and deterministic state helpers are now implemented in the model layer.
 
-### WS-M5-B — policy and authority layer
+### WS-M5-B — orchestration transitions ✅ **completed**
 
-Introduce narrow policy predicates and explicit denial behavior without coupling policy to single
-service stories.
+Deterministic `serviceStart`, `serviceStop`, and `serviceRestart` transitions are implemented with
+explicit `policyDenied`, `dependencyViolation`, and `illegalState` failure branches.
 
-### WS-M5-C — proof completion
+### WS-M5-C — policy and authority layer
+
+Introduce reusable policy predicates and bridge lemmas without coupling policy logic to mutation.
+
+### WS-M5-D — proof completion
 
 Land local preservation first, then composed preservation across service + lifecycle + capability
 bundles.
 
-### WS-M5-D — evidence and testing
+### WS-M5-E — evidence and testing
 
 Expose scenarios in `Main.lean`, refresh fixtures intentionally, and extend Tier 3/Tier 4 coverage.
 
-### WS-M5-E — documentation and closeout
+### WS-M5-F — documentation and closeout
 
 Keep README/spec/GitBook synchronized in the same PR sequence as semantics/proofs/tests.
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -178,6 +178,23 @@ Design details that matter:
 3. **Successful path reuses `storeObject`**
    - object store and lifecycle object-type metadata are updated atomically.
 
+### `SeLe4n/Kernel/Service/Operations.lean`
+
+Primary semantics:
+
+- orchestration transitions (`serviceStart`, `serviceStop`, `serviceRestart`),
+- explicit failure outcomes (`policyDenied`, `dependencyViolation`, `illegalState`),
+- staged-order theorem witness (`serviceRestart_ok_implies_staged_steps`).
+
+Design details that matter:
+
+1. **Transition checks are ordered and explicit**
+   - lookup/state/policy/dependency gates occur in deterministic sequence.
+2. **Policy is separated from mutation**
+   - transitions receive predicate parameters and only mutate after policy approval.
+3. **Restart is composition-first**
+   - restart semantics are encoded as stop-then-start and proven as staged execution.
+
 ### `SeLe4n/Kernel/Lifecycle/Invariant.lean`
 
 Primary semantics:

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -31,25 +31,31 @@ M5 theme: **service-oriented semantics built on M4 lifecycle-capability hardenin
 - model restart intent and isolation boundaries,
 - expose deterministic helper transitions.
 
-#### WS-M5-B — Policy and authority layer
+#### WS-M5-B — Orchestration transitions ✅ **completed**
 
-- encode policy predicates over capability/lifecycle operations,
+- implement deterministic start/stop/restart transitions,
+- expose policy-denial/dependency-violation/invalid-state branches explicitly,
+- codify staged restart ordering in theorem surface.
+
+#### WS-M5-C — Policy and authority layer
+
+- encode reusable policy predicates over capability/lifecycle operations,
 - bridge policy checks to existing invariant bundles,
-- ensure policy denial paths are explicit and testable.
+- avoid coupling policy predicates to single-service mutation scripts.
 
-#### WS-M5-C — Proof completion
+#### WS-M5-D — Proof completion
 
 - local preservation for each service transition,
 - composed preservation across service + lifecycle + capability bundles,
 - failure-path theorem completion.
 
-#### WS-M5-D — Evidence and testing
+#### WS-M5-E — Evidence and testing
 
 - add scenario traces for restart and dependency failures,
 - add/adjust fixtures with rationale notes,
 - add Tier 3 anchors and nightly candidates.
 
-#### WS-M5-E — Documentation and closeout
+#### WS-M5-F — Documentation and closeout
 
 - align spec/README/GitBook with shipped behavior,
 - record M6 assumptions and deferred items,
@@ -112,5 +118,5 @@ Require all:
 ## 7. Contributor operating cadence
 
 1. **Per PR**: state current-slice outcome moved + next-slice unlock.
-2. **Per checkpoint**: map progress to M5 workstreams A-E.
+2. **Per checkpoint**: map progress to M5 workstreams A-F.
 3. **Per milestone closeout**: publish delivered outcomes, deferrals, and risk notes.

--- a/docs/gitbook/15-m5-development-blueprint.md
+++ b/docs/gitbook/15-m5-development-blueprint.md
@@ -46,12 +46,17 @@ failure paths).
 - `SeLe4n/Model/State.lean`
 - `SeLe4n/Kernel/Lifecycle/*` (only if bridge helpers are required)
 
-### WS-M5-B — Orchestration transitions
+### WS-M5-B — Orchestration transitions ✅ **completed**
 
 **Deliverables**
 - start/stop/restart transition helpers,
 - explicit failure outcomes (policy denial, dependency violation, invalid state),
 - deterministic transition-order assumptions.
+
+**Completion status**
+- implemented in `SeLe4n/Kernel/Service/Operations.lean` as `serviceStart`, `serviceStop`, and `serviceRestart`,
+- explicit `policyDenied` and `dependencyViolation` outcomes are now modeled in `KernelError`,
+- staged-order theorem coverage now includes both success and error composition helpers for restart.
 
 **Expected file touch areas**
 - `SeLe4n/Kernel/*/Operations.lean` (new service module or existing integration layer)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.6.1"
+version = "0.6.3"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -151,10 +151,39 @@ run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_error_illegalState' 
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_error_illegalAuthority' SeLe4n/Kernel/Lifecycle/Operations.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_success_updates_object' SeLe4n/Kernel/Lifecycle/Operations.lean
 
+# M5-B orchestration transition anchors must remain present.
+run_check "INVARIANT" rg -n '^def serviceStart' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^def serviceStop' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^def serviceRestart' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^theorem serviceStart_error_policyDenied' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^theorem serviceStart_error_dependencyViolation' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^theorem serviceStop_error_policyDenied' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^theorem serviceStop_error_illegalState' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^theorem serviceRestart_error_of_stop_error' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^theorem serviceRestart_error_of_start_error' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^theorem serviceRestart_ok_implies_staged_steps' SeLe4n/Kernel/Service/Operations.lean
+run_check "INVARIANT" rg -n '^\s*\| policyDenied' SeLe4n/Model/State.lean
+run_check "INVARIANT" rg -n '^\s*\| dependencyViolation' SeLe4n/Model/State.lean
+
 # M3.5 step-7 executable demonstration closure anchors.
 run_check "TRACE" rg -n 'endpointAwaitReceive demoEndpoint 2' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'serviceStart svcApi allowAll' Main.lean
+run_check "TRACE" rg -n 'service start denied branch' Main.lean
+run_check "TRACE" rg -n 'service start dependency branch' Main.lean
+run_check "TRACE" rg -n 'service restart status' Main.lean
+run_check "TRACE" rg -n 'service stop denied branch' Main.lean
+run_check "TRACE" rg -n 'service stop illegal-state branch' Main.lean
+run_check "TRACE" rg -n 'service restart stop-stage failure' Main.lean
+run_check "TRACE" rg -n 'service restart start-stage failure' Main.lean
+run_check "TRACE" rg -n 'service start denied branch: SeLe4n.Model.KernelError.policyDenied' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service start dependency branch: SeLe4n.Model.KernelError.dependencyViolation' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service restart status: some' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service stop denied branch: SeLe4n.Model.KernelError.policyDenied' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service stop illegal-state branch: SeLe4n.Model.KernelError.illegalState' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service restart stop-stage failure: SeLe4n.Model.KernelError.policyDenied' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service restart start-stage failure: SeLe4n.Model.KernelError.dependencyViolation' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'lifecycle retype unauthorized branch' Main.lean
 run_check "TRACE" rg -n 'lifecycle retype illegal-state branch' Main.lean
 run_check "TRACE" rg -n 'lifecycle retype success object kind' Main.lean

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -1,5 +1,13 @@
 scheduled thread: some 1
 source cap rights before mint:
+service start api status: some (SeLe4n.Model.ServiceStatus.running)
+service start denied branch: SeLe4n.Model.KernelError.policyDenied
+service start dependency branch: SeLe4n.Model.KernelError.dependencyViolation
+service restart status: some (SeLe4n.Model.ServiceStatus.running)
+service stop denied branch: SeLe4n.Model.KernelError.policyDenied
+service stop illegal-state branch: SeLe4n.Model.KernelError.illegalState
+service restart stop-stage failure: SeLe4n.Model.KernelError.policyDenied
+service restart start-stage failure: SeLe4n.Model.KernelError.dependencyViolation
 lifecycle retype unauthorized branch: SeLe4n.Model.KernelError.illegalAuthority
 lifecycle retype illegal-state branch: SeLe4n.Model.KernelError.illegalState
 lifecycle retype success object kind: some (SeLe4n.Model.KernelObjectType.endpoint)


### PR DESCRIPTION
### Motivation

- Final audit requested broader executable evidence and deterministic anchors for stop/restart failure paths so the WS-M5-B orchestration surface and CI anchors match the proven semantics. 
- Ensure trace fixtures and Tier 3 invariant checks capture both stop-policy denial and staged restart failure propagation in addition to the previously covered start/dependency cases.

### Description

- Add deterministic orchestration transitions in `SeLe4n/Kernel/Service/Operations.lean` (`serviceStart`, `serviceStop`, `serviceRestart`) and staged-order theorems including `serviceRestart_ok_implies_staged_steps`. 
- Extend the model error taxonomy with `policyDenied` and `dependencyViolation` in `SeLe4n/Model/State.lean` and expose the new service module via `import SeLe4n.Kernel.Service.Operations` in `SeLe4n/Kernel/API.lean`. 
- Broaden executable evidence by adding `svcRestartBroken` and multiple stop/restart failure branches in `Main.lean`, update the smoke fixture `tests/fixtures/main_trace_smoke.expected`, and strengthen trace anchors in `scripts/test_tier3_invariant_surface.sh`. 
- Synchronize docs and module maps (`README.md`, GitBook chapters, `docs/SEL4_SPEC.md`, `docs/TESTING_FRAMEWORK_PLAN.md`, various gitbook pages) and bump the patch `version` in `lakefile.toml` to `0.6.3`.

### Testing

- Ran `lake build` as part of the full test pipeline and the build completed successfully (all Lean targets built). 
- Executed `./scripts/test_tier2_trace.sh` and fixture comparison passed (smoke trace matched the updated `tests/fixtures/main_trace_smoke.expected`). 
- Executed `./scripts/test_tier3_invariant_surface.sh` (Tier 3 anchors and theorem-symbol checks) and all invariant/anchor checks passed. 
- Executed `./scripts/test_full.sh` and `./scripts/test_nightly.sh` (staged Tier 4 candidates + determinism replay) and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992bcaba61c832b8b2b92b67431d93d)