### PR TITLE
Harden M6 doc-sync gates; assert WS‑M6‑D complete and tighten Tier‑3 checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-C completed; WS-M6-D and WS-M6-E in progress).
+- **Active slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-D completed; WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces (WS-M5-A through WS-M5-F completed).
 - **First real-hardware architecture focus:** Raspberry Pi 5 (post-M6 binding path).
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -184,8 +184,10 @@ Use this workstream mapping for implementation planning and review checklists:
    - boundary state updates are deterministic via `advanceTimerState` and `writeRegisterState`.
 3. **WS-M6-C — proof-layer integration** ✅ **completed**
    - local + composed preservation hooks over adapter assumptions are implemented in `SeLe4n/Kernel/Architecture/Invariant.lean` (`proofLayerInvariantBundle` and adapter preservation/failure theorems).
-4. **WS-M6-D — evidence and test-surface expansion**
-   - expand executable traces and symbol anchors for boundary behavior.
+4. **WS-M6-D — evidence and test-surface expansion** ✅ **completed**
+   - executable trace coverage now includes boundary success/failure branches in `Main.lean`,
+   - fixture semantics and rationale are documented in `tests/scenarios/README.md` and anchored by `tests/fixtures/main_trace_smoke.expected`,
+   - Tier 3 symbol/trace anchors now gate architecture-boundary evidence continuity.
 5. **WS-M6-E — docs and handoff packaging**
    - keep README/spec/development/GitBook synchronized.
 

--- a/docs/PROJECT_AUDIT.md
+++ b/docs/PROJECT_AUDIT.md
@@ -63,7 +63,7 @@ Framework quality properties verified:
 
 Current documentation set is synchronized around:
 
-- **Current slice:** M6 architecture-binding interfaces + assumption hardening with WS-M6-A through WS-M6-C completed and WS-M6-D/WS-M6-E in progress.
+- **Current slice:** M6 architecture-binding interfaces + assumption hardening with WS-M6-A through WS-M6-D completed and WS-M6-E in progress.
 - **Most recently completed slice:** M5 service-graph + policy surfaces.
 - **Historical context:** M4-B completion retained as predecessor reference.
 - **Forward path:** M6 workstreams and post-M6 hardware trajectory are documented and linked.
@@ -115,8 +115,8 @@ This obligation-based model is the correct notion of “full” for this reposit
 ### 6.1 Near-term (M6)
 
 - Architecture-assumption interfaces and adapter proof-layer integration are now explicit and exported (WS-M6-A through WS-M6-C completed).
-- Preserve composability with already-closed M1–M5 invariant bundles while advancing WS-M6-D evidence expansion.
-- Add assumption-boundary scenarios and anchors to executable traces as remaining M6 interfaces/evidence land.
+- WS-M6-D evidence expansion is now closed with boundary success/failure trace anchors and fixture-backed semantics.
+- Preserve composability with already-closed M1–M5 invariant bundles while advancing WS-M6-E documentation/handoff completion.
 
 ### 6.2 Mid-term (post-M6 pre-hardware)
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -274,9 +274,9 @@ M6 work is tracked through the following workstreams:
    - runtime boundary contracts provide decidability witnesses so adapter branching is executable.
 3. **WS-M6-C — proof integration** ✅ **completed**
    - adapter assumptions are connected to local and composed invariant-preservation hooks in `SeLe4n/Kernel/Architecture/Invariant.lean` via `proofLayerInvariantBundle` and adapter-path preservation theorems.
-4. **WS-M6-D — evidence + test anchor continuity**
+4. **WS-M6-D — evidence + test anchor continuity** ✅ **completed**
    - extend executable traces, fixtures, and Tier 3 symbol checks for new claims.
-5. **WS-M6-E — docs + handoff packaging**
+5. **WS-M6-E — docs + handoff packaging** (in progress)
    - synchronize roadmap and stage markers across root docs and GitBook.
 
 ### 6.6 Post-M6 first-hardware target

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,7 +4,7 @@
 
 This document defines the active testing baseline and near-term expansion path after M5 closeout.
 
-Current stage context: **M5 service-graph + policy surface delivery is complete (WS-M5-A through WS-M5-F complete); M6 WS-M6-A through WS-M6-C are complete and testing now gates WS-M6-D/WS-M6-E completion without regressing M1–M5 contracts**.
+Current stage context: **M5 service-graph + policy surface delivery is complete (WS-M5-A through WS-M5-F complete); M6 WS-M6-A through WS-M6-D are complete and testing now gates WS-M6-E completion without regressing M1–M5 contracts**.
 
 ## 2. Current enforced tiers
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -47,8 +47,8 @@ M6 scope: **architecture-binding interfaces and hardware-facing assumption harde
 - **WS-M6-A:** assumption inventory and boundary extraction ✅ completed (`SeLe4n/Kernel/Architecture/Assumptions.lean`),
 - **WS-M6-B:** interface API + adapter semantics ✅ completed (`SeLe4n/Kernel/Architecture/Adapter.lean`),
 - **WS-M6-C:** proof integration with existing bundles ✅ completed (`SeLe4n/Kernel/Architecture/Invariant.lean`),
-- **WS-M6-D:** executable evidence and test-anchor expansion,
-- **WS-M6-E:** documentation synchronization and handoff packaging.
+- **WS-M6-D:** executable evidence and test-anchor expansion ✅ completed (`Main.lean`, `tests/fixtures/main_trace_smoke.expected`, `scripts/test_tier3_invariant_surface.sh`),
+- **WS-M6-E:** documentation synchronization and handoff packaging (in progress).
 
 Detailed execution guidance: [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md).
 
@@ -86,7 +86,7 @@ Progress snapshot:
 
 1. architecture assumptions explicit and reviewable ✅ (WS-M6-A complete),
 2. interface artifacts preserve M1–M5 theorem layering ✅ (WS-M6-B and WS-M6-C complete),
-3. test obligations added without regressing required gates (in progress; WS-M6-D/E).
+3. test obligations added without regressing required gates ✅ (WS-M6-D complete; WS-M6-E in progress).
 
 ### Gate: M6 → Raspberry Pi 5 binding slice (planned)
 

--- a/docs/gitbook/18-m6-execution-plan-and-workstreams.md
+++ b/docs/gitbook/18-m6-execution-plan-and-workstreams.md
@@ -74,18 +74,18 @@ capability, IPC, lifecycle, service).
 **Exit signal**
 - achieved: theorem surfaces are importable via `SeLe4n/Kernel/API.lean` and `SeLe4n.lean` without reworking M1–M5 invariant layout.
 
-### WS-M6-D — Evidence, traces, and test anchors
+### WS-M6-D — Evidence, traces, and test anchors ✅ **completed**
 
 **Objective:** Expand evidence so boundary assumptions and failure branches are executable and
 regression-checked.
 
 **Primary deliverables**
-- `Main.lean` scenario growth where boundary behavior is externally visible,
-- fixture updates with semantic intent notes,
-- Tier 3 anchor updates for new theorem/invariant/API claims.
+- `Main.lean` scenario growth where architecture-boundary success/failure behavior is externally visible (`adapterAdvanceTimer`, `adapterReadMemory`, `adapterWriteRegister` branches),
+- fixture updates with semantic intent notes in `tests/scenarios/README.md` and stabilized evidence fragments in `tests/fixtures/main_trace_smoke.expected`,
+- Tier 3 anchor updates in `scripts/test_tier3_invariant_surface.sh` for new theorem/invariant/API and trace claims.
 
 **Exit signal**
-- evidence demonstrates both expected success path and bounded failure semantics.
+- achieved: evidence demonstrates both expected success path and bounded failure semantics.
 
 ### WS-M6-E — Documentation and handoff packaging
 
@@ -109,7 +109,7 @@ handoff.
 | Explicit architecture assumptions | WS-M6-A, WS-M6-E | `lake build`, `./scripts/test_tier3_invariant_surface.sh` | Interfaces and symbols are discoverable and anchored |
 | Adapter semantics and error handling | WS-M6-B | `./scripts/test_fast.sh`, `lake exe sele4n` | Deterministic success/failure behavior is executable |
 | Proof compositionality across boundary | WS-M6-C ✅ completed | `lake build`, `./scripts/test_full.sh` | Local + composed theorems compile and remain layered |
-| Regression-safe evidence growth | WS-M6-D | `./scripts/test_smoke.sh`, `./scripts/test_nightly.sh` | Fixture and nightly checks validate expected traces |
+| Regression-safe evidence growth | WS-M6-D ✅ completed | `./scripts/test_smoke.sh`, `./scripts/test_nightly.sh` | Fixture and nightly checks validate expected traces |
 | Slice handoff coherence | WS-M6-E | docs review + CI-required set | Spec/README/DEVELOPMENT/GitBook all match |
 
 ---

--- a/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
+++ b/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
@@ -54,7 +54,7 @@ The framework self-audit confirms both sides of correctness:
 As M6 progresses:
 
 1. keep architecture-bound interfaces and proof-layer obligations synchronized (WS-M6-A through WS-M6-C now complete),
-2. expand executable fixtures for assumption-boundary behaviors (WS-M6-D focus),
+2. preserve assumption-boundary fixture/trace coverage now closed under WS-M6-D,
 3. keep documentation synchronized in the same PR as any stage change (WS-M6-E focus),
 4. preserve deterministic replay and anchor discoverability as hard non-regression gates.
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-C complete; WS-M6-D and WS-M6-E in progress).
+- **Current slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-D complete; WS-M6-E in progress).
 - **Most recently completed slice:** M5 service-graph + policy surfaces.
 - **First real hardware architecture focus:** Raspberry Pi 5 (post-M6 binding trajectory).
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.7.6"
+version = "0.7.7"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -282,9 +282,10 @@ run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'Workstreams A\+B\+C\+D\+E complete|WS-A \+ WS-B \+ WS-C \+ WS-D \+ WS-E complete|WS-A/WS-B/WS-C/WS-D/WS-E are complete' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md
 run_check "DOC" rg -n 'Active slice:.*M6|Current slice:.*M6|Current Slice: M5' README.md docs/gitbook/README.md docs/gitbook/SUMMARY.md docs/gitbook/09-m5-closeout-snapshot.md
-run_check "DOC" rg -n 'WS-M6-A through WS-M6-C completed|WS-M6-D/WS-M6-E in progress' docs/PROJECT_AUDIT.md
-run_check "DOC" rg -n 'WS-M6-A through WS-M6-C now complete|WS-M6-D focus|WS-M6-E focus' docs/gitbook/19-end-to-end-audit-and-quality-gates.md
-run_check "DOC" rg -n 'M6 WS-M6-A through WS-M6-C are complete|WS-M6-D/WS-M6-E completion' docs/TESTING_FRAMEWORK_PLAN.md
+run_check "DOC" rg -n 'WS-M6-A through WS-M6-D completed and WS-M6-E in progress' docs/PROJECT_AUDIT.md
+run_check "DOC" rg -n 'WS-M6-A through WS-M6-C now complete|closed under WS-M6-D|WS-M6-E focus' docs/gitbook/19-end-to-end-audit-and-quality-gates.md
+run_check "DOC" rg -n 'M6 WS-M6-A through WS-M6-D are complete|WS-M6-E completion' docs/TESTING_FRAMEWORK_PLAN.md
+run_check "DOC" rg -n 'WS-M6-D complete; WS-M6-E in progress' docs/gitbook/05-specification-and-roadmap.md
 run_check "DOC" rg -n 'M5 service-graph \+ policy surfaces' README.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md
 run_check "DOC" rg -n 'WS-M5-D|WS-M5-E|proof package ✅ \*\*completed\*\*|Evidence and validation ✅ \*\*completed\*\*|WS-M5-A/B/C/D/E complete|WS-M5-D — Proof completion ✅ \*\*completed\*\*' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/README.md docs/gitbook/09-m5-closeout-snapshot.md docs/gitbook/15-m5-development-blueprint.md docs/gitbook/12-proof-and-invariant-map.md docs/gitbook/13-future-slices-and-delivery-plan.md
 run_check "DOC" rg -n 'M4-B \(complete\)|Completed predecessor slice: M4-B' docs/SEL4_SPEC.md docs/gitbook/16-completed-slice-m4b.md docs/gitbook/09-m5-closeout-snapshot.md

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -6,7 +6,7 @@ This directory tracks fixture-backed executable trace checks used by
 ## Stage alignment
 
 - Closed baseline: M1-M3.5 (scheduler, capability, IPC handshake coherence).
-- Active stage: M5 service-graph + policy surface development.
+- Active stage: M6 architecture-binding interface delivery (WS-M6-A through WS-M6-D complete; WS-M6-E in progress).
 - Previous stage (closed): M4-B lifecycle-capability composition hardening (WS-A..WS-E complete).
 
 ## Fixture source
@@ -28,18 +28,18 @@ This directory tracks fixture-backed executable trace checks used by
    ./scripts/test_tier2_trace.sh
    ./scripts/test_smoke.sh
    ```
-4. Document why fixture changes are expected and which slice they support (M4-B closeout or M5 execution).
+4. Document why fixture changes are expected and which slice they support (M4-B, M5, or M6 execution).
 
 
 
-## Current fixture rationale notes (M5 evidence closure additions)
+## Current fixture rationale notes (M6 WS-M6-D closure additions)
 
-M5 evidence lines now capture deterministic service-policy behavior without overfitting on output formatting:
+M6 evidence adds architecture-boundary adapter trace anchors while retaining the M5 service-policy closure lines:
 
-- `service restart status` keeps the success path visible for orchestration sequencing.
-- `service start denied branch` and `service stop denied branch` pin policy-denial behavior.
-- `service start dependency branch` and `service restart start-stage failure` pin dependency-failure behavior.
-- `service isolation api↔denied` and `service isolation api↔db` pin explicit positive/negative isolation-edge checks.
+- `adapter timer success path value` and `adapter read success path byte` pin successful boundary-visible behavior.
+- `adapter timer invalid-context branch`, `adapter timer unsupported branch`, and `adapter read denied branch` pin bounded failure semantics.
+- `adapter register write success path value` and `adapter register write unsupported branch` pin deterministic register boundary behavior across success/failure branches.
+- `service restart status`, `service start denied branch`, `service stop denied branch`, and dependency/isolation lines remain as M5 regression anchors to ensure no service-policy drift while M6 evolves.
 
 ## Historical fixture rationale notes (M4-B closeout baseline)
 


### PR DESCRIPTION
### Motivation
- Remove remaining milestone-state drift after the WS‑M6‑D closeout so roadmap and root docs consistently state the same M6 progress. 
- Make Tier‑3 invariant/doc-anchor checks stricter to catch future doc/test desynchronization early. 
- Preserve test/fixture semantics and CI guardrails while improving doc-anchor precision.

### Description
- Updated roadmap and root documentation to record that `WS-M6-D` is complete and `WS-M6-E` is in progress by editing `docs/gitbook/05-specification-and-roadmap.md`, `README.md`, `docs/gitbook/README.md`, `docs/PROJECT_AUDIT.md`, `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/gitbook/18-m6-execution-plan-and-workstreams.md`, and `tests/scenarios/README.md` to keep stage markers consistent. 
- Hardened Tier‑3 doc-surface checks in `scripts/test_tier3_invariant_surface.sh` by tightening the regexes to assert the current canonical M6 wording and adding an explicit check for the roadmap gate line. 
- Adjusted supporting GitBook entries to mark `WS-M6-D` evidence/trace anchors as completed and clarified fixture rationale in `tests/scenarios/README.md` to reflect the M6 additions.

### Testing
- Ran `./scripts/audit_testing_framework.sh` (full auditing sequence including Tier 0–4 checks) and it completed successfully. 
- Ran `./scripts/test_full.sh` (Tier 0–3 + smoke) and it passed. 
- Ran `./scripts/test_nightly.sh` (includes Tier 4 staged candidates) and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699394be1000832ba6f2435e4965be56)