### PR TITLE
Add M5-C service policy invariant, sync docs/tests, and bump patch to 0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model and WS-M5-B orchestration transitions completed).
+- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model, WS-M5-B orchestration transitions, and WS-M5-C policy surfaces completed).
 - **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
 
 For normative milestones, acceptance criteria, and scope decisions, use
@@ -56,7 +56,7 @@ lake exe sele4n
 - `SeLe4n/Kernel/Capability/*.lean` — capability/CSpace operations and invariants.
 - `SeLe4n/Kernel/IPC/*.lean` — endpoint IPC semantics and invariants.
 - `SeLe4n/Kernel/Lifecycle/*.lean` — lifecycle/retype semantics and invariants.
-- `SeLe4n/Kernel/Service/*.lean` — service orchestration transitions for start/stop/restart.
+- `SeLe4n/Kernel/Service/*.lean` — service orchestration transitions and policy-surface invariants.
 - `Main.lean` — executable scenario traces.
 
 ## License

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -7,3 +7,4 @@ import SeLe4n.Kernel.Scheduler.Operations
 import SeLe4n.Kernel.Lifecycle.Operations
 import SeLe4n.Kernel.Lifecycle.Invariant
 import SeLe4n.Kernel.Service.Operations
+import SeLe4n.Kernel.Service.Invariant

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -1,0 +1,123 @@
+import SeLe4n.Kernel.Service.Operations
+import SeLe4n.Kernel.Capability.Invariant
+import SeLe4n.Kernel.Lifecycle.Invariant
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+/-- Reusable policy predicate surface over a single service entry. -/
+abbrev ServicePolicyPredicate := SystemState → ServiceGraphEntry → Prop
+
+/-- Policy component: backing object identity remains lifecycle-typed. -/
+def policyBackingObjectTyped : ServicePolicyPredicate :=
+  fun st svc => ∃ ty, SystemState.lookupObjectTypeMeta st svc.identity.backingObject = some ty
+
+/-- Policy component: lifecycle metadata records an owner-slot reference to the backing object. -/
+def policyOwnerAuthorityRefRecorded : ServicePolicyPredicate :=
+  fun st svc =>
+    ∃ slot,
+      SystemState.lookupCapabilityRefMeta st { cnode := svc.identity.owner, slot := slot } =
+        some (.object svc.identity.backingObject)
+
+/-- Policy component: owner CNode contains concrete authority to the backing object. -/
+def policyOwnerAuthoritySlotPresent : ServicePolicyPredicate :=
+  fun st svc =>
+    ∃ slot cap,
+      SystemState.lookupSlotCap st { cnode := svc.identity.owner, slot := slot } = some cap ∧
+      cap.target = .object svc.identity.backingObject
+
+/-- M5 policy bundle entrypoint (WS-M5-C): reusable, mutation-free policy assumptions. -/
+def servicePolicySurfaceInvariant (st : SystemState) : Prop :=
+  ∀ sid svc,
+    lookupService st sid = some svc →
+      policyBackingObjectTyped st svc ∧
+      (policyOwnerAuthorityRefRecorded st svc → policyOwnerAuthoritySlotPresent st svc)
+
+/-- Bridge lemma: lifecycle typing assumptions imply policy backing-object typing. -/
+theorem policyBackingObjectTyped_of_lifecycleInvariant
+    (st : SystemState)
+    (svc : ServiceGraphEntry)
+    (obj : KernelObject)
+    (hLifecycle : lifecycleInvariantBundle st)
+    (hObj : st.objects svc.identity.backingObject = some obj) :
+    policyBackingObjectTyped st svc := by
+  rcases hLifecycle with ⟨hIdAlias, _⟩
+  rcases hIdAlias with ⟨hTypeExact, _⟩
+  refine ⟨obj.objectType, ?_⟩
+  simpa [lifecycleIdentityTypeExact, SystemState.objectTypeMetadataConsistent,
+    SystemState.lookupObjectTypeMeta, hObj] using hTypeExact svc.identity.backingObject
+
+/-- Bridge lemma: lifecycle capability-reference backing implies concrete slot authority. -/
+theorem policyOwnerAuthoritySlotPresent_of_lifecycleInvariant
+    (st : SystemState)
+    (svc : ServiceGraphEntry)
+    (hLifecycle : lifecycleInvariantBundle st)
+    (hRef : policyOwnerAuthorityRefRecorded st svc) :
+    policyOwnerAuthoritySlotPresent st svc := by
+  rcases hLifecycle with ⟨_, hCapRefBundle⟩
+  rcases hCapRefBundle with ⟨_hExact, hBacked⟩
+  rcases hRef with ⟨slot, hMeta⟩
+  rcases hBacked { cnode := svc.identity.owner, slot := slot } svc.identity.backingObject hMeta with
+    ⟨cap, hLookup, hTarget⟩
+  exact ⟨slot, cap, hLookup, hTarget⟩
+
+/-- Bridge lemma: capability lookup-soundness assumptions imply owner-slot witness facts. -/
+theorem policyOwnerAuthoritySlotPresent_of_capabilityLookup
+    (st : SystemState)
+    (svc : ServiceGraphEntry)
+    (slot : SeLe4n.Slot)
+    (cap : Capability)
+    (hCap : capabilityInvariantBundle st)
+    (hLookup : cspaceLookupSlot { cnode := svc.identity.owner, slot := slot } st = .ok (cap, st))
+    (hTarget : cap.target = .object svc.identity.backingObject) :
+    policyOwnerAuthoritySlotPresent st svc := by
+  have hSound : cspaceLookupSound st := hCap.2.1
+  have hSoundFacts := hSound { cnode := svc.identity.owner, slot := slot } cap st hLookup
+  rcases hSoundFacts with ⟨hStEq, _hOwns, hSlotCap⟩
+  cases hStEq
+  exact ⟨slot, cap, hSlotCap, hTarget⟩
+
+/-- Composed bridge theorem from lifecycle contracts to the service policy surface.
+
+The assumption `hBackingObjects` states that each registered service references an existing backing
+object identity in the object store. Under this assumption, lifecycle metadata consistency provides
+all policy-surface obligations. -/
+theorem servicePolicySurfaceInvariant_of_lifecycleInvariant
+    (st : SystemState)
+    (hLifecycle : lifecycleInvariantBundle st)
+    (hBackingObjects :
+      ∀ sid svc, lookupService st sid = some svc →
+        ∃ obj, st.objects svc.identity.backingObject = some obj) :
+    servicePolicySurfaceInvariant st := by
+  intro sid svc hSvc
+  rcases hBackingObjects sid svc hSvc with ⟨obj, hObj⟩
+  refine ⟨policyBackingObjectTyped_of_lifecycleInvariant st svc obj hLifecycle hObj, ?_⟩
+  intro hRef
+  exact policyOwnerAuthoritySlotPresent_of_lifecycleInvariant st svc hLifecycle hRef
+
+/-- Policy-denial branch remains a check-only outcome (no state mutation step). -/
+theorem serviceStart_policyDenied_separates_check_from_mutation
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStart : ServicePolicy)
+    (svc : ServiceGraphEntry)
+    (hSvc : lookupService st sid = some svc)
+    (hStopped : svc.status = .stopped)
+    (hDenied : policyAllowsStart svc = false) :
+    serviceStart sid policyAllowsStart st = .error .policyDenied := by
+  exact serviceStart_error_policyDenied st sid policyAllowsStart svc hSvc hStopped hDenied
+
+/-- Stop-policy denial branch remains a check-only outcome (no state mutation step). -/
+theorem serviceStop_policyDenied_separates_check_from_mutation
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (svc : ServiceGraphEntry)
+    (hSvc : lookupService st sid = some svc)
+    (hRunning : svc.status = .running)
+    (hDenied : policyAllowsStop svc = false) :
+    serviceStop sid policyAllowsStop st = .error .policyDenied := by
+  exact serviceStop_error_policyDenied st sid policyAllowsStop svc hSvc hRunning hDenied
+
+end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A and WS-M5-B complete)**.
+Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A, WS-M5-B, and WS-M5-C complete)**.
 M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
 baseline.
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A and WS-M5-B complete)**.
+Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A, WS-M5-B, and WS-M5-C complete)**.
 
 ---
 
@@ -227,9 +227,11 @@ The active milestone family (M5) targets operational realism while preserving th
    - deterministic `serviceStart`, `serviceStop`, and `serviceRestart` transitions are implemented,
    - explicit `policyDenied`, `dependencyViolation`, and `illegalState` branches are executable,
    - staged success/failure ordering helper theorems are available for restart composition.
-3. **Policy decomposition track**
-   - outline reusable authority predicates that can layer over M4 bundles without reshaping closed theorem
-     interfaces.
+3. **Policy decomposition track** ✅ **completed baseline**
+   - reusable policy predicates and authority surfaces are implemented in
+     `SeLe4n/Kernel/Service/Invariant.lean`,
+   - bridge lemmas connect policy assumptions to lifecycle/capability bundles,
+   - policy denial branches are explicitly represented as check-only (non-mutation) outcomes.
 4. **Architecture-binding track**
    - catalog architecture assumptions currently abstracted and define interface surfaces for future
      binding work.

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M5 stage.
 
-Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A and WS-M5-B complete; M4-B fully closed)**.
+Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A, WS-M5-B, and WS-M5-C complete; M4-B fully closed)**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -83,6 +83,10 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
   - deterministic orchestration transitions (`serviceStart`, `serviceStop`, `serviceRestart`),
   - explicit `policyDenied`, `dependencyViolation`, and `illegalState` branches,
   - staged-order theorem surface for restart composition.
+- `SeLe4n/Kernel/Service/Invariant.lean`
+  - reusable policy predicate components and `servicePolicySurfaceInvariant`,
+  - bridge lemmas connecting service policy assumptions to lifecycle/capability bundles,
+  - explicit policy-denial check-vs-mutation theorem entrypoints.
 
 ### API + executable
 

--- a/docs/gitbook/09-current-slice-m5.md
+++ b/docs/gitbook/09-current-slice-m5.md
@@ -7,7 +7,7 @@ foundation.
 
 ## Current status
 
-- **Slice state:** active implementation (WS-M5-A and WS-M5-B completed; WS-M5-C onward in progress).
+- **Slice state:** active implementation (WS-M5-A, WS-M5-B, and WS-M5-C completed; WS-M5-D onward in progress).
 - **Baseline assumption:** M4-B theorem and invariant surfaces are stable and should be consumed as
   dependency contracts.
 
@@ -30,9 +30,10 @@ Service identity, status, dependency, isolation, and deterministic state helpers
 Deterministic `serviceStart`, `serviceStop`, and `serviceRestart` transitions are implemented with
 explicit `policyDenied`, `dependencyViolation`, and `illegalState` failure branches.
 
-### WS-M5-C — policy and authority layer
+### WS-M5-C — policy and authority layer ✅ **completed**
 
-Introduce reusable policy predicates and bridge lemmas without coupling policy logic to mutation.
+Reusable policy predicates and bridge lemmas are implemented in `SeLe4n/Kernel/Service/Invariant.lean`
+without coupling policy logic to service-state mutation helpers.
 
 ### WS-M5-D — proof completion
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -195,6 +195,28 @@ Design details that matter:
 3. **Restart is composition-first**
    - restart semantics are encoded as stop-then-start and proven as staged execution.
 
+### `SeLe4n/Kernel/Service/Invariant.lean`
+
+Primary semantics:
+
+- reusable policy components (`policyBackingObjectTyped`, `policyOwnerAuthorityRefRecorded`,
+  `policyOwnerAuthoritySlotPresent`),
+- service policy bundle entrypoint (`servicePolicySurfaceInvariant`),
+- bridge theorem (`servicePolicySurfaceInvariant_of_lifecycleInvariant`) for deriving policy
+  obligations from lifecycle contracts plus backing-object existence assumptions.
+
+Design details that matter:
+
+1. **Policy and mutation are separated by construction**
+   - service policy predicates are pure state predicates and do not mutate kernel state.
+2. **Bridge shape is compositional**
+   - bridge lemmas are local and reusable so policy obligations can be discharged without copying
+     transition proofs.
+3. **Failure branch intent is explicit**
+   - `serviceStart_policyDenied_separates_check_from_mutation` and
+     `serviceStop_policyDenied_separates_check_from_mutation` keep denial outcomes tied to check-only
+     semantics.
+
 ### `SeLe4n/Kernel/Lifecycle/Invariant.lean`
 
 Primary semantics:

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -110,3 +110,16 @@ local and composed lifecycle preservation entrypoints (`lifecycleRetypeObject_pr
 `lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle`, and
 `lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle`), and fixture-backed executable trace evidence
 for unauthorized/illegal-state/success lifecycle retype outcomes plus composed lifecycle+capability behavior.
+
+## 8. M5 policy-surface layering (WS-M5-C complete)
+
+Policy surface entrypoints now live in `SeLe4n/Kernel/Service/Invariant.lean` and are explicitly
+kept mutation-free:
+
+- reusable components: `policyBackingObjectTyped`, `policyOwnerAuthorityRefRecorded`,
+  `policyOwnerAuthoritySlotPresent`,
+- bundle entrypoint: `servicePolicySurfaceInvariant`,
+- bridge lemmas: lifecycle/capability assumptions can discharge policy authority obligations,
+- composed bridge: `servicePolicySurfaceInvariant_of_lifecycleInvariant` lifts lifecycle contracts
+  (plus backing-object existence assumptions) into the service policy bundle,
+- check-vs-mutation separation: policy-denial theorem surfaces remain explicit and deterministic.

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -37,11 +37,11 @@ M5 theme: **service-oriented semantics built on M4 lifecycle-capability hardenin
 - expose policy-denial/dependency-violation/invalid-state branches explicitly,
 - codify staged restart ordering in theorem surface.
 
-#### WS-M5-C — Policy and authority layer
+#### WS-M5-C — Policy and authority layer ✅ **completed**
 
-- encode reusable policy predicates over capability/lifecycle operations,
-- bridge policy checks to existing invariant bundles,
-- avoid coupling policy predicates to single-service mutation scripts.
+- reusable policy predicates are encoded over service/lifecycle/capability surfaces,
+- bridge policy checks are connected to existing invariant bundles,
+- policy predicates remain separated from service-state mutation scripts.
 
 #### WS-M5-D — Proof completion
 

--- a/docs/gitbook/15-m5-development-blueprint.md
+++ b/docs/gitbook/15-m5-development-blueprint.md
@@ -62,12 +62,19 @@ failure paths).
 - `SeLe4n/Kernel/*/Operations.lean` (new service module or existing integration layer)
 - `SeLe4n/Kernel/API.lean`
 
-### WS-M5-C — Policy surfaces
+### WS-M5-C — Policy surfaces ✅ **completed**
 
 **Deliverables**
 - reusable policy predicates,
 - bridge lemmas connecting policy to lifecycle/capability assumptions,
 - explicit separation between policy checks and state mutation.
+
+**Completion status**
+- implemented in `SeLe4n/Kernel/Service/Invariant.lean` as reusable policy predicates and
+  `servicePolicySurfaceInvariant`,
+- bridge lemmas now connect service-policy authority expectations to lifecycle and capability
+  bundles,
+- policy-denial theorem surfaces now explicitly encode check-only (non-mutation) outcomes.
 
 **Expected file touch areas**
 - `SeLe4n/Kernel/*/Invariant.lean`

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.6.3"
+version = "0.6.5"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -165,6 +165,19 @@ run_check "INVARIANT" rg -n '^theorem serviceRestart_ok_implies_staged_steps' Se
 run_check "INVARIANT" rg -n '^\s*\| policyDenied' SeLe4n/Model/State.lean
 run_check "INVARIANT" rg -n '^\s*\| dependencyViolation' SeLe4n/Model/State.lean
 
+# M5-C policy-surface anchors must remain present.
+run_check "INVARIANT" rg -n '^abbrev ServicePolicyPredicate' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^def policyBackingObjectTyped' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^def policyOwnerAuthorityRefRecorded' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^def policyOwnerAuthoritySlotPresent' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^def servicePolicySurfaceInvariant' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem policyBackingObjectTyped_of_lifecycleInvariant' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem policyOwnerAuthoritySlotPresent_of_lifecycleInvariant' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem policyOwnerAuthoritySlotPresent_of_capabilityLookup' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem servicePolicySurfaceInvariant_of_lifecycleInvariant' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceStart_policyDenied_separates_check_from_mutation' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceStop_policyDenied_separates_check_from_mutation' SeLe4n/Kernel/Service/Invariant.lean
+
 # M3.5 step-7 executable demonstration closure anchors.
 run_check "TRACE" rg -n 'endpointAwaitReceive demoEndpoint 2' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean


### PR DESCRIPTION
### Motivation

- Surface reusable, mutation-free service policy predicates so downstream proof packages can discharge policy obligations at the bundle level instead of reassembling component lemmas. 
- Make the new M5-C policy layer discoverable and regression-protected via the kernel API and Tier‑3 anchors. 
- Ensure docs/GitBook, invariant anchors, and the test matrix reflect the implemented policy surface and release a small audited patch version.

### Description

- Added `SeLe4n/Kernel/Service/Invariant.lean` implementing the policy predicate surface (`ServicePolicyPredicate`, `policyBackingObjectTyped`, `policyOwnerAuthorityRefRecorded`, `policyOwnerAuthoritySlotPresent`), the bundle entrypoint `servicePolicySurfaceInvariant`, bridge lemmas, the composed bridge theorem `servicePolicySurfaceInvariant_of_lifecycleInvariant`, and the check-vs-mutation separation theorems `serviceStart_policyDenied_separates_check_from_mutation` and `serviceStop_policyDenied_separates_check_from_mutation`.
- Exported the new invariant surface by adding `import SeLe4n.Kernel.Service.Invariant` to `SeLe4n/Kernel/API.lean` so the API/compiled surface includes the policy symbols. 
- Synchronized documentation and GitBook: updated `README.md`, `docs/DEVELOPMENT.md`, `docs/SEL4_SPEC.md`, `docs/TESTING_FRAMEWORK_PLAN.md`, and multiple `docs/gitbook/*` chapters to mark WS‑M5‑C complete and document the policy-surface shape and bridge contract. 
- Extended `scripts/test_tier3_invariant_surface.sh` with M5‑C anchors to lock the new theorem names and added the new file to the Tier‑3 checks; bumped `lakefile.toml` patch version to `0.6.5`.

### Testing

- Ran `source /root/.elan/env && lake build` and the project built successfully. 
- Ran `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_tier3_invariant_surface.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh` and all checks passed in the audit environment. 
- Ran the repository audit `./scripts/audit_testing_framework.sh` which exercised the intentional Tier‑2 negative-control mismatch; the audit observed the expected control-data detection behavior and reported success for the framework. 
- Verified Tier‑3 anchors detect the new M5‑C symbols via the updated `scripts/test_tier3_invariant_surface.sh` and confirmed trace/fixture replay checks remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c4b4e114832ba6d9170cb2638948)