### PR TITLE
Expand and refine project documentation going into M6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 - **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening.
 - **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A through WS-M5-F completed).
+- **First real-hardware architecture focus:** Raspberry Pi 5 (post-M6 binding path).
 
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
@@ -16,12 +17,14 @@ For normative milestones, acceptance criteria, and scope decisions, use
 - **Developer setup + workflow:** [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
 - **Testing tiers + CI contract:** [`docs/TESTING_FRAMEWORK_PLAN.md`](docs/TESTING_FRAMEWORK_PLAN.md)
 - **Long-form handbook (GitBook):** [`docs/gitbook/README.md`](docs/gitbook/README.md)
+- **Current-slice execution plan:** [`docs/gitbook/18-m6-execution-plan-and-workstreams.md`](docs/gitbook/18-m6-execution-plan-and-workstreams.md)
 - **M5 closeout snapshot chapter:** [`docs/gitbook/09-m5-closeout-snapshot.md`](docs/gitbook/09-m5-closeout-snapshot.md)
 - **Completed slice archive (M4-B):** [`docs/gitbook/16-completed-slice-m4b.md`](docs/gitbook/16-completed-slice-m4b.md)
 - **Project usage/value guide:** [`docs/gitbook/17-project-usage-value.md`](docs/gitbook/17-project-usage-value.md)
 - **Architecture and module map:** [`docs/gitbook/03-architecture-and-module-map.md`](docs/gitbook/03-architecture-and-module-map.md)
 - **Codebase deep reference:** [`docs/gitbook/11-codebase-reference.md`](docs/gitbook/11-codebase-reference.md)
 - **Proof and invariant map:** [`docs/gitbook/12-proof-and-invariant-map.md`](docs/gitbook/12-proof-and-invariant-map.md)
+- **Hardware direction (Raspberry Pi 5 first):** [`docs/gitbook/10-path-to-real-hardware-mobile-first.md`](docs/gitbook/10-path-to-real-hardware-mobile-first.md)
 
 ## Quick start
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -170,6 +170,27 @@ For each milestone-moving PR, include a short section that states:
 2. what evidence command validates that movement,
 3. what post-M6 dependency is now unblocked.
 
+### 5.2 M6 workstream model
+
+Use this workstream mapping for implementation planning and review checklists:
+
+1. **WS-M6-A — assumption inventory and boundary extraction**
+   - make architecture assumptions explicit interface artifacts.
+2. **WS-M6-B — interface API and adapter semantics**
+   - define deterministic adapter behavior with explicit errors.
+3. **WS-M6-C — proof-layer integration**
+   - add local + composed preservation hooks over adapter assumptions.
+4. **WS-M6-D — evidence and test-surface expansion**
+   - expand executable traces and symbol anchors for boundary behavior.
+5. **WS-M6-E — docs and handoff packaging**
+   - keep README/spec/development/GitBook synchronized.
+
+### 5.3 Hardware direction note
+
+The first real hardware architecture focus after M6 is **Raspberry Pi 5**.
+M6 contributors should explicitly describe which Raspberry Pi 5 follow-on dependency each
+milestone-moving PR unblocks.
+
 ---
 
 ## 6. Proof engineering standards

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -260,7 +260,28 @@ M6 explicitly owns the deferred architecture-binding scope:
 2. define proof-carrying adapters from architecture-neutral semantics,
 3. harden hardware-facing boot/runtime boundary assumptions with explicit contracts.
 
-### 6.5 Risks and mitigations retained from the M4-B → M5 handoff
+### 6.5 M6 execution workstreams (active)
+
+M6 work is tracked through the following workstreams:
+
+1. **WS-M6-A — assumption inventory + boundary extraction**
+   - enumerate architecture-facing assumptions and map them into interface surfaces.
+2. **WS-M6-B — interface API + adapter semantics**
+   - implement deterministic adapter behavior with explicit unsupported/invalid branches.
+3. **WS-M6-C — proof integration**
+   - connect adapter assumptions to local and composed invariant preservation theorem surfaces.
+4. **WS-M6-D — evidence + test anchor continuity**
+   - extend executable traces, fixtures, and Tier 3 symbol checks for new claims.
+5. **WS-M6-E — docs + handoff packaging**
+   - synchronize roadmap and stage markers across root docs and GitBook.
+
+### 6.6 Post-M6 first-hardware target
+
+The first real hardware architecture focus after M6 is **Raspberry Pi 5**.
+Post-M6 slices should instantiate M6 contracts for Raspberry Pi 5 constraints without resetting
+architecture-neutral theorem layering.
+
+### 6.7 Risks and mitigations retained from the M4-B → M5 handoff
 
 1. **Risk: composition proofs become monolithic and brittle**
    - mitigation: require local-first preservation entrypoints before composed proof merges.

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -2,101 +2,74 @@
 
 ## 1. Motivation
 
-seLe4n is a Lean 4 formalization effort for building an executable, machine-checked model of core
-seL4-style microkernel behavior. The project exists to make three concerns evolve together in one
-engineering loop:
+seLe4n is a Lean 4 formalization effort for an executable, machine-checked model of core
+seL4-style microkernel behavior. The project keeps three concerns in one engineering loop:
 
 1. deterministic transition semantics,
 2. machine-checked invariant preservation,
 3. milestone-oriented delivery with explicit acceptance criteria.
 
-This combination is deliberate: high-assurance work is most useful when it remains operationally
-iterable by contributors who are not formal-methods specialists.
-
 ## 2. Why this project matters
 
-seLe4n addresses a common reliability gap in systems work:
-
-- architecture docs can drift from what code actually does,
-- prototype code can drift from proof claims,
-- milestone goals can drift from test and CI gates.
-
-The repository structure and documentation strategy are designed to prevent that drift by coupling
-semantics, proofs, executable traces, and milestone docs.
+seLe4n reduces a common systems-assurance failure mode: drift between code, proof claims, and
+planning artifacts. The repository structure and test/documentation workflow are designed to keep
+these artifacts synchronized.
 
 ## 3. What is implemented today
 
 Closed baseline slices:
 
-- Bootstrap: initial Lean project + model scaffolding,
-- M1: scheduler semantics and preservation surfaces,
-- M2: CSpace/capability operations + authority invariants,
-- M3: IPC seed semantics,
-- M3.5: waiting handshake + scheduler coherence predicates,
-- M4-A: lifecycle/retype foundations,
-- M4-B: lifecycle-capability hardening with stale-reference safety.
+- Bootstrap,
+- M1 scheduler semantics and preservation,
+- M2 capability/CSpace operations + authority invariants,
+- M3 IPC seed semantics,
+- M3.5 waiting handshake + scheduler coherence,
+- M4-A lifecycle/retype foundations,
+- M4-B lifecycle-capability composition hardening,
+- M5 service-graph and policy-surface completion.
 
-Current planning focus:
+Current active slice:
 
-- M6 architecture-binding interface preparation on top of completed M5 service/policy semantics.
+- **M6 architecture-binding interfaces and hardware-facing assumption hardening**.
 
-## 4. How to think about the architecture
+## 4. Architecture mental model
 
 The codebase is organized as layered contracts:
 
-- **Model layer** (`SeLe4n/Model/*`): object/state representation and typed lookup/update helpers.
-- **Subsystem transitions** (`SeLe4n/Kernel/*/Operations.lean`): executable behavior with explicit
-  error paths.
-- **Invariant layer** (`SeLe4n/Kernel/*/Invariant.lean`): named safety predicates and composed
-  bundles.
-- **Executable evidence** (`Main.lean`): scenario traces used by Tier 2 fixture checks.
+- **Model layer** (`SeLe4n/Model/*`): object/state representation and update helpers.
+- **Subsystem transitions** (`SeLe4n/Kernel/*/Operations.lean`): executable behavior with
+  explicit error paths.
+- **Invariant layer** (`SeLe4n/Kernel/*/Invariant.lean`): named predicates and composed bundles.
+- **Executable evidence** (`Main.lean`): scenario traces used by fixture checks.
 - **Validation scripts** (`scripts/test_*.sh`): tiered CI contract from hygiene to nightly lanes.
 
-## 5. Contributor mental model (definition-of-done loop)
+## 5. Current-slice outcomes (M6)
 
-For milestone-moving changes, contributors should follow this sequence:
+M6 is successful when contributors deliver all of the following:
 
-1. update transition semantics first,
-2. add or refine narrow invariant components,
+1. architecture assumptions converted to explicit interface artifacts,
+2. adapter theorem surfaces that preserve M1–M5 layering,
+3. hardened boot/runtime boundary contracts,
+4. test and evidence continuity without relaxing Tier 0–3 requirements.
+
+See the dedicated execution chapter: [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md).
+
+## 6. Hardware trajectory update
+
+The first real hardware architecture focus for seLe4n is **Raspberry Pi 5**. This direction
+follows M6 interface stabilization and emphasizes incremental binding without invalidating
+architecture-neutral proof investment.
+
+See [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md).
+
+## 7. Contributor definition-of-done loop
+
+For milestone-moving changes:
+
+1. update transition semantics,
+2. add/refine narrow invariant components,
 3. prove local preservation,
 4. prove composed preservation,
-5. expose behavior in executable traces where relevant,
-6. wire proof/trace symbols into test tiers,
-7. update spec + README + GitBook in the same PR.
-
-## 6. Target outcomes for the current slice (M6)
-
-M6 focuses on converting architecture assumptions into explicit interface contracts while preserving
-completed M1–M5 theorem and evidence surfaces.
-
-Primary target outcomes:
-
-1. **Architecture-assumption interfaces**
-   - represent architecture-facing assumptions as stable, reviewable interface artifacts.
-2. **Adapter theorem surfaces**
-   - expose proof-carrying adapters from architecture-neutral semantics to bound contexts.
-3. **Boundary contract hardening**
-   - define boot/runtime boundary obligations as explicit contracts for future platform work.
-4. **Testing-obligation continuity**
-   - extend evidence checks without weakening existing Tier 0–3 required gates.
-
-## 7. Project technical value for developers
-
-seLe4n can be used today as:
-
-1. a **reference microkernel semantics lab** for experimenting with state-machine changes safely,
-2. a **proof-aware regression framework** where theorem symbols and executable traces guard claims,
-3. an **onboarding corpus** for learning practical Lean theorem-proving in systems contexts,
-4. a **design review artifact** for discussing authority and lifecycle edge cases with precision,
-5. a **staging ground for hardware-bound assurance plans** before architecture-specific lock-in.
-
-## 8. Long-horizon direction
-
-The long-horizon objective remains mobile-first hardware relevance through staged refinement:
-
-1. architecture-neutral semantic hardening,
-2. explicit architecture binding interfaces,
-3. subsystem trust-boundary mapping,
-4. integration with platform and test evidence.
-
-See the roadmap and delivery-plan chapters for execution-level details.
+5. expose behavior in executable traces,
+6. add symbol/fixture anchors in tests,
+7. synchronize spec, README, and GitBook docs.

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -5,144 +5,114 @@ planning and delivery guidance.
 
 ## 1. Baseline status
 
-M4 foundation status for planning purposes:
+Milestone status for planning purposes:
 
-- **M4-A complete**: lifecycle/retype semantics, lifecycle invariants, and baseline preservation.
-- **M4-B complete**: lifecycle-capability composition hardening and stale-reference safety.
+- M4-A complete,
+- M4-B complete,
+- M5 complete,
+- **M6 active**.
 
-That means M5 planning should build on existing transition and theorem surfaces rather than
-restructuring them.
+M6 planning should build on existing transition and theorem surfaces rather than restructuring
+closed milestone contracts.
 
-## 2. M4 outcomes that are now assumed stable
+## 2. Stable outcomes now treated as contracts
 
-Contributors should treat these as established contracts:
+Contributors should treat these as stable unless a spec-level change is explicitly approved:
 
-1. deterministic lifecycle transition/error behavior,
-2. lifecycle identity/aliasing and capability-reference invariant components,
-3. lifecycle + capability composed preservation entrypoints,
-4. executable trace anchors for lifecycle and composition stories,
-5. Tier 3 symbol checks for critical theorem/bundle surfaces.
+1. deterministic lifecycle/capability/service transition behavior,
+2. layered invariant composition across scheduler/capability/IPC/lifecycle/service modules,
+3. local + composed preservation entrypoints for established transitions,
+4. fixture-backed executable traces for core success/failure stories,
+5. Tier 3 theorem/invariant symbol anchors for claimed surfaces.
 
-## 3. Completed slice definition: M5
+## 3. Current slice definition: M6
 
-M5 scope is to model **service-level operational stories** on top of M4 semantics.
+M6 scope: **architecture-binding interfaces and hardware-facing assumption hardening**.
 
-### M5 target outcomes
+### M6 target outcomes
 
-1. **Service-graph semantics**
-   - model services, dependencies, and restart/isolation boundaries.
-2. **Policy-oriented authority constraints**
-   - represent policy checks as reusable theorem-facing predicates.
-3. **Composed preservation over orchestration paths**
-   - prove safety across start/stop/restart and dependency transitions.
-4. **Failure-path completeness**
-   - include denied-policy, missing-dependency, and stale-reference-style failures.
-5. **Executable scenario coverage**
-   - add `Main.lean` stories showing service lifecycle success and failure.
+1. **Assumption extraction and interface definition**
+   - architecture-facing assumptions become explicit interfaces.
+2. **Adapter semantics and bounded error surfaces**
+   - adapter operations remain deterministic and failure-explicit.
+3. **Composed proof continuity**
+   - adapters connect to existing invariant bundles without flattening proof layering.
+4. **Hardware-boundary contract hardening**
+   - boot/runtime obligations are represented as concrete contracts.
+5. **Evidence continuity**
+   - tests and traces expand with no Tier 0–3 contract regression.
 
-### Non-goals for M5 (to prevent scope drift)
+### M6 workstreams
 
-- no architecture-specific memory-model lock-in,
-- no full seL4 boot pipeline modeling,
-- no replacement of M1-M4 theorem interfaces unless required for soundness.
+- **WS-M6-A:** assumption inventory and boundary extraction,
+- **WS-M6-B:** interface API + adapter semantics,
+- **WS-M6-C:** proof integration with existing bundles,
+- **WS-M6-D:** executable evidence and test-anchor expansion,
+- **WS-M6-E:** documentation synchronization and handoff packaging.
 
-## 4. M5 closeout summary (all workstreams complete)
+Detailed execution guidance: [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md).
 
-### Workstream A — Service graph model and transition API
+### Non-goals for M6
 
-Deliver:
+- full platform bring-up,
+- architecture-specific performance tuning,
+- replacing M1–M5 theorem APIs unless required for soundness,
+- broad subsystem redesign not required for architecture-boundary clarity.
 
-- service node/state representation,
-- dependency edges and restart policy shape,
-- deterministic transition helpers for activation/deactivation/restart.
+## 4. Next-slice preview (post-M6)
 
-Exit signal:
+Immediate next-slice direction is **Raspberry Pi 5-first binding and validation planning**.
 
-- transitions compile and return explicit `KernelError`-compatible failures.
+Indicative outcomes:
 
-### Workstream B — Policy surfaces and authority decomposition
+1. instantiate M6 adapter contracts for Raspberry Pi 5 assumptions,
+2. add platform-constraint evidence stories grounded in current model behavior,
+3. map trust boundaries for a minimal realistic deployment partition.
 
-Deliver:
+## 5. Transition gates
 
-- policy predicates that constrain capability actions in service context,
-- theorem-friendly decomposition (small components, then bundle),
-- bridge lemmas connecting policy predicates to existing capability invariants.
+### Gate: M5 closeout (completed)
 
-Exit signal:
+Verified signals:
 
-- policy logic can be reused without importing unrelated service internals.
+1. service semantics and policy surfaces merged and stable,
+2. success/failure scenarios fixture-backed,
+3. Tier 3 anchors include M5 theorem/invariant symbols,
+4. docs synchronized for M5 closure.
 
-### Workstream C — Proof layering for service operations
+### Gate: M5 → M6 (active, in progress)
 
-Deliver:
+Require all:
 
-- local preservation per service transition,
-- composed preservation across service + lifecycle + capability bundles,
-- failure-path preservation theorems.
+1. architecture assumptions explicit and reviewable,
+2. interface artifacts preserve M1–M5 theorem layering,
+3. test obligations added without regressing required gates.
 
-Exit signal:
+### Gate: M6 → Raspberry Pi 5 binding slice (planned)
 
-- proof naming and locality follow existing conventions; no `sorry`/`axiom` debt.
+Require all:
 
-### Workstream D — Trace/test expansion
+1. boundary contracts can be instantiated without hidden assumptions,
+2. adapter failure semantics are explicit and theorem-addressed,
+3. documentation identifies platform obligations vs model guarantees.
 
-Deliver:
+## 6. Risk register (active)
 
-- executable service scenarios (good and bad paths),
-- fixture anchors with semantic intent notes,
-- Tier 3 symbol anchors for new theorem surfaces.
+1. **Semantic/proof skew**
+   - risk: adapter semantics change without theorem updates,
+   - mitigation: enforce transition + theorem pairing in PR templates.
+2. **Roadmap drift**
+   - risk: docs describe conflicting active slices,
+   - mitigation: synchronize README/spec/DEVELOPMENT/GitBook in one PR.
+3. **Boundary overcoupling**
+   - risk: architecture interfaces leak into unrelated invariants,
+   - mitigation: require local interface contracts + bridge lemmas.
+4. **Hardware-path premature lock-in**
+   - risk: overfitting before contracts stabilize,
+   - mitigation: keep Raspberry Pi 5 work post-M6 and contract-driven.
 
-Exit signal:
+## 7. Contributor operating cadence
 
-- `test_smoke` + `test_full` remain green with stable, intentional fixture deltas.
-
-### Workstream E — Documentation + milestone closeout ✅ **complete**
-
-Deliver:
-
-- synchronized updates across spec, README, GitBook,
-- explicit M6 deferrals and assumptions,
-- short risk log for unresolved architectural unknowns.
-
-Exit signal:
-
-- docs consistently describe active/next slice and accepted deferrals.
-
-## 5. Evidence map (what reviewers should require)
-
-For each M5 target outcome, require concrete evidence:
-
-1. transition code + theorem entrypoint,
-2. executable trace or symbol anchor,
-3. test command output in PR notes,
-4. explicit deferred items.
-
-## 6. Suggested checkpoint cadence
-
-- **M5-C1**: service graph definitions + initial transitions,
-- **M5-C2**: policy predicate set + bridge lemmas,
-- **M5-C3**: local preservation completion,
-- **M5-C4**: composed/failure-path preservation,
-- **M5-C5**: trace/fixture/Tier 3 completion,
-- **M5-C6**: docs and closeout memo.
-
-## 7. Delivery model (kept from prior slices)
-
-1. semantics first,
-2. invariants second,
-3. proofs third,
-4. executable evidence fourth,
-5. docs and acceptance closeout final.
-
-This sequencing minimizes churn and keeps proof updates aligned with behavior changes.
-
-## 8. Cross-reference index
-
-For current execution planning, use M6-focused roadmap chapters after this M5 closeout baseline.
-
-- [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
-- [Completed Slice: M4-B](16-completed-slice-m4b.md)
-- [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
-- [M4-B Execution Playbook](14-m4b-execution-playbook.md)
-- [M5 Development Blueprint](15-m5-development-blueprint.md)
-- [Project Usage and Value](17-project-usage-value.md)
+1. per PR: state M6 workstream advanced + next unlock,
+2. per checkpoint: map changes to M6 outcome matrix,
+3. per milestone closeout: publish delivered outcomes, deferrals, and risk updates.

--- a/docs/gitbook/10-path-to-real-hardware-mobile-first.md
+++ b/docs/gitbook/10-path-to-real-hardware-mobile-first.md
@@ -1,80 +1,85 @@
-# Path to Real Hardware (Mobile-First)
+# Path to Real Hardware (Raspberry Pi 5 First)
 
-## Why mobile-first
+## Why this chapter changed
 
-Mobile devices are an important practical target for high-assurance compartmentalization:
+The project hardware direction is now explicitly **Raspberry Pi 5 first**.
 
-- they run heterogeneous, privilege-sensitive workloads,
-- they are exposed to hostile networks and app ecosystems,
-- and they require strong isolation with tight performance/power constraints.
+Earlier documentation described a broad mobile-first direction. That remains useful context, but
+execution planning now prioritizes a concrete first architecture target to reduce ambiguity and
+improve milestone accountability.
 
-A mobile-first strategy gives seLe4n a realistic deployment pressure profile early.
+## 1. Hardware reality check
 
-## Reality check: model-to-hardware is a multi-stage bridge
+seLe4n is currently a formal and executable model project, not a direct deployable kernel image.
+The path to real hardware is staged and contract-driven:
 
-seLe4n today is a formal/executable model project, not a drop-in deployable kernel. A credible
-hardware path requires staged convergence across semantics, tooling, architecture binding, and
-system integration.
+1. architecture-neutral semantics and invariants,
+2. explicit architecture-binding interfaces,
+3. platform-specific binding of those interfaces,
+4. traceable evidence from model behavior to platform assumptions.
 
-## Staged roadmap toward hardware relevance
+## 2. Why Raspberry Pi 5 first
 
-### Stage H0: Semantic completeness in architecture-neutral model
+1. practical ARM64 platform for repeated experiments,
+2. realistic enough interrupt/memory/boot profile for architecture-bound modeling,
+3. broad tooling availability for incremental bring-up,
+4. good tradeoff between accessibility and systems realism.
 
-- complete lifecycle/capability/IPC/scheduler interactions,
-- harden invariant composition and error-path coverage,
-- strengthen executable scenarios to represent realistic subsystem choreography.
+## 3. Stage model toward Raspberry Pi 5 relevance
 
-### Stage H1: Architecture-binding interface plan
+### Stage H0 — Completed baseline hardening (M1–M5)
 
-- identify architecture-dependent assumptions currently abstracted,
-- define explicit interfaces for CPU mode transitions, interrupt surfaces, and memory mappings,
-- keep architecture-neutral theorems reusable where possible.
+- scheduler/capability/IPC/lifecycle/service semantics and proof bundles,
+- deterministic success/failure semantics and executable evidence,
+- testing tiers and CI contracts.
 
-### Stage H2: Boot and platform model alignment
+### Stage H1 — Current execution (M6)
 
-- model assumptions required at early boot (object initialization, capability roots, thread startup),
-- encode minimal platform contracts needed before user-space service graph starts.
+- extract architecture assumptions as explicit interfaces,
+- define proof-carrying adapters from architecture-neutral semantics,
+- harden boot/runtime boundary obligations as concrete contracts.
 
-### Stage H3: Mobile-oriented subsystem decomposition
+### Stage H2 — Raspberry Pi 5 contract instantiation (post-M6)
 
-- define trusted/less-trusted component boundaries for mobile use-cases,
-- map expected services (UI, radio, storage, sensor brokering) to capability/IPC patterns,
-- prioritize least-privilege capability distribution strategies.
+- instantiate M6 interfaces for Raspberry Pi 5 constraints,
+- map platform assumptions to theorem obligations,
+- keep core theorem surfaces reusable.
 
-### Stage H4: Performance and predictability envelope
+### Stage H3 — Minimal platform-oriented trust partition
 
-- identify IPC and scheduling hot paths that matter on mobile SoCs,
-- introduce scenario-driven performance hypotheses (without prematurely overfitting),
-- track proof-friendly simplifications versus deployment realism trade-offs.
+- define first constrained deployment partition,
+- map service graph boundaries to capability distribution constraints,
+- validate expected failure semantics for restart/isolation paths.
 
-### Stage H5: Prototype integration path
+### Stage H4 — Evidence convergence
 
-- produce a small demonstrator topology that mirrors a realistic mobile security partition,
-- connect formal model assumptions to implementation obligations,
-- establish traceability from theorem claims to system-level tests.
+- connect executable scenarios to platform-facing assumptions,
+- extend symbol/fixture coverage to architecture-bound claims,
+- package evidence for iterative integration decisions.
 
-## Mobile-first target outcomes (long horizon)
+## 4. Raspberry Pi 5 target outcomes (long horizon)
 
-1. clear trust-boundary documentation for mobile service partitions,
-2. lifecycle/capability semantics robust enough for dynamic service management,
-3. explicit failure semantics for compromised/restarted services,
-4. architecture-binding strategy that does not invalidate core proofs,
-5. incremental evidence chain from model behavior to deployment constraints.
+1. explicit platform-assumption contract inventory,
+2. architecture-binding interfaces that do not invalidate core proofs,
+3. predictable failure semantics for boundary violations,
+4. reusable traceability from theorem claims to validation artifacts,
+5. incremental integration path from model-level confidence to platform-level confidence.
 
-## Risks and mitigations
+## 5. Risks and mitigations
 
-1. **Risk: overcommitting to hardware details too early**
-   - mitigation: preserve architecture-neutral core while isolating binding interfaces.
-2. **Risk: proof complexity explosion during architecture binding**
-   - mitigation: keep theorem layering compositional and interface-driven.
-3. **Risk: performance surprises on mobile IPC/scheduling paths**
-   - mitigation: add scenario-guided profiling hypotheses early in H4 planning.
-4. **Risk: docs drift between formal model and integration assumptions**
-   - mitigation: treat roadmap and assumption docs as versioned artifacts with PR gating.
+1. **Premature platform lock-in**
+   - mitigation: complete M6 contract surfaces before broad platform encoding.
+2. **Proof complexity growth at binding boundary**
+   - mitigation: maintain local-first theorem layering and narrow adapter contracts.
+3. **Evidence mismatch between model and platform assumptions**
+   - mitigation: enforce synchronized updates across traces, tests, and docs.
+4. **Roadmap ambiguity**
+   - mitigation: keep README/spec/GitBook synchronized on Raspberry Pi 5-first direction.
 
-## What contributors can do now
+## 6. What contributors can do now
 
-- keep M4 work crisp and deterministic,
-- document assumptions where lifecycle semantics intersect capability authority,
-- add executable scenarios that resemble real compartment orchestration,
-- and keep spec/development/testing/gitbook docs synchronized as the roadmap evolves.
+- align milestone PRs to M6 workstreams,
+- document architecture assumptions explicitly,
+- add executable evidence for boundary success/failure behavior,
+- avoid implicit platform assumptions in architecture-neutral modules,
+- keep handoff notes explicit for the Raspberry Pi 5 slice.

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -1,378 +1,110 @@
 # Codebase Reference (Deep Developer Map)
 
-This chapter is a practical map of the current Lean codebase so developers can reason about where
-semantics live, where proofs live, how runtime traces are produced, and how to evolve modules
-without breaking milestone contracts.
-
----
+This chapter maps where semantics, proofs, and execution evidence live in the current repository.
+It also highlights where M6 and post-M6 (Raspberry Pi 5-first) work should land.
 
 ## 1. Repository-level structure
 
 - `SeLe4n.lean`
-  - package export root; re-exports the public model + kernel API surface.
+  - package export root.
 - `Main.lean`
-  - executable scenario integration trace used in Tier 2 smoke checks.
+  - executable scenario trace harness used by smoke checks.
 - `SeLe4n/`
-  - foundational model, transition, and proof modules.
+  - model, transition, and theorem modules.
 - `scripts/`
-  - tiered test entrypoints (`test_fast`, `test_smoke`, `test_full`, `test_nightly`) and shared
-    logging/check helpers (`test_lib.sh`).
+  - tiered test runners and support helpers.
+- `tests/fixtures/`
+  - expected trace fragments for regression checks.
 
-Design intent:
+## 2. Module inventory by responsibility
 
-- Keep the import boundary stable at `SeLe4n.lean` so external users can import one root while
-  internal modules continue to evolve.
-- Keep executable evidence (`Main.lean`) independent from theorem files so scenario growth does not
-  force theorem namespace churn.
+### Foundation layer
 
----
+- `SeLe4n/Prelude.lean`
+  - IDs/aliases and core monadic kernel execution shape.
+- `SeLe4n/Machine.lean`
+  - machine-level state helpers.
+- `SeLe4n/Model/Object.lean`
+  - object-level representations.
+- `SeLe4n/Model/State.lean`
+  - global system-state composition and update helpers.
 
-## 2. Foundation layer
+### Kernel transition/invariant families
 
-### `SeLe4n/Prelude.lean`
+- `SeLe4n/Kernel/Scheduler/Operations.lean`
+- `SeLe4n/Kernel/Scheduler/Invariant.lean`
+- `SeLe4n/Kernel/Capability/Operations.lean`
+- `SeLe4n/Kernel/Capability/Invariant.lean`
+- `SeLe4n/Kernel/IPC/Invariant.lean`
+- `SeLe4n/Kernel/Lifecycle/Operations.lean`
+- `SeLe4n/Kernel/Lifecycle/Invariant.lean`
+- `SeLe4n/Kernel/Service/Operations.lean`
+- `SeLe4n/Kernel/Service/Invariant.lean`
+- `SeLe4n/Kernel/API.lean`
 
-Purpose:
+### Evidence and automation
 
-- defines core ID aliases (`ObjId`, `ThreadId`, `CPtr`, `Slot`, etc.),
-- defines `KernelM`, a small state+error monad for executable transitions.
+- `scripts/test_tier0_hygiene.sh`
+- `scripts/test_tier1_build.sh`
+- `scripts/test_tier2_trace.sh`
+- `scripts/test_tier3_invariant_surface.sh`
+- `scripts/test_tier4_nightly_candidates.sh`
+- umbrella runners: `test_fast.sh`, `test_smoke.sh`, `test_full.sh`, `test_nightly.sh`
 
-Why this design matters:
+## 3. How M6 should map onto this codebase
 
-- all kernel operations and proof statements ultimately rely on these type aliases and monadic
-  conventions,
-- aliases remain architecture-neutral (`Nat`) intentionally to keep early slices focused on
-  semantic correctness over representation detail,
-- `KernelM` stays intentionally minimal (`σ → Except ε (α × σ)`) so transition proofs can unfold
-  directly without heavy monad-transformer infrastructure.
+### M6 boundary extraction (WS-M6-A)
 
-### `SeLe4n/Machine.lean`
+Likely touch points:
 
-Purpose:
+- `SeLe4n/Machine.lean`
+- `SeLe4n/Model/State.lean`
+- `SeLe4n/Kernel/API.lean`
 
-- defines abstract machine state (`RegisterFile`, `MachineState`),
-- provides pure primitive update/read helpers (`readReg`, `writeReg`, `readMem`, `writeMem`, etc.).
+Goal: isolate architecture-facing assumptions into explicit, named interface surfaces.
 
-Why this design matters:
+### M6 adapter semantics (WS-M6-B)
 
-- transitions can carry machine context while proof effort stays concentrated on kernel object
-  semantics,
-- machine details are available to future milestones without forcing immediate architecture lock-in.
+Likely touch points:
 
----
+- operation modules that consume boundary assumptions,
+- `SeLe4n/Kernel/API.lean` for stable export/interface shape.
 
-## 3. Object and global-state modeling layer
+Goal: explicit deterministic adapter semantics with failure branches.
 
-### `SeLe4n/Model/Object.lean`
+### M6 proof integration (WS-M6-C)
 
-Primary contents:
+Likely touch points:
 
-- capability rights + capability target model (`AccessRight`, `CapTarget`, `Capability`),
-- M3.5 IPC-visible thread status (`ThreadIpcState`),
-- endpoint model (`EndpointState`, queue, optional waiting receiver),
-- CNode structure + operations (`lookup`, `insert`, `remove`, `revokeTargetLocal`),
-- global `KernelObject` sum type and `KernelObjectType` discriminator.
+- `*/Invariant.lean` modules,
+- composed bundle entrypoints in service/lifecycle/capability integrations.
 
-Key design choices:
+Goal: local + composed preservation hooks over adapter assumptions.
 
-1. **Capability target is explicit (`object` or `cnodeSlot`)**
-   - preserves room for richer CSpace stories without changing capability shape later.
-2. **CNode represented as slot list**
-   - favors proof readability and deterministic update semantics over optimized lookup structure.
-3. **`revokeTargetLocal` explicitly scoped**
-   - only revokes sibling slots in one CNode while preserving source slot authority;
-   - full graph-based revocation is deferred intentionally and documented in comments.
+### M6 evidence expansion (WS-M6-D)
 
-### `SeLe4n/Model/State.lean`
+Likely touch points:
 
-Primary contents:
+- `Main.lean`,
+- `tests/fixtures/main_trace_smoke.expected`,
+- tier scripts where new symbol checks are needed.
 
-- `KernelError` (including `illegalState`/`illegalAuthority` lifecycle errors), `SchedulerState`, `SystemState`, `SlotRef`,
-- global lookup/store transitions (`lookupObject`, `storeObject`, `setCurrentThread`),
-- typed CSpace helpers (`lookupCNode`, `lookupSlotCap`, `ownsSlot`, `ownedSlots`),
-- small support lemmas that simplify subsystem-level invariants.
+Goal: executable/test evidence for both success and bounded failure behavior.
 
-Key design choices:
+## 4. Post-M6 placement guidance for Raspberry Pi 5 direction
 
-1. **Object store as function map (`ObjId → Option KernelObject`)**
-   - replacement updates are simple and theorem-friendly.
-2. **`SlotRef` as first-class typed address**
-   - avoids ad-hoc `(obj,slot)` tuple handling across capability and invariant code.
-3. **Ownership relation local to CNode identity**
-   - enough to state authority monotonicity constraints in current milestones.
+When M6 interfaces stabilize, Raspberry Pi 5-specific work should:
 
----
+1. instantiate interface contracts rather than rewriting core modules,
+2. avoid embedding platform details directly into architecture-neutral invariant bundles,
+3. preserve import stability from `SeLe4n.lean` and interface discoverability from `Kernel/API.lean`.
 
-## 4. Scheduler layer (M1 contract)
+## 5. High-signal contributor checklist
 
-### `SeLe4n/Kernel/Scheduler/Invariant.lean`
+Before opening an architecture-boundary PR:
 
-Core invariants:
-
-1. `runQueueUnique`
-2. `currentThreadValid`
-3. `queueCurrentConsistent`
-4. composed aliases (`schedulerWellFormed`, `schedulerInvariantBundle`)
-
-Preservation entrypoints:
-
-- scheduler operations preserve the component predicates and bundle-level aliases.
-
-### `SeLe4n/Kernel/Scheduler/Operations.lean`
-
-Primary transitions:
-
-- `chooseThread`
-- `schedule`
-- `handleYield`
-
-Operational semantics snapshot:
-
-- `chooseThread` returns head of runnable queue or `none`, without state mutation,
-- `schedule` sets `current` to first runnable TCB if object is valid TCB; otherwise clears
-  `current` to prevent invalid selection,
-- `handleYield` currently aliases `schedule` to keep syscall surface stable while implementation
-  remains narrow.
-
-Proof style:
-
-- strong use of case analysis over runnable queue shape and object lookup result,
-- small helper lemmas (`chooseThread_returns_runnable_or_none`,
-  `setCurrentThread_*_preserves_*`) reduce repetition in bundle theorem proofs.
-
----
-
-## 5. Capability + CSpace layer (M2 contract)
-
-### `SeLe4n/Kernel/Capability/Operations.lean`
-
-Primary semantics:
-
-- slot access/update (`cspaceLookupSlot`, `cspaceInsertSlot`),
-- minting with attenuation (`rightsSubset`, `mintDerivedCap`, `cspaceMint`),
-- lifecycle/authority operations (`cspaceDeleteSlot`, `cspaceRevoke`).
-
-Design details that matter:
-
-1. **Attenuation as explicit list-subset rule**
-   - requested rights must be subset of source rights.
-2. **Mint does not silently widen authority**
-   - failure path is explicit via `invalidCapability`.
-3. **Revoke is local by design**
-   - aligns with the current CNode-local revoke helper in object model.
-
-### `SeLe4n/Kernel/Lifecycle/Operations.lean`
-
-Primary semantics:
-
-- lifecycle retype authority predicate (`lifecycleRetypeAuthority`),
-- deterministic retype transition (`lifecycleRetypeObject`),
-- explicit branch theorems for illegal-state and illegal-authority outcomes.
-
-Design details that matter:
-
-1. **Metadata coherence gate before mutation**
-   - retype fails with `illegalState` when object-store type and lifecycle metadata diverge.
-2. **Authority is explicit and narrow**
-   - retype authority requires direct-object target and `write` rights; violations return
-     `illegalAuthority`.
-3. **Successful path reuses `storeObject`**
-   - object store and lifecycle object-type metadata are updated atomically.
-
-### `SeLe4n/Kernel/Service/Operations.lean`
-
-Primary semantics:
-
-- orchestration transitions (`serviceStart`, `serviceStop`, `serviceRestart`),
-- explicit failure outcomes (`policyDenied`, `dependencyViolation`, `illegalState`),
-- staged-order theorem witness (`serviceRestart_ok_implies_staged_steps`).
-
-Design details that matter:
-
-1. **Transition checks are ordered and explicit**
-   - lookup/state/policy/dependency gates occur in deterministic sequence.
-2. **Policy is separated from mutation**
-   - transitions receive predicate parameters and only mutate after policy approval.
-3. **Restart is composition-first**
-   - restart semantics are encoded as stop-then-start and proven as staged execution.
-
-### `SeLe4n/Kernel/Service/Invariant.lean`
-
-Primary semantics:
-
-- reusable policy components (`policyBackingObjectTyped`, `policyOwnerAuthorityRefRecorded`,
-  `policyOwnerAuthoritySlotPresent`),
-- service policy bundle entrypoint (`servicePolicySurfaceInvariant`),
-- bridge theorem (`servicePolicySurfaceInvariant_of_lifecycleInvariant`) for deriving policy
-  obligations from lifecycle contracts plus backing-object existence assumptions.
-
-Design details that matter:
-
-1. **Policy and mutation are separated by construction**
-   - service policy predicates are pure state predicates and do not mutate kernel state.
-2. **Bridge shape is compositional**
-   - bridge lemmas are local and reusable so policy obligations can be discharged without copying
-     transition proofs.
-3. **Failure branch intent is explicit**
-   - `serviceStart_policyDenied_separates_check_from_mutation` and
-     `serviceStop_policyDenied_separates_check_from_mutation` keep denial outcomes tied to check-only
-     semantics.
-
-### `SeLe4n/Kernel/Lifecycle/Invariant.lean`
-
-Primary semantics:
-
-- identity/aliasing lifecycle invariants (`lifecycleIdentityAliasingInvariant`),
-- capability-reference lifecycle invariants (`lifecycleCapabilityReferenceInvariant`),
-- composed lifecycle invariant bundle (`lifecycleInvariantBundle`),
-- M4-B stale-reference hardening surfaces (`lifecycleStaleReferenceExclusionInvariant`,
-  `lifecycleIdentityStaleReferenceInvariant`).
-
-Design details that matter:
-
-1. **Invariant layering is explicit**
-   - identity/aliasing constraints are defined and reviewed independently from capability-reference constraints.
-2. **Naming is milestone-oriented**
-   - definitions are narrow and named so later preservation theorems can compose cleanly.
-3. **Metadata-to-bundle bridge is explicit**
-   - `lifecycleInvariantBundle_of_metadata_consistent` connects model-level consistency assumptions to the lifecycle bundle surface.
-4. **WS-B stale-reference hardening is explicit**
-   - theorems lift stale-reference components from lifecycle bundle assumptions and preserve them across `lifecycleRetypeObject`.
-
-### `SeLe4n/Kernel/Capability/Invariant.lean`
-
-Core components:
-
-1. `cspaceSlotUnique`
-2. `cspaceLookupSound`
-3. `cspaceAttenuationRule`
-4. `lifecycleAuthorityMonotonicity`
-
-Composition surfaces:
-
-- `capabilityInvariantBundle`
-- `lifecycleCapabilityStaleAuthorityInvariant`
-- `m3IpcSeedInvariantBundle`
-- `m35IpcSchedulerInvariantBundle`
-
-Cross-layer role:
-
-- capability theorems are composed with scheduler and IPC predicates to preserve milestone
-  continuity while proof surfaces grow.
-
----
-
-## 6. IPC layer (M3 + M3.5 contract)
-
-### `SeLe4n/Kernel/IPC/Invariant.lean`
-
-Primary transitions:
-
-- `endpointSend`
-- `endpointAwaitReceive`
-- `endpointReceive`
-
-Core invariant surfaces:
-
-- endpoint-local validity (`endpointQueueWellFormed`, `endpointObjectValid`, `endpointInvariant`),
-- system-level IPC validity (`ipcInvariant`),
-- M3.5 scheduler coherence contract:
-  - `runnableThreadIpcReady`,
-  - `blockedOnSendNotRunnable`,
-  - `blockedOnReceiveNotRunnable`,
-  - `ipcSchedulerContractPredicates`.
-
-Handshake behavior modeled today:
-
-- waiting receiver path (`endpointAwaitReceive`) marks thread blocked on receive and records
-  waiting receiver in endpoint,
-- send path can satisfy waiting receiver directly (handoff-like behavior),
-- queued senders are still supported and drained by `endpointReceive`.
-
-Proof organization:
-
-- local helper lemmas for store/update effects,
-- transition-specific preservation theorems,
-- composed theorem entrypoints over IPC + scheduler + capability surfaces.
-
----
-
-## 7. Executable evidence and trace contract
-
-### `Main.lean`
-
-`main` builds a deterministic scenario in this order:
-
-1. scheduler step (`schedule`),
-2. root capability lookup,
-3. lifecycle retype unauthorized + illegal-state + success branches,
-4. mint + sibling mint,
-5. composed revoke/delete/retype alias-guard failure and success path,
-6. post-revoke/post-delete lookup checks,
-7. waiting-receiver handshake send,
-8. queued senders + receives,
-9. expected error on extra receive.
-
-Why this matters:
-
-- each stage emits trace lines consumed by Tier 2 fixture checks,
-- executable traces provide semantic evidence beyond “build succeeds”.
-
-### `tests/fixtures/main_trace_smoke.expected`
-
-- stores stable semantic fragments expected in executable output,
-- intentionally fragment-based (not full exact output snapshot) so harmless formatting shifts do not
-  destabilize the gate.
-
-### `scripts/test_tier2_trace.sh`
-
-- runs `lake exe sele4n`,
-- checks each non-empty fixture line appears in output,
-- emits diagnostics and optional trace artifacts for CI debugging.
-
----
-
-## 8. Test framework logging and color prefixes
-
-The shared `scripts/test_lib.sh` logging layer now supports color-coded prefixes:
-
-- category prefixes (`[META]`, `[TRACE]`, `[HYGIENE]`, `[BUILD]`, `[INVARIANT]`) are colorized,
-- status prefixes in messages (`RUN`, `PASS`, `FAIL`) are colorized,
-- color output is automatically disabled when stdout is not a TTY or `NO_COLOR` is set.
-
-This gives local developers faster scanability while preserving CI-safe plain output behavior.
-
----
-
-## 9. Safe change workflow by module
-
-When editing a module, follow this decision path:
-
-1. identify which milestone contract the file owns,
-2. identify composed bundles that include that contract,
-3. adjust local helper lemmas nearest the transition,
-4. keep theorem entrypoint naming stable where practical,
-5. update docs and fixture anchors in the same commit range.
-
----
-
-## 10. Debug playbooks
-
-### A) Proof breakage after transition changes
-
-1. Re-run `lake build` and note first failing theorem.
-2. Inspect transition-local helper lemmas before editing bundle theorem scripts.
-3. Re-establish component theorem first, then bundle theorem.
-
-### B) Trace fixture mismatch
-
-1. Run Tier 2 script to collect missing lines.
-2. Decide if change is bug or intentional semantics shift.
-3. If intentional, update fixture and document rationale in docs/PR.
-
-### C) Capability authority surprise
-
-1. Check minted rights against source cap (`rightsSubset` path).
-2. Check local revoke behavior (same-CNode sibling target removal only).
-3. Verify ownership assumptions in `SystemState.ownsSlot`-based invariants.
-
-This map should be your primary orientation reference before touching theorem-heavy files.
+1. identify affected module family and invariant bundle,
+2. ensure failure-path semantics are explicit,
+3. update tests/fixtures/symbol anchors as needed,
+4. synchronize docs (README/spec/DEVELOPMENT/GitBook),
+5. include a short "what this unlocks for Raspberry Pi 5 path" note.

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -1,110 +1,79 @@
 # Future Slices and Delivery Plan
 
-This chapter describes the forward path beyond M4 closeout and provides execution structure to keep
-implementation, proofs, tests, and docs aligned.
+This chapter captures the forward plan after the M5 closeout and during active M6 execution.
 
-## 1. Planning principles
+## 1. Planning assumptions
 
-1. keep each slice reviewable in one coherent thread,
-2. preserve theorem layering (local first, composed second),
-3. treat executable traces as contract evidence,
-4. ship docs and deferrals with each milestone change,
-5. preserve deterministic semantics before broadening scope.
+Forward planning is constrained by two rules:
 
-## 2. Immediate next slice (M6)
+1. no regression of closed milestone contracts (M1–M5),
+2. no hidden architecture assumptions in post-M6 platform plans.
 
-M6 theme: **architecture-binding interfaces built on completed M5 service/policy semantics**.
+## 2. Active execution window: M6
 
-### M6 target outcomes
+Current focus remains:
 
-1. explicit architecture assumptions represented as stable interface artifacts,
-2. proof-carrying adapter surfaces from architecture-neutral semantics to architecture-bound contexts,
-3. platform contract checklist coverage for boot/runtime boundary expectations,
-4. preservation-proof hooks that keep M1–M5 theorem layering reusable during binding,
-5. fixture/test-plan extensions that validate interface assumptions without weakening existing gates.
+- architecture-binding interfaces,
+- adapter theorem surfaces,
+- hardware-facing boundary contracts,
+- test/documentation continuity.
 
-### M5 closeout baseline consumed by M6
+Execution details are maintained in [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md).
 
-#### WS-M5-A — Service graph model ✅ **completed**
+## 3. Immediate next slice (post-M6): Raspberry Pi 5 first binding
 
-- service identity, status, dependency, isolation, and deterministic state helpers are stable.
+### Target outcomes
 
-#### WS-M5-B — Orchestration transitions ✅ **completed**
+1. instantiate M6 interfaces for Raspberry Pi 5 assumptions,
+2. keep architecture-neutral invariants reusable,
+3. produce explicit mapping from platform assumptions to theorem obligations,
+4. validate minimal realistic scenario traces for platform-oriented boundaries.
 
-- deterministic start/stop/restart transitions with explicit failure branches are stable.
+### Candidate workstreams
 
-#### WS-M5-C — Policy and authority layer ✅ **completed**
+- **WS-M7-A:** Raspberry Pi 5 assumption binding and interface instantiation,
+- **WS-M7-B:** platform-aware adapter evidence and failure-path modeling,
+- **WS-M7-C:** trust-boundary scenario package for a minimal deployment topology,
+- **WS-M7-D:** docs/testing/acceptance closeout for hardware-binding readiness.
 
-- reusable policy predicates and bridge lemmas to lifecycle/capability surfaces are stable.
+## 4. Mid-horizon slices (M8+ directional)
 
-#### WS-M5-D — Proof completion ✅ **completed**
-
-- local and composed preservation theorem entrypoints (including failure-path coverage) are stable.
-
-#### WS-M5-E — Evidence and testing ✅ **completed**
-
-- executable traces, fixtures, and Tier 3/4 anchor coverage for M5 scenarios are stable.
-
-#### WS-M5-F — Documentation and closeout ✅ **completed**
-
-- spec/README/GitBook now consistently mark M5 complete and document M6 deferrals.
-
-## 3. Mid-term slice preview (M7+)
-
-Post-M6 themes are intentionally deferred until architecture-binding interfaces stabilize.
-
-Indicative outcomes:
-
-1. subsystem integration plans that consume M6 interface contracts,
-2. refinement-oriented evidence packaging over architecture-bound assumptions,
-3. platform-specific validation strategy increments gated by M6 artifacts.
-
-## 4. Long-horizon trajectory (mobile-first relevance)
-
-1. architecture-neutral semantic hardening (M1-M5),
-2. architecture-binding interface stabilization (M6+),
-3. subsystem trust-boundary mapping,
-4. prototype integration with traceability back to theorem claims,
-5. hardware-oriented validation strategy alignment.
-
-See [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first.md).
+1. subsystem integration plans consuming M6/M7 contracts,
+2. refinement evidence packaging from model claims to implementation obligations,
+3. platform-validation increments gated by stabilized interfaces and theorem anchors.
 
 ## 5. Transition gates
 
-### Gate: M5 closeout (completed)
+### Gate A — M6 closeout
 
-Verified signals:
+All required:
 
-1. service-graph semantics, policy surfaces, and proof package are merged and stable,
-2. success/failure orchestration scenarios are fixture-backed,
-3. Tier 3 anchors include claimed M5 theorem/invariant symbols,
-4. docs explicitly mark M5 completion and M6 deferrals.
+1. architecture contracts explicit and reviewable,
+2. proof adapters compositional and compiled,
+3. required test tiers green,
+4. docs synchronized.
 
-### Gate: M5 → M6 (active entry gate)
+### Gate B — Raspberry Pi 5 binding slice closeout
 
-Require all:
+All required:
 
-1. architecture-binding assumptions are explicit and reviewable,
-2. interface artifacts preserve M1–M5 theorem layering contracts,
-3. new testing obligations are added without regressing Tier 0–3 required gates.
+1. M6 contracts instantiated for Raspberry Pi 5 constraints,
+2. failure semantics for bound adapters explicit,
+3. trust-boundary narrative backed by executable/test evidence.
 
-## 6. Risk register (active)
+## 6. Risk register and mitigations
 
-1. **Semantic/proof skew**
-   - risk: transitions evolve without theorem updates.
-   - mitigation: enforce transition + theorem pairing in PR checklist.
-2. **Trace/fixture fragility**
-   - risk: fixtures reflect formatting noise instead of semantics.
-   - mitigation: document semantic intent per fixture delta.
-3. **Roadmap drift**
-   - risk: docs describe different active slices.
-   - mitigation: synchronize README/spec/GitBook in same PR.
-4. **Policy overcoupling**
-   - risk: policy model entangles service internals and capability internals.
-   - mitigation: require bridge lemmas and module boundary review.
+1. **Contract instability risk**
+   - mitigation: keep adapter interfaces narrow and versioned through milestone docs.
+2. **Platform over-assumption risk**
+   - mitigation: separate platform obligations from model guarantees in every PR.
+3. **Evidence lag risk**
+   - mitigation: require fixture/symbol updates with every milestone-moving change.
+4. **Documentation fragmentation risk**
+   - mitigation: update roadmap + hardware chapter + README together.
 
-## 7. Contributor operating cadence
+## 7. Delivery rhythm
 
-1. **Per PR**: state current-slice outcome moved + next-slice unlock.
-2. **Per checkpoint**: map progress to M5 workstreams A-F.
-3. **Per milestone closeout**: publish delivered outcomes, deferrals, and risk notes.
+1. milestone-moving PRs should include "what this unlocks next" language,
+2. checkpoint reviews should score progress against workstreams/outcomes,
+3. closeout PRs should include achieved outcomes + explicit deferrals by destination slice.

--- a/docs/gitbook/18-m6-execution-plan-and-workstreams.md
+++ b/docs/gitbook/18-m6-execution-plan-and-workstreams.md
@@ -1,0 +1,165 @@
+# M6 Execution Plan and Workstreams
+
+This chapter is the delivery playbook for the **current active slice (M6)**.
+
+M6 goal: turn architecture-facing assumptions into explicit interfaces and proof-carrying contracts,
+while preserving all established M1–M5 semantics/invariants/evidence obligations.
+
+---
+
+## 1. Slice-level target outcomes (definition of success)
+
+M6 is considered complete only when all outcomes are met:
+
+1. **Architecture-assumption interfaces are explicit**
+   - architecture-bound assumptions are represented in named Lean-level interfaces,
+   - assumptions are discoverable, reviewable, and test-addressable,
+   - hidden architecture coupling in operational semantics is reduced.
+
+2. **Proof-carrying adapter surfaces exist**
+   - adapter predicates/theorems bridge architecture-neutral semantics to architecture-bound contexts,
+   - theorem layering remains compositional (local first, composed second),
+   - failure-path obligations remain explicit.
+
+3. **Hardware-facing boundary contracts are hardened**
+   - boot/runtime boundary assumptions are documented as contracts rather than narrative,
+   - contract surfaces identify what is guaranteed by model code vs expected from platform adapters,
+   - future hardware work can consume these contracts without rewriting core proof bundles.
+
+4. **Evidence and CI continuity is preserved**
+   - required Tier 0–3 gates remain green,
+   - added surfaces get symbol/fixture coverage where appropriate,
+   - roadmap claims in docs remain synchronized with code and tests.
+
+---
+
+## 2. M6 workstream breakdown
+
+### WS-M6-A — Assumption inventory and boundary extraction
+
+**Objective:** Enumerate architecture-facing assumptions currently implicit in model behavior and
+lift them into explicit interface artifacts.
+
+**Primary deliverables**
+- assumption inventory document section(s),
+- typed interface skeletons for architecture-bound contracts,
+- mapping from existing transitions/invariants to new boundary surfaces.
+
+**Exit signal**
+- reviewers can point to a bounded list of assumptions and their interface location.
+
+### WS-M6-B — Interface API and adapter semantics
+
+**Objective:** Define interface APIs that maintain deterministic transition behavior and explicit
+error branching.
+
+**Primary deliverables**
+- architecture-binding adapter API in kernel/model modules,
+- explicit error mapping for unsupported/invalid bound-context cases,
+- deterministic state update semantics at the adapter boundary.
+
+**Exit signal**
+- adapter entrypoints compile and preserve existing transition-level determinism expectations.
+
+### WS-M6-C — Proof-layer integration
+
+**Objective:** Integrate adapter assumptions with existing theorem bundles (scheduler,
+capability, IPC, lifecycle, service).
+
+**Primary deliverables**
+- local preservation theorems for boundary-facing operations,
+- composed preservation hooks from adapter contracts into bundle-level invariants,
+- explicit failure-path preservation statements for denied/unsupported adapter conditions.
+
+**Exit signal**
+- new theorem surfaces are importable without reworking M1–M5 invariant layout.
+
+### WS-M6-D — Evidence, traces, and test anchors
+
+**Objective:** Expand evidence so boundary assumptions and failure branches are executable and
+regression-checked.
+
+**Primary deliverables**
+- `Main.lean` scenario growth where boundary behavior is externally visible,
+- fixture updates with semantic intent notes,
+- Tier 3 anchor updates for new theorem/invariant/API claims.
+
+**Exit signal**
+- evidence demonstrates both expected success path and bounded failure semantics.
+
+### WS-M6-E — Documentation and handoff packaging
+
+**Objective:** Keep roadmap/spec/development/GitBook synchronized and prepare post-M6 execution
+handoff.
+
+**Primary deliverables**
+- synchronized stage markers in root docs and GitBook,
+- explicit list of post-M6 unlocks and deferrals,
+- risk register updates tied to new boundary contracts.
+
+**Exit signal**
+- M6 claims are fully traceable from docs → code → proofs → tests.
+
+---
+
+## 3. Current-slice outcome matrix
+
+| Outcome | Workstreams | Evidence command(s) | Completion signal |
+|---|---|---|---|
+| Explicit architecture assumptions | WS-M6-A, WS-M6-E | `lake build`, `./scripts/test_tier3_invariant_surface.sh` | Interfaces and symbols are discoverable and anchored |
+| Adapter semantics and error handling | WS-M6-B | `./scripts/test_fast.sh`, `lake exe sele4n` | Deterministic success/failure behavior is executable |
+| Proof compositionality across boundary | WS-M6-C | `lake build`, `./scripts/test_full.sh` | Local + composed theorems compile and remain layered |
+| Regression-safe evidence growth | WS-M6-D | `./scripts/test_smoke.sh`, `./scripts/test_nightly.sh` | Fixture and nightly checks validate expected traces |
+| Slice handoff coherence | WS-M6-E | docs review + CI-required set | Spec/README/DEVELOPMENT/GitBook all match |
+
+---
+
+## 4. Raspberry Pi 5 first-hardware direction
+
+The first real-hardware architecture focus for seLe4n is **Raspberry Pi 5**. M6 does not attempt
+full hardware enablement; it prepares the architecture-binding contracts needed for that path.
+
+### Why Raspberry Pi 5 first
+
+1. practical and accessible ARM64 platform for repeatable lab validation,
+2. modern enough hardware profile for realistic interrupt/memory/boot assumptions,
+3. strong community tooling ecosystem for incremental bring-up,
+4. suitable for demonstrating constrained but meaningful trust-boundary deployments.
+
+### What M6 must unlock specifically for Raspberry Pi 5
+
+1. CPU/exception/interrupt boundary assumptions represented as interface contracts,
+2. boot-time object and capability-root expectations captured as explicit prerequisites,
+3. memory-mapping assumptions isolated from architecture-neutral invariants,
+4. adapter hooks that permit later platform-specific refinement without proof reset.
+
+---
+
+## 5. Post-M6 immediate slice preview (M7 directional)
+
+Planned immediate follow-on after M6 stabilization:
+
+1. **Raspberry Pi 5 binding prototype track**
+   - instantiate M6 interfaces for Raspberry Pi 5-specific constraints,
+   - preserve architecture-neutral theorem reuse where possible.
+2. **Platform-constraint evidence track**
+   - extend executable scenarios and traces to reflect realistic boot/runtime assumptions.
+3. **Trust-boundary validation track**
+   - map service graph expectations onto a minimal realistic deployment partition.
+
+These tracks should remain incremental and should not force bulk redesign of M1–M5 proof
+surfaces.
+
+---
+
+## 6. Contributor checklist for M6 milestone-moving PRs
+
+Include this in each milestone-moving PR description:
+
+- M6 workstream(s) advanced (`WS-M6-*`):
+- target outcome(s) advanced:
+- theorem/invariant/API surfaces introduced or modified:
+- evidence commands run:
+- fixture changes and semantic rationale:
+- deferred items and destination slice:
+- what this unlocks next (especially for Raspberry Pi 5 path):

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -5,7 +5,8 @@ This GitBook is the long-form documentation for seLe4n.
 ## Project stage snapshot
 
 - **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening.
-- **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A/B/C/D/E/F complete).
+- **Most recently completed slice:** M5 service-graph + policy surfaces.
+- **First real hardware architecture focus:** Raspberry Pi 5 (post-M6 binding trajectory).
 
 Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance reference.
 
@@ -18,24 +19,25 @@ Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance
 3. [Architecture & Module Map](03-architecture-and-module-map.md)
 4. [Project Design Deep Dive](04-project-design-deep-dive.md)
 
-### 2) Active planning + latest closeout
+### 2) Active planning and execution
 
-5. [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
-6. [Specification & Roadmap](05-specification-and-roadmap.md)
+5. [Specification & Roadmap](05-specification-and-roadmap.md)
+6. [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md)
 7. [Development Workflow](06-development-workflow.md)
 8. [Testing & CI](07-testing-and-ci.md)
 9. [Codebase Reference](11-codebase-reference.md)
 10. [Proof and Invariant Map](12-proof-and-invariant-map.md)
 
-### 3) Slice history and forward planning
+### 3) Slice history and long-horizon path
 
-11. [Completed Slice: M4-A](08-completed-slice-m4a.md)
-12. [Completed Slice: M4-B](16-completed-slice-m4b.md)
-13. [M4-B Execution Playbook](14-m4b-execution-playbook.md)
-14. [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
-15. [M5 Development Blueprint](15-m5-development-blueprint.md)
-16. [Project Usage and Value](17-project-usage-value.md)
-17. [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first.md)
+11. [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
+12. [Completed Slice: M4-A](08-completed-slice-m4a.md)
+13. [Completed Slice: M4-B](16-completed-slice-m4b.md)
+14. [M4-B Execution Playbook](14-m4b-execution-playbook.md)
+15. [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
+16. [M5 Development Blueprint](15-m5-development-blueprint.md)
+17. [Project Usage and Value](17-project-usage-value.md)
+18. [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)
 
 ## Anti-duplication guidance
 
@@ -44,4 +46,5 @@ To keep this handbook maintainable:
 - put normative scope and acceptance criteria in `docs/SEL4_SPEC.md`,
 - keep current-slice chapters focused on active execution details,
 - keep completed-slice chapters as concise historical references,
-- prefer links to foundational chapters instead of restating shared definitions.
+- use cross-links when reusing definitions,
+- and keep Raspberry Pi 5 planning details synchronized between roadmap and hardware chapters.

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -9,10 +9,10 @@
 - [Architecture & Module Map](03-architecture-and-module-map.md)
 - [Project Design Deep Dive](04-project-design-deep-dive.md)
 
-## Active planning + latest closeout
+## Active planning and execution
 
-- [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 - [Specification & Roadmap](05-specification-and-roadmap.md)
+- [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md)
 - [Development Workflow](06-development-workflow.md)
 - [Testing & CI](07-testing-and-ci.md)
 - [Codebase Reference](11-codebase-reference.md)
@@ -20,10 +20,11 @@
 
 ## Slice history and roadmap
 
+- [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 - [Completed Slice: M4-A](08-completed-slice-m4a.md)
 - [Completed Slice: M4-B](16-completed-slice-m4b.md)
 - [M4-B Execution Playbook](14-m4b-execution-playbook.md)
 - [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
 - [M5 Development Blueprint](15-m5-development-blueprint.md)
 - [Project Usage and Value](17-project-usage-value.md)
-- [Path to Real Hardware (Mobile-First)](10-path-to-real-hardware-mobile-first.md)
+- [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)


### PR DESCRIPTION
Expanded the top-level project docs to clearly state the active M6 slice, add direct navigation to the new M6 execution chapter, and explicitly mark Raspberry Pi 5 as the first hardware architecture focus. 

Updated the normative spec and development guide with concrete M6 workstream structure (WS-M6-A through WS-M6-E), plus explicit post-M6 Raspberry Pi 5 direction notes for contributor planning. 

Reorganized GitBook navigation (README + SUMMARY) to highlight active execution docs first, add the new M6 execution chapter, and retitle the hardware path toward Raspberry Pi 5-first planning. 

Refined core GitBook content for current-state accuracy and next-slice planning, including:

refreshed project overview with M6 outcomes and Raspberry Pi 5 trajectory, 

expanded roadmap with M6 outcomes/workstreams, transition gates, and post-M6 target outcomes, 

updated future slice plan around Raspberry Pi 5 binding workstreams and gates, 

rewritten hardware path chapter to explicitly center Raspberry Pi 5 and staged convergence, 

refreshed codebase reference to map current modules and where M6/Raspberry Pi 5 work should land. 

Added a new dedicated GitBook chapter: M6 Execution Plan and Workstreams, with detailed slice outcomes, workstream deliverables/exit signals, an outcome matrix, and Raspberry Pi 5 unlock criteria.
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e673c9e4832ba1d8d4a62dc09f3e)