### PR TITLE
docs: rename GitBook M5 chapter to 09-m5-closeout-snapshot and sync references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M5 service-graph + policy surfaces (WS-M5-A service graph model, WS-M5-B orchestration transitions, WS-M5-C policy surfaces, WS-M5-D proof package, and WS-M5-E evidence/testing completed; WS-M5-F closeout in progress).
-- **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
+- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening.
+- **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A through WS-M5-F completed).
 
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
@@ -16,7 +16,7 @@ For normative milestones, acceptance criteria, and scope decisions, use
 - **Developer setup + workflow:** [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
 - **Testing tiers + CI contract:** [`docs/TESTING_FRAMEWORK_PLAN.md`](docs/TESTING_FRAMEWORK_PLAN.md)
 - **Long-form handbook (GitBook):** [`docs/gitbook/README.md`](docs/gitbook/README.md)
-- **Current slice handbook chapter:** [`docs/gitbook/09-current-slice-m5.md`](docs/gitbook/09-current-slice-m5.md)
+- **M5 closeout snapshot chapter:** [`docs/gitbook/09-m5-closeout-snapshot.md`](docs/gitbook/09-m5-closeout-snapshot.md)
 - **Completed slice archive (M4-B):** [`docs/gitbook/16-completed-slice-m4b.md`](docs/gitbook/16-completed-slice-m4b.md)
 - **Project usage/value guide:** [`docs/gitbook/17-project-usage-value.md`](docs/gitbook/17-project-usage-value.md)
 - **Architecture and module map:** [`docs/gitbook/03-architecture-and-module-map.md`](docs/gitbook/03-architecture-and-module-map.md)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M5 service-graph + policy surface delivery (active implementation; WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E complete; WS-M5-F in progress)**.
+Current stage: **M6 architecture-binding interface preparation (active) with M5 service-graph + policy delivery fully closed (WS-M5-A through WS-M5-F complete)**.
 M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
 baseline.
 
@@ -14,8 +14,7 @@ Primary goals for contributors:
 - preserve theorem-entrypoint continuity across milestones,
 - ship narrow, reviewable slices,
 - keep docs synchronized with active and next slice plans,
-- deliver M5 service-level semantics and policy layering without regressing closed M1–M4-B
-  contracts.
+- deliver M6 architecture-binding interfaces without regressing closed M1–M5 contracts.
 
 ---
 
@@ -151,25 +150,25 @@ Before maintainers mark M4-B complete, verify:
 
 ---
 
-## 5. Current slice planning discipline (M5)
+## 5. Current slice planning discipline (M6)
 
-To reduce milestone thrash, each M5 PR should state how it advances M5 outcomes while preserving
+To reduce milestone thrash, each M6 PR should state how it advances M6 outcomes while preserving
 closed milestone contracts:
 
-1. service-graph-oriented semantics,
-2. policy-oriented authority decomposition,
-3. architecture-binding assumptions made explicit as interfaces.
+1. architecture-assumption interfaces that remain explicit and reviewable,
+2. adapter-surface theorem hooks that preserve M1–M5 layering,
+3. hardware-facing boundary assumptions documented as contracts.
 
 A lightweight “what this unlocks next” paragraph is now expected in milestone-moving PRs.
 
 
-### 5.1 M5 narrative standard
+### 5.1 M6 narrative standard
 
 For each milestone-moving PR, include a short section that states:
 
-1. what concrete M5 outcome moved,
+1. what concrete M6 outcome moved,
 2. what evidence command validates that movement,
-3. what dependency for the next slice (M6) is now unblocked.
+3. what post-M6 dependency is now unblocked.
 
 ---
 

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -2,7 +2,7 @@
 
 ## 1. Executive summary
 
-Audit conclusion: **the repository is currently healthy, internally consistent with the M4-B closeout claim, and operationally testable end-to-end**.
+Audit conclusion: **the repository is currently healthy, internally consistent with M5 closeout (including WS-M5-F), and operationally testable end-to-end**.
 
 What was re-validated in this audit pass:
 
@@ -29,9 +29,9 @@ This audit evaluated three dimensions:
    - negative-control failure detection behavior.
 
 3. **Documentation fidelity and path clarity**
-   - consistency of current stage (M4-B completed workstreams),
+   - consistency of current stage (M5 completed workstreams with M6 handoff),
    - coherence across README/spec/development/testing/gitbook surfaces,
-   - explicit forward plan into M5 preparation.
+   - explicit forward plan into M6 interface preparation.
 
 ## 3. Current-state findings
 
@@ -53,11 +53,11 @@ This audit evaluated three dimensions:
 
 ### 3.3 Documentation status
 
-Documentation is substantially complete for current milestone closure:
+Documentation is synchronized for current milestone closure and handoff:
 
-- current stage language is synchronized around M4-B workstream completion,
-- testing responsibilities and triage map are explicit,
-- roadmap path from M4-B to M5 is documented in both spec and handbook slices.
+- current stage language reflects M5 closeout and M6 as active planning focus,
+- testing responsibilities and triage map are explicit and preserved across tiers,
+- roadmap path from M5 closeout to M6 is documented in spec and handbook slices.
 
 ## 4. Coverage interpretation (important)
 
@@ -73,9 +73,9 @@ For this repository, “full coverage” should be interpreted as **closure of c
 
 ### 4.2 Remaining coverage opportunities
 
-1. Increase executable scenario breadth for deeper M5-target stories (service graphs/isolation motifs).
-2. Expand explicit failure-path fixtures for future policy decomposition operations.
-3. Add additional deterministic replay seeds once new scenario generators land.
+1. Increase executable scenario breadth for M6 interface-assumption stories.
+2. Expand explicit fixtures for architecture-binding assumption checks once interfaces land.
+3. Add additional deterministic replay seeds as new architecture-bound adapters are introduced.
 
 ## 5. Risk register and mitigations
 
@@ -90,25 +90,25 @@ For this repository, “full coverage” should be interpreted as **closure of c
 
 ## 6. Path of development (recommended near-term plan)
 
-### 6.1 M5 preparation track A — service-graph semantics
+### 6.1 M6 track A — architecture-assumption interfaces
 
-- define minimal service-node state model extensions,
-- introduce restart/isolation transition seeds,
-- preserve reuse of closed M1-M4 bundle contracts.
+- define minimal, explicit architecture assumption interfaces,
+- keep interfaces theorem-friendly and reviewable,
+- preserve reuse of closed M1–M5 bundle contracts.
 
-### 6.2 M5 preparation track B — policy-oriented authority layer
+### 6.2 M6 track B — adapter and proof surfaces
 
-- specify policy predicates that compose over current capability/lifecycle invariants,
-- add local preservation theorems before bundle-level composition.
+- define adapter surfaces from architecture-neutral semantics,
+- add local preservation hooks before broader composition.
 
-### 6.3 M5 preparation track C — architecture-binding interfaces
+### 6.3 M6 track C — boundary validation growth
 
-- codify minimal architecture-assumption interfaces,
-- keep core generic proofs architecture-agnostic,
-- stage architecture-specific obligations as additive modules.
+- stage boot/runtime boundary obligations as explicit contracts,
+- expand fixtures and symbol anchors for interface assumptions,
+- keep tiered test obligations additive and deterministic.
 
 ## 7. Final verdict
 
-The project is in a strong state for M5 kickoff preparation: build/test/doc infrastructure is functioning, milestone claims are corroborated by current checks, and the testing framework demonstrates both positive-pass and negative-control behavior.
+The project is in a strong state for M6 interface-preparation work: build/test/doc infrastructure is functioning, milestone claims are corroborated by current checks, and the testing framework demonstrates both positive-pass and negative-control behavior.
 
 To keep quality optimal, continue expanding obligation-based coverage in lockstep with new semantics rather than pursuing metric-only line coverage that is poorly matched to theorem-centric Lean development.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -7,13 +7,13 @@ This document is the normative specification baseline for seLe4n.
 It defines:
 
 1. What milestone behavior is already closed and considered stable.
-2. The **current delivery slice** (M5) with concrete target outcomes.
-3. The **next delivery slice** preview (M6-directional) so work continues without roadmap drift.
+2. The **current delivery slice** (M6) with concrete target outcomes.
+3. The **next delivery slice** preview (post-M6 directional) so work continues without roadmap drift.
 4. Acceptance criteria and non-goals for focused, reviewable implementation.
 5. Change-control expectations for code, proofs, executable traces, and docs.
 6. A forward plan for the next milestone family so contributors can stage work intentionally.
 
-Current stage: **M5 service-graph semantics and policy-oriented authority layering (active; WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E complete; WS-M5-F closeout in progress)**.
+Current stage: **M6 architecture-binding interfaces and hardware-facing assumption hardening (active) with M5 service-graph/policy workstreams WS-M5-A through WS-M5-F completed**.
 
 ---
 
@@ -26,14 +26,14 @@ Current stage: **M5 service-graph semantics and policy-oriented authority layeri
 - **M3.5 (complete)**: waiting/handshake IPC semantics + scheduler coherence contract.
 - **M4-A (complete)**: lifecycle/retype transition foundations + initial lifecycle invariants.
 - **M4-B (complete)**: lifecycle-capability composition hardening and richer scenario coverage.
-- **M5 (current slice)**: service-graph semantics and policy-oriented authority constraints.
-- **M6 (next slice preview)**: architecture-binding interfaces and hardware-facing assumption hardening.
+- **M5 (complete)**: service-graph semantics and policy-oriented authority constraints.
+- **M6 (current slice)**: architecture-binding interfaces and hardware-facing assumption hardening.
 
 ---
 
 ## 3. Stable baseline contracts (must not regress)
 
-The following contracts are considered stable and preserved while M5 evolves:
+The following contracts are considered stable and preserved while M6 evolves:
 
 1. M1 scheduler invariant bundle and entrypoint preservation theorems.
 2. M2 capability/CSpace transition APIs (`lookup`, `insert`, `mint`, `delete`, `revoke`) and
@@ -201,11 +201,11 @@ A PR series claiming M4-B completion should include all of:
 
 ---
 
-## 6. Current slice: M5 service graph + policy surfaces
+## 6. Completed slice baseline: M5 service graph + policy surfaces
 
 ### 6.1 M5 target direction: service graph + policy surfaces
 
-The active milestone family (M5) targets operational realism while preserving theorem layering:
+The completed milestone family (M5) delivered operational realism while preserving theorem layering:
 
 1. model service restart/isolation stories that exercise lifecycle+IPC+capability composition,
 2. introduce policy-friendly authority constraints without replacing existing invariants,
@@ -218,7 +218,7 @@ The active milestone family (M5) targets operational realism while preserving th
 - invariant bundles expose reusable theorem surfaces for policy composition.
 
 
-### 6.3 M5 execution tracks (active)
+### 6.3 M5 execution tracks (completed)
 
 1. **Service-graph modeling track** ✅ **completed baseline**
    - service identity/status/dependency/isolation model and deterministic state helpers are implemented,
@@ -244,11 +244,23 @@ The active milestone family (M5) targets operational realism while preserving th
    - fixture anchors in `tests/fixtures/main_trace_smoke.expected` are updated with semantic intent
      rationale in `tests/scenarios/README.md`,
    - Tier 3 and Tier 4 candidate checks include M5 evidence-line anchors.
-6. **Architecture-binding track (M6 preview)**
-   - catalog architecture assumptions currently abstracted and define interface surfaces for future
-     binding work.
+6. **Documentation closeout track (WS-M5-F)** ✅ **completed baseline**
+   - spec/README/GitBook are synchronized to reflect M5 completion and M6 handoff,
+   - achieved outcomes and explicit M6 deferrals are documented as milestone boundaries.
 
-### 6.4 Risks and mitigations for the M4-B → M5 handoff
+### 6.4 M5 closeout outcomes and M6 deferrals
+
+M5 closeout delivers deterministic service orchestration semantics, policy-surface predicates,
+composed preservation theorem coverage, and fixture-backed executable evidence as stable baseline
+contracts for the next slice.
+
+M6 explicitly owns the deferred architecture-binding scope:
+
+1. make architecture assumptions first-class interface artifacts,
+2. define proof-carrying adapters from architecture-neutral semantics,
+3. harden hardware-facing boot/runtime boundary assumptions with explicit contracts.
+
+### 6.5 Risks and mitigations retained from the M4-B → M5 handoff
 
 1. **Risk: composition proofs become monolithic and brittle**
    - mitigation: require local-first preservation entrypoints before composed proof merges.
@@ -316,13 +328,13 @@ The current milestone contract spans these concrete module families:
    - `Main.lean` scenario path,
    - Tier 2 fixture-backed semantic fragment checks.
 
-M4 work must extend this surface without regressing any closed milestone contract.
+M6 work must extend this surface without regressing any closed milestone contract.
 
 ---
 
 ## 10. Documentation acceptance expectations
 
-A PR claiming meaningful M4-B progress must include:
+A PR claiming meaningful M6 progress must include:
 
 1. updates to normative docs (`README`, spec, development guide),
 2. updates to GitBook roadmap and slice pages affected by semantic change,

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -2,9 +2,9 @@
 
 ## 1. Purpose
 
-This document defines the active testing baseline and near-term expansion path for the M5 stage.
+This document defines the active testing baseline and near-term expansion path after M5 closeout.
 
-Current stage context: **M5 service-graph + policy surface delivery active (WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E complete; M4-B fully closed)**.
+Current stage context: **M5 service-graph + policy surface delivery is complete (WS-M5-A through WS-M5-F complete); testing now gates M6 architecture-binding prep without regressing M1–M5 contracts**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -38,7 +38,7 @@ Closed baseline slices:
 
 Current planning focus:
 
-- M5 kickoff preparation: service graph semantics and policy-oriented authority modeling.
+- M6 architecture-binding interface preparation on top of completed M5 service/policy semantics.
 
 ## 4. How to think about the architecture
 
@@ -64,21 +64,21 @@ For milestone-moving changes, contributors should follow this sequence:
 6. wire proof/trace symbols into test tiers,
 7. update spec + README + GitBook in the same PR.
 
-## 6. Target outcomes for the next slice (M5)
+## 6. Target outcomes for the current slice (M6)
 
-M5 is intended to convert the M4 lifecycle-capability foundation into service-oriented system
-reasoning.
+M6 focuses on converting architecture assumptions into explicit interface contracts while preserving
+completed M1–M5 theorem and evidence surfaces.
 
 Primary target outcomes:
 
-1. **Service graph model**
-   - represent service instances and restart/isolation relationships in a theorem-friendly form.
-2. **Policy surfaces**
-   - encode policy constraints over capability authority without breaking existing bundle layering.
-3. **Failure semantics for orchestration stories**
-   - ensure restart/recovery paths are explicit and theorem-covered, not only success paths.
-4. **Architecture-binding assumptions**
-   - make platform assumptions first-class interfaces so core proofs remain reusable.
+1. **Architecture-assumption interfaces**
+   - represent architecture-facing assumptions as stable, reviewable interface artifacts.
+2. **Adapter theorem surfaces**
+   - expose proof-carrying adapters from architecture-neutral semantics to bound contexts.
+3. **Boundary contract hardening**
+   - define boot/runtime boundary obligations as explicit contracts for future platform work.
+4. **Testing-obligation continuity**
+   - extend evidence checks without weakening existing Tier 0–3 required gates.
 
 ## 7. Project technical value for developers
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -23,7 +23,7 @@ Contributors should treat these as established contracts:
 4. executable trace anchors for lifecycle and composition stories,
 5. Tier 3 symbol checks for critical theorem/bundle surfaces.
 
-## 3. Next slice definition: M5
+## 3. Completed slice definition: M5
 
 M5 scope is to model **service-level operational stories** on top of M4 semantics.
 
@@ -46,7 +46,7 @@ M5 scope is to model **service-level operational stories** on top of M4 semantic
 - no full seL4 boot pipeline modeling,
 - no replacement of M1-M4 theorem interfaces unless required for soundness.
 
-## 4. Workstreams for completing M5
+## 4. M5 closeout summary (all workstreams complete)
 
 ### Workstream A — Service graph model and transition API
 
@@ -96,7 +96,7 @@ Exit signal:
 
 - `test_smoke` + `test_full` remain green with stable, intentional fixture deltas.
 
-### Workstream E — Documentation + milestone closeout
+### Workstream E — Documentation + milestone closeout ✅ **complete**
 
 Deliver:
 
@@ -138,7 +138,9 @@ This sequencing minimizes churn and keeps proof updates aligned with behavior ch
 
 ## 8. Cross-reference index
 
-- [Current Slice: M5](09-current-slice-m5.md)
+For current execution planning, use M6-focused roadmap chapters after this M5 closeout baseline.
+
+- [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 - [Completed Slice: M4-B](16-completed-slice-m4b.md)
 - [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
 - [M4-B Execution Playbook](14-m4b-execution-playbook.md)

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -39,12 +39,12 @@ When semantics or milestone boundaries change, keep these in sync:
 
 ## Current focus and immediate next focus
 
-- **Completed baseline slice:** M4-A lifecycle/retype foundations.
-- **Current delivery slice:** M4-B lifecycle-capability composition hardening.
-- **Next slice preview:** M5 service-graph + policy surfaces.
+- **Completed baseline slice:** M5 service-graph + policy surfaces.
+- **Current delivery slice:** M6 architecture-binding interface preparation.
+- **Historical predecessor slice:** M4-B lifecycle-capability composition hardening.
 
-Contributors should treat M4-A theorem surfaces as stable interfaces and layer M4-B semantics on
-top, rather than reshaping already-closed M4-A contracts.
+Contributors should treat M1–M5 theorem surfaces as stable interfaces and layer M6 architecture
+binding work on top, rather than reshaping already-closed contracts.
 
 ## Definition of done for milestone-moving PRs
 
@@ -57,7 +57,7 @@ A PR that claims milestone movement should include:
 5. explicit deferred-work note tied to next slice.
 
 
-## M4-B execution rhythm (recommended)
+## M6 execution rhythm (recommended)
 
 For active-slice work, use a weekly rhythm:
 

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -54,11 +54,11 @@ Type-checking alone can miss semantic regressions. Tier 2 fixture checks ensure 
 stories remain visible and intentional, especially for milestone claims tied to executable behavior
 (e.g., mint/revoke/delete and IPC handshake flows).
 
-## M4 closeout + M5 testing trajectory
+## M4-B and M5 closeout testing trajectory
 
 - **M4-A:** lifecycle semantic trace fragments are landed and fixture-backed in Tier 2 smoke coverage.
 - **M4-B:** WS-A/WS-B/WS-C/WS-D/WS-E are complete, including Tier 3 M4-B symbol anchors and staged Tier 4 nightly candidates.
-- **M5 (active; WS-M5-E complete):** Tier 2/Tier 3 now cover service restart/policy-denial/dependency-failure/isolation evidence, with Tier 4 candidates checking determinism plus M5 evidence-line anchors.
+- **M5 (complete; WS-M5-F complete):** Tier 2/Tier 3 cover service restart/policy-denial/dependency-failure/isolation evidence, with Tier 4 candidates checking determinism plus M5 evidence-line anchors as preserved baselines for M6.
 
 ## Practical failure triage
 

--- a/docs/gitbook/09-m5-closeout-snapshot.md
+++ b/docs/gitbook/09-m5-closeout-snapshot.md
@@ -1,13 +1,13 @@
-# Current Slice: M5 Service-Graph and Policy Surfaces
+# M5 Closeout Snapshot: Service-Graph and Policy Surfaces
 
 ## Objective
 
 M5 builds service-level operational semantics on top of the stabilized M4 lifecycle-capability
 foundation.
 
-## Current status
+## Slice status
 
-- **Slice state:** active implementation (WS-M5-A, WS-M5-B, WS-M5-C, WS-M5-D, and WS-M5-E completed; WS-M5-F closeout in progress).
+- **Slice state:** completed (WS-M5-A through WS-M5-F completed).
 - **Baseline assumption:** M4-B theorem and invariant surfaces are stable and should be consumed as
   dependency contracts.
 
@@ -45,9 +45,9 @@ and composed bundle preservation is available through
 
 `Main.lean` now includes restart/denial/dependency failure plus isolation-edge evidence lines, fixture anchors include those semantic fragments, and Tier 3/Tier 4 checks validate the expanded evidence surface.
 
-### WS-M5-F — documentation and closeout
+### WS-M5-F — documentation and closeout ✅ **completed**
 
-Keep README/spec/GitBook synchronized in the same PR sequence as semantics/proofs/tests.
+README/spec/GitBook are synchronized and now explicitly mark M5 complete with M6 deferrals.
 
 ## Entry and guardrails
 
@@ -58,6 +58,18 @@ Before landing M5 PRs, verify:
 3. failure paths are explicit in semantics and theorem statements,
 4. trace/fixture deltas explain semantic intent,
 5. docs state what M5 target outcome advanced.
+
+## M5 achieved outcomes and M6 deferrals
+
+M5 achieved deterministic service-graph orchestration semantics, policy/capability/lifecycle bridge
+lemmas, composed preservation theorem surfaces, and fixture-backed evidence across success/failure
+stories.
+
+Deferred to M6:
+
+1. architecture-binding interface definitions,
+2. hardware-facing contract hardening for boot/runtime boundaries,
+3. adapter-layer theorem packaging for architecture-specific assumptions.
 
 ## Related chapters
 

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -11,65 +11,53 @@ implementation, proofs, tests, and docs aligned.
 4. ship docs and deferrals with each milestone change,
 5. preserve deterministic semantics before broadening scope.
 
-## 2. Immediate next slice (M5)
+## 2. Immediate next slice (M6)
 
-M5 theme: **service-oriented semantics built on M4 lifecycle-capability hardening**.
+M6 theme: **architecture-binding interfaces built on completed M5 service/policy semantics**.
 
-### M5 target outcomes
+### M6 target outcomes
 
-1. service dependency graph representation and transition semantics,
-2. policy-aware authority constraints integrated with capability surfaces,
-3. preservation theorems for restart/isolation and failure paths,
-4. executable scenario evidence for orchestration behaviors,
-5. Tier 3 anchors for M5 theorem/bundle surfaces.
+1. explicit architecture assumptions represented as stable interface artifacts,
+2. proof-carrying adapter surfaces from architecture-neutral semantics to architecture-bound contexts,
+3. platform contract checklist coverage for boot/runtime boundary expectations,
+4. preservation-proof hooks that keep M1–M5 theorem layering reusable during binding,
+5. fixture/test-plan extensions that validate interface assumptions without weakening existing gates.
 
-### M5 implementation workstreams
+### M5 closeout baseline consumed by M6
 
 #### WS-M5-A — Service graph model ✅ **completed**
 
-- define service identity, status, and dependency structure,
-- model restart intent and isolation boundaries,
-- expose deterministic helper transitions.
+- service identity, status, dependency, isolation, and deterministic state helpers are stable.
 
 #### WS-M5-B — Orchestration transitions ✅ **completed**
 
-- implement deterministic start/stop/restart transitions,
-- expose policy-denial/dependency-violation/invalid-state branches explicitly,
-- codify staged restart ordering in theorem surface.
+- deterministic start/stop/restart transitions with explicit failure branches are stable.
 
 #### WS-M5-C — Policy and authority layer ✅ **completed**
 
-- reusable policy predicates are encoded over service/lifecycle/capability surfaces,
-- bridge policy checks are connected to existing invariant bundles,
-- policy predicates remain separated from service-state mutation scripts.
+- reusable policy predicates and bridge lemmas to lifecycle/capability surfaces are stable.
 
 #### WS-M5-D — Proof completion ✅ **completed**
 
-- local preservation for each service transition,
-- composed preservation across service + lifecycle + capability bundles,
-- failure-path theorem completion.
+- local and composed preservation theorem entrypoints (including failure-path coverage) are stable.
 
 #### WS-M5-E — Evidence and testing ✅ **completed**
 
-- scenario traces now cover restart, dependency failure, policy denial, and isolation-edge checks,
-- fixture anchors include service semantics with rationale notes in `tests/scenarios/README.md`,
-- Tier 3 anchors and Tier 4 nightly candidate checks now include M5 evidence lines.
+- executable traces, fixtures, and Tier 3/4 anchor coverage for M5 scenarios are stable.
 
-#### WS-M5-F — Documentation and closeout
+#### WS-M5-F — Documentation and closeout ✅ **completed**
 
-- align spec/README/GitBook with shipped behavior,
-- record M6 assumptions and deferred items,
-- publish slice closeout summary and risk notes.
+- spec/README/GitBook now consistently mark M5 complete and document M6 deferrals.
 
-## 3. Mid-term slice preview (M6)
+## 3. Mid-term slice preview (M7+)
 
-M6 theme: **architecture binding interface preparation**.
+Post-M6 themes are intentionally deferred until architecture-binding interfaces stabilize.
 
 Indicative outcomes:
 
-1. explicit architecture assumptions represented as stable interfaces,
-2. proof-carrying adapters from architecture-neutral semantics,
-3. platform contract checklist for boot/runtime boundary expectations.
+1. subsystem integration plans that consume M6 interface contracts,
+2. refinement-oriented evidence packaging over architecture-bound assumptions,
+3. platform-specific validation strategy increments gated by M6 artifacts.
 
 ## 4. Long-horizon trajectory (mobile-first relevance)
 
@@ -83,22 +71,22 @@ See [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first
 
 ## 5. Transition gates
 
-### Gate: M4 → M5
+### Gate: M5 closeout (completed)
+
+Verified signals:
+
+1. service-graph semantics, policy surfaces, and proof package are merged and stable,
+2. success/failure orchestration scenarios are fixture-backed,
+3. Tier 3 anchors include claimed M5 theorem/invariant symbols,
+4. docs explicitly mark M5 completion and M6 deferrals.
+
+### Gate: M5 → M6 (active entry gate)
 
 Require all:
 
-1. M4-B semantics/theorems merged and fixture-backed,
-2. stale-reference and failure-path coverage in place,
-3. Tier 3 anchors cover M4-B claims,
-4. docs explicitly describe M5 assumptions.
-
-### Gate: M5 → M6
-
-Require all:
-
-1. service graph semantics cover realistic restart/isolation stories,
-2. policy surfaces prove reusable across multiple service scenarios,
-3. architecture-binding assumptions are explicit and reviewable.
+1. architecture-binding assumptions are explicit and reviewable,
+2. interface artifacts preserve M1–M5 theorem layering contracts,
+3. new testing obligations are added without regressing Tier 0–3 required gates.
 
 ## 6. Risk register (active)
 

--- a/docs/gitbook/15-m5-development-blueprint.md
+++ b/docs/gitbook/15-m5-development-blueprint.md
@@ -116,12 +116,17 @@ failure paths).
 - `scripts/test_tier4_nightly_candidates.sh`
 - `tests/scenarios/README.md`
 
-### WS-M5-F — Documentation closeout
+### WS-M5-F — Documentation closeout ✅ **completed**
 
 **Deliverables**
 - synchronized updates across spec/README/GitBook,
 - explicit M5 achieved outcomes + M6 deferrals,
 - updated cross-linking for current vs historical slice docs.
+
+**Completion status**
+- README, spec, development guide, and GitBook milestone markers are synchronized to mark M5 complete,
+- achieved M5 semantics/proof/evidence outcomes and explicit M6 deferrals are documented consistently,
+- cross-links now distinguish M5 closeout status from historical M4 slice references.
 
 ## 4. Recommended implementation sequence (PR-ready)
 
@@ -157,7 +162,7 @@ Copy this into M5 PR descriptions:
 
 ## 7. Cross-references
 
-- Current-slice status: [Current Slice: M5](09-current-slice-m5.md)
+- M5 closeout status: [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 - Historical predecessor: [Completed Slice: M4-B](16-completed-slice-m4b.md)
 - Development workflow standards: [Development Workflow](06-development-workflow.md)
 - Testing contract: [Testing & CI](07-testing-and-ci.md)

--- a/docs/gitbook/16-completed-slice-m4b.md
+++ b/docs/gitbook/16-completed-slice-m4b.md
@@ -22,7 +22,7 @@ soundness issue is identified.
 
 - For acceptance criteria and formal milestone scope: [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md).
 - For execution details and reusable delivery pattern: [M4-B Execution Playbook](14-m4b-execution-playbook.md).
-- For next-slice planning: [Current Slice: M5](09-current-slice-m5.md),
+- For handoff context: [M5 Closeout Snapshot](09-m5-closeout-snapshot.md),
   [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md), and
   [M5 Development Blueprint](15-m5-development-blueprint.md).
 

--- a/docs/gitbook/17-project-usage-value.md
+++ b/docs/gitbook/17-project-usage-value.md
@@ -51,5 +51,5 @@ platform-specific interfaces are introduced.
 ## 4. Related chapters
 
 - active execution plan: [M5 Development Blueprint](15-m5-development-blueprint.md)
-- current slice status: [Current Slice: M5](09-current-slice-m5.md)
+- latest milestone closeout status: [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 - roadmap context: [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,8 +4,8 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M5 service-graph + policy surfaces (active; WS-M5-A/B/C/D/E complete, WS-M5-F in progress).
-- **Most recently completed slice:** M4-B lifecycle-capability composition hardening.
+- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening.
+- **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A/B/C/D/E/F complete).
 
 Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance reference.
 
@@ -18,9 +18,9 @@ Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance
 3. [Architecture & Module Map](03-architecture-and-module-map.md)
 4. [Project Design Deep Dive](04-project-design-deep-dive.md)
 
-### 2) Current slice execution
+### 2) Active planning + latest closeout
 
-5. [Current Slice: M5](09-current-slice-m5.md)
+5. [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 6. [Specification & Roadmap](05-specification-and-roadmap.md)
 7. [Development Workflow](06-development-workflow.md)
 8. [Testing & CI](07-testing-and-ci.md)

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -9,9 +9,9 @@
 - [Architecture & Module Map](03-architecture-and-module-map.md)
 - [Project Design Deep Dive](04-project-design-deep-dive.md)
 
-## Current slice execution
+## Active planning + latest closeout
 
-- [Current Slice: M5](09-current-slice-m5.md)
+- [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 - [Specification & Roadmap](05-specification-and-roadmap.md)
 - [Development Workflow](06-development-workflow.md)
 - [Testing & CI](07-testing-and-ci.md)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.6.7"
+version = "0.7.0"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -233,10 +233,10 @@ run_check "TRACE" rg -n 'post-delete lookup \(expected error\): SeLe4n.Model.Ker
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete|WS-A \+ WS-B \+ WS-C \+ WS-D \+ WS-E complete|WS-A/WS-B/WS-C/WS-D/WS-E are complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md
-run_check "DOC" rg -n 'Active slice:|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-current-slice-m5.md
-run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md
-run_check "DOC" rg -n 'WS-M5-D|WS-M5-E|proof package ✅ \*\*completed\*\*|Evidence and validation ✅ \*\*completed\*\*|WS-M5-A/B/C/D/E complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/README.md docs/gitbook/09-current-slice-m5.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
-run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-current-slice-m5.md
+run_check "DOC" rg -n 'Active slice:|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-m5-closeout-snapshot.md
+run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md
+run_check "DOC" rg -n 'WS-M5-D|WS-M5-E|proof package ✅ \*\*completed\*\*|Evidence and validation ✅ \*\*completed\*\*|WS-M5-A/B/C/D/E complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
+run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-m5-closeout-snapshot.md
 run_check "DOC" rg -n 'Workstream B — invariant hardening ✅' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'Workstream C — preservation theorem expansion ✅' docs/gitbook/14-m4b-execution-playbook.md
 run_check "DOC" rg -n 'Workstream D — executable \+ fixture evidence ✅' docs/gitbook/14-m4b-execution-playbook.md


### PR DESCRIPTION
### Motivation

- The GitBook chapter filename `09-current-slice-m5.md` did not reflect that the chapter is a closeout snapshot, which caused mismatches in docs and automated checks.
- Documentation cross-references and Tier 3 anchor checks must remain consistent with on-disk filenames to avoid CI/test breakage.
- The milestone markers across README/spec/development/testing/GitBook were updated to reflect M5 as closed and M6 as the active planning focus, so filenames and links must match that state.

### Description

- Renamed `docs/gitbook/09-current-slice-m5.md` to `docs/gitbook/09-m5-closeout-snapshot.md` and updated all in-repo references to the new path.
- Synchronized handbook and navigation links in `README.md`, `docs/gitbook/README.md`, `docs/gitbook/SUMMARY.md`, `docs/gitbook/05-specification-and-roadmap.md`, `docs/gitbook/15-m5-development-blueprint.md`, `docs/gitbook/16-completed-slice-m4b.md`, and `docs/gitbook/17-project-usage-value.md` to point at the renamed file.
- Updated `scripts/test_tier3_invariant_surface.sh` to check the new GitBook file path and adjusted related doc text in `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/PROJECT_AUDIT.md`, and `docs/TESTING_FRAMEWORK_PLAN.md` to reflect M5 closeout / M6 active planning language.
- Bumped `version` in `lakefile.toml` and committed the synchronized documentation and test-script edits.

### Testing

- Ran `./scripts/test_fast.sh` and the Tier 0/Tier 1 hygiene and build checks passed.
- Ran `./scripts/test_smoke.sh` and the Tier 0/1/2 fixture-backed checks passed.
- Ran `./scripts/test_full.sh` which executed Tier 0–3 checks (including the updated doc-anchor checks) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992da91887c832b8c9e56e1cf8ef15d)