### PR TITLE
Sync WS-M6-C proof-layer, export invariant surface, and harden Tier-3 doc anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A and WS-M6-B completed; WS-M6-C through WS-M6-E in progress).
+- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-C completed; WS-M6-D and WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A through WS-M5-F completed).
 - **First real-hardware architecture focus:** Raspberry Pi 5 (post-M6 binding path).
 
@@ -63,6 +63,7 @@ lake exe sele4n
 - `SeLe4n/Kernel/Service/*.lean` — service orchestration transitions and policy-surface invariants.
 - `SeLe4n/Kernel/Architecture/Assumptions.lean` — WS-M6-A assumption inventory, typed contract references (`ContractRef`), architecture-boundary contract skeletons, and runtime-branch decidability witnesses used by adapters.
 - `SeLe4n/Kernel/Architecture/Adapter.lean` — WS-M6-B deterministic adapter APIs (`adapterAdvanceTimer`, `adapterWriteRegister`, `adapterReadMemory`) with explicit bound-context error mapping.
+- `SeLe4n/Kernel/Architecture/Invariant.lean` — WS-M6-C proof-layer integration hooks (`proofLayerInvariantBundle`) and local/composed preservation theorems for adapter success/failure paths.
 - `Main.lean` — executable scenario traces.
 
 ## License

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -7,3 +7,4 @@ import SeLe4n.Kernel.API
 import SeLe4n.Kernel.Architecture.Assumptions
 
 import SeLe4n.Kernel.Architecture.Adapter
+import SeLe4n.Kernel.Architecture.Invariant

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -12,3 +12,4 @@ import SeLe4n.Kernel.Service.Invariant
 import SeLe4n.Kernel.Architecture.Assumptions
 
 import SeLe4n.Kernel.Architecture.Adapter
+import SeLe4n.Kernel.Architecture.Invariant

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -1,0 +1,136 @@
+import SeLe4n.Kernel.Architecture.Adapter
+import SeLe4n.Kernel.Service.Invariant
+
+namespace SeLe4n.Kernel.Architecture
+
+open SeLe4n.Model
+open SeLe4n.Kernel
+
+/-- WS-M6-C composed theorem surface: architecture-adapter hooks over all active invariant bundles. -/
+def proofLayerInvariantBundle (st : SystemState) : Prop :=
+  schedulerInvariantBundle st ∧
+    capabilityInvariantBundle st ∧
+    m3IpcSeedInvariantBundle st ∧
+    m35IpcSchedulerInvariantBundle st ∧
+    lifecycleInvariantBundle st ∧
+    serviceLifecycleCapabilityInvariantBundle st
+
+/-- Proof-carrying local preservation hooks required to compose adapter paths with invariant bundles. -/
+structure AdapterProofHooks (contract : RuntimeBoundaryContract) where
+  preserveAdvanceTimer :
+    ∀ ticks st,
+      proofLayerInvariantBundle st →
+      contract.timerMonotonic st (advanceTimerState ticks st) →
+      ticks ≠ 0 →
+      proofLayerInvariantBundle (advanceTimerState ticks st)
+  preserveWriteRegister :
+    ∀ reg value st,
+      proofLayerInvariantBundle st →
+      contract.registerContextStable st (writeRegisterState reg value st) →
+      proofLayerInvariantBundle (writeRegisterState reg value st)
+  preserveReadMemory :
+    ∀ addr st,
+      proofLayerInvariantBundle st →
+      contract.memoryAccessAllowed st addr →
+      proofLayerInvariantBundle st
+
+theorem adapterAdvanceTimer_ok_preserves_proofLayerInvariantBundle
+    (contract : RuntimeBoundaryContract)
+    (hooks : AdapterProofHooks contract)
+    (ticks : Nat)
+    (st st' : SystemState)
+    (hInv : proofLayerInvariantBundle st)
+    (hStep : adapterAdvanceTimer contract ticks st = .ok ((), st')) :
+    proofLayerInvariantBundle st' := by
+  by_cases hTicks : ticks = 0
+  · have hErr := adapterAdvanceTimer_error_invalidContext contract st
+    subst ticks
+    rw [hErr] at hStep
+    simp at hStep
+  · by_cases hMono : contract.timerMonotonic st (advanceTimerState ticks st)
+    · simp [adapterAdvanceTimer, hTicks, hMono] at hStep
+      cases hStep
+      exact hooks.preserveAdvanceTimer ticks st hInv hMono hTicks
+    · have hErr :=
+        adapterAdvanceTimer_error_unsupportedBinding contract ticks st hTicks hMono
+      rw [hErr] at hStep
+      simp at hStep
+
+theorem adapterWriteRegister_ok_preserves_proofLayerInvariantBundle
+    (contract : RuntimeBoundaryContract)
+    (hooks : AdapterProofHooks contract)
+    (reg : SeLe4n.RegName)
+    (value : SeLe4n.RegValue)
+    (st st' : SystemState)
+    (hInv : proofLayerInvariantBundle st)
+    (hStep : adapterWriteRegister contract reg value st = .ok ((), st')) :
+    proofLayerInvariantBundle st' := by
+  by_cases hStable : contract.registerContextStable st (writeRegisterState reg value st)
+  · simp [adapterWriteRegister, hStable] at hStep
+    cases hStep
+    exact hooks.preserveWriteRegister reg value st hInv hStable
+  · have hErr :=
+      adapterWriteRegister_error_unsupportedBinding contract reg value st hStable
+    rw [hErr] at hStep
+    simp at hStep
+
+theorem adapterReadMemory_ok_preserves_proofLayerInvariantBundle
+    (contract : RuntimeBoundaryContract)
+    (hooks : AdapterProofHooks contract)
+    (addr : SeLe4n.PAddr)
+    (st st' : SystemState)
+    (byte : UInt8)
+    (hInv : proofLayerInvariantBundle st)
+    (hStep : adapterReadMemory contract addr st = .ok (byte, st')) :
+    proofLayerInvariantBundle st' := by
+  rcases adapterReadMemory_ok_returns_machine_byte contract addr st st' byte hStep with ⟨hStEq, _⟩
+  subst st'
+  have hAllow : contract.memoryAccessAllowed st addr := by
+    by_cases hAllowed : contract.memoryAccessAllowed st addr
+    · exact hAllowed
+    · have hErr := adapterReadMemory_error_unsupportedBinding contract addr st hAllowed
+      rw [hErr] at hStep
+      simp at hStep
+  exact hooks.preserveReadMemory addr st hInv hAllow
+
+theorem adapterAdvanceTimer_error_invalidContext_preserves_proofLayerInvariantBundle
+    (contract : RuntimeBoundaryContract)
+    (st : SystemState)
+    (hInv : proofLayerInvariantBundle st)
+    (_hErr : adapterAdvanceTimer contract 0 st = .error (mapAdapterError .invalidContext)) :
+    proofLayerInvariantBundle st :=
+  hInv
+
+theorem adapterAdvanceTimer_error_unsupportedBinding_preserves_proofLayerInvariantBundle
+    (contract : RuntimeBoundaryContract)
+    (ticks : Nat)
+    (st : SystemState)
+    (hInv : proofLayerInvariantBundle st)
+    (_hTicks : ticks ≠ 0)
+    (_hReject : ¬ contract.timerMonotonic st (advanceTimerState ticks st))
+    (_hErr : adapterAdvanceTimer contract ticks st = .error (mapAdapterError .unsupportedBinding)) :
+    proofLayerInvariantBundle st :=
+  hInv
+
+theorem adapterWriteRegister_error_unsupportedBinding_preserves_proofLayerInvariantBundle
+    (contract : RuntimeBoundaryContract)
+    (reg : SeLe4n.RegName)
+    (value : SeLe4n.RegValue)
+    (st : SystemState)
+    (hInv : proofLayerInvariantBundle st)
+    (_hReject : ¬ contract.registerContextStable st (writeRegisterState reg value st))
+    (_hErr : adapterWriteRegister contract reg value st = .error (mapAdapterError .unsupportedBinding)) :
+    proofLayerInvariantBundle st :=
+  hInv
+
+theorem adapterReadMemory_error_unsupportedBinding_preserves_proofLayerInvariantBundle
+    (contract : RuntimeBoundaryContract)
+    (addr : SeLe4n.PAddr)
+    (st : SystemState)
+    (hInv : proofLayerInvariantBundle st)
+    (_hDeny : ¬ contract.memoryAccessAllowed st addr)
+    (_hErr : adapterReadMemory contract addr st = .error (mapAdapterError .unsupportedBinding)) :
+    proofLayerInvariantBundle st :=
+  hInv
+
+end SeLe4n.Kernel.Architecture

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -182,8 +182,8 @@ Use this workstream mapping for implementation planning and review checklists:
    - unsupported/invalid bound-context cases map through `mapAdapterError`,
    - runtime contracts carry explicit decidability witnesses for executable branch selection,
    - boundary state updates are deterministic via `advanceTimerState` and `writeRegisterState`.
-3. **WS-M6-C — proof-layer integration**
-   - add local + composed preservation hooks over adapter assumptions.
+3. **WS-M6-C — proof-layer integration** ✅ **completed**
+   - local + composed preservation hooks over adapter assumptions are implemented in `SeLe4n/Kernel/Architecture/Invariant.lean` (`proofLayerInvariantBundle` and adapter preservation/failure theorems).
 4. **WS-M6-D — evidence and test-surface expansion**
    - expand executable traces and symbol anchors for boundary behavior.
 5. **WS-M6-E — docs and handoff packaging**

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -63,7 +63,7 @@ Framework quality properties verified:
 
 Current documentation set is synchronized around:
 
-- **Current slice:** M6 architecture-binding interfaces + assumption hardening.
+- **Current slice:** M6 architecture-binding interfaces + assumption hardening with WS-M6-A through WS-M6-C completed and WS-M6-D/WS-M6-E in progress.
 - **Most recently completed slice:** M5 service-graph + policy surfaces.
 - **Historical context:** M4-B completion retained as predecessor reference.
 - **Forward path:** M6 workstreams and post-M6 hardware trajectory are documented and linked.
@@ -114,9 +114,9 @@ This obligation-based model is the correct notion of “full” for this reposit
 
 ### 6.1 Near-term (M6)
 
-- Architecture-assumption interfaces are now explicit with theorem-friendly contracts (WS-M6-A completed); continue adapter/proof integration follow-through.
-- Preserve composability with already-closed M1–M5 invariant bundles.
-- Add assumption-boundary scenarios to executable traces as each interface lands.
+- Architecture-assumption interfaces and adapter proof-layer integration are now explicit and exported (WS-M6-A through WS-M6-C completed).
+- Preserve composability with already-closed M1–M5 invariant bundles while advancing WS-M6-D evidence expansion.
+- Add assumption-boundary scenarios and anchors to executable traces as remaining M6 interfaces/evidence land.
 
 ### 6.2 Mid-term (post-M6 pre-hardware)
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -272,8 +272,8 @@ M6 work is tracked through the following workstreams:
    - deterministic adapter behavior now lands in `SeLe4n/Kernel/Architecture/Adapter.lean`,
    - unsupported/invalid bound-context branches are explicit via `mapAdapterError` and adapter entrypoints,
    - runtime boundary contracts provide decidability witnesses so adapter branching is executable.
-3. **WS-M6-C — proof integration**
-   - connect adapter assumptions to local and composed invariant preservation theorem surfaces.
+3. **WS-M6-C — proof integration** ✅ **completed**
+   - adapter assumptions are connected to local and composed invariant-preservation hooks in `SeLe4n/Kernel/Architecture/Invariant.lean` via `proofLayerInvariantBundle` and adapter-path preservation theorems.
 4. **WS-M6-D — evidence + test anchor continuity**
    - extend executable traces, fixtures, and Tier 3 symbol checks for new claims.
 5. **WS-M6-E — docs + handoff packaging**

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path after M5 closeout.
 
-Current stage context: **M5 service-graph + policy surface delivery is complete (WS-M5-A through WS-M5-F complete); testing now gates M6 architecture-binding prep without regressing M1–M5 contracts**.
+Current stage context: **M5 service-graph + policy surface delivery is complete (WS-M5-A through WS-M5-F complete); M6 WS-M6-A through WS-M6-C are complete and testing now gates WS-M6-D/WS-M6-E completion without regressing M1–M5 contracts**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -46,7 +46,7 @@ M6 scope: **architecture-binding interfaces and hardware-facing assumption harde
 
 - **WS-M6-A:** assumption inventory and boundary extraction ✅ completed (`SeLe4n/Kernel/Architecture/Assumptions.lean`),
 - **WS-M6-B:** interface API + adapter semantics ✅ completed (`SeLe4n/Kernel/Architecture/Adapter.lean`),
-- **WS-M6-C:** proof integration with existing bundles,
+- **WS-M6-C:** proof integration with existing bundles ✅ completed (`SeLe4n/Kernel/Architecture/Invariant.lean`),
 - **WS-M6-D:** executable evidence and test-anchor expansion,
 - **WS-M6-E:** documentation synchronization and handoff packaging.
 
@@ -85,7 +85,7 @@ Verified signals:
 Progress snapshot:
 
 1. architecture assumptions explicit and reviewable ✅ (WS-M6-A complete),
-2. interface artifacts preserve M1–M5 theorem layering (WS-M6-B complete; WS-M6-C in progress),
+2. interface artifacts preserve M1–M5 theorem layering ✅ (WS-M6-B and WS-M6-C complete),
 3. test obligations added without regressing required gates (in progress; WS-M6-D/E).
 
 ### Gate: M6 → Raspberry Pi 5 binding slice (planned)

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -73,14 +73,15 @@ Implemented touch points:
 
 Outcome: explicit deterministic adapter entrypoints compile with bounded failure mapping for invalid/unsupported architecture-bound contexts, using runtime-contract decidability witnesses for executable branch selection.
 
-### M6 proof integration (WS-M6-C)
+### M6 proof integration (WS-M6-C) ✅ **completed**
 
-Likely touch points:
+Implemented touch points:
 
-- `*/Invariant.lean` modules,
-- composed bundle entrypoints in service/lifecycle/capability integrations.
+- `SeLe4n/Kernel/Architecture/Invariant.lean`,
+- `SeLe4n/Kernel/API.lean`,
+- `SeLe4n.lean`.
 
-Goal: local + composed preservation hooks over adapter assumptions.
+Outcome: adapter assumptions are connected to theorem-layer invariants through `proofLayerInvariantBundle`, with explicit local/composed preservation hooks for success and denied/unsupported failure paths.
 
 ### M6 evidence expansion (WS-M6-D)
 

--- a/docs/gitbook/18-m6-execution-plan-and-workstreams.md
+++ b/docs/gitbook/18-m6-execution-plan-and-workstreams.md
@@ -61,18 +61,18 @@ error branching.
 **Exit signal**
 - achieved: adapter entrypoints compile and preserve transition-level determinism expectations (`adapterAdvanceTimer_deterministic`).
 
-### WS-M6-C — Proof-layer integration
+### WS-M6-C — Proof-layer integration ✅ **completed**
 
 **Objective:** Integrate adapter assumptions with existing theorem bundles (scheduler,
 capability, IPC, lifecycle, service).
 
 **Primary deliverables**
-- local preservation theorems for boundary-facing operations,
-- composed preservation hooks from adapter contracts into bundle-level invariants,
-- explicit failure-path preservation statements for denied/unsupported adapter conditions.
+- local preservation theorems for boundary-facing operations are implemented in `SeLe4n/Kernel/Architecture/Invariant.lean`,
+- composed preservation hooks from adapter contracts into bundle-level invariants are exposed through `proofLayerInvariantBundle`,
+- explicit failure-path preservation statements exist for denied/unsupported adapter conditions (`adapterAdvanceTimer_error_invalidContext_preserves_proofLayerInvariantBundle`, `adapterAdvanceTimer_error_unsupportedBinding_preserves_proofLayerInvariantBundle`, `adapterWriteRegister_error_unsupportedBinding_preserves_proofLayerInvariantBundle`, `adapterReadMemory_error_unsupportedBinding_preserves_proofLayerInvariantBundle`).
 
 **Exit signal**
-- new theorem surfaces are importable without reworking M1–M5 invariant layout.
+- achieved: theorem surfaces are importable via `SeLe4n/Kernel/API.lean` and `SeLe4n.lean` without reworking M1–M5 invariant layout.
 
 ### WS-M6-D — Evidence, traces, and test anchors
 
@@ -108,7 +108,7 @@ handoff.
 |---|---|---|---|
 | Explicit architecture assumptions | WS-M6-A, WS-M6-E | `lake build`, `./scripts/test_tier3_invariant_surface.sh` | Interfaces and symbols are discoverable and anchored |
 | Adapter semantics and error handling | WS-M6-B | `./scripts/test_fast.sh`, `lake exe sele4n` | Deterministic success/failure behavior is executable |
-| Proof compositionality across boundary | WS-M6-C | `lake build`, `./scripts/test_full.sh` | Local + composed theorems compile and remain layered |
+| Proof compositionality across boundary | WS-M6-C ✅ completed | `lake build`, `./scripts/test_full.sh` | Local + composed theorems compile and remain layered |
 | Regression-safe evidence growth | WS-M6-D | `./scripts/test_smoke.sh`, `./scripts/test_nightly.sh` | Fixture and nightly checks validate expected traces |
 | Slice handoff coherence | WS-M6-E | docs review + CI-required set | Spec/README/DEVELOPMENT/GitBook all match |
 

--- a/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
+++ b/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
@@ -53,9 +53,9 @@ The framework self-audit confirms both sides of correctness:
 
 As M6 progresses:
 
-1. introduce architecture-bound interfaces with explicit contracts,
-2. attach each new contract to theorem/invariant obligations,
-3. expand executable fixtures for assumption-boundary behaviors,
-4. keep documentation synchronized in the same PR as any stage change.
+1. keep architecture-bound interfaces and proof-layer obligations synchronized (WS-M6-A through WS-M6-C now complete),
+2. expand executable fixtures for assumption-boundary behaviors (WS-M6-D focus),
+3. keep documentation synchronized in the same PR as any stage change (WS-M6-E focus),
+4. preserve deterministic replay and anchor discoverability as hard non-regression gates.
 
 This preserves continuity from M5 completion while safely increasing architecture realism.

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A and WS-M6-B complete; WS-M6-C through WS-M6-E in progress).
+- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-C complete; WS-M6-D and WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces.
 - **First real hardware architecture focus:** Raspberry Pi 5 (post-M6 binding trajectory).
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.7.5"
+version = "0.7.6"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -16,6 +16,17 @@ run_check "INVARIANT" rg -n '^def adapterAdvanceTimer' SeLe4n/Kernel/Architectur
 run_check "INVARIANT" rg -n '^def adapterWriteRegister' SeLe4n/Kernel/Architecture/Adapter.lean
 run_check "INVARIANT" rg -n '^def adapterReadMemory' SeLe4n/Kernel/Architecture/Adapter.lean
 run_check "INVARIANT" rg -n '^theorem adapterAdvanceTimer_deterministic' SeLe4n/Kernel/Architecture/Adapter.lean
+run_check "INVARIANT" rg -n '^def proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^structure AdapterProofHooks' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem adapterAdvanceTimer_ok_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem adapterWriteRegister_ok_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem adapterReadMemory_ok_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem adapterAdvanceTimer_error_invalidContext_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem adapterAdvanceTimer_error_unsupportedBinding_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem adapterWriteRegister_error_unsupportedBinding_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem adapterReadMemory_error_unsupportedBinding_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
+run_check "INVARIANT" rg -n '^import SeLe4n\.Kernel\.Architecture\.Invariant$' SeLe4n/Kernel/API.lean
+run_check "INVARIANT" rg -n '^import SeLe4n\.Kernel\.Architecture\.Invariant$' SeLe4n.lean
 
 run_check "INVARIANT" rg -n '^inductive ArchAssumption' SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^structure BootBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean
@@ -271,6 +282,9 @@ run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete|WS-A \+ WS-B \+ WS-C \+ WS-D \+ WS-E complete|WS-A/WS-B/WS-C/WS-D/WS-E are complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md
 run_check "DOC" rg -n 'Active slice:.*M6|Current slice:.*M6|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-m5-closeout-snapshot.md
+run_check "DOC" rg -n 'WS-M6-A through WS-M6-C completed|WS-M6-D/WS-M6-E in progress' docs/PROJECT_AUDIT.md
+run_check "DOC" rg -n 'WS-M6-A through WS-M6-C now complete|WS-M6-D focus|WS-M6-E focus' docs/gitbook/19-end-to-end-audit-and-quality-gates.md
+run_check "DOC" rg -n 'M6 WS-M6-A through WS-M6-C are complete|WS-M6-D/WS-M6-E completion' docs/TESTING_FRAMEWORK_PLAN.md
 run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md
 run_check "DOC" rg -n 'WS-M5-D|WS-M5-E|proof package ✅ \*\*completed\*\*|Evidence and validation ✅ \*\*completed\*\*|WS-M5-A/B/C/D/E complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
 run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-m5-closeout-snapshot.md


### PR DESCRIPTION
### Motivation
- Surface the WS-M6-C proof-layer so adapter-level assumptions can be composed with existing invariant bundles and be importable via the public API and top-level `SeLe4n.lean`.
- Prevent roadmap/claim drift by converting M6 status statements into CI-enforced anchors so documentation and GitBook remain synchronized with code.
- Ensure downstream consumers and CI can discover the new theorem anchors and that milestone metadata (version) reflects the new surface.

### Description
- Add `SeLe4n/Kernel/Architecture/Invariant.lean` implementing `proofLayerInvariantBundle`, the `AdapterProofHooks` structure, success-path preservation theorems (`adapterAdvanceTimer_ok_preserves_proofLayerInvariantBundle`, `adapterWriteRegister_ok_preserves_proofLayerInvariantBundle`, `adapterReadMemory_ok_preserves_proofLayerInvariantBundle`) and failure-path preservation lemmas for denied/unsupported adapter outcomes (explicit theorem names included in the file).
- Export the new proof surface by importing `SeLe4n.Kernel.Architecture.Invariant` from `SeLe4n/Kernel/API.lean` and `SeLe4n.lean` so the surface is reachable from public entrypoints.
- Tighten CI anchors and Tier-3 checks in `scripts/test_tier3_invariant_surface.sh` to verify presence of the new theorem names and to assert synchronized M6 status lines across `docs/PROJECT_AUDIT.md`, `docs/TESTING_FRAMEWORK_PLAN.md`, and GitBook pages.
- Update documentation and GitBook text to reflect that `WS-M6-A` through `WS-M6-C` are complete and that `WS-M6-D`/`WS-M6-E` are in progress, and bump package `version` in `lakefile.toml` from `0.7.5` to `0.7.6`.

### Testing
- Built the full project with `lake build` and the build completed successfully (40 jobs) and the new module compiles within the module graph (PASS).
- Executed the project binary with `lake exe sele4n` and validated expected trace output (no runtime errors) (PASS).
- Ran the Tier-3 invariant/doc-surface checker `./scripts/test_tier3_invariant_surface.sh` and all added anchors (theorem names and doc status lines) passed (PASS).
- Executed the full nightly stack `./scripts/test_nightly.sh` (which runs `test_full.sh`, `test_smoke.sh`, and Tier 4 gating) and all scripted checks passed (PASS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938c22274c832b946442e796d67cb6)