### PR TITLE
Optimize Lean setup flow; split IPC operations and sync docs (v0.8.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.8.7] - 2026-02-17
+
+### Tooling setup optimization
+- Refactored `scripts/setup_lean_env.sh` to share package-manager helpers and perform `apt-get update` at most once even when both `shellcheck` and `ripgrep` are missing.
+- Preserved all existing installer behavior while reducing duplicated setup work/noise in cold environments.
+
+## [0.8.6] - 2026-02-17
+
+### Audit/Sync hardening
+- Performed full post-WS-A2 repository validation sweep (`test_fast`, `test_smoke`, `test_full`, `test_nightly`) and confirmed all tiers pass without regressions.
+- Synchronized roadmap and audit-context docs so M7 status explicitly reflects WS-A1/WS-A2 as completed while preserving historical audit snapshot intent.
+- Clarified historical audit caveat language so architecture criticisms about IPC split are interpreted as pre-remediation findings, not current-state defects.
+
+## [0.8.5] - 2026-02-17
+
+### Architecture / API modularity (WS-A2)
+- Split IPC transition semantics into `SeLe4n/Kernel/IPC/Operations.lean` and retained invariant/proof obligations in `SeLe4n/Kernel/IPC/Invariant.lean` to restore operations/invariant symmetry.
+- Kept `SeLe4n/Kernel/API.lean` as the stable external facade while explicitly exporting IPC operations and invariant surfaces.
+- Updated development documentation and GitBook architecture maps/workstream tracking to mark WS-A2 complete with closure evidence.
+
 ## [0.8.4] - 2026-02-17
 
 ### CI / Tooling reliability

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
 
-- **Current package version:** `0.8.4` (see `lakefile.toml`).
+- **Current package version:** `0.8.7` (see `lakefile.toml`).
 
 ### Current slice target outcomes (M7)
 

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -1,5 +1,6 @@
 import SeLe4n.Kernel.Scheduler.Invariant
 import SeLe4n.Kernel.Capability.Operations
+import SeLe4n.Kernel.IPC.Operations
 import SeLe4n.Kernel.IPC.Invariant
 import SeLe4n.Kernel.Capability.Invariant
 import SeLe4n.Kernel.Scheduler.Operations

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -1,63 +1,9 @@
-import SeLe4n.Kernel.Capability.Operations
+import SeLe4n.Kernel.Scheduler.Invariant
+import SeLe4n.Kernel.IPC.Operations
 
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model
-
-/-- Add a sender to an endpoint wait queue with explicit state transition. -/
-def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel Unit :=
-  fun st =>
-    match st.objects endpointId with
-    | some (.endpoint ep) =>
-        match ep.state with
-        | .idle =>
-            let ep' : Endpoint := { state := .send, queue := [sender], waitingReceiver := none }
-            storeObject endpointId (.endpoint ep') st
-        | .send =>
-            let ep' : Endpoint := { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }
-            storeObject endpointId (.endpoint ep') st
-        | .receive =>
-            match ep.queue, ep.waitingReceiver with
-            | [], some _ =>
-                let ep' : Endpoint := { state := .idle, queue := [], waitingReceiver := none }
-                storeObject endpointId (.endpoint ep') st
-            | _, _ => .error .endpointStateMismatch
-    | some _ => .error .invalidCapability
-    | none => .error .objectNotFound
-
-/-- Register one waiting receiver on an idle endpoint. -/
-def endpointAwaitReceive (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId) : Kernel Unit :=
-  fun st =>
-    match st.objects endpointId with
-    | some (.endpoint ep) =>
-        match ep.state, ep.queue, ep.waitingReceiver with
-        | .idle, [], none =>
-            let ep' : Endpoint := { state := .receive, queue := [], waitingReceiver := some receiver }
-            storeObject endpointId (.endpoint ep') st
-        | .idle, _, _ => .error .endpointStateMismatch
-        | .send, _, _ => .error .endpointStateMismatch
-        | .receive, _, _ => .error .endpointStateMismatch
-    | some _ => .error .invalidCapability
-    | none => .error .objectNotFound
-
-/-- Consume one queued sender from an endpoint wait queue. -/
-def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
-  fun st =>
-    match st.objects endpointId with
-    | some (.endpoint ep) =>
-        match ep.state, ep.queue, ep.waitingReceiver with
-        | .send, sender :: rest, none =>
-            let nextState : EndpointState := if rest.isEmpty then .idle else .send
-            let ep' : Endpoint := { state := nextState, queue := rest, waitingReceiver := none }
-            match storeObject endpointId (.endpoint ep') st with
-            | .error e => .error e
-            | .ok ((), st') => .ok (sender, st')
-        | .send, [], none => .error .endpointQueueEmpty
-        | .send, _, some _ => .error .endpointStateMismatch
-        | .idle, _, _ => .error .endpointStateMismatch
-        | .receive, _, _ => .error .endpointStateMismatch
-    | some _ => .error .invalidCapability
-    | none => .error .objectNotFound
 
 /- Local store/lookup transport lemmas (M3.5 step-5).
 These lemmas keep endpoint-transition preservation proofs concrete and non-duplicative. -/

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -1,0 +1,62 @@
+import SeLe4n.Model.State
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+/-- Add a sender to an endpoint wait queue with explicit state transition. -/
+def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel Unit :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        match ep.state with
+        | .idle =>
+            let ep' : Endpoint := { state := .send, queue := [sender], waitingReceiver := none }
+            storeObject endpointId (.endpoint ep') st
+        | .send =>
+            let ep' : Endpoint := { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }
+            storeObject endpointId (.endpoint ep') st
+        | .receive =>
+            match ep.queue, ep.waitingReceiver with
+            | [], some _ =>
+                let ep' : Endpoint := { state := .idle, queue := [], waitingReceiver := none }
+                storeObject endpointId (.endpoint ep') st
+            | _, _ => .error .endpointStateMismatch
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Register one waiting receiver on an idle endpoint. -/
+def endpointAwaitReceive (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId) : Kernel Unit :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        match ep.state, ep.queue, ep.waitingReceiver with
+        | .idle, [], none =>
+            let ep' : Endpoint := { state := .receive, queue := [], waitingReceiver := some receiver }
+            storeObject endpointId (.endpoint ep') st
+        | .idle, _, _ => .error .endpointStateMismatch
+        | .send, _, _ => .error .endpointStateMismatch
+        | .receive, _, _ => .error .endpointStateMismatch
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Consume one queued sender from an endpoint wait queue. -/
+def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        match ep.state, ep.queue, ep.waitingReceiver with
+        | .send, sender :: rest, none =>
+            let nextState : EndpointState := if rest.isEmpty then .idle else .send
+            let ep' : Endpoint := { state := nextState, queue := rest, waitingReceiver := none }
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') => .ok (sender, st')
+        | .send, [], none => .error .endpointQueueEmpty
+        | .send, _, some _ => .error .endpointStateMismatch
+        | .idle, _, _ => .error .endpointStateMismatch
+        | .receive, _, _ => .error .endpointStateMismatch
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+end SeLe4n.Kernel

--- a/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
+++ b/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
@@ -63,20 +63,16 @@ Promote proof-surface and determinism checks to enforced CI gates while reducing
 
 ---
 
-### WS-A2 — Architecture modularity and API surface (High)
+### WS-A2 — Architecture modularity and API surface (High) ✅ completed
 
 **Objective**
 Keep module symmetry and maintain a stable syscall-facing facade.
 
-**Scope**
-- preserve IPC operations/invariant separation,
-- keep theorem names and imports stable where feasible,
-- keep `SeLe4n/Kernel/API.lean` as the explicit public boundary.
-
-**Acceptance criteria**
-- no semantic drift in Tier 2 traces,
-- Tier 3 anchors remain accurate and passing,
-- architecture docs reflect dependency and API-boundary changes.
+**Closure evidence (implemented)**
+- IPC transition semantics are now isolated in `SeLe4n/Kernel/IPC/Operations.lean`,
+- IPC invariant/proof obligations remain in `SeLe4n/Kernel/IPC/Invariant.lean`,
+- `SeLe4n/Kernel/API.lean` preserves a stable public import facade while exporting both IPC layers,
+- architecture docs now map IPC as `Kernel/IPC/{Operations,Invariant}.lean` with explicit dependency boundaries.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -228,6 +228,14 @@ Use this model for all milestone-moving work while M7 is active:
 - **Phase 2 (quality depth):** WS-A3 and WS-A4 after boundaries are stable.
 - **Phase 3 (trajectory hardening):** WS-A7 and WS-A8 once migration churn decreases.
 
+### 6.2.1 Current completion snapshot
+
+- ✅ **Completed:** WS-A1, WS-A2
+- ▶️ **Primary in-progress focus:** WS-A3, WS-A5
+- 📝 **Planned follow-on:** WS-A4, WS-A6, WS-A7, WS-A8
+
+(Authoritative closure evidence remains in `docs/AUDIT_REMEDIATION_WORKSTREAMS.md` and GitBook chapter 21.)
+
 ### 6.3 Required checkpoint summary format
 
 Checkpoint summaries should include:

--- a/docs/REPOSITORY_AUDIT.md
+++ b/docs/REPOSITORY_AUDIT.md
@@ -6,7 +6,10 @@
 
 ---
 
-**Post-audit remediation note (M7 WS-A1):** Tier 3 has been promoted into CI, nightly determinism workflow and CI policy documentation are now present (`.github/workflows/lean_action_ci.yml`, `.github/workflows/nightly_determinism.yml`, `docs/CI_POLICY.md`).
+**Post-audit remediation note (M7 WS-A1/WS-A2):**
+- WS-A1 is complete: Tier 3 is promoted into CI and nightly determinism + CI policy documentation are present (`.github/workflows/lean_action_ci.yml`, `.github/workflows/nightly_determinism.yml`, `docs/CI_POLICY.md`).
+- WS-A2 is complete: IPC transition operations are split into `SeLe4n/Kernel/IPC/Operations.lean` and invariant/proof obligations remain in `SeLe4n/Kernel/IPC/Invariant.lean` behind a stable `SeLe4n/Kernel/API.lean` facade.
+- Findings in this audit remain a historical snapshot at audit-time version 0.8.0; authoritative current status for active remediation closure is tracked in `docs/AUDIT_REMEDIATION_WORKSTREAMS.md` and `docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`.
 
 ## Executive Summary
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -62,8 +62,9 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 
 ### IPC subsystem
 
+- `SeLe4n/Kernel/IPC/Operations.lean`
+  - endpoint transitions (`send`, `awaitReceive`, `receive`).
 - `SeLe4n/Kernel/IPC/Invariant.lean`
-  - endpoint transitions (`send`, `awaitReceive`, `receive`),
   - endpoint + IPC invariants,
   - scheduler-coherence contract predicates,
   - preservation theorem entrypoints.
@@ -112,7 +113,7 @@ SeLe4n.lean
     ├── Model/State.lean
     ├── Kernel/Scheduler/{Operations,Invariant}.lean
     ├── Kernel/Capability/{Operations,Invariant}.lean
-    ├── Kernel/IPC/Invariant.lean   ← planned WS-A2 split
+    ├── Kernel/IPC/{Operations,Invariant}.lean
     ├── Kernel/Lifecycle/{Operations,Invariant}.lean
     ├── Kernel/Service/{Operations,Invariant}.lean
     └── Kernel/Architecture/{Assumptions,Adapter,Invariant}.lean

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -35,6 +35,7 @@ It also highlights where M6 closeout artifacts, active audit-remediation work, a
 - `SeLe4n/Kernel/Scheduler/Invariant.lean`
 - `SeLe4n/Kernel/Capability/Operations.lean`
 - `SeLe4n/Kernel/Capability/Invariant.lean`
+- `SeLe4n/Kernel/IPC/Operations.lean`
 - `SeLe4n/Kernel/IPC/Invariant.lean`
 - `SeLe4n/Kernel/Lifecycle/Operations.lean`
 - `SeLe4n/Kernel/Lifecycle/Invariant.lean`

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -31,12 +31,14 @@ Closeout details are maintained in [M6 Execution Plan and Workstreams](18-m6-exe
 
 ### Candidate workstreams
 
-- **WS-A1:** CI hardening and quality-gate promotion,
-- **WS-A2:** architecture modularity and API-surface cleanup,
+- **WS-A1:** CI hardening and quality-gate promotion ✅ completed,
+- **WS-A2:** architecture modularity and API-surface cleanup ✅ completed,
 - **WS-A3:** type-safety uplift for ID/pointer domains,
 - **WS-A4:** test architecture expansion,
 - **WS-A5:** hardware-boundary safety and test-only contract separation,
 - **WS-A6/WS-A7/WS-A8:** documentation, maintainability automation, and platform-security maturity preparation.
+
+Current closure source of truth for M7 outcomes/workstreams: [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md).
 
 ## 4. Mid-horizon slices (M8+ directional)
 

--- a/docs/gitbook/20-repository-audit-remediation-workstreams.md
+++ b/docs/gitbook/20-repository-audit-remediation-workstreams.md
@@ -36,10 +36,10 @@ The remediation program targets eight concrete repository outcomes:
    - improve workflow determinism and cache efficiency,
    - document branch protection and required evidence flows.
 
-2. **WS-A2 — Architecture modularity and API surface**
-   - maintain operations/invariant symmetry,
-   - isolate and stabilize public API surfaces,
-   - reduce hidden coupling between modules.
+2. **WS-A2 — Architecture modularity and API surface** ✅ **completed**
+   - split IPC operations (`SeLe4n/Kernel/IPC/Operations.lean`) from invariant/proof surfaces (`SeLe4n/Kernel/IPC/Invariant.lean`),
+   - preserve `SeLe4n/Kernel/API.lean` as the stable public facade with explicit IPC exports,
+   - update architecture maps to document the now-symmetric module layout and dependency boundaries.
 
 3. **WS-A3 — Type-safety uplift for IDs/pointers**
    - migrate critical aliases to explicit wrappers,

--- a/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
+++ b/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
@@ -59,21 +59,21 @@ Concretely, M7 should leave the repository in a state where:
 - no milestone-moving PR bypasses proof-surface checks ✅,
 - failed checks produce actionable diagnostics ✅.
 
-### WS-A2 — Architecture modularity and API surface
+### WS-A2 — Architecture modularity and API surface ✅ completed
 
 **Intent:** make subsystem boundaries composable for future platform binding work.
 
-**Execution focus now:**
+**Completed closure evidence:**
 
-- maintain symmetry between operations and invariants,
-- keep external entrypoints stable via `SeLe4n/Kernel/API.lean`,
-- preserve theorem discoverability while moving internal modules.
+- IPC transitions are split into `SeLe4n/Kernel/IPC/Operations.lean` while proof/invariant obligations remain in `SeLe4n/Kernel/IPC/Invariant.lean`,
+- external entrypoints remain stable through `SeLe4n/Kernel/API.lean` with explicit IPC operations + invariant exports,
+- architecture maps/documentation now reflect the split and dependency direction without hidden IPC coupling.
 
-**DoD signals:**
+**DoD signals status:**
 
-- IPC layering is split and mapped in docs,
-- dependent imports are minimal and explicit,
-- no trace/theorem regression during refactors.
+- IPC layering is split and mapped in docs ✅,
+- dependent imports are minimal and explicit ✅,
+- no trace/theorem regression during refactors ✅.
 
 ### WS-A3 — Type-safety uplift for IDs and pointers
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.8.4"
+version = "0.8.7"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/setup_lean_env.sh
+++ b/scripts/setup_lean_env.sh
@@ -6,6 +6,23 @@ ELAN_HOME_DEFAULT="${HOME}/.elan"
 ELAN_ENV_FILE="${ELAN_HOME:-$ELAN_HOME_DEFAULT}/env"
 LEAN_TOOLCHAIN_FILE="${ROOT_DIR}/lean-toolchain"
 
+APT_UPDATE_DONE=0
+
+run_pkg_install() {
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+apt_update_once() {
+  if [ "${APT_UPDATE_DONE}" -eq 0 ]; then
+    run_pkg_install apt-get update
+    APT_UPDATE_DONE=1
+  fi
+}
+
 ensure_shellcheck() {
   if command -v shellcheck >/dev/null 2>&1; then
     return 0
@@ -13,16 +30,8 @@ ensure_shellcheck() {
 
   echo "[setup] shellcheck not found; attempting to install"
 
-  run_pkg_install() {
-    if command -v sudo >/dev/null 2>&1; then
-      sudo "$@"
-    else
-      "$@"
-    fi
-  }
-
   if command -v apt-get >/dev/null 2>&1; then
-    run_pkg_install apt-get update
+    apt_update_once
     run_pkg_install env DEBIAN_FRONTEND=noninteractive apt-get install -y shellcheck
   elif command -v dnf >/dev/null 2>&1; then
     run_pkg_install dnf install -y ShellCheck
@@ -51,16 +60,8 @@ ensure_ripgrep() {
 
   echo "[setup] ripgrep (rg) not found; attempting to install"
 
-  run_pkg_install() {
-    if command -v sudo >/dev/null 2>&1; then
-      sudo "$@"
-    else
-      "$@"
-    fi
-  }
-
   if command -v apt-get >/dev/null 2>&1; then
-    run_pkg_install apt-get update
+    apt_update_once
     run_pkg_install env DEBIAN_FRONTEND=noninteractive apt-get install -y ripgrep
   elif command -v dnf >/dev/null 2>&1; then
     run_pkg_install dnf install -y ripgrep

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -72,7 +72,9 @@ run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m3IpcSeedInvariantB
 run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M3.5 step-2 transition anchors must remain present.
-run_check "INVARIANT" rg -n '^def endpointAwaitReceive' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^def endpointSend' SeLe4n/Kernel/IPC/Operations.lean
+run_check "INVARIANT" rg -n '^def endpointAwaitReceive' SeLe4n/Kernel/IPC/Operations.lean
+run_check "INVARIANT" rg -n '^def endpointReceive' SeLe4n/Kernel/IPC/Operations.lean
 run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M3.5 step-3 scheduler-contract predicate anchors must remain present.


### PR DESCRIPTION
### Motivation
- Reduce first-run environment churn by avoiding duplicate package-manager work in the Lean setup script and ensure docs, API surfaces, and test anchors remain synchronized after the WS-A2 IPC split. 
- Keep the public kernel API stable while moving internal IPC transition implementations into a dedicated operations module for clearer module symmetry and easier review.

### Description
- Refactored `scripts/setup_lean_env.sh` to introduce shared helpers `run_pkg_install` and `apt_update_once` so `apt-get update` runs at most once during cold installs while preserving existing installer branches (`apt`, `dnf`, `yum`, `pacman`, `brew`).
- Split IPC transition implementations out of `SeLe4n/Kernel/IPC/Invariant.lean` into a new `SeLe4n/Kernel/IPC/Operations.lean` and updated `SeLe4n/Kernel/IPC/Invariant.lean` to import the operations layer instead of duplicating code.
- Updated `SeLe4n/Kernel/API.lean` to explicitly export the IPC operations and adjusted `scripts/test_tier3_invariant_surface.sh` to assert anchors in `Kernel/IPC/Operations.lean` where appropriate.
- Bumped the project patch version to `0.8.7` in `lakefile.toml`, synced `README.md`, and added a `0.8.7` entry to `CHANGELOG.md`; updated multiple docs/GitBook chapters to record WS-A1/WS-A2 closure and the new IPC module layout.

### Testing
- Ran linting and validation with `shellcheck scripts/setup_lean_env.sh` which passed. 
- Re-ran the suite of project validation runners `./scripts/test_fast.sh`, `./scripts/test_full.sh`, and `./scripts/test_nightly.sh`, all of which completed successfully. 
- Executed the audit harness `./scripts/audit_testing_framework.sh`, which behaved as intended: the script injects a deliberate negative-control expectation (`[CONTROL] impossible expected line`) to verify Tier-2 failure detection and the audit harness reported success after validating that behavior. 
- Confirmed Tiered checks (`test_tier0`..`test_tier3`) and fixture/traces remained green and that documentation/GitBook anchors were updated to reflect the IPC split.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f75cb650832b85af7807428b6f40)