### PR TITLE
Refine WS-A3: add Tier‑3 regression guard, stabilize newtypes, bump to 0.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.8.10] - 2026-02-17
+
+### WS-A3 regression-guard hardening
+- Added Tier-3 invariant-surface guards that require explicit `ThreadId.toObjId` conversion entrypoint presence and fail if an implicit `ThreadId -> ObjId` coercion is reintroduced.
+- Revalidated full Tier 0-4 test coverage (`test_fast`, `test_smoke`, `test_full`, `test_nightly` with experimental candidates) after introducing the new guard.
+
+## [0.8.9] - 2026-02-17
+
+### WS-A3 audit follow-up hardening
+- Removed implicit `ThreadId -> ObjId` coercion and replaced it with explicit `ThreadId.toObjId` conversions at object-store boundaries to preserve stronger compile-time domain separation.
+- Updated scheduler and IPC proof/operation call sites to use explicit conversion points and kept all invariant bundles compiling without placeholder debt.
+- Synchronized GitBook planning chapters so WS-A3 completion state is consistent across current-slice and remediation overview pages.
+
+## [0.8.8] - 2026-02-17
+
+### M7 WS-A3 type-safety uplift
+- Migrated `ThreadId`, `ObjId`, `CPtr`, and `Slot` from raw `Nat` aliases to dedicated wrapper types with migration helpers (`ofNat`/`toNat`) and typed bridge instances where object-store indexing is intentional.
+- Updated scheduler/IPC invariant surfaces to keep thread-domain membership obligations typed as `ThreadId` while preserving object-store key discipline through `ObjId`.
+- Updated active-slice docs/GitBook to mark WS-A3 completed and synced current development status snapshots.
+
 ## [0.8.7] - 2026-02-17
 
 ### Tooling setup optimization

--- a/Main.lean
+++ b/Main.lean
@@ -163,7 +163,7 @@ def main : IO Unit := do
   match SeLe4n.Kernel.schedule bootstrapState with
   | .error err => IO.println s!"scheduler error: {reprStr err}"
   | .ok (_, st1) =>
-      IO.println s!"scheduled thread: {reprStr st1.scheduler.current}"
+      IO.println s!"scheduled thread: {reprStr (st1.scheduler.current.map SeLe4n.ThreadId.toNat)}"
       match SeLe4n.Kernel.cspaceLookupSlot rootSlot st1 with
       | .error err => IO.println s!"source lookup error: {reprStr err}"
       | .ok (srcCap, _) =>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
 
-- **Current package version:** `0.8.7` (see `lakefile.toml`).
+- **Current package version:** `0.8.10` (see `lakefile.toml`).
 
 ### Current slice target outcomes (M7)
 

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -64,7 +64,8 @@ theorem tcb_lookup_of_endpoint_store
 endpoint-object stores do not alter runnable-set membership goals. -/
 theorem runnable_membership_of_endpoint_store
     (st st' : SystemState)
-    (endpointId tid : SeLe4n.ObjId)
+    (endpointId : SeLe4n.ObjId)
+    (tid : SeLe4n.ThreadId)
     (ep' : Endpoint)
     (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
     (hRun : tid ∈ st'.scheduler.runnable) :
@@ -77,7 +78,8 @@ theorem runnable_membership_of_endpoint_store
 endpoint-object stores do not alter non-runnable goals. -/
 theorem not_runnable_membership_of_endpoint_store
     (st st' : SystemState)
-    (endpointId tid : SeLe4n.ObjId)
+    (endpointId : SeLe4n.ObjId)
+    (tid : SeLe4n.ThreadId)
     (ep' : Endpoint)
     (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
     (hNotRun : tid ∉ st.scheduler.runnable) :
@@ -205,22 +207,22 @@ def ipcInvariant (st : SystemState) : Prop :=
 
 /-- Scheduler contract predicate #1 for M3.5: runnable threads are explicitly IPC-ready. -/
 def runnableThreadIpcReady (st : SystemState) : Prop :=
-  ∀ tid tcb,
-    st.objects tid = some (.tcb tcb) →
+  ∀ (tid : SeLe4n.ThreadId) tcb,
+    st.objects tid.toObjId = some (.tcb tcb) →
     tid ∈ st.scheduler.runnable →
     tcb.ipcState = .ready
 
 /-- Scheduler contract predicate #2 for M3.5: send-blocked threads are not runnable. -/
 def blockedOnSendNotRunnable (st : SystemState) : Prop :=
-  ∀ tid tcb endpointId,
-    st.objects tid = some (.tcb tcb) →
+  ∀ (tid : SeLe4n.ThreadId) tcb endpointId,
+    st.objects tid.toObjId = some (.tcb tcb) →
     tcb.ipcState = .blockedOnSend endpointId →
     tid ∉ st.scheduler.runnable
 
 /-- Scheduler contract predicate #3 for M3.5: receive-blocked threads are not runnable. -/
 def blockedOnReceiveNotRunnable (st : SystemState) : Prop :=
-  ∀ tid tcb endpointId,
-    st.objects tid = some (.tcb tcb) →
+  ∀ (tid : SeLe4n.ThreadId) tcb endpointId,
+    st.objects tid.toObjId = some (.tcb tcb) →
     tcb.ipcState = .blockedOnReceive endpointId →
     tid ∉ st.scheduler.runnable
 
@@ -242,8 +244,8 @@ theorem endpointSend_preserves_runnableThreadIpcReady
     runnableThreadIpcReady st' := by
   rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
   intro tid tcb hObj hRun
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hRunOrig : tid ∈ st.scheduler.runnable :=
     runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
   exact hInv tid tcb hObjOrig hRunOrig
@@ -257,8 +259,8 @@ theorem endpointSend_preserves_blockedOnSendNotRunnable
     blockedOnSendNotRunnable st' := by
   rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
   intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
   exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
@@ -271,8 +273,8 @@ theorem endpointSend_preserves_blockedOnReceiveNotRunnable
     blockedOnReceiveNotRunnable st' := by
   rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
   intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
   exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
@@ -298,8 +300,8 @@ theorem endpointAwaitReceive_preserves_runnableThreadIpcReady
     runnableThreadIpcReady st' := by
   rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
   intro tid tcb hObj hRun
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hRunOrig : tid ∈ st.scheduler.runnable :=
     runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
   exact hInv tid tcb hObjOrig hRunOrig
@@ -313,8 +315,8 @@ theorem endpointAwaitReceive_preserves_blockedOnSendNotRunnable
     blockedOnSendNotRunnable st' := by
   rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
   intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
   exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
@@ -327,8 +329,8 @@ theorem endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable
     blockedOnReceiveNotRunnable st' := by
   rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
   intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
   exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
@@ -354,8 +356,8 @@ theorem endpointReceive_preserves_runnableThreadIpcReady
     runnableThreadIpcReady st' := by
   rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
   intro tid tcb hObj hRun
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hRunOrig : tid ∈ st.scheduler.runnable :=
     runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
   exact hInv tid tcb hObjOrig hRunOrig
@@ -369,8 +371,8 @@ theorem endpointReceive_preserves_blockedOnSendNotRunnable
     blockedOnSendNotRunnable st' := by
   rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
   intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
   exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
@@ -383,8 +385,8 @@ theorem endpointReceive_preserves_blockedOnReceiveNotRunnable
     blockedOnReceiveNotRunnable st' := by
   rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
   intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid tcb ep' hStore hObj
+  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
+    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
   have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
   exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
 
@@ -667,17 +669,17 @@ theorem endpointSend_preserves_schedulerInvariantBundle
     | none =>
         simp [currentThreadValid, hCurEq, hCurrent]
     | some tid =>
-        have hCurSome : ∃ tcb : TCB, st.objects tid = some (.tcb tcb) := by
+        have hCurSome : ∃ tcb : TCB, st.objects tid.toObjId = some (.tcb tcb) := by
           simpa [currentThreadValid, hCurrent] using hCur
         rcases hCurSome with ⟨tcb, hTcbObj⟩
-        have hTidNe : tid ≠ endpointId := by
+        have hTidNe : tid.toObjId ≠ endpointId := by
           intro hEq
           subst hEq
-          rcases endpointSend_ok_implies_endpoint_object st st' tid sender hStep with ⟨ep, hEpObj⟩
+          rcases endpointSend_ok_implies_endpoint_object st st' tid.toObjId sender hStep with ⟨ep, hEpObj⟩
           rw [hEpObj] at hTcbObj
           cases hTcbObj
-        have hTcbObj' : st'.objects tid = some (.tcb tcb) := by
-          rw [endpointSend_preserves_other_objects st st' endpointId tid sender hTidNe hStep]
+        have hTcbObj' : st'.objects tid.toObjId = some (.tcb tcb) := by
+          rw [endpointSend_preserves_other_objects st st' endpointId tid.toObjId sender hTidNe hStep]
           exact hTcbObj
         simp [currentThreadValid, hCurEq, hCurrent, hTcbObj']
 
@@ -700,17 +702,17 @@ theorem endpointAwaitReceive_preserves_schedulerInvariantBundle
     | none =>
         simp [currentThreadValid, hCurEq, hCurrent]
     | some tid =>
-        have hCurSome : ∃ tcb : TCB, st.objects tid = some (.tcb tcb) := by
+        have hCurSome : ∃ tcb : TCB, st.objects tid.toObjId = some (.tcb tcb) := by
           simpa [currentThreadValid, hCurrent] using hCur
         rcases hCurSome with ⟨tcb, hTcbObj⟩
-        have hTidNe : tid ≠ endpointId := by
+        have hTidNe : tid.toObjId ≠ endpointId := by
           intro hEq
           subst hEq
-          rcases endpointAwaitReceive_ok_implies_endpoint_object st st' tid receiver hStep with ⟨ep, hEpObj⟩
+          rcases endpointAwaitReceive_ok_implies_endpoint_object st st' tid.toObjId receiver hStep with ⟨ep, hEpObj⟩
           rw [hEpObj] at hTcbObj
           cases hTcbObj
-        have hTcbObj' : st'.objects tid = some (.tcb tcb) := by
-          rw [endpointAwaitReceive_preserves_other_objects st st' endpointId tid receiver hTidNe hStep]
+        have hTcbObj' : st'.objects tid.toObjId = some (.tcb tcb) := by
+          rw [endpointAwaitReceive_preserves_other_objects st st' endpointId tid.toObjId receiver hTidNe hStep]
           exact hTcbObj
         simp [currentThreadValid, hCurEq, hCurrent, hTcbObj']
 
@@ -733,17 +735,17 @@ theorem endpointReceive_preserves_schedulerInvariantBundle
     | none =>
         simp [currentThreadValid, hCurEq, hCurrent]
     | some tid =>
-        have hCurSome : ∃ tcb : TCB, st.objects tid = some (.tcb tcb) := by
+        have hCurSome : ∃ tcb : TCB, st.objects tid.toObjId = some (.tcb tcb) := by
           simpa [currentThreadValid, hCurrent] using hCur
         rcases hCurSome with ⟨tcb, hTcbObj⟩
-        have hTidNe : tid ≠ endpointId := by
+        have hTidNe : tid.toObjId ≠ endpointId := by
           intro hEq
           subst hEq
-          rcases endpointReceive_ok_implies_endpoint_object st st' tid sender hStep with ⟨ep, hEpObj⟩
+          rcases endpointReceive_ok_implies_endpoint_object st st' tid.toObjId sender hStep with ⟨ep, hEpObj⟩
           rw [hEpObj] at hTcbObj
           cases hTcbObj
-        have hTcbObj' : st'.objects tid = some (.tcb tcb) := by
-          rw [endpointReceive_preserves_other_objects st st' endpointId tid sender hTidNe hStep]
+        have hTcbObj' : st'.objects tid.toObjId = some (.tcb tcb) := by
+          rw [endpointReceive_preserves_other_objects st st' endpointId tid.toObjId sender hTidNe hStep]
           exact hTcbObj
         simp [currentThreadValid, hCurEq, hCurrent, hTcbObj']
 

--- a/SeLe4n/Kernel/Scheduler/Invariant.lean
+++ b/SeLe4n/Kernel/Scheduler/Invariant.lean
@@ -30,7 +30,7 @@ resolves to a TCB in the object store. -/
 def currentThreadValid (st : SystemState) : Prop :=
   match st.scheduler.current with
   | none => True
-  | some tid => ∃ tcb : TCB, st.objects tid = some (.tcb tcb)
+  | some tid => ∃ tcb : TCB, st.objects tid.toObjId = some (.tcb tcb)
 
 /-- Invariant bundle that should eventually mirror seL4 proof obligations. -/
 def kernelInvariant (st : SystemState) : Prop :=

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -18,7 +18,7 @@ def schedule : Kernel Unit :=
     match st.scheduler.runnable with
     | [] => setCurrentThread none st
     | t :: _ =>
-        match st.objects t with
+        match st.objects t.toObjId with
         | some (.tcb _) => setCurrentThread (some t) st
         | _ => setCurrentThread none st
 
@@ -34,7 +34,7 @@ theorem schedule_eq_chooseThread_then_setCurrent :
           match next with
           | none => setCurrentThread none st'
           | some tid =>
-              match st'.objects tid with
+              match st'.objects tid.toObjId with
               | some (.tcb _) => setCurrentThread (some tid) st'
               | _ => setCurrentThread none st') := by
   funext st
@@ -42,7 +42,7 @@ theorem schedule_eq_chooseThread_then_setCurrent :
   | nil =>
       simp [schedule, chooseThread, setCurrentThread, hRun]
   | cons t ts =>
-      cases hObj : st.objects t <;>
+      cases hObj : st.objects t.toObjId <;>
       simp [schedule, chooseThread, setCurrentThread, hRun, hObj]
 
 theorem setCurrentThread_preserves_wellFormed
@@ -86,7 +86,7 @@ theorem setCurrentThread_none_preserves_currentThreadValid
 theorem setCurrentThread_some_preserves_currentThreadValid
     (st st' : SystemState)
     (tid : SeLe4n.ThreadId)
-    (hObj : ∃ tcb : TCB, st.objects tid = some (.tcb tcb))
+    (hObj : ∃ tcb : TCB, st.objects tid.toObjId = some (.tcb tcb))
     (hStep : setCurrentThread (some tid) st = .ok ((), st')) :
     currentThreadValid st' := by
   simp [setCurrentThread] at hStep
@@ -126,7 +126,7 @@ theorem schedule_preserves_wellFormed
       cases hStep
       simp [schedulerWellFormed, queueCurrentConsistent]
   | cons t ts =>
-      cases hObj : st.objects t with
+      cases hObj : st.objects t.toObjId with
       | none =>
           simp [schedule, setCurrentThread, hRun, hObj] at hStep
           cases hStep
@@ -166,7 +166,7 @@ theorem schedule_preserves_queueCurrentConsistent
       cases hStep
       simp [queueCurrentConsistent]
   | cons t ts =>
-      cases hObj : st.objects t with
+      cases hObj : st.objects t.toObjId with
       | none =>
           simp [schedule, setCurrentThread, hRun, hObj] at hStep
           cases hStep
@@ -222,7 +222,7 @@ theorem schedule_preserves_runQueueUnique
       exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
         simpa [schedule, hRun] using hStep)
   | cons t ts =>
-      cases hObj : st.objects t with
+      cases hObj : st.objects t.toObjId with
       | none =>
           exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
             simpa [schedule, hRun, hObj] using hStep)
@@ -247,7 +247,7 @@ theorem schedule_preserves_currentThreadValid
       exact setCurrentThread_none_preserves_currentThreadValid st st' (by
         simpa [schedule, hRun] using hStep)
   | cons t ts =>
-      cases hObj : st.objects t with
+      cases hObj : st.objects t.toObjId with
       | none =>
           exact setCurrentThread_none_preserves_currentThreadValid st st' (by
             simpa [schedule, hRun, hObj] using hStep)

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -1,10 +1,49 @@
 namespace SeLe4n
 
 /-- Identifier for objects in the global kernel object store. -/
-abbrev ObjId := Nat
+structure ObjId where
+  val : Nat
+deriving DecidableEq, Repr, Inhabited
+
+namespace ObjId
+
+/-- Constructor helper kept explicit for migration ergonomics. -/
+@[inline] def ofNat (n : Nat) : ObjId := ⟨n⟩
+
+/-- Projection helper kept explicit for migration ergonomics. -/
+@[inline] def toNat (id : ObjId) : Nat := id.val
+
+instance instOfNat (n : Nat) : OfNat ObjId n where
+  ofNat := ⟨n⟩
+
+instance : ToString ObjId where
+  toString id := toString id.toNat
+
+end ObjId
 
 /-- Identifier for threads (TCBs). -/
-abbrev ThreadId := Nat
+structure ThreadId where
+  val : Nat
+deriving DecidableEq, Repr, Inhabited
+
+namespace ThreadId
+
+/-- Constructor helper kept explicit for migration ergonomics. -/
+@[inline] def ofNat (n : Nat) : ThreadId := ⟨n⟩
+
+/-- Projection helper kept explicit for migration ergonomics. -/
+@[inline] def toNat (id : ThreadId) : Nat := id.val
+
+/-- Explicit conversion used at object-store boundaries. -/
+@[inline] def toObjId (id : ThreadId) : ObjId := ObjId.ofNat id.toNat
+
+instance instOfNat (n : Nat) : OfNat ThreadId n where
+  ofNat := ⟨n⟩
+
+instance : ToString ThreadId where
+  toString tid := toString tid.toNat
+
+end ThreadId
 
 /-- Scheduling domain identifier. -/
 abbrev DomainId := Nat
@@ -16,10 +55,46 @@ abbrev Priority := Nat
 abbrev Irq := Nat
 
 /-- Capability-space pointer value. -/
-abbrev CPtr := Nat
+structure CPtr where
+  val : Nat
+deriving DecidableEq, Repr, Inhabited
+
+namespace CPtr
+
+/-- Constructor helper kept explicit for migration ergonomics. -/
+@[inline] def ofNat (n : Nat) : CPtr := ⟨n⟩
+
+/-- Projection helper kept explicit for migration ergonomics. -/
+@[inline] def toNat (ptr : CPtr) : Nat := ptr.val
+
+instance instOfNat (n : Nat) : OfNat CPtr n where
+  ofNat := ⟨n⟩
+
+instance : ToString CPtr where
+  toString ptr := toString ptr.toNat
+
+end CPtr
 
 /-- Slot index within a CNode. -/
-abbrev Slot := Nat
+structure Slot where
+  val : Nat
+deriving DecidableEq, Repr, Inhabited
+
+namespace Slot
+
+/-- Constructor helper kept explicit for migration ergonomics. -/
+@[inline] def ofNat (n : Nat) : Slot := ⟨n⟩
+
+/-- Projection helper kept explicit for migration ergonomics. -/
+@[inline] def toNat (slot : Slot) : Nat := slot.val
+
+instance instOfNat (n : Nat) : OfNat Slot n where
+  ofNat := ⟨n⟩
+
+instance : ToString Slot where
+  toString slot := toString slot.toNat
+
+end Slot
 
 /-- Endpoint or notification badge value. -/
 abbrev Badge := Nat

--- a/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
+++ b/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
@@ -76,20 +76,16 @@ Keep module symmetry and maintain a stable syscall-facing facade.
 
 ---
 
-### WS-A3 — Type-safety uplift for IDs and pointers (High)
+### WS-A3 — Type-safety uplift for IDs and pointers (High) ✅ completed
 
 **Objective**
 Eliminate cross-domain confusion by replacing raw aliases with wrappers.
 
-**Scope**
-- migrate `ThreadId`, `ObjId`, `CPtr`, and `Slot` to newtypes,
-- update operation signatures and theorem statements,
-- add migration helper constructors/projections for proof ergonomics.
-
-**Acceptance criteria**
-- invalid cross-domain argument mixes fail at compile-time,
-- no net loss of theorem coverage,
-- no new placeholder debt (`sorry`/`admit`).
+**Closure evidence (implemented)**
+- migrated `ThreadId`, `ObjId`, `CPtr`, and `Slot` from `abbrev` aliases to dedicated wrapper structures in `SeLe4n/Prelude.lean`,
+- added explicit constructor/projection helpers (`ofNat`/`toNat`) and typed bridge instances used by existing theorem and transition surfaces,
+- adapted scheduler/IPC invariant typing so runnable-membership obligations are carried by `ThreadId` while object-store keys remain `ObjId`,
+- validated all test tiers (`test_fast`, `test_smoke`, `test_full`, `test_nightly`) with no placeholder debt introduced.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -230,8 +230,8 @@ Use this model for all milestone-moving work while M7 is active:
 
 ### 6.2.1 Current completion snapshot
 
-- ✅ **Completed:** WS-A1, WS-A2
-- ▶️ **Primary in-progress focus:** WS-A3, WS-A5
+- ✅ **Completed:** WS-A1, WS-A2, WS-A3
+- ▶️ **Primary in-progress focus:** WS-A5
 - 📝 **Planned follow-on:** WS-A4, WS-A6, WS-A7, WS-A8
 
 (Authoritative closure evidence remains in `docs/AUDIT_REMEDIATION_WORKSTREAMS.md` and GitBook chapter 21.)

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -33,7 +33,7 @@ Closeout details are maintained in [M6 Execution Plan and Workstreams](18-m6-exe
 
 - **WS-A1:** CI hardening and quality-gate promotion ✅ completed,
 - **WS-A2:** architecture modularity and API-surface cleanup ✅ completed,
-- **WS-A3:** type-safety uplift for ID/pointer domains,
+- **WS-A3:** type-safety uplift for ID/pointer domains ✅ completed,
 - **WS-A4:** test architecture expansion,
 - **WS-A5:** hardware-boundary safety and test-only contract separation,
 - **WS-A6/WS-A7/WS-A8:** documentation, maintainability automation, and platform-security maturity preparation.

--- a/docs/gitbook/20-repository-audit-remediation-workstreams.md
+++ b/docs/gitbook/20-repository-audit-remediation-workstreams.md
@@ -41,10 +41,10 @@ The remediation program targets eight concrete repository outcomes:
    - preserve `SeLe4n/Kernel/API.lean` as the stable public facade with explicit IPC exports,
    - update architecture maps to document the now-symmetric module layout and dependency boundaries.
 
-3. **WS-A3 — Type-safety uplift for IDs/pointers**
-   - migrate critical aliases to explicit wrappers,
-   - prevent cross-domain misuse at compile time,
-   - preserve theorem ergonomics with migration helpers.
+3. **WS-A3 — Type-safety uplift for IDs/pointers** ✅ **completed**
+   - migrated critical aliases to explicit wrappers,
+   - enforce explicit object-store conversion boundaries via `ThreadId.toObjId`,
+   - preserved theorem ergonomics with migration helpers and explicit conversion points.
 
 4. **WS-A4 — Test architecture expansion**
    - add high-scale and edge-heavy scenarios,

--- a/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
+++ b/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
@@ -75,21 +75,22 @@ Concretely, M7 should leave the repository in a state where:
 - dependent imports are minimal and explicit ✅,
 - no trace/theorem regression during refactors ✅.
 
-### WS-A3 — Type-safety uplift for IDs and pointers
+### WS-A3 — Type-safety uplift for IDs and pointers ✅ completed
 
 **Intent:** remove classes of cross-domain misuse at compile time.
 
-**Execution focus now:**
+**Completed closure evidence:**
 
-- migrate high-risk aliases first (`ThreadId`, `ObjId`, `CPtr`, `Slot`),
-- preserve ergonomics with helper constructors/projections,
-- align theorem statements and executable traces after migration.
+- high-risk aliases (`ThreadId`, `ObjId`, `CPtr`, `Slot`) are migrated to wrapper types in `SeLe4n/Prelude.lean`,
+- migration ergonomics are preserved through explicit helper constructors/projections and typed bridging where object-store indexing is required,
+- scheduler/IPC theorem surfaces are adapted to keep thread-domain and object-domain obligations explicit while preserving bundle-level entrypoints,
+- validation coverage across Tier 0–4 scripts passes without introducing any placeholder debt.
 
-**DoD signals:**
+**DoD signals status:**
 
-- mixed-domain mistakes fail to typecheck,
-- migration does not introduce theorem API ambiguity,
-- no newly introduced `sorry`/`admit`/placeholder debt.
+- mixed-domain mistakes fail to typecheck ✅,
+- theorem/API surfaces remain coherent after migration ✅,
+- no newly introduced `sorry`/`admit`/placeholder debt ✅.
 
 ### WS-A4 — Test architecture expansion
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.8.7"
+version = "0.8.10"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -43,6 +43,10 @@ run_check "INVARIANT" rg -n '^theorem assumptionContractMap_nonempty' SeLe4n/Ker
 run_check "INVARIANT" rg -n '^theorem assumptionTransitionMap_nonempty' SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^theorem assumptionInvariantMap_nonempty' SeLe4n/Kernel/Architecture/Assumptions.lean
 
+# WS-A3 boundary hardening anchors must remain explicit.
+run_check "INVARIANT" rg -n '^@\[inline\] def toObjId' SeLe4n/Prelude.lean
+run_check "INVARIANT" bash -lc "if rg -n '^instance : Coe ThreadId ObjId where' SeLe4n/Prelude.lean; then echo 'Implicit ThreadId -> ObjId coercion must remain absent.' >&2; exit 1; fi"
+
 # Invariant bundle surface anchors (M1/M2/M3 composed entrypoints).
 run_check "INVARIANT" rg -n '^(def|abbrev) schedulerInvariantBundle' SeLe4n/Kernel/Scheduler/Invariant.lean
 run_check "INVARIANT" rg -n '^def capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean


### PR DESCRIPTION
### Motivation

- Prevent accidental reintroduction of an implicit `ThreadId → ObjId` coercion by making object-store boundary conversion explicit and CI-enforced. 
- Preserve the type-safety uplift from WS-A3 (IDs/pointers migrated to wrappers) while keeping proof ergonomics and executable traces stable. 
- Ensure repository documentation and GitBook state reflect the completed WS-A3 workstream and that the package version is consistent across artifacts. 

### Description

- Migrated critical ID/pointer aliases to wrapper structures in `SeLe4n/Prelude.lean` for `ObjId`, `ThreadId`, `CPtr`, and `Slot`, and added `ofNat`/`toNat` helpers and `ToString`/`OfNat` instances. 
- Removed any implicit `Coe ThreadId → ObjId` usage and added the explicit conversion `ThreadId.toObjId`, updating scheduler/IPC call sites and theorem surfaces to use `tid.toObjId` and adjusting `Main.lean` output to use `ThreadId.toNat`. 
- Added a Tier‑3 invariant-surface regression guard in `scripts/test_tier3_invariant_surface.sh` that requires the presence of `@[inline] def toObjId` and fails if an `instance : Coe ThreadId ObjId` is reintroduced. 
- Synced product metadata and docs: bumped to `0.8.10` in `lakefile.toml`/`README.md`, added a `CHANGELOG.md` entry, and updated GitBook/docs pages to mark WS-A3 completed and document the explicit boundary policy. 

### Testing

- Ran full build and proof/hygiene checks via `lake build` and the Tier 0 hygiene scripts, which completed successfully. 
- Executed the repository test matrix: `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, `./scripts/test_full.sh`, and `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh`, and all tiers passed (including fixture comparisons and nightly determinism candidate runs). 
- Extended Tier‑3 invariant checks were run (the new `toObjId` presence/implicit-coercion absence guards) and passed on the current tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994026be974832b9bab616609939bbe)