### PR TITLE
Audit and tighten M5 testing/docs sync; add isolation evidence and fixture anchors

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -76,7 +76,7 @@ def bootstrapState : SystemState :=
           identity := { sid := svcApi, backingObject := 1, owner := 10 }
           status := .stopped
           dependencies := [svcDb]
-          isolatedFrom := []
+          isolatedFrom := [svcDenied]
         }
       else if sid = svcDenied then
         some {
@@ -167,6 +167,8 @@ def main : IO Unit := do
       | .error err => IO.println s!"service restart start-stage failure: {reprStr err}"
       | .ok _ =>
           IO.println "unexpected service restart success with broken dependencies"
+      IO.println s!"service isolation api↔denied: {reprStr <| SeLe4n.Model.hasIsolationEdge st1 svcApi svcDenied}"
+      IO.println s!"service isolation api↔db: {reprStr <| SeLe4n.Model.hasIsolationEdge st1 svcApi svcDb}"
 
       match SeLe4n.Kernel.lifecycleRetypeObject rootSlot 12
           (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st1 with

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model, WS-M5-B orchestration transitions, and WS-M5-C policy surfaces and WS-M5-D proof package completed).
+- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model, WS-M5-B orchestration transitions, WS-M5-C policy surfaces, WS-M5-D proof package, and WS-M5-E evidence/testing completed; WS-M5-F closeout in progress).
 - **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
 
 For normative milestones, acceptance criteria, and scope decisions, use

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D complete)**.
+Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E complete; WS-M5-F in progress)**.
 M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
 baseline.
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -13,7 +13,7 @@ It defines:
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D complete)**.
+Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E complete; WS-M5-F closeout in progress)**.
 
 ---
 
@@ -238,7 +238,13 @@ The active milestone family (M5) targets operational realism while preserving th
    - composed service+lifecycle+capability preservation is exposed via
      `serviceLifecycleCapabilityInvariantBundle`,
    - explicit failure-path preservation theorem coverage exists for start/stop/restart branches.
-5. **Architecture-binding track**
+5. **Evidence/testing track (WS-M5-E)** ✅ **completed baseline**
+   - executable trace coverage includes service restart success, policy denial, dependency failure,
+     and explicit isolation-edge checks,
+   - fixture anchors in `tests/fixtures/main_trace_smoke.expected` are updated with semantic intent
+     rationale in `tests/scenarios/README.md`,
+   - Tier 3 and Tier 4 candidate checks include M5 evidence-line anchors.
+6. **Architecture-binding track (M6 preview)**
    - catalog architecture assumptions currently abstracted and define interface surfaces for future
      binding work.
 

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path for the M5 stage.
 
-Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D complete; M4-B fully closed)**.
+Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E complete; M4-B fully closed)**.
 
 ## 2. Current enforced tiers
 
@@ -36,12 +36,12 @@ PR CI must call repository scripts directly and keep workflow logic thin.
 4. Keep Tier 3 milestone-closure anchors for M1 scheduler and M2 capability transition/preservation surfaces so completed milestones remain continuously verified.
 5. Preserve category-labeled failure output (`HYGIENE`, `BUILD`, `TRACE`, `INVARIANT`, `META`).
 
-## 5. Active M5 testing expansion targets
+## 5. M5 evidence/testing closure status (WS-M5-E complete)
 
-1. Add service-graph restart/isolation/dependency-failure scenario fixtures.
-2. Add grouped Tier 3 checks for M5 service/policy theorem and bundle symbols.
-3. Expand nightly checks toward repeat-run determinism and broader scenario sweeps.
-4. Standardize new artifact names for debugging service/policy regression failures.
+1. Service-graph restart/isolation/dependency-failure fixture fragments are present in `tests/fixtures/main_trace_smoke.expected`.
+2. Tier 3 includes grouped M5 service/policy theorem and bundle symbol checks plus trace anchors.
+3. Tier 4 staged nightly candidates now assert determinism and M5 evidence-line presence before full-suite replay.
+4. Artifact names remain standardized under `tests/artifacts/nightly/` for CI triage.
 
 ## 6. Fixture policy
 
@@ -99,7 +99,7 @@ Primary risks to target next:
 - scenario breadth gaps,
 - long-horizon confidence blind spots.
 
-## 9. M5-specific testing growth plan
+## 9. M5-specific testing growth plan (completed baseline)
 
 1. add service-orchestration fixture fragments that remain stable across formatting changes,
 2. add grouped service/policy theorem anchor checks in Tier 3,
@@ -107,21 +107,21 @@ Primary risks to target next:
 4. record any new artifact outputs with consistent naming for CI triage.
 
 
-## 10. M5 test implementation plan (detailed)
+## 10. M5 test implementation baseline (achieved)
 
-1. **Phase T1 — service scenario seeds**
-   - add at least one service start/restart success trace,
-   - add at least one policy/dependency failure trace.
-2. **Phase T2 — fixture hardening**
-   - capture stable semantic fragments only,
-   - avoid transient formatting-dependent assertions.
-3. **Phase T3 — Tier 3 anchor expansion**
-   - add symbol anchors for M5 invariant and preservation theorem surfaces,
-   - keep anchors grouped by milestone objective for triage clarity.
-4. **Phase T4 — nightly evolution**
-   - preserve explicit Tier 4 extension-point behavior by default in `./scripts/test_nightly.sh`,
-   - stage repeat-run determinism + full-suite replay candidates in `./scripts/test_tier4_nightly_candidates.sh`,
-   - keep candidate execution opt-in (`NIGHTLY_ENABLE_EXPERIMENTAL=1`) so required mainline gates remain stable.
+1. **Phase T1 — service scenario seeds** ✅
+   - includes service start/restart success trace anchors,
+   - includes policy-denial and dependency-failure trace anchors.
+2. **Phase T2 — fixture hardening** ✅
+   - fixture captures stable semantic fragments,
+   - avoids formatting-dependent expectations.
+3. **Phase T3 — Tier 3 anchor expansion** ✅
+   - includes M5 invariant/preservation symbol anchors,
+   - keeps anchor groups organized by milestone objective for triage clarity.
+4. **Phase T4 — nightly evolution** ✅
+   - Tier 4 default remains an explicit extension point in `./scripts/test_nightly.sh`,
+   - staged candidates in `./scripts/test_tier4_nightly_candidates.sh` run determinism + evidence checks + full-suite replay,
+   - candidate execution remains opt-in (`NIGHTLY_ENABLE_EXPERIMENTAL=1`) for stable required mainline gates.
 
 ## 11. Coverage model and "full coverage" interpretation
 

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -58,7 +58,7 @@ stories remain visible and intentional, especially for milestone claims tied to 
 
 - **M4-A:** lifecycle semantic trace fragments are landed and fixture-backed in Tier 2 smoke coverage.
 - **M4-B:** WS-A/WS-B/WS-C/WS-D/WS-E are complete, including Tier 3 M4-B symbol anchors and staged Tier 4 nightly candidates.
-- **M5 (active):** expand Tier 2/Tier 3 coverage to service-graph transitions, policy-denial branches, and composed service+lifecycle+capability preservation theorem anchors.
+- **M5 (active; WS-M5-E complete):** Tier 2/Tier 3 now cover service restart/policy-denial/dependency-failure/isolation evidence, with Tier 4 candidates checking determinism plus M5 evidence-line anchors.
 
 ## Practical failure triage
 

--- a/docs/gitbook/09-current-slice-m5.md
+++ b/docs/gitbook/09-current-slice-m5.md
@@ -7,7 +7,7 @@ foundation.
 
 ## Current status
 
-- **Slice state:** active implementation (WS-M5-A, WS-M5-B, WS-M5-C, and WS-M5-D completed; WS-M5-E onward in progress).
+- **Slice state:** active implementation (WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E completed; WS-M5-F closeout in progress).
 - **Baseline assumption:** M4-B theorem and invariant surfaces are stable and should be consumed as
   dependency contracts.
 
@@ -41,9 +41,9 @@ Local preservation theorem entrypoints now cover `serviceStart`, `serviceStop`, 
 and composed bundle preservation is available through
 `serviceLifecycleCapabilityInvariantBundle` plus explicit failure-path theorems.
 
-### WS-M5-E — evidence and testing
+### WS-M5-E — evidence and testing ✅ **completed**
 
-Expose scenarios in `Main.lean`, refresh fixtures intentionally, and extend Tier 3/Tier 4 coverage.
+`Main.lean` now includes restart/denial/dependency failure plus isolation-edge evidence lines, fixture anchors include those semantic fragments, and Tier 3/Tier 4 checks validate the expanded evidence surface.
 
 ### WS-M5-F — documentation and closeout
 

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -49,11 +49,11 @@ M5 theme: **service-oriented semantics built on M4 lifecycle-capability hardenin
 - composed preservation across service + lifecycle + capability bundles,
 - failure-path theorem completion.
 
-#### WS-M5-E — Evidence and testing
+#### WS-M5-E — Evidence and testing ✅ **completed**
 
-- add scenario traces for restart and dependency failures,
-- add/adjust fixtures with rationale notes,
-- add Tier 3 anchors and nightly candidates.
+- scenario traces now cover restart, dependency failure, policy denial, and isolation-edge checks,
+- fixture anchors include service semantics with rationale notes in `tests/scenarios/README.md`,
+- Tier 3 anchors and Tier 4 nightly candidate checks now include M5 evidence lines.
 
 #### WS-M5-F — Documentation and closeout
 

--- a/docs/gitbook/15-m5-development-blueprint.md
+++ b/docs/gitbook/15-m5-development-blueprint.md
@@ -97,17 +97,24 @@ failure paths).
 - `SeLe4n/Kernel/*/Invariant.lean`
 - `docs/gitbook/12-proof-and-invariant-map.md`
 
-### WS-M5-E — Evidence and validation
+### WS-M5-E — Evidence and validation ✅ **completed**
 
 **Deliverables**
 - executable scenarios in `Main.lean`,
 - fixture updates with semantic intent notes,
 - Tier 3 symbol checks for theorem/bundle surface additions.
 
+**Completion status**
+- executable scenarios in `Main.lean` now cover restart, policy-denial, dependency-failure, and isolation-edge stories,
+- smoke fixture anchors were extended and documented with M5 semantic rationale notes,
+- Tier 3 symbol checks and Tier 4 nightly candidates now assert the M5 evidence surface.
+
 **Expected file touch areas**
 - `Main.lean`
 - `tests/fixtures/*`
 - `scripts/test_tier3_invariant_surface.sh`
+- `scripts/test_tier4_nightly_candidates.sh`
+- `tests/scenarios/README.md`
 
 ### WS-M5-F — Documentation closeout
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M5 service-graph + policy surfaces (active; WS-M5-A/B/C/D complete, WS-M5-E/F in progress).
+- **Current slice:** M5 service-graph + policy surfaces (active; WS-M5-A/B/C/D/E complete, WS-M5-F in progress).
 - **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
 
 Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance reference.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.6.6"
+version = "0.6.7"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -201,6 +201,8 @@ run_check "TRACE" rg -n 'service stop denied branch' Main.lean
 run_check "TRACE" rg -n 'service stop illegal-state branch' Main.lean
 run_check "TRACE" rg -n 'service restart stop-stage failure' Main.lean
 run_check "TRACE" rg -n 'service restart start-stage failure' Main.lean
+run_check "TRACE" rg -n 'service isolation api↔denied' Main.lean
+run_check "TRACE" rg -n 'service isolation api↔db' Main.lean
 run_check "TRACE" rg -n 'service start denied branch: SeLe4n.Model.KernelError.policyDenied' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'service start dependency branch: SeLe4n.Model.KernelError.dependencyViolation' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'service restart status: some' tests/fixtures/main_trace_smoke.expected
@@ -208,6 +210,8 @@ run_check "TRACE" rg -n 'service stop denied branch: SeLe4n.Model.KernelError.po
 run_check "TRACE" rg -n 'service stop illegal-state branch: SeLe4n.Model.KernelError.illegalState' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'service restart stop-stage failure: SeLe4n.Model.KernelError.policyDenied' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'service restart start-stage failure: SeLe4n.Model.KernelError.dependencyViolation' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service isolation api↔denied: true' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'service isolation api↔db: false' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'lifecycle retype unauthorized branch' Main.lean
 run_check "TRACE" rg -n 'lifecycle retype illegal-state branch' Main.lean
 run_check "TRACE" rg -n 'lifecycle retype success object kind' Main.lean
@@ -231,7 +235,7 @@ run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete|WS-A \+ WS-B \+ WS-C \+ WS-D \+ WS-E complete|WS-A/WS-B/WS-C/WS-D/WS-E are complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md
 run_check "DOC" rg -n 'Active slice:|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-current-slice-m5.md
 run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md
-run_check "DOC" rg -n 'WS-M5-D|proof package ✅ \*\*completed\*\*|WS-M5-A/B/C/D complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
+run_check "DOC" rg -n 'WS-M5-D|WS-M5-E|proof package ✅ \*\*completed\*\*|Evidence and validation ✅ \*\*completed\*\*|WS-M5-A/B/C/D/E complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
 run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-current-slice-m5.md
 run_check "DOC" rg -n 'Workstream B — invariant hardening ✅' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'Workstream C — preservation theorem expansion ✅' docs/gitbook/14-m4b-execution-playbook.md

--- a/scripts/test_tier4_nightly_candidates.sh
+++ b/scripts/test_tier4_nightly_candidates.sh
@@ -22,6 +22,9 @@ mkdir -p "${ARTIFACT_DIR}"
 run_check "TRACE" bash -lc 'lake exe sele4n > tests/artifacts/nightly/sele4n_run1.trace'
 run_check "TRACE" bash -lc 'lake exe sele4n > tests/artifacts/nightly/sele4n_run2.trace'
 run_check "TRACE" bash -lc 'diff -u tests/artifacts/nightly/sele4n_run1.trace tests/artifacts/nightly/sele4n_run2.trace > tests/artifacts/nightly/sele4n_determinism.diff'
+run_check "TRACE" rg -n 'service restart status: some' tests/artifacts/nightly/sele4n_run1.trace
+run_check "TRACE" rg -n 'service start denied branch: SeLe4n.Model.KernelError.policyDenied' tests/artifacts/nightly/sele4n_run1.trace
+run_check "TRACE" rg -n 'service isolation api↔denied: true' tests/artifacts/nightly/sele4n_run1.trace
 run_check "META" "${SCRIPT_DIR}/test_full.sh"
 
 finalize_report

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -8,6 +8,8 @@ service stop denied branch: SeLe4n.Model.KernelError.policyDenied
 service stop illegal-state branch: SeLe4n.Model.KernelError.illegalState
 service restart stop-stage failure: SeLe4n.Model.KernelError.policyDenied
 service restart start-stage failure: SeLe4n.Model.KernelError.dependencyViolation
+service isolation api↔denied: true
+service isolation api↔db: false
 lifecycle retype unauthorized branch: SeLe4n.Model.KernelError.illegalAuthority
 lifecycle retype illegal-state branch: SeLe4n.Model.KernelError.illegalState
 lifecycle retype success object kind: some (SeLe4n.Model.KernelObjectType.endpoint)

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -31,7 +31,17 @@ This directory tracks fixture-backed executable trace checks used by
 4. Document why fixture changes are expected and which slice they support (M4-B closeout or M5 execution).
 
 
-## Current fixture rationale notes (M4-B closeout baseline)
+
+## Current fixture rationale notes (M5 evidence closure additions)
+
+M5 evidence lines now capture deterministic service-policy behavior without overfitting on output formatting:
+
+- `service restart status` keeps the success path visible for orchestration sequencing.
+- `service start denied branch` and `service stop denied branch` pin policy-denial behavior.
+- `service start dependency branch` and `service restart start-stage failure` pin dependency-failure behavior.
+- `service isolation api↔denied` and `service isolation api↔db` pin explicit positive/negative isolation-edge checks.
+
+## Historical fixture rationale notes (M4-B closeout baseline)
 
 The smoke fixture captures stable semantic anchors rather than formatting-dependent text:
 


### PR DESCRIPTION
### Motivation

- Ensure documentation and GitBook accurately reflect the implemented M5 WS‑E evidence/testing closure rather than future-plan wording. 
- Surface and validate newly introduced service-isolation evidence in the executable trace so Tier 2/Tier 3/Tier 4 checks anchor the M5 claims. 
- Harden the testing/audit flow so the audit negative-control (Tier 2 failure) remains explicit and reproducible.

### Description

- Added explicit isolation evidence and printed checks in `Main.lean` by setting `svcApi.isolatedFrom := [svcDenied]` and printing `service isolation api↔denied` and `service isolation api↔db`. 
- Extended the smoke fixture `tests/fixtures/main_trace_smoke.expected` with `service isolation api↔denied: true` and `service isolation api↔db: false`. 
- Updated test scripts to assert the new evidence: `scripts/test_tier3_invariant_surface.sh` now checks for the new trace anchors and `scripts/test_tier4_nightly_candidates.sh` asserts evidence presence in nightly artifacts. 
- Tightened and synchronized documentation and GitBook chapters to mark WS‑M5‑E as completed (updates to `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, `README.md`, and multiple `docs/gitbook/*` files) and clarified historical vs current fixture rationale in `tests/scenarios/README.md`. 
- Bumped package `version` in `lakefile.toml` and preserved the existing audit behavior documented in `scripts/audit_testing_framework.sh` (Tier 2 negative-control remains deliberate). 

### Testing

- Ran `./scripts/test_fast.sh` and `./scripts/test_smoke.sh` and they passed. 
- Ran the full-suite `./scripts/test_full.sh` and `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` including Tier 4 staged candidate determinism checks and they passed. 
- Executed the audit `./scripts/audit_testing_framework.sh` which deliberately injects a Tier 2 negative-control expectation and verifies that Tier 2 fails as intended, and the audit reported successful verification of that behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992d587e8c0832b976d1473bfc52c0e)