### PR TITLE
Sync M5‑D proof‑package: add composed invariant bundle, preservation theorems, docs and CI anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model, WS-M5-B orchestration transitions, and WS-M5-C policy surfaces completed).
+- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model, WS-M5-B orchestration transitions, and WS-M5-C policy surfaces and WS-M5-D proof package completed).
 - **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
 
 For normative milestones, acceptance criteria, and scope decisions, use

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -34,6 +34,18 @@ def servicePolicySurfaceInvariant (st : SystemState) : Prop :=
       policyBackingObjectTyped st svc ∧
       (policyOwnerAuthorityRefRecorded st svc → policyOwnerAuthoritySlotPresent st svc)
 
+/-- Cross-subsystem M5 proof-package bundle over service policy + lifecycle + capability surfaces. -/
+def serviceLifecycleCapabilityInvariantBundle (st : SystemState) : Prop :=
+  servicePolicySurfaceInvariant st ∧ lifecycleInvariantBundle st ∧ capabilityInvariantBundle st
+
+theorem serviceLifecycleCapabilityInvariantBundle_of_components
+    (st : SystemState)
+    (hPolicy : servicePolicySurfaceInvariant st)
+    (hLifecycle : lifecycleInvariantBundle st)
+    (hCap : capabilityInvariantBundle st) :
+    serviceLifecycleCapabilityInvariantBundle st := by
+  exact ⟨hPolicy, hLifecycle, hCap⟩
+
 /-- Bridge lemma: lifecycle typing assumptions imply policy backing-object typing. -/
 theorem policyBackingObjectTyped_of_lifecycleInvariant
     (st : SystemState)
@@ -119,5 +131,171 @@ theorem serviceStop_policyDenied_separates_check_from_mutation
     (hDenied : policyAllowsStop svc = false) :
     serviceStop sid policyAllowsStop st = .error .policyDenied := by
   exact serviceStop_error_policyDenied st sid policyAllowsStop svc hSvc hRunning hDenied
+
+theorem storeServiceState_preserves_servicePolicySurfaceInvariant
+    (st : SystemState)
+    (sid : ServiceId)
+    (svc : ServiceGraphEntry)
+    (newStatus : ServiceStatus)
+    (hSvc : lookupService st sid = some svc)
+    (hPolicy : servicePolicySurfaceInvariant st) :
+    servicePolicySurfaceInvariant (storeServiceState sid { svc with status := newStatus } st) := by
+  intro sid' svc' hLookup
+  by_cases hSid : sid' = sid
+  · subst sid'
+    have hLookupEq :
+        lookupService (storeServiceState sid { svc with status := newStatus } st) sid =
+          some { svc with status := newStatus } :=
+      storeServiceState_lookup_eq st sid { svc with status := newStatus }
+    rw [hLookupEq] at hLookup
+    cases hLookup
+    rcases hPolicy sid svc hSvc with ⟨hTyped, hBridge⟩
+    refine ⟨?_, ?_⟩
+    · simpa [policyBackingObjectTyped] using hTyped
+    · intro hRef
+      have hRefOld : policyOwnerAuthorityRefRecorded st svc := by
+        simpa [policyOwnerAuthorityRefRecorded] using hRef
+      have hPresentOld : policyOwnerAuthoritySlotPresent st svc := hBridge hRefOld
+      simpa [policyOwnerAuthoritySlotPresent] using hPresentOld
+  · have hLookupNe := storeServiceState_lookup_ne st sid sid' { svc with status := newStatus } hSid
+    have hLookupOld : lookupService st sid' = some svc' := by simpa [hLookupNe] using hLookup
+    exact hPolicy sid' svc' hLookupOld
+
+theorem storeServiceState_preserves_lifecycleInvariantBundle
+    (st : SystemState)
+    (sid : ServiceId)
+    (svc : ServiceGraphEntry)
+    (newStatus : ServiceStatus)
+    (hLifecycle : lifecycleInvariantBundle st) :
+    lifecycleInvariantBundle (storeServiceState sid { svc with status := newStatus } st) := by
+  simpa [lifecycleInvariantBundle, lifecycleIdentityAliasingInvariant, lifecycleIdentityTypeExact,
+    lifecycleIdentityNoTypeAliasConflict, lifecycleCapabilityReferenceInvariant,
+    lifecycleCapabilityRefExact, lifecycleCapabilityRefObjectTargetBacked, storeServiceState,
+    SystemState.objectTypeMetadataConsistent, SystemState.capabilityRefMetadataConsistent,
+    SystemState.lookupObjectTypeMeta, SystemState.lookupCapabilityRefMeta,
+    SystemState.lookupSlotCap, SystemState.lookupCNode] using hLifecycle
+
+theorem storeServiceState_preserves_capabilityInvariantBundle
+    (st : SystemState)
+    (sid : ServiceId)
+    (svc : ServiceGraphEntry)
+    (newStatus : ServiceStatus) :
+    capabilityInvariantBundle (storeServiceState sid { svc with status := newStatus } st) := by
+  exact capabilityInvariantBundle_holds (storeServiceState sid { svc with status := newStatus } st)
+
+theorem serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle
+    (st st' : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStart : ServicePolicy)
+    (hInv : serviceLifecycleCapabilityInvariantBundle st)
+    (hStep : serviceStart sid policyAllowsStart st = .ok ((), st')) :
+    serviceLifecycleCapabilityInvariantBundle st' := by
+  rcases hInv with ⟨hPolicy, hLifecycle, hCap⟩
+  unfold serviceStart at hStep
+  cases hLookup : lookupService st sid with
+  | none => simp [hLookup] at hStep
+  | some svc =>
+      have hSvc : lookupService st sid = some svc := hLookup
+      by_cases hStopped : svc.status = .stopped
+      · by_cases hAllow : policyAllowsStart svc
+        · by_cases hDeps : dependenciesSatisfied st sid
+          · unfold storeServiceEntry at hStep
+            simp [hLookup, hStopped, hAllow, hDeps, storeServiceState] at hStep
+            cases hStep
+            exact ⟨
+              storeServiceState_preserves_servicePolicySurfaceInvariant st sid svc .running hSvc hPolicy,
+              storeServiceState_preserves_lifecycleInvariantBundle st sid svc .running hLifecycle,
+              storeServiceState_preserves_capabilityInvariantBundle st sid svc .running
+            ⟩
+          · simp [hLookup, hStopped, hAllow, hDeps] at hStep
+        · simp [hLookup, hStopped, hAllow] at hStep
+      · simp [hLookup, hStopped] at hStep
+
+theorem serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle
+    (st st' : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (hInv : serviceLifecycleCapabilityInvariantBundle st)
+    (hStep : serviceStop sid policyAllowsStop st = .ok ((), st')) :
+    serviceLifecycleCapabilityInvariantBundle st' := by
+  rcases hInv with ⟨hPolicy, hLifecycle, hCap⟩
+  unfold serviceStop at hStep
+  cases hLookup : lookupService st sid with
+  | none => simp [hLookup] at hStep
+  | some svc =>
+      have hSvc : lookupService st sid = some svc := hLookup
+      by_cases hRunning : svc.status = .running
+      · by_cases hAllow : policyAllowsStop svc
+        · unfold storeServiceEntry at hStep
+          simp [hLookup, hRunning, hAllow, storeServiceState] at hStep
+          cases hStep
+          exact ⟨
+            storeServiceState_preserves_servicePolicySurfaceInvariant st sid svc .stopped hSvc hPolicy,
+            storeServiceState_preserves_lifecycleInvariantBundle st sid svc .stopped hLifecycle,
+            storeServiceState_preserves_capabilityInvariantBundle st sid svc .stopped
+          ⟩
+        · simp [hLookup, hRunning, hAllow] at hStep
+      · simp [hLookup, hRunning] at hStep
+
+theorem serviceRestart_preserves_serviceLifecycleCapabilityInvariantBundle
+    (st st' : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy)
+    (hInv : serviceLifecycleCapabilityInvariantBundle st)
+    (hStep : serviceRestart sid policyAllowsStop policyAllowsStart st = .ok ((), st')) :
+    serviceLifecycleCapabilityInvariantBundle st' := by
+  rcases serviceRestart_ok_implies_staged_steps st st' sid policyAllowsStop policyAllowsStart hStep with
+    ⟨stStopped, hStop, hStart⟩
+  have hStoppedInv : serviceLifecycleCapabilityInvariantBundle stStopped :=
+    serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle
+      st stStopped sid policyAllowsStop hInv hStop
+  exact serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle
+    stStopped st' sid policyAllowsStart hStoppedInv hStart
+
+theorem serviceStart_failure_preserves_serviceLifecycleCapabilityInvariantBundle
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStart : ServicePolicy)
+    (e : KernelError)
+    (hInv : serviceLifecycleCapabilityInvariantBundle st)
+    (_hStep : serviceStart sid policyAllowsStart st = .error e) :
+    serviceLifecycleCapabilityInvariantBundle st := by
+  exact hInv
+
+theorem serviceStop_failure_preserves_serviceLifecycleCapabilityInvariantBundle
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (e : KernelError)
+    (hInv : serviceLifecycleCapabilityInvariantBundle st)
+    (_hStep : serviceStop sid policyAllowsStop st = .error e) :
+    serviceLifecycleCapabilityInvariantBundle st := by
+  exact hInv
+
+theorem serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle
+    (st : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy)
+    (e : KernelError)
+    (hInv : serviceLifecycleCapabilityInvariantBundle st)
+    (_hStep : serviceRestart sid policyAllowsStop policyAllowsStart st = .error e)
+    (_hStop : serviceStop sid policyAllowsStop st = .error e) :
+    serviceLifecycleCapabilityInvariantBundle st := by
+  exact hInv
+
+theorem serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle
+    (st stStopped : SystemState)
+    (sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy)
+    (e : KernelError)
+    (hInv : serviceLifecycleCapabilityInvariantBundle st)
+    (hStop : serviceStop sid policyAllowsStop st = .ok ((), stStopped))
+    (_hStart : serviceStart sid policyAllowsStart stStopped = .error e) :
+    serviceLifecycleCapabilityInvariantBundle stStopped := by
+  exact serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle
+    st stStopped sid policyAllowsStop hInv hStop
 
 end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A, WS-M5-B, and WS-M5-C complete)**.
+Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D complete)**.
 M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
 baseline.
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A, WS-M5-B, and WS-M5-C complete)**.
+Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D complete)**.
 
 ---
 
@@ -232,7 +232,13 @@ The active milestone family (M5) targets operational realism while preserving th
      `SeLe4n/Kernel/Service/Invariant.lean`,
    - bridge lemmas connect policy assumptions to lifecycle/capability bundles,
    - policy denial branches are explicitly represented as check-only (non-mutation) outcomes.
-4. **Architecture-binding track**
+4. **Proof-package track (WS-M5-D)** ✅ **completed baseline**
+   - local preservation theorem entrypoints are available for `serviceStart`, `serviceStop`, and
+     `serviceRestart`,
+   - composed service+lifecycle+capability preservation is exposed via
+     `serviceLifecycleCapabilityInvariantBundle`,
+   - explicit failure-path preservation theorem coverage exists for start/stop/restart branches.
+5. **Architecture-binding track**
    - catalog architecture assumptions currently abstracted and define interface surfaces for future
      binding work.
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M5 stage.
 
-Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A, WS-M5-B, and WS-M5-C complete; M4-B fully closed)**.
+Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D complete; M4-B fully closed)**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/09-current-slice-m5.md
+++ b/docs/gitbook/09-current-slice-m5.md
@@ -7,7 +7,7 @@ foundation.
 
 ## Current status
 
-- **Slice state:** active implementation (WS-M5-A, WS-M5-B, and WS-M5-C completed; WS-M5-D onward in progress).
+- **Slice state:** active implementation (WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D completed; WS-M5-E onward in progress).
 - **Baseline assumption:** M4-B theorem and invariant surfaces are stable and should be consumed as
   dependency contracts.
 
@@ -35,10 +35,11 @@ explicit `policyDenied`, `dependencyViolation`, and `illegalState` failure branc
 Reusable policy predicates and bridge lemmas are implemented in `SeLe4n/Kernel/Service/Invariant.lean`
 without coupling policy logic to service-state mutation helpers.
 
-### WS-M5-D — proof completion
+### WS-M5-D — proof completion ✅ **completed**
 
-Land local preservation first, then composed preservation across service + lifecycle + capability
-bundles.
+Local preservation theorem entrypoints now cover `serviceStart`, `serviceStop`, and `serviceRestart`,
+and composed bundle preservation is available through
+`serviceLifecycleCapabilityInvariantBundle` plus explicit failure-path theorems.
 
 ### WS-M5-E — evidence and testing
 

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -123,3 +123,22 @@ kept mutation-free:
 - composed bridge: `servicePolicySurfaceInvariant_of_lifecycleInvariant` lifts lifecycle contracts
   (plus backing-object existence assumptions) into the service policy bundle,
 - check-vs-mutation separation: policy-denial theorem surfaces remain explicit and deterministic.
+
+## 9. M5 proof package layering (WS-M5-D complete)
+
+Proof-package entrypoints now extend the M5 policy surface to full local + composed preservation:
+
+- composed bundle entrypoint: `serviceLifecycleCapabilityInvariantBundle`,
+- local preservation entrypoints:
+  - `serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle`,
+  - `serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle`,
+  - `serviceRestart_preserves_serviceLifecycleCapabilityInvariantBundle`,
+- failure-path preservation entrypoints:
+  - `serviceStart_failure_preserves_serviceLifecycleCapabilityInvariantBundle`,
+  - `serviceStop_failure_preserves_serviceLifecycleCapabilityInvariantBundle`,
+  - `serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle`,
+  - `serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle`.
+
+This keeps the M5 theorem surface aligned with the local-first composition rule:
+prove per-transition preservation first, then expose cross-subsystem bundle preservation with
+explicit failure-path statements.

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -25,7 +25,7 @@ M5 theme: **service-oriented semantics built on M4 lifecycle-capability hardenin
 
 ### M5 implementation workstreams
 
-#### WS-M5-A — Service graph model
+#### WS-M5-A — Service graph model ✅ **completed**
 
 - define service identity, status, and dependency structure,
 - model restart intent and isolation boundaries,
@@ -43,7 +43,7 @@ M5 theme: **service-oriented semantics built on M4 lifecycle-capability hardenin
 - bridge policy checks are connected to existing invariant bundles,
 - policy predicates remain separated from service-state mutation scripts.
 
-#### WS-M5-D — Proof completion
+#### WS-M5-D — Proof completion ✅ **completed**
 
 - local preservation for each service transition,
 - composed preservation across service + lifecycle + capability bundles,

--- a/docs/gitbook/15-m5-development-blueprint.md
+++ b/docs/gitbook/15-m5-development-blueprint.md
@@ -81,12 +81,17 @@ failure paths).
 - `SeLe4n/Kernel/Capability/Invariant.lean`
 - `SeLe4n/Kernel/Lifecycle/Invariant.lean`
 
-### WS-M5-D — Proof package
+### WS-M5-D — Proof package ✅ **completed**
 
 **Deliverables**
 - local preservation theorem entrypoint per transition,
 - composed preservation theorem(s) over service + lifecycle + capability bundles,
 - failure-path preservation theorem coverage.
+
+**Completion status**
+- local preservation theorem entrypoints now cover `serviceStart`, `serviceStop`, and `serviceRestart`,
+- composed preservation now lands through `serviceLifecycleCapabilityInvariantBundle`,
+- explicit failure-path preservation theorem surfaces now cover start/stop/restart failure branches.
 
 **Expected file touch areas**
 - `SeLe4n/Kernel/*/Invariant.lean`

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M5 service-graph + policy surfaces (active).
+- **Current slice:** M5 service-graph + policy surfaces (active; WS-M5-A/B/C/D complete, WS-M5-E/F in progress).
 - **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
 
 Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance reference.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.6.5"
+version = "0.6.6"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -178,6 +178,17 @@ run_check "INVARIANT" rg -n '^theorem servicePolicySurfaceInvariant_of_lifecycle
 run_check "INVARIANT" rg -n '^theorem serviceStart_policyDenied_separates_check_from_mutation' SeLe4n/Kernel/Service/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem serviceStop_policyDenied_separates_check_from_mutation' SeLe4n/Kernel/Service/Invariant.lean
 
+# M5-D proof-package anchors must remain present.
+run_check "INVARIANT" rg -n '^def serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceLifecycleCapabilityInvariantBundle_of_components' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceRestart_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceStart_failure_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceStop_failure_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
+
 # M3.5 step-7 executable demonstration closure anchors.
 run_check "TRACE" rg -n 'endpointAwaitReceive demoEndpoint 2' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean
@@ -220,6 +231,7 @@ run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete|WS-A \+ WS-B \+ WS-C \+ WS-D \+ WS-E complete|WS-A/WS-B/WS-C/WS-D/WS-E are complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md
 run_check "DOC" rg -n 'Active slice:|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-current-slice-m5.md
 run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md
+run_check "DOC" rg -n 'WS-M5-D|proof package ✅ \*\*completed\*\*|WS-M5-A/B/C/D complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
 run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-current-slice-m5.md
 run_check "DOC" rg -n 'Workstream B — invariant hardening ✅' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'Workstream C — preservation theorem expansion ✅' docs/gitbook/14-m4b-execution-playbook.md


### PR DESCRIPTION
### Motivation

- Ensure the code-level M5 proof-package (composed service+lifecycle+capability invariant) is represented in the library and that documentation/GitBook milestones are consistent with the implemented theorem surface. 
- Provide local-first preservation lemmas for service transitions so composed proofs can be expressed and relied upon by higher-level reasoning and CI checks. 
- Harden Tier‑3 doc/test guardrails so future refactors cannot silently regress the M5 proof-package anchors or roadmap wording.

### Description

- Added a composed M5 proof-package bundle `serviceLifecycleCapabilityInvariantBundle` and a constructor lemma in `SeLe4n/Kernel/Service/Invariant.lean`. 
- Implemented per-transition preservation and failure-preservation theorems plus supporting helpers (`storeServiceState_preserves_*`, `serviceStart_preserves_*`, `serviceStop_preserves_*`, `serviceRestart_preserves_*`, and corresponding failure lemmas) in `SeLe4n/Kernel/Service/Invariant.lean`. 
- Updated doc and GitBook prose to mark WS‑M5‑A and WS‑M5‑D as completed across `README.md`, `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/gitbook/*` files, and added proof-package description text to the proof/invariant map chapter. 
- Strengthened CI/Tier‑3 checks by adding regex anchors for the new proof-package symbols in `scripts/test_tier3_invariant_surface.sh` and extended the doc anchor coverage to include the future-slices chapter. 
- Bumped project patch version in `lakefile.toml` to `0.6.6` to reflect the synced doc/test/proof state.

### Testing

- Ran `./scripts/setup_lean_env.sh` which completed successfully though `apt` emitted a transient external mirror `403` warning that did not prevent toolchain setup. 
- Built the project with `source /root/.elan/env && lake build` which completed successfully (34 jobs). 
- Executed the full validation suite: `./scripts/test_tier3_invariant_surface.sh`, `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh`, all of which passed in this environment. 
- Ran `./scripts/audit_testing_framework.sh` which completed; the audit harness intentionally triggers a Tier‑2 negative-control trace expectation and reported that mismatch as the expected audit outcome. 
- Hygiene checks including the `rg` forbidden-marker check and `shellcheck` on scripts passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ccd1fc68832ba838174767ade761)