### PR TITLE
Expand and refine project documentation for current slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,23 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** M7 audit remediation workstreams (WS-A1 through WS-A8) with CI, architecture, type-safety, testing, and documentation hardening as the immediate execution focus.
+- **Active slice:** M7 audit remediation workstreams (WS-A1 through WS-A8) with outcome-driven closure targets across CI, architecture, type-safety, testing, and documentation hardening.
 - **Most recently completed slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-E completed).
 - **First real-hardware architecture focus:** Raspberry Pi 5 (post-remediation binding path).
 
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
+
+### Current slice target outcomes (M7)
+
+1. enforce Tier 0–3 quality gates with deterministic and reproducible CI evidence,
+2. complete architecture/API boundary cleanup and preserve stable public surfaces,
+3. migrate high-risk identity/pointer aliases toward stronger type safety,
+4. broaden scenario/test evidence for scale and adversarial-style paths,
+5. isolate test-only permissive contracts from runtime-facing modules,
+6. align root docs and GitBook around active + next-slice execution plans.
+
+For workstream-level details and closure criteria, use [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/AUDIT_REMEDIATION_WORKSTREAMS.md) and GitBook chapter [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md).
 
 ## Start here
 
@@ -20,9 +31,11 @@ For normative milestones, acceptance criteria, and scope decisions, use
 - **Current repository audit baseline (architecture/code/test/docs/CI/security):** [`docs/REPOSITORY_AUDIT.md`](docs/REPOSITORY_AUDIT.md)
 - **Audit remediation workstreams (M7+ execution plan):** [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/AUDIT_REMEDIATION_WORKSTREAMS.md)
 - **Long-form handbook (GitBook):** [`docs/gitbook/README.md`](docs/gitbook/README.md)
+- **M7 execution outcomes and workstreams (active slice):** [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md)
 - **M6 execution plan (completed slice):** [`docs/gitbook/18-m6-execution-plan-and-workstreams.md`](docs/gitbook/18-m6-execution-plan-and-workstreams.md)
 - **M5 closeout snapshot chapter:** [`docs/gitbook/09-m5-closeout-snapshot.md`](docs/gitbook/09-m5-closeout-snapshot.md)
 - **Completed slice archive (M4-B):** [`docs/gitbook/16-completed-slice-m4b.md`](docs/gitbook/16-completed-slice-m4b.md)
+- **Next slice development path (post-M7):** [`docs/gitbook/22-next-slice-development-path.md`](docs/gitbook/22-next-slice-development-path.md)
 - **Project usage/value guide:** [`docs/gitbook/17-project-usage-value.md`](docs/gitbook/17-project-usage-value.md)
 - **Architecture and module map:** [`docs/gitbook/03-architecture-and-module-map.md`](docs/gitbook/03-architecture-and-module-map.md)
 - **Codebase deep reference:** [`docs/gitbook/11-codebase-reference.md`](docs/gitbook/11-codebase-reference.md)

--- a/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
+++ b/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
@@ -1,29 +1,43 @@
 # Repository Audit Remediation Workstreams
 
-This plan translates the findings in [`docs/REPOSITORY_AUDIT.md`](./REPOSITORY_AUDIT.md)
-into execution-ready workstreams for the active M7 slice and post-remediation delivery.
+This plan translates findings in [`docs/REPOSITORY_AUDIT.md`](./REPOSITORY_AUDIT.md)
+into execution-ready workstreams for the active M7 slice and the post-remediation handoff.
 
 ## 1. Program goals
 
-1. Close every criticism and recommendation from the repository audit with explicit ownership,
-   dependencies, acceptance criteria, and evidence.
-2. Preserve M1–M6 proof discipline while executing remediation before hardware-binding expansion.
-3. Keep documentation, CI, and test evidence synchronized as first-class deliverables.
+1. close every criticism and recommendation from the repository audit with explicit ownership,
+   dependencies, acceptance criteria, and evidence,
+2. preserve M1–M6 proof discipline while executing remediation before hardware-binding expansion,
+3. keep documentation, CI, and test evidence synchronized as first-class deliverables,
+4. produce a clean handoff contract for the first post-M7 hardware-facing slice.
 
-## 2. Workstream map (all audit items covered)
+## 2. Current slice outcomes (M7-O1..M7-O8)
 
-| WS ID | Theme | Priority | Audit items covered |
-|---|---|---|---|
-| WS-A1 | CI hardening and quality gate promotion | High | Testing #1, CI/CD #1/#3/#4/#5/#6, Recommendation #1/#2 |
-| WS-A2 | Architecture modularity and API surface | High | Architecture #1/#3, Recommendation #3 |
-| WS-A3 | Type-safety uplift for IDs and pointers | High | Code Quality aliasing criticism, Security #1, Recommendation #4 |
-| WS-A4 | Test architecture expansion (scale + stochastic) | Medium | Testing #2–#8, Recommendation #10/#12/#13/#17 |
-| WS-A5 | Hardware-boundary safety and test-only contract separation | High | Security #3, Recommendation #5 |
-| WS-A6 | Documentation IA refresh and contributor experience | Medium | Documentation #1/#3/#4/#5, Recommendation #7/#8/#11 |
-| WS-A7 | Proof documentation and maintainability automation | Medium | Documentation #6, Code Quality duplication criticisms, Recommendation #6/#14/#15 |
-| WS-A8 | Platform and security maturity for post-remediation hardware trajectory | Medium/Low | CI/CD #2, Security #2/#4, Recommendation #9/#16 |
+| Outcome ID | Target outcome |
+|---|---|
+| M7-O1 | CI and proof gates are enforced, reproducible, and documented as policy. |
+| M7-O2 | Architecture modules are symmetric and API boundaries are explicit. |
+| M7-O3 | Core identifier/pointer domains are type-safe by construction. |
+| M7-O4 | Test evidence covers scale, edge, and sequence-diversity scenarios. |
+| M7-O5 | Test-only permissive contracts are isolated from runtime-facing surfaces. |
+| M7-O6 | Documentation IA is consistent and contributor-first from root to GitBook. |
+| M7-O7 | Theorem surfaces are documented and repetitive proofs are reduced. |
+| M7-O8 | Platform/security baseline maturity is in place for next-slice start. |
 
-## 3. Detailed workstreams
+## 3. Workstream map (all audit items covered)
+
+| WS ID | Theme | Priority | M7 outcomes advanced | Audit items covered |
+|---|---|---|---|---|
+| WS-A1 | CI hardening and quality gate promotion | High | M7-O1 | Testing #1, CI/CD #1/#3/#4/#5/#6, Recommendation #1/#2 |
+| WS-A2 | Architecture modularity and API surface | High | M7-O2 | Architecture #1/#3, Recommendation #3 |
+| WS-A3 | Type-safety uplift for IDs and pointers | High | M7-O3 | Code Quality aliasing criticism, Security #1, Recommendation #4 |
+| WS-A4 | Test architecture expansion (scale + stochastic) | Medium | M7-O4 | Testing #2–#8, Recommendation #10/#12/#13/#17 |
+| WS-A5 | Hardware-boundary safety and test-only contract separation | High | M7-O5 | Security #3, Recommendation #5 |
+| WS-A6 | Documentation IA refresh and contributor experience | Medium | M7-O6 | Documentation #1/#3/#4/#5, Recommendation #7/#8/#11 |
+| WS-A7 | Proof documentation and maintainability automation | Medium | M7-O7 | Documentation #6, Code Quality duplication criticisms, Recommendation #6/#14/#15 |
+| WS-A8 | Platform and security maturity for post-remediation trajectory | Medium/Low | M7-O8 | CI/CD #2, Security #2/#4, Recommendation #9/#16 |
+
+## 4. Detailed workstreams
 
 ### WS-A1 — CI hardening and quality gate promotion (High)
 
@@ -31,62 +45,45 @@ into execution-ready workstreams for the active M7 slice and post-remediation de
 Promote proof-surface and determinism checks to enforced CI gates while reducing pipeline latency.
 
 **Scope**
-- add `test_full.sh` (Tier 3) as required CI status check,
-- add optional scheduled/nightly Tier 4 job,
-- add cache for `~/.elan` and `.lake`,
+- keep `test_full.sh` (Tier 3) as required CI status check,
+- maintain/expand scheduled Tier 4 or nightly deterministic validation,
+- maintain cache strategy for `~/.elan` and `.lake`,
 - document branch protection and required checks,
-- pin/setup installer provenance and add baseline security scans.
-
-**Deliverables**
-- expanded `.github/workflows/lean_action_ci.yml`,
-- CI policy section in `docs/DEVELOPMENT.md`,
-- reproducibility and security-check notes in `docs/TESTING_FRAMEWORK_PLAN.md`.
+- preserve installer provenance and baseline security scanning posture.
 
 **Acceptance criteria**
 - PRs cannot merge without Tier 0–3 passing,
-- CI runtime median drops after cache warmup,
-- deterministic replay runs at least nightly,
-- branch protection expectations documented and discoverable.
+- deterministic replay runs are visible and auditable,
+- branch protection expectations are documented and discoverable.
 
 ---
 
 ### WS-A2 — Architecture modularity and API surface (High)
 
 **Objective**
-Restore module symmetry and prepare a stable syscall-facing facade.
+Keep module symmetry and maintain a stable syscall-facing facade.
 
 **Scope**
-- split `SeLe4n/Kernel/IPC/Invariant.lean` into `Operations.lean` + `Invariant.lean`,
-- keep theorem names and imports backward-compatible during migration,
-- introduce a thin, stable API facade in `SeLe4n/Kernel/API.lean` for external callers.
-
-**Deliverables**
-- IPC module split with migration notes,
-- dependency update in architecture docs,
-- API facade section defining intended public surface.
+- preserve IPC operations/invariant separation,
+- keep theorem names and imports stable where feasible,
+- keep `SeLe4n/Kernel/API.lean` as the explicit public boundary.
 
 **Acceptance criteria**
 - no semantic drift in Tier 2 traces,
-- Tier 3 anchors updated and passing,
-- architecture chapter includes updated dependency graph.
+- Tier 3 anchors remain accurate and passing,
+- architecture docs reflect dependency and API-boundary changes.
 
 ---
 
 ### WS-A3 — Type-safety uplift for IDs and pointers (High)
 
 **Objective**
-Eliminate cross-domain confusion by replacing raw `Nat` aliases with wrappers.
+Eliminate cross-domain confusion by replacing raw aliases with wrappers.
 
 **Scope**
-- migrate `ThreadId`, `ObjId`, `CPtr`, and `Slot` to `structure` newtypes,
-- derive/implement equality, ordering, and serialization helpers as needed,
+- migrate `ThreadId`, `ObjId`, `CPtr`, and `Slot` to newtypes,
 - update operation signatures and theorem statements,
-- add migration helper constructors for ergonomic proofs/tests.
-
-**Deliverables**
-- newtype definitions in foundational modules,
-- compile-clean updates across transitions and invariants,
-- proof adaptation notes for contributors.
+- add migration helper constructors/projections for proof ergonomics.
 
 **Acceptance criteria**
 - invalid cross-domain argument mixes fail at compile-time,
@@ -101,20 +98,14 @@ Eliminate cross-domain confusion by replacing raw `Nat` aliases with wrappers.
 Scale evidence beyond fixed-path fixtures and improve behavioral confidence depth.
 
 **Scope**
-- extend Tier 2 scenarios for deep CSpace radix, large run queues, multi-endpoint IPC,
-  service dependency chains, and memory-boundary addresses,
-- annotate fixture lines with semantic comments and source scenario IDs,
-- prototype Lean-native assertions for state-level checks,
-- add property/fuzz-style sequence generation where practical.
-
-**Deliverables**
-- expanded `Main.lean` scenario coverage,
-- richer fixture and `tests/scenarios/README.md` mapping,
-- optional Lean-native test harness module.
+- extend Tier 2 scenarios for deep CSpace, large run queues, multi-endpoint IPC,
+  service dependency chains, and boundary-address stories,
+- annotate fixture lines with semantic comments and scenario IDs,
+- add Lean-native state assertions and sequence-diversity checks where practical.
 
 **Acceptance criteria**
-- fixture scenarios traceably map to targeted risk classes,
-- at least one stochastic/property suite runs in CI or nightly,
+- fixture scenarios map to targeted risk classes,
+- at least one sequence-diversity/stochastic check exists in CI or nightly,
 - failure diagnostics remain concise and actionable.
 
 ---
@@ -125,18 +116,13 @@ Scale evidence beyond fixed-path fixtures and improve behavioral confidence dept
 Prevent accidental production use of permissive runtime contracts.
 
 **Scope**
-- move `runtimeContractAcceptAll`/`runtimeContractDenyAll` out of `Main.lean`,
-- place them in a dedicated testing-only module namespace,
+- move permissive contracts into testing-only namespace/modules,
+- preserve clear import boundaries,
 - document trusted vs test-only contract usage rules.
 
-**Deliverables**
-- `SeLe4n/Testing/Contracts.lean` (or equivalent) with explicit usage intent,
-- import boundaries that keep test utilities out of runtime-facing surfaces,
-- docs updates in development/testing guides.
-
 **Acceptance criteria**
-- no non-test module imports permissive contracts,
-- boundary policy is documented and enforced by review checklist.
+- non-test modules do not import permissive contracts,
+- boundary policy is documented and visible in contributor workflow.
 
 ---
 
@@ -146,21 +132,14 @@ Prevent accidental production use of permissive runtime contracts.
 Improve discoverability, consistency, and onboarding speed.
 
 **Scope**
-- publish a root `CONTRIBUTING.md` that points to `docs/DEVELOPMENT.md`,
-- introduce a root `CHANGELOG.md` with version/milestone history,
-- normalize checklist template semantics (`[ ]` by default),
-- add architecture dependency diagrams to handbook chapters,
-- rebalance thin GitBook chapters with concrete content or merge them.
-
-**Deliverables**
-- CONTRIBUTING + CHANGELOG,
-- updated docs/checklists/handbook navigation,
-- architecture visuals maintained with module changes.
+- publish/maintain root contribution and change history artifacts,
+- synchronize root docs with GitBook navigation,
+- rebalance handbook chapters around active slice and next-slice path.
 
 **Acceptance criteria**
 - new contributors find contribution policy from repo root,
-- version progression is auditable in one file,
-- no ambiguous pre-checked checklist templates remain.
+- slice progression is auditable in one navigation flow,
+- no conflicting active-slice markers remain.
 
 ---
 
@@ -170,18 +149,13 @@ Improve discoverability, consistency, and onboarding speed.
 Increase theorem-level explainability while reducing repetitive proof boilerplate.
 
 **Scope**
-- add concise docstrings for theorem significance,
-- refactor repeated endpoint transport lemmas into parameterized helpers,
-- explore a generic preservation tactic for bundle-preservation patterns.
-
-**Deliverables**
-- theorem docstring policy and rollout tracker,
-- reduced duplication in IPC and bundle-preservation proofs,
-- optional helper tactic/module with examples.
+- add concise theorem-purpose docstrings,
+- refactor repeated proof patterns into helper lemmas/tactics where helpful,
+- maintain readability while reducing maintenance surface.
 
 **Acceptance criteria**
-- theorem doc coverage reaches agreed threshold (target: 100% for public theorem surfaces),
-- duplicated proof patterns reduced measurably,
+- public theorem surface doc coverage reaches agreed threshold,
+- repeated proof patterns are measurably reduced,
 - no readability regression in final proofs.
 
 ---
@@ -192,34 +166,29 @@ Increase theorem-level explainability while reducing repetitive proof boilerplat
 Prepare for hardware realism and stronger security claims beyond capability invariants.
 
 **Scope**
-- add ARM64/cross-platform CI path before full Raspberry Pi 5 binding,
-- establish baseline SAST/secret scanning even with minimal dependencies,
-- define staged information-flow model plan (noninterference trajectory).
-
-**Deliverables**
-- cross-platform CI job(s),
-- security scanning workflow,
-- information-flow proof roadmap document.
+- add architecture-relevant CI path(s),
+- maintain baseline SAST/secret scanning,
+- define staged information-flow model milestones.
 
 **Acceptance criteria**
 - architecture-targeted CI evidence exists pre-hardware binding,
 - security scans run automatically,
-- info-flow milestones are explicit and reviewable.
+- information-flow milestones are explicit and reviewable.
 
-## 4. Sequencing and dependency plan
+## 5. Sequencing and dependency plan
 
 ### Phase 1 (Immediate hardening)
 - WS-A1, WS-A2, WS-A5 start immediately.
-- WS-A6 starts in parallel for low-risk documentation fixes (checklists, diagrams, navigation).
+- WS-A6 runs in parallel for doc/navigation synchronization.
 
 ### Phase 2 (Core model quality uplift)
-- WS-A3 begins after WS-A2 IPC split stabilizes.
-- WS-A4 expands fixtures/scenarios as type migration lands.
+- WS-A3 begins after WS-A2 boundary stability is verified.
+- WS-A4 expands scenarios as type migration lands.
 
 ### Phase 3 (Scalability and long-horizon verification)
 - WS-A7 and WS-A8 execute incrementally after Phase 2 baseline closes.
 
-## 5. Traceability matrix: audit criticisms → workstreams
+## 6. Traceability matrix: audit criticisms → workstreams
 
 - **Architecture criticisms** → WS-A2, WS-A6.
 - **Code quality criticisms** → WS-A3, WS-A7.
@@ -227,15 +196,32 @@ Prepare for hardware realism and stronger security claims beyond capability inva
 - **Documentation criticisms** → WS-A6, WS-A7.
 - **CI/CD criticisms** → WS-A1, WS-A8.
 - **Security criticisms** → WS-A3, WS-A5, WS-A8.
-- **Recommendations #1–#17** → distributed across WS-A1..WS-A8 (see Section 2 mapping).
+- **Recommendations #1–#17** → distributed across WS-A1..WS-A8 (see Section 3 mapping).
 
-## 6. Execution governance
+## 7. Execution governance and reporting
 
 Each workstream PR should include:
 
-1. scope statement (what criticism/recommendation IDs are being closed),
-2. evidence links (tests, theorem anchors, docs sections),
-3. rollback/compatibility note (especially WS-A2 and WS-A3),
-4. synchronized documentation updates in the same PR.
+1. scope statement (audit IDs closed),
+2. outcome statement (M7-O* advanced),
+3. evidence links (tests, theorem anchors, docs sections),
+4. rollback/compatibility note for risky refactors,
+5. synchronized documentation updates in the same PR.
 
-This keeps the audit remediation program measurable, reviewable, and aligned with proof integrity.
+Each checkpoint report should include:
+
+- completed workstreams,
+- blocked in-progress workstreams and unblock plans,
+- evidence delta since previous checkpoint,
+- confidence assessment for the M7 exit gate.
+
+## 8. M7 exit package and next-slice handoff
+
+M7 closeout is valid only when:
+
+1. high-priority workstreams are complete with reproducible evidence,
+2. medium-priority workstreams are complete or explicitly deferred with accepted risk,
+3. documentation and GitBook agree on completion status,
+4. next-slice dependencies are listed with owner and start criteria.
+
+This closeout package is the contractual handoff for the first post-M7 hardware-facing slice.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 This guide defines day-to-day implementation workflow and proof-engineering expectations.
 
-Current stage: **M6 architecture-binding interface preparation is complete (WS-M6-A through WS-M6-E closed), and the active M7 slice focuses on repository-audit remediation workstreams (WS-A1 through WS-A8)**.
+Current stage: **M6 architecture-binding interface preparation is complete (WS-M6-A through WS-M6-E closed), and the active M7 slice focuses on repository-audit remediation workstreams (WS-A1 through WS-A8) with explicit outcome-based closure gates**.
 M4-B lifecycle-capability composition hardening is closed and treated as a stable dependency
 baseline.
 
@@ -200,7 +200,48 @@ milestone-moving PR unblocks.
 
 ---
 
-## 6. Proof engineering standards
+
+## 6. M7 execution operating model (active)
+
+Use this model for all milestone-moving work while M7 is active:
+
+1. bind every PR to one or more WS-A* workstream IDs,
+2. state which M7 outcome(s) are advanced,
+3. include reproducible command evidence,
+4. update docs/GitBook in the same PR range,
+5. include a one-line downstream unlock statement.
+
+### 6.1 M7 target outcomes
+
+- **M7-O1:** CI/proof gate enforcement and determinism evidence,
+- **M7-O2:** architecture/API boundary clarity and symmetry,
+- **M7-O3:** type-safe identity/pointer domains,
+- **M7-O4:** expanded scale and sequence-diversity testing,
+- **M7-O5:** strict separation of runtime vs test-only contracts,
+- **M7-O6:** synchronized contributor documentation and GitBook IA,
+- **M7-O7:** maintainable, documented theorem surfaces,
+- **M7-O8:** platform/security maturity baseline for post-M7 startup.
+
+### 6.2 Workstream sequencing policy
+
+- **Phase 1 (stabilization):** WS-A1, WS-A2, WS-A5, plus low-risk WS-A6 updates.
+- **Phase 2 (quality depth):** WS-A3 and WS-A4 after boundaries are stable.
+- **Phase 3 (trajectory hardening):** WS-A7 and WS-A8 once migration churn decreases.
+
+### 6.3 Required checkpoint summary format
+
+Checkpoint summaries should include:
+
+1. completed workstreams and moved outcomes,
+2. in-progress workstreams with blockers and mitigation,
+3. evidence commands run since last checkpoint,
+4. confidence signal for M7 exit readiness.
+
+For full workstream definitions, see [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](./AUDIT_REMEDIATION_WORKSTREAMS.md) and GitBook chapter [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](./gitbook/21-m7-current-slice-outcomes-and-workstreams.md).
+
+---
+
+## 7. Proof engineering standards
 
 1. Prefer explicit theorem statements and local proof structure over brittle tactic compression.
 2. Keep conjunction-heavy invariants factored into named components.
@@ -215,7 +256,7 @@ milestone-moving PR unblocks.
 
 ---
 
-## 7. Documentation responsibilities
+## 8. Documentation responsibilities
 
 Any PR changing transitions, invariants, milestone scope, or tests must update docs in the same
 commit range:
@@ -236,7 +277,7 @@ Docs should explicitly answer:
 
 ---
 
-## 8. Required contributor validation loop
+## 9. Required contributor validation loop
 
 Run before opening a PR:
 
@@ -258,7 +299,7 @@ If a command is blocked by environment limitations, report the limitation and im
 
 ---
 
-## 9. PR checklist (copy into PR descriptions)
+## 10. PR checklist (copy into PR descriptions)
 
 - [ ] Scope fits one coherent milestone slice.
 - [ ] Transition APIs expose explicit success/error branching.
@@ -274,7 +315,7 @@ If a command is blocked by environment limitations, report the limitation and im
 
 ---
 
-## 10. Codebase touch matrix (what to update when)
+## 11. Codebase touch matrix (what to update when)
 
 This section helps avoid partial updates when changing a subsystem.
 
@@ -342,7 +383,7 @@ Validation focus:
 
 ---
 
-## 11. Proof review checklist (maintainers)
+## 12. Proof review checklist (maintainers)
 
 When reviewing theorem changes, verify:
 
@@ -354,7 +395,7 @@ When reviewing theorem changes, verify:
 
 ---
 
-## 12. Documentation depth contract
+## 13. Documentation depth contract
 
 For any milestone movement, docs should answer all of:
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -52,7 +52,7 @@ The active remediation slice is successful when contributors deliver all of the 
 3. type-safety, testing-depth, and documentation-governance upgrades mapped to audit findings,
 4. traceable closure of audit criticisms/recommendations with synchronized code/proof/test/docs evidence.
 
-See the dedicated execution chapter: [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md).
+See dedicated execution chapters: [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md) and [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md).
 
 ## 6. Hardware trajectory update
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -10,7 +10,8 @@ Milestone status for planning purposes:
 - M4-A complete,
 - M4-B complete,
 - M5 complete,
-- **M6 complete**.
+- **M6 complete**,
+- **M7 active (audit remediation workstreams)**.
 
 Post-M6 planning should build on existing transition and theorem surfaces rather than restructuring
 closed milestone contracts.
@@ -23,58 +24,57 @@ Contributors should treat these as stable unless a spec-level change is explicit
 2. layered invariant composition across scheduler/capability/IPC/lifecycle/service modules,
 3. local + composed preservation entrypoints for established transitions,
 4. fixture-backed executable traces for core success/failure stories,
-5. Tier 3 theorem/invariant symbol anchors for claimed surfaces.
+5. Tier 3 theorem/invariant symbol anchors for claimed surfaces,
+6. explicit architecture-boundary assumptions and adapter preservation hooks from M6.
 
 ## 3. Completed predecessor slice recap: M6
 
 M6 scope: **architecture-binding interfaces and hardware-facing assumption hardening**.
 
-### M6 target outcomes
+### M6 target outcomes (all complete)
 
-1. **Assumption extraction and interface definition**
-   - architecture-facing assumptions become explicit interfaces.
-2. **Adapter semantics and bounded error surfaces**
-   - adapter operations remain deterministic and failure-explicit.
-3. **Composed proof continuity**
-   - adapters connect to existing invariant bundles without flattening proof layering.
-4. **Hardware-boundary contract hardening**
-   - boot/runtime obligations are represented as concrete contracts.
-5. **Evidence continuity**
-   - tests and traces expand with no Tier 0–3 contract regression.
+1. assumption extraction and interface definition,
+2. adapter semantics and bounded error surfaces,
+3. composed proof continuity,
+4. hardware-boundary contract hardening,
+5. evidence continuity across test tiers.
 
-### M6 workstreams
+Detailed archive: [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md).
 
-- **WS-M6-A:** assumption inventory and boundary extraction ✅ completed (`SeLe4n/Kernel/Architecture/Assumptions.lean`),
-- **WS-M6-B:** interface API + adapter semantics ✅ completed (`SeLe4n/Kernel/Architecture/Adapter.lean`),
-- **WS-M6-C:** proof integration with existing bundles ✅ completed (`SeLe4n/Kernel/Architecture/Invariant.lean`),
-- **WS-M6-D:** executable evidence and test-anchor expansion ✅ completed (`Main.lean`, `tests/fixtures/main_trace_smoke.expected`, `scripts/test_tier3_invariant_surface.sh`),
-- **WS-M6-E:** documentation synchronization and handoff packaging ✅ completed.
-
-Detailed execution guidance: [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md).
-
-### Non-goals for M6
-
-- full platform bring-up,
-- architecture-specific performance tuning,
-- replacing M1–M5 theorem APIs unless required for soundness,
-- broad subsystem redesign not required for architecture-boundary clarity.
-
-## 4. M6 closeout handoff signals
-
-1. WS-M6-A through WS-M6-E are complete and traceable from docs to code/proofs/tests.
-2. Boundary contracts are explicit enough to support Raspberry Pi 5-first instantiation work.
-3. Risk controls now focus on contract-instantiation discipline rather than boundary extraction.
-
-## 5. Current active slice preview: M7 audit remediation
+## 4. Current active slice: M7 audit remediation
 
 Current active direction is **repository-audit remediation workstreams (WS-A1 through WS-A8)**.
 
-Indicative outcomes:
+### M7 slice objectives
 
-1. promote CI/test gates and harden delivery controls,
-2. complete architecture and API-surface cleanup identified by the audit,
-3. improve type safety and test-scale coverage without regressing M1–M6 proofs,
-4. synchronize documentation and governance artifacts as measurable closure evidence.
+1. harden CI/test gates and branch-policy evidence,
+2. improve architecture API clarity and module symmetry,
+3. complete high-value type-safety migration,
+4. expand test depth for scale and edge-heavy scenarios,
+5. isolate test-only contracts from runtime-facing paths,
+6. align root docs + handbook for current/next-slice clarity,
+7. improve proof maintainability and theorem explainability,
+8. establish platform/security readiness for the next slice.
+
+### M7 planning links
+
+- [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
+- [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
+- [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](../AUDIT_REMEDIATION_WORKSTREAMS.md)
+
+## 5. Next-slice preview (post-M7)
+
+After M7 closes, planned direction is a **hardware-oriented expansion slice** with Raspberry Pi 5
+as first architecture focus.
+
+Primary goals for that slice:
+
+1. bind explicit assumptions to platform-facing constraints,
+2. evolve adapters with architecture-specific specialization while preserving determinism,
+3. add architecture-targeted evidence tracks in CI/test layers,
+4. publish staged information-flow/security proof milestones.
+
+See [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md).
 
 ## 6. Transition gates
 
@@ -87,27 +87,28 @@ Verified signals:
 3. Tier 3 anchors include M5 theorem/invariant symbols,
 4. docs synchronized for M5 closure.
 
-### Gate: M5 → M6 (completed)
+### Gate: M6 closeout (completed)
 
-Progress snapshot:
+Verified signals:
 
-1. architecture assumptions explicit and reviewable ✅ (WS-M6-A complete),
-2. interface artifacts preserve M1–M5 theorem layering ✅ (WS-M6-B and WS-M6-C complete),
-3. test obligations added without regressing required gates ✅ (WS-M6-D and WS-M6-E complete).
+1. architecture assumptions explicit and reviewable,
+2. interface artifacts preserve M1–M5 theorem layering,
+3. test obligations added without regressing required gates.
 
-### Gate: audit remediation → Raspberry Pi 5 binding slice (planned)
+### Gate: M7 → next slice (planned)
 
 Require all:
 
-1. high-priority remediation workstreams are closed with evidence,
+1. high-priority remediation workstreams are closed with reproducible evidence,
 2. CI and test obligations (including promoted proof-surface gates) are stable,
-3. documentation consistently marks audit remediation as complete and hardware-binding as next.
+3. documentation consistently marks M7 as complete and next-slice path as active,
+4. hardware-path assumptions and ownership table are published.
 
-## 7. Risk register (post-M6 / remediation-active updated)
+## 7. Risk register (remediation-active)
 
 1. **Semantic/proof skew**
-   - risk: adapter semantics change without theorem updates,
-   - mitigation: enforce transition + theorem pairing in PR templates.
+   - risk: transition changes land without theorem updates,
+   - mitigation: enforce transition + theorem pairing and Tier 3 anchors.
 2. **Roadmap drift**
    - risk: docs describe conflicting active slices,
    - mitigation: synchronize README/spec/DEVELOPMENT/GitBook in one PR.
@@ -116,10 +117,10 @@ Require all:
    - mitigation: require local interface contracts + bridge lemmas.
 4. **Hardware-path premature lock-in**
    - risk: overfitting before remediation controls stabilize,
-   - mitigation: keep Raspberry Pi 5 work post-remediation and contract-driven.
+   - mitigation: keep platform work contract-driven and simulation-backed initially.
 
 ## 8. Contributor operating cadence
 
-1. per PR: state M6 workstream advanced + next unlock,
-2. per checkpoint: map changes to M6 outcome matrix,
+1. per PR: state workstream advanced + target outcome moved,
+2. per checkpoint: map changes to current-slice outcome matrix,
 3. per milestone closeout: publish delivered outcomes, deferrals, and risk updates.

--- a/docs/gitbook/20-repository-audit-remediation-workstreams.md
+++ b/docs/gitbook/20-repository-audit-remediation-workstreams.md
@@ -3,60 +3,112 @@
 This chapter is the execution companion to the full repository audit in
 [`docs/REPOSITORY_AUDIT.md`](../REPOSITORY_AUDIT.md).
 
-For the full implementation plan (workstream definitions, sequencing, and traceability), use:
+For the implementation plan that defines each workstream in detail, use:
 [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](../AUDIT_REMEDIATION_WORKSTREAMS.md).
+
+For current-slice target outcomes and closure gates, use:
+[M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md).
 
 ## 1. Why this chapter exists
 
-The audit identified a healthy codebase with targeted gaps across CI enforcement, architecture
-symmetry, type safety, test scale, and contributor discoverability. This chapter turns those
-findings into the active M7 delivery program.
+The audit shows a strong formal core with practical delivery gaps around CI enforcement,
+module symmetry, type-safety boundaries, test scale, and documentation discoverability.
 
-## 2. Workstream portfolio (WS-A1..WS-A8)
+This chapter converts those findings into an execution portfolio contributors can use directly.
+
+## 2. Program-level outcomes
+
+The remediation program targets eight concrete repository outcomes:
+
+1. enforceable CI gates and deterministic validation,
+2. cleaner architecture boundaries and public API stability,
+3. type-safe identity domains to reduce alias confusion,
+4. broader test evidence including scale and adversarial paths,
+5. explicit production-vs-test hardware contract boundaries,
+6. cohesive contributor-facing documentation and navigation,
+7. proof-surface maintainability and theorem explainability,
+8. platform/security baseline readiness for hardware-facing expansion.
+
+## 3. Workstream portfolio (WS-A1..WS-A8)
 
 1. **WS-A1 — CI hardening and quality gate promotion**
-   - promote Tier 3 to required CI,
-   - add caching, nightly determinism, and documented branch protection.
+   - promote Tier 3 obligations to strict merge gates,
+   - improve workflow determinism and cache efficiency,
+   - document branch protection and required evidence flows.
 
 2. **WS-A2 — Architecture modularity and API surface**
-   - split IPC operations/invariants,
-   - define a stable API facade boundary.
+   - maintain operations/invariant symmetry,
+   - isolate and stabilize public API surfaces,
+   - reduce hidden coupling between modules.
 
 3. **WS-A3 — Type-safety uplift for IDs/pointers**
-   - replace critical `Nat` aliases with newtype wrappers.
+   - migrate critical aliases to explicit wrappers,
+   - prevent cross-domain misuse at compile time,
+   - preserve theorem ergonomics with migration helpers.
 
 4. **WS-A4 — Test architecture expansion**
-   - add scale scenarios, fixture traceability, and stochastic/property-style checks.
+   - add high-scale and edge-heavy scenarios,
+   - improve fixture provenance and scenario traceability,
+   - incorporate stochastic/property-style checks where practical.
 
 5. **WS-A5 — Hardware-boundary safety + test-only contracts**
-   - isolate permissive runtime contracts into testing-only modules.
+   - isolate permissive contracts to test-only modules,
+   - prevent accidental production-surface usage,
+   - document trusted-contract policy and review expectations.
 
 6. **WS-A6 — Documentation IA and contributor UX**
-   - add root CONTRIBUTING/CHANGELOG,
-   - normalize checklist templates,
-   - add architecture diagrams and rebalance thin chapters.
+   - standardize root-level contributor guidance,
+   - align handbook structure with current execution flow,
+   - keep active/next slice status synchronized everywhere.
 
 7. **WS-A7 — Proof documentation and maintainability automation**
-   - theorem docstrings,
-   - reduced proof duplication,
-   - reusable preservation helpers.
+   - increase theorem docstring coverage,
+   - reduce repetitive proof patterns,
+   - preserve readability while improving changeability.
 
-8. **WS-A8 — Platform/security maturity for the post-remediation path**
-   - cross-platform CI,
-   - baseline security scanning,
-   - staged information-flow roadmap.
+8. **WS-A8 — Platform/security maturity for post-remediation path**
+   - add architecture-relevant CI expansion,
+   - establish baseline automated scanning,
+   - define staged information-flow roadmap milestones.
 
-## 3. Sequencing
+## 4. Sequencing model
 
-- **Phase 1:** WS-A1, WS-A2, WS-A5, plus low-risk WS-A6 doc fixes.
-- **Phase 2:** WS-A3 and WS-A4 once IPC split is stable.
-- **Phase 3:** WS-A7 and WS-A8 for deeper scalability and security maturity.
+- **Phase 1: hardening foundations**
+  - WS-A1, WS-A2, WS-A5 plus low-risk WS-A6 updates.
+- **Phase 2: quality depth expansion**
+  - WS-A3 and WS-A4 after boundary stability improves.
+- **Phase 3: scalability and trajectory maturity**
+  - WS-A7 and WS-A8 once migration churn is controlled.
 
-## 4. Completion contract
+This sequencing minimizes proof churn and avoids rework while safety rails are established.
+
+## 5. Workstream-ready PR checklist
+
+Every remediation PR should include:
+
+1. audit criticism/recommendation IDs closed,
+2. workstream ID(s) and target outcome ID(s),
+3. exact command evidence with reproducible outputs,
+4. synchronized documentation updates,
+5. explicit “what this unlocks next” statement.
+
+## 6. Completion contract
 
 A workstream is considered closed only when all are true:
 
 1. mapped audit criticism/recommendation IDs are explicitly closed,
 2. tests/theorem anchors/docs are updated together,
 3. PR evidence is reproducible via documented commands,
-4. no regression in proof completeness expectations.
+4. no regression in proof completeness expectations,
+5. active-slice and next-slice documentation are synchronized across root docs and GitBook.
+
+## 7. Handoff to next slice
+
+When WS-A1..WS-A8 close, maintainers should publish a short remediation closeout packet with:
+
+- completed/deferred workstream table,
+- residual risks accepted for next slice,
+- next-slice kickoff dependencies and owners,
+- links to updated roadmap and hardware-path chapters.
+
+That packet is the gate artifact for starting the post-M7 hardware-facing slice.

--- a/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
+++ b/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
@@ -1,0 +1,208 @@
+# M7 Current Slice Outcomes and Workstreams
+
+This chapter is the practical execution map for the active slice.
+
+Use this chapter when you need to answer:
+
+- what outcomes M7 must deliver,
+- which workstream closes which risk,
+- how we sequence delivery,
+- and what evidence is required before M7 can close.
+
+For normative scope, always defer to [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md).
+For audit source findings, use [`docs/REPOSITORY_AUDIT.md`](../REPOSITORY_AUDIT.md).
+For implementation-level details, use [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](../AUDIT_REMEDIATION_WORKSTREAMS.md).
+
+## 1. M7 slice goal statement
+
+M7 exists to convert audit findings into durable delivery controls without destabilizing M1–M6 proof guarantees.
+
+Concretely, M7 should leave the repository in a state where:
+
+1. CI quality gates are strict, reproducible, and fast enough to sustain contribution velocity.
+2. Architecture boundary modules are symmetric and easy to navigate.
+3. Type confusion classes (ID/pointer alias misuse) are structurally harder to write.
+4. Test evidence scales beyond happy-path fixtures.
+5. Documentation and contributor workflow are consistent from root README to GitBook chapters.
+6. Security and platform readiness are sufficient to start the post-remediation hardware slice.
+
+## 2. Target outcome matrix (what “M7 done” means)
+
+| Outcome ID | Target outcome | Primary workstreams | Required closure evidence |
+|---|---|---|---|
+| M7-O1 | Tiered CI is enforced as policy, not convention | WS-A1 | Required checks active + CI workflow docs + deterministic replay evidence |
+| M7-O2 | Kernel module boundaries are clearer and externally consumable | WS-A2 | IPC split complete, stable API facade, updated architecture map |
+| M7-O3 | Core identity domains are type-safe by construction | WS-A3 | newtype migration merged, theorem surfaces adapted, no placeholder debt |
+| M7-O4 | Test evidence covers scale and adversarial-style paths | WS-A4 | expanded scenarios + fixture traceability + at least one stochastic/property track |
+| M7-O5 | Hardware contract safety is explicit and non-production test contracts are isolated | WS-A5 | permissive contract isolation + usage policy docs + import boundary enforcement |
+| M7-O6 | Documentation IA is contributor-first and milestone-accurate | WS-A6 | root contribution/changelog artifacts + synchronized handbook navigation |
+| M7-O7 | Proof surfaces are explainable and easier to maintain | WS-A7 | theorem docstring coverage + duplicated proof reduction evidence |
+| M7-O8 | Platform and baseline security maturity gates are operational | WS-A8 | cross-platform CI signal + scanning workflow + information-flow roadmap draft |
+
+## 3. Workstream deep map
+
+### WS-A1 — CI hardening and quality gate promotion
+
+**Intent:** shift from “best effort checks” to enforced proof and determinism gates.
+
+**Execution focus now:**
+
+- keep Tier 0–3 checks required,
+- preserve deterministic replay posture,
+- reduce cold-start cost through caching and reliable setup.
+
+**DoD signals:**
+
+- branch protection requirements are documented and reproducible,
+- no milestone-moving PR bypasses proof-surface checks,
+- failed checks produce actionable diagnostics.
+
+### WS-A2 — Architecture modularity and API surface
+
+**Intent:** make subsystem boundaries composable for future platform binding work.
+
+**Execution focus now:**
+
+- maintain symmetry between operations and invariants,
+- keep external entrypoints stable via `SeLe4n/Kernel/API.lean`,
+- preserve theorem discoverability while moving internal modules.
+
+**DoD signals:**
+
+- IPC layering is split and mapped in docs,
+- dependent imports are minimal and explicit,
+- no trace/theorem regression during refactors.
+
+### WS-A3 — Type-safety uplift for IDs and pointers
+
+**Intent:** remove classes of cross-domain misuse at compile time.
+
+**Execution focus now:**
+
+- migrate high-risk aliases first (`ThreadId`, `ObjId`, `CPtr`, `Slot`),
+- preserve ergonomics with helper constructors/projections,
+- align theorem statements and executable traces after migration.
+
+**DoD signals:**
+
+- mixed-domain mistakes fail to typecheck,
+- migration does not introduce theorem API ambiguity,
+- no newly introduced `sorry`/`admit`/placeholder debt.
+
+### WS-A4 — Test architecture expansion
+
+**Intent:** grow confidence from curated stories to broader behavioral coverage.
+
+**Execution focus now:**
+
+- add scale-heavy and edge-case-rich scenarios,
+- improve fixture readability and scenario traceability,
+- add at least one stochastic/property-oriented validation path.
+
+**DoD signals:**
+
+- scenario-to-risk mapping exists and is easy to audit,
+- failure output is concise enough for rapid debugging,
+- CI or nightly runs include nontrivial sequence diversity.
+
+### WS-A5 — Hardware-boundary safety and test-only contract separation
+
+**Intent:** prevent permissive contracts from leaking into runtime-facing semantics.
+
+**Execution focus now:**
+
+- isolate permissive runtime contracts in testing-only namespaces,
+- encode import boundaries that make misuse obvious in review,
+- document trusted-contract policy and examples.
+
+**DoD signals:**
+
+- no production path references permissive test contracts,
+- policy is enforced by contributor checklist language,
+- contract intent is unambiguous in code and docs.
+
+### WS-A6 — Documentation IA and contributor UX
+
+**Intent:** make contributor onboarding and milestone navigation frictionless.
+
+**Execution focus now:**
+
+- keep root docs and handbook chapter ordering synchronized,
+- avoid stale slice markers,
+- capture current and next-slice context in every milestone chapter.
+
+**DoD signals:**
+
+- a new contributor can find setup/workflow/testing path from root in minutes,
+- GitBook hierarchy mirrors actual development flow,
+- active slice status is consistent across canonical docs.
+
+### WS-A7 — Proof documentation and maintainability automation
+
+**Intent:** reduce proof fragility and increase theorem-level legibility.
+
+**Execution focus now:**
+
+- add concise theorem purpose docstrings,
+- eliminate copy-paste proof blocks via reusable helpers,
+- preserve readability while reducing maintenance surface.
+
+**DoD signals:**
+
+- public theorem surfaces are documented,
+- repeated proof patterns are parameterized,
+- reviewers can identify preservation obligations faster.
+
+### WS-A8 — Platform/security maturity for next slice readiness
+
+**Intent:** avoid a large maturity cliff at hardware-binding start.
+
+**Execution focus now:**
+
+- establish architecture-relevant CI signals,
+- automate baseline scanning and security hygiene,
+- define information-flow proof trajectory.
+
+**DoD signals:**
+
+- at least one architecture-targeted CI lane is operational,
+- scanning evidence is present in automation,
+- post-M7 security proof path is published.
+
+## 4. Dependency and sequencing model
+
+M7 workstreams are intentionally staged:
+
+1. **Stabilization-first:** WS-A1, WS-A2, WS-A5, and doc hygiene from WS-A6.
+2. **Model-quality uplift:** WS-A3 and WS-A4 after architecture boundaries are stable.
+3. **Scalability/trajectory hardening:** WS-A7 and WS-A8 once migration churn is reduced.
+
+This order protects the proof baseline while allowing high-value hardening early.
+
+## 5. Operating rhythm for M7 execution
+
+For each PR that advances M7, include:
+
+1. **Workstream binding:** WS-A* ID(s) being advanced.
+2. **Outcome binding:** which M7-O* target(s) move.
+3. **Evidence commands:** exact checks used for validation.
+4. **Docs sync:** links to updated handbook/reference sections.
+5. **Next unlock:** one sentence on which downstream task is now unblocked.
+
+For each checkpoint summary, report:
+
+- completed outcome IDs,
+- in-progress workstreams with blockers,
+- deferred items and rationale,
+- confidence status for the M7 → next-slice gate.
+
+## 6. Exit gate to start the next slice
+
+M7 should be declared complete only when all are true:
+
+1. all high-priority workstreams (WS-A1, WS-A2, WS-A3, WS-A5) are closed with reproducible evidence,
+2. medium-priority workstreams have either closure evidence or explicit, risk-accepted deferrals,
+3. CI/test/docs state is consistent across root docs and GitBook,
+4. next-slice kickoff dependencies are explicitly listed and owned.
+
+That closure package becomes the handoff contract for the first post-remediation hardware-oriented slice.

--- a/docs/gitbook/22-next-slice-development-path.md
+++ b/docs/gitbook/22-next-slice-development-path.md
@@ -1,0 +1,95 @@
+# Next Slice Development Path (Post-M7)
+
+This chapter describes the expected development path after M7 audit remediation closes.
+
+The immediate objective after M7 is to start a hardware-oriented slice with lower integration risk,
+using Raspberry Pi 5 as the first concrete architecture target.
+
+## 1. Why this path exists
+
+M1–M6 built a proof-bearing semantic model and architecture boundary contracts.
+M7 hardens repository operations so that expansion can happen with stronger safety rails.
+The next slice should convert that readiness into controlled hardware-facing progress.
+
+## 2. Next-slice mission
+
+Build a first hardware-instantiation lane that demonstrates:
+
+1. architecture assumptions can be concretely bound without weakening theorem discipline,
+2. adapter boundaries support realistic platform interactions,
+3. trace/test/proof evidence remains reproducible during platform-specific growth.
+
+## 3. Proposed workstreams for the next slice
+
+> Naming is provisional until ratified in `docs/SEL4_SPEC.md`.
+
+### WS-N1 — Assumption-to-platform binding package
+
+- map architecture assumptions to Raspberry Pi 5-facing implementation notes,
+- define obligation tables (what is trusted, validated, or deferred),
+- add explicit mismatch handling for unsupported hardware states.
+
+### WS-N2 — Hardware adapter specialization and simulation-backed validation
+
+- implement architecture-specialized adapter stubs behind stable interfaces,
+- maintain deterministic fallback paths for CI/non-hardware environments,
+- add simulation traces that approximate hardware interaction sequences.
+
+### WS-N3 — Architecture-targeted test and replay tracks
+
+- extend test tiers with architecture-focused traces,
+- add replay bundles that validate deterministic behavior under specialized adapters,
+- ensure failure-path diagnostics remain concise.
+
+### WS-N4 — Security/information-flow pre-foundation
+
+- introduce first noninterference-oriented modeling scope,
+- align capability and scheduler assumptions with future information-flow statements,
+- publish acceptance criteria for security-proof slice successors.
+
+### WS-N5 — Developer operations for hardware-adjacent work
+
+- standardize local vs CI execution profiles,
+- publish contributor instructions for architecture-specific checks,
+- tighten changelog discipline around platform-facing semantics.
+
+## 4. Entry criteria from M7
+
+The next slice should not start until these conditions are true:
+
+1. M7 high-priority outcomes are fully closed,
+2. CI baseline includes reliable quality gates and deterministic replay,
+3. type-safety migration for core IDs/pointers is complete or explicitly risk-accepted,
+4. test-only permissive contracts are isolated from runtime surfaces,
+5. docs consistently represent M7 as complete and next-slice as active.
+
+## 5. Target outcomes for the next slice
+
+1. **N-O1:** first architecture binding package is reviewable and traceable.
+2. **N-O2:** adapter specialization path is executable in non-hardware CI mode.
+3. **N-O3:** architecture-focused trace suite is integrated into tiered testing.
+4. **N-O4:** information-flow trajectory is concretely staged (not just conceptual).
+5. **N-O5:** contributor UX for platform-facing changes remains predictable.
+
+## 6. Risks and mitigations
+
+1. **Overcoupling risk**
+   - mitigation: keep adapter interfaces stable, isolate platform-specific modules.
+2. **Evidence drift risk**
+   - mitigation: require trace/test/doc updates in the same PR range.
+3. **Security claim inflation risk**
+   - mitigation: stage claims explicitly and tie each to concrete proof obligations.
+4. **Hardware lock-in risk**
+   - mitigation: maintain simulation-backed abstractions and portability notes.
+
+## 7. Recommended kickoff package
+
+When opening the first next-slice PR set, include:
+
+1. updated spec status markers,
+2. next-slice workstream board with owners,
+3. architecture binding assumptions table,
+4. minimal adapter specialization prototype,
+5. CI/test evidence commands and expected outputs.
+
+This keeps the transition from “remediation” to “expansion” measurable and low-risk.

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,9 +4,9 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** M7 audit remediation workstreams (WS-A1 through WS-A8) as the immediate execution focus.
+- **Current slice:** M7 audit remediation workstreams (WS-A1 through WS-A8) with outcome-driven closure gates.
 - **Most recently completed slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-E complete).
-- **First real hardware architecture focus:** Raspberry Pi 5 (post-remediation binding trajectory).
+- **Planned next slice:** post-M7 hardware-oriented development path (Raspberry Pi 5 first) with architecture-specific adapter and evidence expansion.
 
 Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance reference.
 
@@ -22,31 +22,36 @@ Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance
 ### 2) Active planning and execution
 
 5. [Specification & Roadmap](05-specification-and-roadmap.md)
-6. [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md)
-7. [Development Workflow](06-development-workflow.md)
-8. [Testing & CI](07-testing-and-ci.md)
-9. [Codebase Reference](11-codebase-reference.md)
-10. [Proof and Invariant Map](12-proof-and-invariant-map.md)
-11. [End-to-End Audit and Quality Gates](19-end-to-end-audit-and-quality-gates.md)
-12. [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
+6. [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
+7. [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
+8. [Development Workflow](06-development-workflow.md)
+9. [Testing & CI](07-testing-and-ci.md)
+10. [Codebase Reference](11-codebase-reference.md)
+11. [Proof and Invariant Map](12-proof-and-invariant-map.md)
+12. [End-to-End Audit and Quality Gates](19-end-to-end-audit-and-quality-gates.md)
 
-### 3) Slice history and long-horizon path
+### 3) Transition and long-horizon path
 
-13. [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
-14. [Completed Slice: M4-A](08-completed-slice-m4a.md)
-15. [Completed Slice: M4-B](16-completed-slice-m4b.md)
-16. [M4-B Execution Playbook](14-m4b-execution-playbook.md)
-17. [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
-18. [M5 Development Blueprint](15-m5-development-blueprint.md)
-19. [Project Usage and Value](17-project-usage-value.md)
-20. [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)
+13. [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md)
+14. [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)
+15. [Project Usage and Value](17-project-usage-value.md)
+
+### 4) Slice history archive
+
+16. [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md)
+17. [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
+18. [Completed Slice: M4-A](08-completed-slice-m4a.md)
+19. [Completed Slice: M4-B](16-completed-slice-m4b.md)
+20. [M4-B Execution Playbook](14-m4b-execution-playbook.md)
+21. [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
+22. [M5 Development Blueprint](15-m5-development-blueprint.md)
 
 ## Anti-duplication guidance
 
 To keep this handbook maintainable:
 
 - put normative scope and acceptance criteria in `docs/SEL4_SPEC.md`,
-- keep current-slice chapters focused on active execution details,
+- keep active-slice chapters focused on current execution details and closure evidence,
 - keep completed-slice chapters as concise historical references,
 - use cross-links when reusing definitions,
-- and keep Raspberry Pi 5 planning details synchronized between roadmap and hardware chapters.
+- and keep Raspberry Pi 5 planning details synchronized between roadmap, next-slice, and hardware chapters.

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -12,21 +12,26 @@
 ## Active planning and execution
 
 - [Specification & Roadmap](05-specification-and-roadmap.md)
-- [M6 Execution Plan and Workstreams (Closeout)](18-m6-execution-plan-and-workstreams.md)
+- [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
+- [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
 - [Development Workflow](06-development-workflow.md)
 - [Testing & CI](07-testing-and-ci.md)
 - [Codebase Reference](11-codebase-reference.md)
 - [Proof and Invariant Map](12-proof-and-invariant-map.md)
 - [End-to-End Audit and Quality Gates](19-end-to-end-audit-and-quality-gates.md)
-- [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
 
-## Slice history and roadmap
+## Transition and long-horizon path
 
+- [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md)
+- [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)
+- [Project Usage and Value](17-project-usage-value.md)
+
+## Slice history archive
+
+- [M6 Execution Plan and Workstreams (Closeout)](18-m6-execution-plan-and-workstreams.md)
 - [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
 - [Completed Slice: M4-A](08-completed-slice-m4a.md)
 - [Completed Slice: M4-B](16-completed-slice-m4b.md)
 - [M4-B Execution Playbook](14-m4b-execution-playbook.md)
 - [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
 - [M5 Development Blueprint](15-m5-development-blueprint.md)
-- [Project Usage and Value](17-project-usage-value.md)
-- [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)


### PR DESCRIPTION
Expanded the root project docs to better frame the active M7 slice with explicit target outcomes and direct links to the new execution-path chapters, so contributors can quickly find current-slice and next-slice planning context from the repository entrypoint.

Significantly expanded the core remediation program doc with an outcome matrix (M7-O1..M7-O8), audit-to-workstream traceability, detailed WS-A1..WS-A8 scopes, phased sequencing, governance/reporting expectations, and explicit M7 exit handoff criteria.

Updated the development guide with a dedicated M7 operating model section that standardizes PR expectations (workstream binding, outcome binding, evidence, docs sync, and checkpoint format).

Reorganized the GitBook IA/navigation (README.md and SUMMARY.md) to separate active execution, transition/long-horizon planning, and historical archive sections, and added the new M7 and post-M7 chapters into primary navigation.

Added two new GitBook chapters: one for current-slice M7 outcomes/workstreams and closure gates, and one for the post-M7 development path with proposed next-slice workstreams, entry criteria, risks, and kickoff package guidance.

Refined the roadmap chapter to explicitly represent M7 as active, link to execution chapters, define post-M7 goals, and clarify the M7→next-slice transition gate criteria
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993de8f5400832ba82e99cea211118e)