### PR TITLE
Implement workstream WS-M6-B, audit, and update documentation

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -124,6 +124,41 @@ def bootstrapState : SystemState :=
     }
   }
 
+
+
+def runtimeContractAcceptAll : SeLe4n.Kernel.Architecture.RuntimeBoundaryContract :=
+  {
+    timerMonotonic := fun st st' => st.machine.timer ≤ st'.machine.timer
+    registerContextStable := fun _ _ => True
+    memoryAccessAllowed := fun _ _ => True
+    timerMonotonicDecidable := by
+      intro st st'
+      infer_instance
+    registerContextStableDecidable := by
+      intro st st'
+      infer_instance
+    memoryAccessAllowedDecidable := by
+      intro st addr
+      infer_instance
+  }
+
+def runtimeContractDenyAll : SeLe4n.Kernel.Architecture.RuntimeBoundaryContract :=
+  {
+    timerMonotonic := fun _ _ => False
+    registerContextStable := fun _ _ => False
+    memoryAccessAllowed := fun _ _ => False
+    timerMonotonicDecidable := by
+      intro st st'
+      infer_instance
+    registerContextStableDecidable := by
+      intro st st'
+      infer_instance
+    memoryAccessAllowedDecidable := by
+      intro st addr
+      infer_instance
+  }
+
+
 def main : IO Unit := do
   match SeLe4n.Kernel.schedule bootstrapState with
   | .error err => IO.println s!"scheduler error: {reprStr err}"
@@ -133,6 +168,34 @@ def main : IO Unit := do
       | .error err => IO.println s!"source lookup error: {reprStr err}"
       | .ok (srcCap, _) =>
           IO.println s!"source cap rights before mint: {reprStr srcCap.rights}"
+      match SeLe4n.Kernel.Architecture.adapterAdvanceTimer runtimeContractAcceptAll 2 st1 with
+      | .error err => IO.println s!"adapter timer success path error: {reprStr err}"
+      | .ok (_, stTimer) =>
+          IO.println s!"adapter timer success path value: {reprStr stTimer.machine.timer}"
+      match SeLe4n.Kernel.Architecture.adapterAdvanceTimer runtimeContractAcceptAll 0 st1 with
+      | .error err => IO.println s!"adapter timer invalid-context branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected adapter timer success with zero ticks"
+      match SeLe4n.Kernel.Architecture.adapterAdvanceTimer runtimeContractDenyAll 1 st1 with
+      | .error err => IO.println s!"adapter timer unsupported branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected adapter timer success under denied contract"
+      match SeLe4n.Kernel.Architecture.adapterReadMemory runtimeContractDenyAll 0 st1 with
+      | .error err => IO.println s!"adapter read denied branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected adapter read success under denied contract"
+      match SeLe4n.Kernel.Architecture.adapterReadMemory runtimeContractAcceptAll 0 st1 with
+      | .error err => IO.println s!"adapter read success path error: {reprStr err}"
+      | .ok (byte, _) =>
+          IO.println s!"adapter read success path byte: {reprStr byte}"
+      match SeLe4n.Kernel.Architecture.adapterWriteRegister runtimeContractAcceptAll 7 99 st1 with
+      | .error err => IO.println s!"adapter register write success path error: {reprStr err}"
+      | .ok (_, stReg) =>
+          IO.println s!"adapter register write success path value: {reprStr <| SeLe4n.readReg stReg.machine.regs 7}"
+      match SeLe4n.Kernel.Architecture.adapterWriteRegister runtimeContractDenyAll 7 99 st1 with
+      | .error err => IO.println s!"adapter register write unsupported branch: {reprStr err}"
+      | .ok _ =>
+          IO.println "unexpected adapter register write success under denied contract"
       let allowAll : SeLe4n.Kernel.ServicePolicy := fun _ => true
       let denyAll : SeLe4n.Kernel.ServicePolicy := fun _ => false
       match SeLe4n.Kernel.serviceStart svcApi allowAll st1 with

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A completed; WS-M6-B through WS-M6-E in progress).
+- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A and WS-M6-B completed; WS-M6-C through WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A through WS-M5-F completed).
 - **First real-hardware architecture focus:** Raspberry Pi 5 (post-M6 binding path).
 
@@ -61,7 +61,8 @@ lake exe sele4n
 - `SeLe4n/Kernel/IPC/*.lean` — endpoint IPC semantics and invariants.
 - `SeLe4n/Kernel/Lifecycle/*.lean` — lifecycle/retype semantics and invariants.
 - `SeLe4n/Kernel/Service/*.lean` — service orchestration transitions and policy-surface invariants.
-- `SeLe4n/Kernel/Architecture/Assumptions.lean` — WS-M6-A assumption inventory, typed contract references (`ContractRef`), and architecture-boundary contract skeletons.
+- `SeLe4n/Kernel/Architecture/Assumptions.lean` — WS-M6-A assumption inventory, typed contract references (`ContractRef`), architecture-boundary contract skeletons, and runtime-branch decidability witnesses used by adapters.
+- `SeLe4n/Kernel/Architecture/Adapter.lean` — WS-M6-B deterministic adapter APIs (`adapterAdvanceTimer`, `adapterWriteRegister`, `adapterReadMemory`) with explicit bound-context error mapping.
 - `Main.lean` — executable scenario traces.
 
 ## License

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -5,3 +5,5 @@ import SeLe4n.Model.State
 import SeLe4n.Kernel.API
 
 import SeLe4n.Kernel.Architecture.Assumptions
+
+import SeLe4n.Kernel.Architecture.Adapter

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -10,3 +10,5 @@ import SeLe4n.Kernel.Service.Operations
 import SeLe4n.Kernel.Service.Invariant
 
 import SeLe4n.Kernel.Architecture.Assumptions
+
+import SeLe4n.Kernel.Architecture.Adapter

--- a/SeLe4n/Kernel/Architecture/Adapter.lean
+++ b/SeLe4n/Kernel/Architecture/Adapter.lean
@@ -1,0 +1,125 @@
+import SeLe4n.Kernel.Architecture.Assumptions
+
+namespace SeLe4n.Kernel.Architecture
+
+open SeLe4n.Model
+
+/-- Explicit architecture-binding failure branches for WS-M6-B adapter entrypoints. -/
+inductive AdapterErrorKind where
+  | invalidContext
+  | unsupportedBinding
+  deriving Repr, DecidableEq
+
+/-- Deterministic mapping from adapter failures onto kernel-visible error tags. -/
+def mapAdapterError : AdapterErrorKind → KernelError
+  | .invalidContext => .illegalState
+  | .unsupportedBinding => .notImplemented
+
+/-- Deterministic pure timer projection used by runtime-boundary adapters. -/
+def advanceTimerState (ticks : Nat) (st : SystemState) : SystemState :=
+  { st with machine := { st.machine with timer := st.machine.timer + ticks } }
+
+/-- Deterministic pure register projection used by runtime-boundary adapters. -/
+def writeRegisterState (reg : SeLe4n.RegName) (value : SeLe4n.RegValue) (st : SystemState) : SystemState :=
+  { st with machine := { st.machine with regs := SeLe4n.writeReg st.machine.regs reg value } }
+
+/-- Runtime adapter: advance timer only for non-zero ticks and when contract monotonicity admits the step. -/
+def adapterAdvanceTimer (contract : RuntimeBoundaryContract) (ticks : Nat) : Kernel Unit :=
+  fun st =>
+    if _hTicks : ticks = 0 then
+      .error (mapAdapterError .invalidContext)
+    else
+      let st' := advanceTimerState ticks st
+      letI : Decidable (contract.timerMonotonic st st') := contract.timerMonotonicDecidable st st'
+      if contract.timerMonotonic st st' then
+        .ok ((), st')
+      else
+        .error (mapAdapterError .unsupportedBinding)
+
+/-- Runtime adapter: write a register only when context-stability admits the update. -/
+def adapterWriteRegister
+    (contract : RuntimeBoundaryContract)
+    (reg : SeLe4n.RegName)
+    (value : SeLe4n.RegValue) : Kernel Unit :=
+  fun st =>
+    let st' := writeRegisterState reg value st
+    letI : Decidable (contract.registerContextStable st st') :=
+      contract.registerContextStableDecidable st st'
+    if contract.registerContextStable st st' then
+      .ok ((), st')
+    else
+      .error (mapAdapterError .unsupportedBinding)
+
+/-- Runtime adapter: memory read is admitted only when contract allows the address. -/
+def adapterReadMemory
+    (contract : RuntimeBoundaryContract)
+    (addr : SeLe4n.PAddr) : Kernel UInt8 :=
+  fun st =>
+    letI : Decidable (contract.memoryAccessAllowed st addr) :=
+      contract.memoryAccessAllowedDecidable st addr
+    if contract.memoryAccessAllowed st addr then
+      .ok (SeLe4n.readMem st.machine addr, st)
+    else
+      .error (mapAdapterError .unsupportedBinding)
+
+theorem adapterAdvanceTimer_error_invalidContext
+    (contract : RuntimeBoundaryContract)
+    (st : SystemState) :
+    adapterAdvanceTimer contract 0 st = .error (mapAdapterError .invalidContext) := by
+  simp [adapterAdvanceTimer]
+
+theorem adapterAdvanceTimer_error_unsupportedBinding
+    (contract : RuntimeBoundaryContract)
+    (ticks : Nat)
+    (st : SystemState)
+    (hTicks : ticks ≠ 0)
+    (hReject : ¬ contract.timerMonotonic st (advanceTimerState ticks st)) :
+    adapterAdvanceTimer contract ticks st = .error (mapAdapterError .unsupportedBinding) := by
+  simp [adapterAdvanceTimer, hTicks, hReject]
+
+theorem adapterWriteRegister_error_unsupportedBinding
+    (contract : RuntimeBoundaryContract)
+    (reg : SeLe4n.RegName)
+    (value : SeLe4n.RegValue)
+    (st : SystemState)
+    (hReject : ¬ contract.registerContextStable st (writeRegisterState reg value st)) :
+    adapterWriteRegister contract reg value st = .error (mapAdapterError .unsupportedBinding) := by
+  simp [adapterWriteRegister, hReject]
+
+theorem adapterReadMemory_error_unsupportedBinding
+    (contract : RuntimeBoundaryContract)
+    (addr : SeLe4n.PAddr)
+    (st : SystemState)
+    (hDeny : ¬ contract.memoryAccessAllowed st addr) :
+    adapterReadMemory contract addr st = .error (mapAdapterError .unsupportedBinding) := by
+  simp [adapterReadMemory, hDeny]
+
+theorem adapterReadMemory_ok_returns_machine_byte
+    (contract : RuntimeBoundaryContract)
+    (addr : SeLe4n.PAddr)
+    (st st' : SystemState)
+    (byte : UInt8)
+    (hStep : adapterReadMemory contract addr st = .ok (byte, st')) :
+    st' = st ∧ byte = SeLe4n.readMem st.machine addr := by
+  by_cases hAllow : contract.memoryAccessAllowed st addr
+  · simp [adapterReadMemory, hAllow] at hStep
+    rcases hStep with ⟨hByte, hSt⟩
+    exact ⟨hSt.symm, hByte.symm⟩
+  · simp [adapterReadMemory, hAllow] at hStep
+
+theorem adapterAdvanceTimer_deterministic
+    (contract : RuntimeBoundaryContract)
+    (ticks : Nat)
+    (st st₁ st₂ : SystemState)
+    (h₁ : adapterAdvanceTimer contract ticks st = .ok ((), st₁))
+    (h₂ : adapterAdvanceTimer contract ticks st = .ok ((), st₂)) :
+    st₁ = st₂ := by
+  have hEq : (.ok ((), st₁) : Except KernelError (Unit × SystemState)) = .ok ((), st₂) := by
+    calc
+      (.ok ((), st₁) : Except KernelError (Unit × SystemState)) =
+          adapterAdvanceTimer contract ticks st := by simpa using h₁.symm
+      _ = .ok ((), st₂) := h₂
+  cases hEq
+  rfl
+
+end SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Architecture/Assumptions.lean
+++ b/SeLe4n/Kernel/Architecture/Assumptions.lean
@@ -44,6 +44,9 @@ structure RuntimeBoundaryContract where
   timerMonotonic : SystemState → SystemState → Prop
   registerContextStable : SystemState → SystemState → Prop
   memoryAccessAllowed : SystemState → SeLe4n.PAddr → Prop
+  timerMonotonicDecidable : ∀ st st', Decidable (timerMonotonic st st')
+  registerContextStableDecidable : ∀ st st', Decidable (registerContextStable st st')
+  memoryAccessAllowedDecidable : ∀ st addr, Decidable (memoryAccessAllowed st addr)
 
 /-- Typed interrupt-boundary contract skeleton consumed by IRQ adapter paths. -/
 structure InterruptBoundaryContract where

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -177,8 +177,11 @@ Use this workstream mapping for implementation planning and review checklists:
 1. **WS-M6-A — assumption inventory and boundary extraction** ✅ **completed**
    - architecture assumptions are now explicit interface artifacts in `SeLe4n/Kernel/Architecture/Assumptions.lean` (`ArchAssumption`, `ContractRef`),
    - extracted assumptions are mapped to transition and invariant surfaces for reviewable boundary ownership.
-2. **WS-M6-B — interface API and adapter semantics**
-   - define deterministic adapter behavior with explicit errors.
+2. **WS-M6-B — interface API and adapter semantics** ✅ **completed**
+   - deterministic adapter APIs are now explicit in `SeLe4n/Kernel/Architecture/Adapter.lean`,
+   - unsupported/invalid bound-context cases map through `mapAdapterError`,
+   - runtime contracts carry explicit decidability witnesses for executable branch selection,
+   - boundary state updates are deterministic via `advanceTimerState` and `writeRegisterState`.
 3. **WS-M6-C — proof-layer integration**
    - add local + composed preservation hooks over adapter assumptions.
 4. **WS-M6-D — evidence and test-surface expansion**

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -268,8 +268,10 @@ M6 work is tracked through the following workstreams:
    - architecture-facing assumptions are enumerated in `SeLe4n/Kernel/Architecture/Assumptions.lean` via `ArchAssumption` and `assumptionInventory`,
    - boundary contract skeletons are explicit via `BootBoundaryContract`, `RuntimeBoundaryContract`, and `InterruptBoundaryContract` with first-class `ContractRef` obligations,
    - transition/invariant mapping is captured in `assumptionTransitionMap` and `assumptionInvariantMap`.
-2. **WS-M6-B — interface API + adapter semantics**
-   - implement deterministic adapter behavior with explicit unsupported/invalid branches.
+2. **WS-M6-B — interface API + adapter semantics** ✅ **completed**
+   - deterministic adapter behavior now lands in `SeLe4n/Kernel/Architecture/Adapter.lean`,
+   - unsupported/invalid bound-context branches are explicit via `mapAdapterError` and adapter entrypoints,
+   - runtime boundary contracts provide decidability witnesses so adapter branching is executable.
 3. **WS-M6-C — proof integration**
    - connect adapter assumptions to local and composed invariant preservation theorem surfaces.
 4. **WS-M6-D — evidence + test anchor continuity**

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -45,7 +45,7 @@ M6 scope: **architecture-binding interfaces and hardware-facing assumption harde
 ### M6 workstreams
 
 - **WS-M6-A:** assumption inventory and boundary extraction ✅ completed (`SeLe4n/Kernel/Architecture/Assumptions.lean`),
-- **WS-M6-B:** interface API + adapter semantics,
+- **WS-M6-B:** interface API + adapter semantics ✅ completed (`SeLe4n/Kernel/Architecture/Adapter.lean`),
 - **WS-M6-C:** proof integration with existing bundles,
 - **WS-M6-D:** executable evidence and test-anchor expansion,
 - **WS-M6-E:** documentation synchronization and handoff packaging.
@@ -85,7 +85,7 @@ Verified signals:
 Progress snapshot:
 
 1. architecture assumptions explicit and reviewable ✅ (WS-M6-A complete),
-2. interface artifacts preserve M1–M5 theorem layering (in progress; WS-M6-B/C),
+2. interface artifacts preserve M1–M5 theorem layering (WS-M6-B complete; WS-M6-C in progress),
 3. test obligations added without regressing required gates (in progress; WS-M6-D/E).
 
 ### Gate: M6 → Raspberry Pi 5 binding slice (planned)

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -63,14 +63,15 @@ Implemented touch points:
 
 Outcome: architecture-facing assumptions are isolated into explicit, named interface surfaces (including first-class contract references) and exported for downstream adapter/proof work.
 
-### M6 adapter semantics (WS-M6-B)
+### M6 adapter semantics (WS-M6-B) ✅ **completed**
 
-Likely touch points:
+Implemented touch points:
 
-- operation modules that consume boundary assumptions,
-- `SeLe4n/Kernel/API.lean` for stable export/interface shape.
+- `SeLe4n/Kernel/Architecture/Adapter.lean`
+- `SeLe4n/Kernel/API.lean`
+- `SeLe4n.lean`
 
-Goal: explicit deterministic adapter semantics with failure branches.
+Outcome: explicit deterministic adapter entrypoints compile with bounded failure mapping for invalid/unsupported architecture-bound contexts, using runtime-contract decidability witnesses for executable branch selection.
 
 ### M6 proof integration (WS-M6-C)
 

--- a/docs/gitbook/18-m6-execution-plan-and-workstreams.md
+++ b/docs/gitbook/18-m6-execution-plan-and-workstreams.md
@@ -48,18 +48,18 @@ lift them into explicit interface artifacts.
 **Exit signal**
 - achieved: reviewers can point to a bounded list of assumptions and their interface location.
 
-### WS-M6-B — Interface API and adapter semantics
+### WS-M6-B — Interface API and adapter semantics ✅ **completed**
 
 **Objective:** Define interface APIs that maintain deterministic transition behavior and explicit
 error branching.
 
 **Primary deliverables**
-- architecture-binding adapter API in kernel/model modules,
-- explicit error mapping for unsupported/invalid bound-context cases,
-- deterministic state update semantics at the adapter boundary.
+- architecture-binding adapter API landed in `SeLe4n/Kernel/Architecture/Adapter.lean`,
+- explicit error mapping for unsupported/invalid bound-context cases via `mapAdapterError`,
+- deterministic state update semantics at the adapter boundary via `advanceTimerState` and `writeRegisterState`, with runtime contract decidability witnesses making branches executable.
 
 **Exit signal**
-- adapter entrypoints compile and preserve existing transition-level determinism expectations.
+- achieved: adapter entrypoints compile and preserve transition-level determinism expectations (`adapterAdvanceTimer_deterministic`).
 
 ### WS-M6-C — Proof-layer integration
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A complete; WS-M6-B through WS-M6-E in progress).
+- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A and WS-M6-B complete; WS-M6-C through WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces.
 - **First real hardware architecture focus:** Raspberry Pi 5 (post-M6 binding trajectory).
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.7.3"
+version = "0.7.5"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -9,9 +9,20 @@ parse_common_args "$@"
 cd "${REPO_ROOT}"
 
 # M6 WS-M6-A assumption inventory anchors.
+# M6 WS-M6-B adapter API anchors.
+run_check "INVARIANT" rg -n '^inductive AdapterErrorKind' SeLe4n/Kernel/Architecture/Adapter.lean
+run_check "INVARIANT" rg -n '^def mapAdapterError' SeLe4n/Kernel/Architecture/Adapter.lean
+run_check "INVARIANT" rg -n '^def adapterAdvanceTimer' SeLe4n/Kernel/Architecture/Adapter.lean
+run_check "INVARIANT" rg -n '^def adapterWriteRegister' SeLe4n/Kernel/Architecture/Adapter.lean
+run_check "INVARIANT" rg -n '^def adapterReadMemory' SeLe4n/Kernel/Architecture/Adapter.lean
+run_check "INVARIANT" rg -n '^theorem adapterAdvanceTimer_deterministic' SeLe4n/Kernel/Architecture/Adapter.lean
+
 run_check "INVARIANT" rg -n '^inductive ArchAssumption' SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^structure BootBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^structure RuntimeBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n "^\s*timerMonotonicDecidable\s*:" SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n "^\s*registerContextStableDecidable\s*:" SeLe4n/Kernel/Architecture/Assumptions.lean
+run_check "INVARIANT" rg -n "^\s*memoryAccessAllowedDecidable\s*:" SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^structure InterruptBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^inductive ContractRef' SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^def assumptionContractMap' SeLe4n/Kernel/Architecture/Assumptions.lean
@@ -203,6 +214,19 @@ run_check "INVARIANT" rg -n '^theorem serviceRestart_stop_failure_preserves_serv
 run_check "INVARIANT" rg -n '^theorem serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
 
 # M3.5 step-7 executable demonstration closure anchors.
+run_check "TRACE" rg -n 'adapter timer success path value' Main.lean
+run_check "TRACE" rg -n 'adapter timer invalid-context branch' Main.lean
+run_check "TRACE" rg -n 'adapter timer unsupported branch' Main.lean
+run_check "TRACE" rg -n 'adapter read denied branch' Main.lean
+run_check "TRACE" rg -n 'adapter read success path byte' Main.lean
+run_check "TRACE" rg -n 'adapter register write success path value' Main.lean
+run_check "TRACE" rg -n 'adapter register write unsupported branch' Main.lean
+run_check "TRACE" rg -n 'adapter timer invalid-context branch: SeLe4n.Model.KernelError.illegalState' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'adapter timer unsupported branch: SeLe4n.Model.KernelError.notImplemented' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'adapter read denied branch: SeLe4n.Model.KernelError.notImplemented' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'adapter read success path byte: 0' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'adapter register write success path value: 99' tests/fixtures/main_trace_smoke.expected
+run_check "TRACE" rg -n 'adapter register write unsupported branch: SeLe4n.Model.KernelError.notImplemented' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'endpointAwaitReceive demoEndpoint 2' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' Main.lean
 run_check "TRACE" rg -n 'handshake send matched waiting receiver' tests/fixtures/main_trace_smoke.expected

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -1,5 +1,12 @@
 scheduled thread: some 1
-source cap rights before mint:
+source cap rights before mint: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]
+adapter timer success path value: 2
+adapter timer invalid-context branch: SeLe4n.Model.KernelError.illegalState
+adapter timer unsupported branch: SeLe4n.Model.KernelError.notImplemented
+adapter read denied branch: SeLe4n.Model.KernelError.notImplemented
+adapter read success path byte: 0
+adapter register write success path value: 99
+adapter register write unsupported branch: SeLe4n.Model.KernelError.notImplemented
 service start api status: some (SeLe4n.Model.ServiceStatus.running)
 service start denied branch: SeLe4n.Model.KernelError.policyDenied
 service start dependency branch: SeLe4n.Model.KernelError.dependencyViolation
@@ -24,4 +31,4 @@ queued two senders on endpoint
 endpoint receive #1 sender: 1
 endpoint receive #2 sender: 2
 endpoint receive #3 (expected mismatch): SeLe4n.Model.KernelError.endpointStateMismatch
-minted cap rights:
+minted cap rights: [SeLe4n.Model.AccessRight.read]


### PR DESCRIPTION
I completed a deeper audit/refinement pass on the prior WS‑M6‑B work and simplified the adapter API design by moving decidability witnesses into RuntimeBoundaryContract, so adapter branches are executable without passing deciders at each call site. 

I refactored the adapter module to consume those contract-carried witnesses directly in adapterAdvanceTimer, adapterWriteRegister, and adapterReadMemory, while preserving explicit invalid/unsupported error mapping and deterministic theorem coverage (adapterAdvanceTimer_deterministic). 

I expanded executable WS‑M6‑B evidence in Main.lean to cover both success and failure for timer, memory-read, and register-write adapter paths, and updated the smoke fixture accordingly. 

I strengthened Tier-3 regression coverage by adding adapter trace anchors for all new WS‑M6‑B evidence lines (including expected error tags). 

I kept docs synced with this refined model by explicitly noting executable branching via runtime contract decidability witnesses in the repo map and M6 execution plan text. 
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937caee91c832b8f61589b7bc4d45d)