### PR TITLE
Harden Lean setup bootstrap and sync workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ For normative milestones, acceptance criteria, and scope decisions, use
 ./scripts/setup_lean_env.sh
 ```
 
+The setup script now retries `shellcheck` installation with existing package indexes when `apt-get update` is partially unavailable (for example, blocked optional third-party repositories), so bootstrap remains resilient in restricted CI environments.
+
 ### 2) Build and run
 
 ```bash

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -16,6 +16,8 @@ rg -n "axiom|sorry|TODO" SeLe4n Main.lean
 ./scripts/test_full.sh
 ```
 
+Bootstrap note: `./scripts/setup_lean_env.sh` retries `shellcheck` installation even when `apt-get update` is partially unavailable (for example, blocked optional third-party repos), reducing setup friction in restricted CI/container environments.
+
 ## Milestone-oriented implementation pattern
 
 1. update/introduce transition,

--- a/scripts/setup_lean_env.sh
+++ b/scripts/setup_lean_env.sh
@@ -22,8 +22,13 @@ ensure_shellcheck() {
   }
 
   if command -v apt-get >/dev/null 2>&1; then
-    run_pkg_install apt-get update
-    run_pkg_install env DEBIAN_FRONTEND=noninteractive apt-get install -y shellcheck
+    if ! run_pkg_install env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends shellcheck; then
+      echo "[setup] shellcheck install without apt index refresh failed; running apt-get update and retrying"
+      if ! run_pkg_install apt-get update; then
+        echo "[setup] warning: apt-get update failed (often due to optional or blocked third-party repositories); retrying shellcheck install with existing indexes"
+      fi
+      run_pkg_install env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends shellcheck
+    fi
   elif command -v dnf >/dev/null 2>&1; then
     run_pkg_install dnf install -y ShellCheck
   elif command -v yum >/dev/null 2>&1; then


### PR DESCRIPTION
### Motivation
- Make local and CI bootstrap for Lean more resilient on apt-based systems where `apt-get update` may fail or be partially blocked, and ensure documentation accurately reflects the new behavior.

### Description
- Update `scripts/setup_lean_env.sh` to attempt `apt-get install` for `shellcheck` first and only run `apt-get update` on failure, then retry the install and emit a clear warning if `apt-get update` itself fails.
- Add a short explanatory note to `README.md` documenting the bootstrap fallback behavior for contributor quick-starts.
- Mirror the same bootstrap guidance in `docs/gitbook/06-development-workflow.md` so the GitBook remains synchronized with repo behavior.

### Testing
- Performed static checks and linters: `bash -n scripts/setup_lean_env.sh` and `shellcheck scripts/setup_lean_env.sh`, both succeeded.
- Ran the full project checks: `bash scripts/test_full.sh` and the audit entrypoint `bash scripts/audit_testing_framework.sh`, which completed successfully (the audit also verified the testing framework correctly detects the Tier 2 control-data mismatch as expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993820b7b70832b8868643beb8e5e6e)