### PR TITLE
Tighten M6 doc-sync validation and finalize WS‑M6‑A audit follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening.
+- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A completed; WS-M6-B through WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A through WS-M5-F completed).
 - **First real-hardware architecture focus:** Raspberry Pi 5 (post-M6 binding path).
 
@@ -61,6 +61,7 @@ lake exe sele4n
 - `SeLe4n/Kernel/IPC/*.lean` — endpoint IPC semantics and invariants.
 - `SeLe4n/Kernel/Lifecycle/*.lean` — lifecycle/retype semantics and invariants.
 - `SeLe4n/Kernel/Service/*.lean` — service orchestration transitions and policy-surface invariants.
+- `SeLe4n/Kernel/Architecture/Assumptions.lean` — WS-M6-A assumption inventory, typed contract references (`ContractRef`), and architecture-boundary contract skeletons.
 - `Main.lean` — executable scenario traces.
 
 ## License

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -4,3 +4,4 @@ import SeLe4n.Model.Object
 import SeLe4n.Model.State
 import SeLe4n.Kernel.API
 
+import SeLe4n.Kernel.Architecture.Assumptions

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -8,3 +8,5 @@ import SeLe4n.Kernel.Lifecycle.Operations
 import SeLe4n.Kernel.Lifecycle.Invariant
 import SeLe4n.Kernel.Service.Operations
 import SeLe4n.Kernel.Service.Invariant
+
+import SeLe4n.Kernel.Architecture.Assumptions

--- a/SeLe4n/Kernel/Architecture/Assumptions.lean
+++ b/SeLe4n/Kernel/Architecture/Assumptions.lean
@@ -1,0 +1,117 @@
+import SeLe4n.Model.State
+
+namespace SeLe4n.Kernel.Architecture
+
+open SeLe4n.Model
+
+/-- Enumerated architecture-facing assumptions extracted in WS-M6-A. -/
+inductive ArchAssumption where
+  | deterministicTimerProgress
+  | deterministicRegisterContext
+  | memoryAccessSafety
+  | bootObjectTyping
+  | irqRoutingTotality
+  deriving Repr, DecidableEq
+
+/-- Existing transition/API surfaces that consume architecture-facing assumptions. -/
+inductive TransitionSurface where
+  | chooseThread
+  | schedule
+  | handleYield
+  | endpointSend
+  | endpointAwaitReceive
+  | endpointReceive
+  | lifecycleRetype
+  deriving Repr, DecidableEq
+
+/-- Existing invariant bundles that must remain architecture-neutral. -/
+inductive InvariantSurface where
+  | schedulerInvariantBundle
+  | capabilityInvariantBundle
+  | m3IpcSeedInvariantBundle
+  | m35IpcSchedulerInvariantBundle
+  | lifecycleInvariantBundle
+  | serviceInvariantBundle
+  deriving Repr, DecidableEq
+
+/-- Typed boot-boundary contract skeleton consumed by later adapters. -/
+structure BootBoundaryContract where
+  objectTypeMetadataConsistent : Prop
+  capabilityRefMetadataConsistent : Prop
+
+/-- Typed runtime-boundary contract skeleton consumed by scheduler/IPC adapters. -/
+structure RuntimeBoundaryContract where
+  timerMonotonic : SystemState → SystemState → Prop
+  registerContextStable : SystemState → SystemState → Prop
+  memoryAccessAllowed : SystemState → SeLe4n.PAddr → Prop
+
+/-- Typed interrupt-boundary contract skeleton consumed by IRQ adapter paths. -/
+structure InterruptBoundaryContract where
+  irqLineSupported : SeLe4n.Irq → Prop
+  irqHandlerMapped : SystemState → SeLe4n.Irq → Prop
+
+/-- First-class references to extracted boundary contract obligations. -/
+inductive ContractRef where
+  | bootObjectTypeMetadataConsistent
+  | bootCapabilityRefMetadataConsistent
+  | runtimeTimerMonotonic
+  | runtimeRegisterContextStable
+  | runtimeMemoryAccessAllowed
+  | interruptIrqLineSupported
+  | interruptIrqHandlerMapped
+  deriving Repr, DecidableEq
+
+/-- Assumption inventory map: each extracted assumption points to required contract obligations. -/
+def assumptionContractMap : ArchAssumption → List ContractRef
+  | .deterministicTimerProgress => [.runtimeTimerMonotonic]
+  | .deterministicRegisterContext => [.runtimeRegisterContextStable]
+  | .memoryAccessSafety => [.runtimeMemoryAccessAllowed]
+  | .bootObjectTyping => [.bootObjectTypeMetadataConsistent, .bootCapabilityRefMetadataConsistent]
+  | .irqRoutingTotality => [.interruptIrqLineSupported, .interruptIrqHandlerMapped]
+
+/-- Assumption-to-transition mapping extracted from current semantics. -/
+def assumptionTransitionMap : ArchAssumption → List TransitionSurface
+  | .deterministicTimerProgress => [.chooseThread, .schedule, .handleYield]
+  | .deterministicRegisterContext => [.chooseThread, .schedule, .handleYield]
+  | .memoryAccessSafety => [.endpointSend, .endpointAwaitReceive, .endpointReceive]
+  | .bootObjectTyping => [.lifecycleRetype]
+  | .irqRoutingTotality => [.handleYield]
+
+/-- Assumption-to-invariant mapping extracted from current theorem bundles. -/
+def assumptionInvariantMap : ArchAssumption → List InvariantSurface
+  | .deterministicTimerProgress => [.schedulerInvariantBundle]
+  | .deterministicRegisterContext => [.schedulerInvariantBundle, .m35IpcSchedulerInvariantBundle]
+  | .memoryAccessSafety => [.m3IpcSeedInvariantBundle, .m35IpcSchedulerInvariantBundle]
+  | .bootObjectTyping => [.capabilityInvariantBundle, .lifecycleInvariantBundle]
+  | .irqRoutingTotality => [.schedulerInvariantBundle, .serviceInvariantBundle]
+
+/-- Canonical WS-M6-A inventory list used by docs/tests for discoverability checks. -/
+def assumptionInventory : List ArchAssumption :=
+  [ .deterministicTimerProgress
+  , .deterministicRegisterContext
+  , .memoryAccessSafety
+  , .bootObjectTyping
+  , .irqRoutingTotality
+  ]
+
+/-- Boundary extraction completeness marker for WS-M6-A. -/
+def assumptionInventoryComplete : Prop :=
+  ∀ a, a ∈ assumptionInventory
+
+theorem assumptionInventoryComplete_holds : assumptionInventoryComplete := by
+  intro a
+  cases a <;> simp [assumptionInventory]
+
+/-- Every extracted assumption has at least one boundary-contract obligation. -/
+theorem assumptionContractMap_nonempty (a : ArchAssumption) : (assumptionContractMap a).length > 0 := by
+  cases a <;> decide
+
+/-- Every extracted assumption maps to at least one transition-level touchpoint. -/
+theorem assumptionTransitionMap_nonempty (a : ArchAssumption) : (assumptionTransitionMap a).length > 0 := by
+  cases a <;> decide
+
+/-- Every extracted assumption maps to at least one invariant-level touchpoint. -/
+theorem assumptionInvariantMap_nonempty (a : ArchAssumption) : (assumptionInvariantMap a).length > 0 := by
+  cases a <;> decide
+
+end SeLe4n.Kernel.Architecture

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -174,8 +174,9 @@ For each milestone-moving PR, include a short section that states:
 
 Use this workstream mapping for implementation planning and review checklists:
 
-1. **WS-M6-A — assumption inventory and boundary extraction**
-   - make architecture assumptions explicit interface artifacts.
+1. **WS-M6-A — assumption inventory and boundary extraction** ✅ **completed**
+   - architecture assumptions are now explicit interface artifacts in `SeLe4n/Kernel/Architecture/Assumptions.lean` (`ArchAssumption`, `ContractRef`),
+   - extracted assumptions are mapped to transition and invariant surfaces for reviewable boundary ownership.
 2. **WS-M6-B — interface API and adapter semantics**
    - define deterministic adapter behavior with explicit errors.
 3. **WS-M6-C — proof-layer integration**

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -114,7 +114,7 @@ This obligation-based model is the correct notion of “full” for this reposit
 
 ### 6.1 Near-term (M6)
 
-- Define architecture-assumption interfaces with explicit, theorem-friendly contracts.
+- Architecture-assumption interfaces are now explicit with theorem-friendly contracts (WS-M6-A completed); continue adapter/proof integration follow-through.
 - Preserve composability with already-closed M1–M5 invariant bundles.
 - Add assumption-boundary scenarios to executable traces as each interface lands.
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -264,8 +264,10 @@ M6 explicitly owns the deferred architecture-binding scope:
 
 M6 work is tracked through the following workstreams:
 
-1. **WS-M6-A — assumption inventory + boundary extraction**
-   - enumerate architecture-facing assumptions and map them into interface surfaces.
+1. **WS-M6-A — assumption inventory + boundary extraction** ✅ **completed**
+   - architecture-facing assumptions are enumerated in `SeLe4n/Kernel/Architecture/Assumptions.lean` via `ArchAssumption` and `assumptionInventory`,
+   - boundary contract skeletons are explicit via `BootBoundaryContract`, `RuntimeBoundaryContract`, and `InterruptBoundaryContract` with first-class `ContractRef` obligations,
+   - transition/invariant mapping is captured in `assumptionTransitionMap` and `assumptionInvariantMap`.
 2. **WS-M6-B — interface API + adapter semantics**
    - implement deterministic adapter behavior with explicit unsupported/invalid branches.
 3. **WS-M6-C — proof integration**

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -44,7 +44,7 @@ M6 scope: **architecture-binding interfaces and hardware-facing assumption harde
 
 ### M6 workstreams
 
-- **WS-M6-A:** assumption inventory and boundary extraction,
+- **WS-M6-A:** assumption inventory and boundary extraction ✅ completed (`SeLe4n/Kernel/Architecture/Assumptions.lean`),
 - **WS-M6-B:** interface API + adapter semantics,
 - **WS-M6-C:** proof integration with existing bundles,
 - **WS-M6-D:** executable evidence and test-anchor expansion,
@@ -82,11 +82,11 @@ Verified signals:
 
 ### Gate: M5 → M6 (active, in progress)
 
-Require all:
+Progress snapshot:
 
-1. architecture assumptions explicit and reviewable,
-2. interface artifacts preserve M1–M5 theorem layering,
-3. test obligations added without regressing required gates.
+1. architecture assumptions explicit and reviewable ✅ (WS-M6-A complete),
+2. interface artifacts preserve M1–M5 theorem layering (in progress; WS-M6-B/C),
+3. test obligations added without regressing required gates (in progress; WS-M6-D/E).
 
 ### Gate: M6 → Raspberry Pi 5 binding slice (planned)
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -53,15 +53,15 @@ It also highlights where M6 and post-M6 (Raspberry Pi 5-first) work should land.
 
 ## 3. How M6 should map onto this codebase
 
-### M6 boundary extraction (WS-M6-A)
+### M6 boundary extraction (WS-M6-A) ✅ **completed**
 
-Likely touch points:
+Implemented touch points:
 
-- `SeLe4n/Machine.lean`
-- `SeLe4n/Model/State.lean`
+- `SeLe4n/Kernel/Architecture/Assumptions.lean`
 - `SeLe4n/Kernel/API.lean`
+- `SeLe4n.lean`
 
-Goal: isolate architecture-facing assumptions into explicit, named interface surfaces.
+Outcome: architecture-facing assumptions are isolated into explicit, named interface surfaces (including first-class contract references) and exported for downstream adapter/proof work.
 
 ### M6 adapter semantics (WS-M6-B)
 

--- a/docs/gitbook/18-m6-execution-plan-and-workstreams.md
+++ b/docs/gitbook/18-m6-execution-plan-and-workstreams.md
@@ -35,18 +35,18 @@ M6 is considered complete only when all outcomes are met:
 
 ## 2. M6 workstream breakdown
 
-### WS-M6-A — Assumption inventory and boundary extraction
+### WS-M6-A — Assumption inventory and boundary extraction ✅ **completed**
 
 **Objective:** Enumerate architecture-facing assumptions currently implicit in model behavior and
 lift them into explicit interface artifacts.
 
 **Primary deliverables**
-- assumption inventory document section(s),
-- typed interface skeletons for architecture-bound contracts,
-- mapping from existing transitions/invariants to new boundary surfaces.
+- assumption inventory surfaced in `SeLe4n/Kernel/Architecture/Assumptions.lean` (`ArchAssumption`, `assumptionInventory`),
+- typed interface skeletons landed as `BootBoundaryContract`, `RuntimeBoundaryContract`, `InterruptBoundaryContract`, plus first-class `ContractRef` obligations,
+- mapping from existing transitions/invariants captured by `assumptionTransitionMap` and `assumptionInvariantMap`.
 
 **Exit signal**
-- reviewers can point to a bounded list of assumptions and their interface location.
+- achieved: reviewers can point to a bounded list of assumptions and their interface location.
 
 ### WS-M6-B — Interface API and adapter semantics
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening.
+- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A complete; WS-M6-B through WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces.
 - **First real hardware architecture focus:** Raspberry Pi 5 (post-M6 binding trajectory).
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.7.0"
+version = "0.7.3"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -8,6 +8,19 @@ source "${SCRIPT_DIR}/test_lib.sh"
 parse_common_args "$@"
 cd "${REPO_ROOT}"
 
+# M6 WS-M6-A assumption inventory anchors.
+run_check "INVARIANT" rg -n '^inductive ArchAssumption' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^structure BootBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^structure RuntimeBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^structure InterruptBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^inductive ContractRef' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^def assumptionContractMap' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^def assumptionTransitionMap' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^def assumptionInvariantMap' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^theorem assumptionContractMap_nonempty' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^theorem assumptionTransitionMap_nonempty' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n '^theorem assumptionInvariantMap_nonempty' SeLe4n/Kernel/Architecture/Assumptions.lean
+
 # Invariant bundle surface anchors (M1/M2/M3 composed entrypoints).
 run_check "INVARIANT" rg -n '^(def|abbrev) schedulerInvariantBundle' SeLe4n/Kernel/Scheduler/Invariant.lean
 run_check "INVARIANT" rg -n '^def capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
@@ -233,7 +246,7 @@ run_check "TRACE" rg -n 'post-delete lookup \(expected error\): SeLe4n.Model.Ker
 run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete|WS-A \+ WS-B \+ WS-C \+ WS-D \+ WS-E complete|WS-A/WS-B/WS-C/WS-D/WS-E are complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md
-run_check "DOC" rg -n 'Active slice:|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-m5-closeout-snapshot.md
+run_check "DOC" rg -n 'Active slice:.*M6|Current slice:.*M6|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-m5-closeout-snapshot.md
 run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md
 run_check "DOC" rg -n 'WS-M5-D|WS-M5-E|proof package ✅ \*\*completed\*\*|Evidence and validation ✅ \*\*completed\*\*|WS-M5-A/B/C/D/E complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
 run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-m5-closeout-snapshot.md


### PR DESCRIPTION
### Motivation

- Make WS‑M6‑A a discoverable, testable artifact by surfacing architecture-facing assumptions and typed contract references so downstream adapters/proofs can import a stable API. 
- Prevent roadmap/documentation drift by ensuring README/GitBook language and CI/Tier‑3 anchors remain synchronized with implemented symbols. 
- Harden Tier‑3 invariant anchors so refactors that touch M6 artifacts must update tests/docs in the same change set.

### Description

- Added `SeLe4n/Kernel/Architecture/Assumptions.lean` with `ArchAssumption`, `ContractRef`, `BootBoundaryContract`, `RuntimeBoundaryContract`, `InterruptBoundaryContract`, `assumptionInventory`, `assumptionContractMap`, `assumptionTransitionMap`, `assumptionInvariantMap`, and non-emptiness theorems (`assumptionContractMap_nonempty`, `assumptionTransitionMap_nonempty`, `assumptionInvariantMap_nonempty`).
- Exported the new surface by importing `SeLe4n.Kernel.Architecture.Assumptions` from `SeLe4n.lean` and `SeLe4n.Kernel.API` so the inventory and contract refs are available at the top-level API surface.
- Tightened Tier‑3 checks in `scripts/test_tier3_invariant_surface.sh` to assert presence of the new symbols and strengthened doc-sync regex to explicitly require M6-active phrasing (`Active slice:.*M6|Current slice:.*M6`).
- Synchronized user-facing docs (`README.md`, `docs/gitbook/README.md`, and multiple GitBook pages) to explicitly mention typed `ContractRef` obligations and updated phrasing (`WS-M6-B through WS-M6-E`), and bumped the patch version in `lakefile.toml` to `0.7.3`.

### Testing

- Performed a full build with `lake build`, which completed successfully.
- Ran the bundled test runners `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh`, and the suites reported Tier 0–3 checks passing.
- Executed the Tier‑3 invariant surface checks via `./scripts/test_tier3_invariant_surface.sh`, which detected the new anchors (`ContractRef`, `assumptionContractMap`, `assumptionContractMap_nonempty`, `assumptionTransitionMap_nonempty`, `assumptionInvariantMap_nonempty`).
- Ran the testing-framework audit `./scripts/audit_testing_framework.sh`; the audit completed and correctly reported a deliberate Tier‑2 negative-control mismatch (one expected trace line missing) as a successful control-path validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699376bb935c832bb13bee78a5380e48)