### PR TITLE
WS-A4: Expand test architecture scale scenarios, update docs, bump patch to 0.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.12] - 2026-02-17
+
+### Testing / WS-A4 completion hardening
+- Expanded Tier 2 fixture-backed trace coverage in `Main.lean` + `tests/fixtures/main_trace_smoke.expected` to explicitly cover all audit-recommended scale categories: deep CNode radix shape, large runnable queue (10+), multiple IPC endpoints, service dependency chain depth-5, and boundary memory addresses.
+- Kept Tier 2 scenario/risk tagging format for audit traceability while adding new WS-A4 scale scenarios under `WS-A4-SCALE-*` IDs.
+- Revalidated Tier 0–4 scripts (including seeded `trace_sequence_probe`) with the expanded scenarios and refreshed M7 workstream documentation evidence.
+
 All notable changes to this project are documented in this file.
 
 ## [0.8.10] - 2026-02-17

--- a/Main.lean
+++ b/Main.lean
@@ -233,6 +233,118 @@ def main : IO Unit := do
       IO.println s!"service isolation api↔denied: {reprStr <| SeLe4n.Model.hasIsolationEdge st1 svcApi svcDenied}"
       IO.println s!"service isolation api↔db: {reprStr <| SeLe4n.Model.hasIsolationEdge st1 svcApi svcDb}"
 
+      let deepRadixCNode : CNode := {
+        guard := 3
+        radix := 12
+        slots := [
+          (1, { target := .object 1, rights := [.read], badge := none }),
+          (1024, { target := .object 12, rights := [.read, .write], badge := none })
+        ]
+      }
+      let stDeepCNode : SystemState :=
+        { st1 with
+          objects := fun oid =>
+            if oid = 200 then some (.cnode deepRadixCNode) else st1.objects oid
+        }
+      IO.println s!"deep cnode radix fixture: {reprStr <| (stDeepCNode.objects 200).map (fun obj => match obj with | .cnode cn => cn.radix | _ => 0)}"
+
+      let largeRunnable : List SeLe4n.ThreadId :=
+        (List.range 12).map (fun i => SeLe4n.ThreadId.ofNat (i + 1))
+      let stLargeQueue : SystemState :=
+        { st1 with scheduler := { st1.scheduler with runnable := largeRunnable, current := none } }
+      IO.println s!"large runnable queue length: {reprStr stLargeQueue.scheduler.runnable.length}"
+      match SeLe4n.Kernel.schedule stLargeQueue with
+      | .error err => IO.println s!"large queue schedule error: {reprStr err}"
+      | .ok (_, stLargeScheduled) =>
+          IO.println s!"large queue scheduled current: {reprStr (stLargeScheduled.scheduler.current.map SeLe4n.ThreadId.toNat)}"
+
+      let stMultiEndpoint : SystemState :=
+        { st1 with
+          objects := fun oid =>
+            if oid = demoEndpoint then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+            else if oid = 31 then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+            else st1.objects oid
+        }
+      match SeLe4n.Kernel.endpointSend demoEndpoint 4 stMultiEndpoint with
+      | .error err => IO.println s!"multi-endpoint send A error: {reprStr err}"
+      | .ok (_, stEp1) =>
+          match SeLe4n.Kernel.endpointSend 31 5 stEp1 with
+          | .error err => IO.println s!"multi-endpoint send B error: {reprStr err}"
+          | .ok (_, stEp2) =>
+              match SeLe4n.Kernel.endpointReceive demoEndpoint stEp2 with
+              | .error err => IO.println s!"multi-endpoint receive A error: {reprStr err}"
+              | .ok (senderA, stEp3) =>
+                  match SeLe4n.Kernel.endpointReceive 31 stEp3 with
+                  | .error err => IO.println s!"multi-endpoint receive B error: {reprStr err}"
+                  | .ok (senderB, _) =>
+                      IO.println s!"multi-endpoint receive senders: {senderA}, {senderB}"
+
+      let chainRoot : ServiceId := 205
+      let chainL4 : ServiceId := 204
+      let chainL3 : ServiceId := 203
+      let chainL2 : ServiceId := 202
+      let chainL1 : ServiceId := 201
+      let chainTop : ServiceId := 200
+      let stServiceChain : SystemState :=
+        { st1 with
+          services := fun sid =>
+            if sid = chainRoot then
+              some {
+                identity := { sid := chainRoot, backingObject := 12, owner := 10 }
+                status := .running
+                dependencies := []
+                isolatedFrom := []
+              }
+            else if sid = chainL4 then
+              some {
+                identity := { sid := chainL4, backingObject := 12, owner := 10 }
+                status := .running
+                dependencies := [chainRoot]
+                isolatedFrom := []
+              }
+            else if sid = chainL3 then
+              some {
+                identity := { sid := chainL3, backingObject := 12, owner := 10 }
+                status := .running
+                dependencies := [chainL4]
+                isolatedFrom := []
+              }
+            else if sid = chainL2 then
+              some {
+                identity := { sid := chainL2, backingObject := 12, owner := 10 }
+                status := .running
+                dependencies := [chainL3]
+                isolatedFrom := []
+              }
+            else if sid = chainL1 then
+              some {
+                identity := { sid := chainL1, backingObject := 12, owner := 10 }
+                status := .running
+                dependencies := [chainL2]
+                isolatedFrom := []
+              }
+            else if sid = chainTop then
+              some {
+                identity := { sid := chainTop, backingObject := 12, owner := 10 }
+                status := .stopped
+                dependencies := [chainL1]
+                isolatedFrom := []
+              }
+            else
+              st1.services sid
+        }
+      match SeLe4n.Kernel.serviceStart chainTop allowAll stServiceChain with
+      | .error err => IO.println s!"service dependency chain start error: {reprStr err}"
+      | .ok (_, stChainStarted) =>
+          IO.println s!"service dependency chain depth-5 start status: {reprStr <| (SeLe4n.Model.lookupService stChainStarted chainTop).map ServiceGraphEntry.status}"
+
+      match SeLe4n.Kernel.Architecture.adapterReadMemory runtimeContractAcceptAll 0 st1 with
+      | .error err => IO.println s!"boundary memory low-address error: {reprStr err}"
+      | .ok (byte, _) => IO.println s!"boundary memory low-address byte: {reprStr byte}"
+      match SeLe4n.Kernel.Architecture.adapterReadMemory runtimeContractAcceptAll 18446744073709551615 st1 with
+      | .error err => IO.println s!"boundary memory high-address error: {reprStr err}"
+      | .ok (byte, _) => IO.println s!"boundary memory high-address byte: {reprStr byte}"
+
       match SeLe4n.Kernel.lifecycleRetypeObject rootSlot 12
           (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st1 with
       | .error err =>

--- a/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
+++ b/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
@@ -96,6 +96,7 @@ Scale evidence beyond fixed-path fixtures and improve behavioral confidence dept
 
 **Closure evidence (implemented)**
 - Tier 2 fixture entries are now scenario/risk tagged (`scenario_id | risk_class | expected_trace_fragment`) with comment support for readable, auditable maintenance,
+- Tier 2 fixtures now explicitly cover the audit-recommended scale set (deep CNode radix shape, large runnable queue, multiple IPC endpoints, depth-5 service dependency chain, boundary memory addresses),
 - Tier 2 trace parser surfaces scenario+risk metadata in concise failure reports,
 - Tier 4 nightly candidates execute seeded `trace_sequence_probe` runs that check IPC endpoint-state consistency under sequence-diverse operation streams.
 

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -39,12 +39,11 @@ When semantics or milestone boundaries change, keep these in sync:
 
 ## Current focus and immediate next focus
 
-- **Completed baseline slice:** M5 service-graph + policy surfaces.
-- **Current delivery slice:** M6 architecture-binding interface preparation.
-- **Historical predecessor slice:** M4-B lifecycle-capability composition hardening.
+- **Completed baseline slices:** M5 service-graph + policy surfaces, M6 architecture-binding interface preparation.
+- **Current delivery slice:** M7 audit remediation workstreams (WS-A1 through WS-A8).
+- **Current testing focus:** WS-A4 test architecture expansion evidence is complete and maintained as a regression contract.
 
-Contributors should treat M1–M5 theorem surfaces as stable interfaces and layer M6 architecture
-binding work on top, rather than reshaping already-closed contracts.
+Contributors should treat M1–M6 theorem surfaces as stable interfaces and land M7 remediation work without reshaping already-closed contracts.
 
 ## Definition of done for milestone-moving PRs
 

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -10,6 +10,7 @@
 - **Tier 2 (trace/behavior)**
   - executable scenario (`lake exe sele4n`) checked against stable fixture fragments,
   - fixture lines support scenario/risk tags (`scenario_id | risk_class | expected_trace_fragment`) for audit traceability.
+  - fixtures include WS-A4 scale scenarios for deep CNode radix, large runnable queues, multi-endpoint IPC, depth-5 service dependencies, and boundary memory addresses.
 - **Tier 3 (invariant and documentation anchor surface)**
   - validates critical theorem/bundle/doc anchors expected for active milestone slices,
   - includes executable-trace anchor checks for milestone-critical lifecycle fragments.

--- a/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
+++ b/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
@@ -99,6 +99,7 @@ Concretely, M7 should leave the repository in a state where:
 **Completed closure evidence:**
 
 - Tier 2 fixture lines now use a scenario-labeled `scenario_id | risk_class | expected_trace_fragment` format with comment support for readable maintenance,
+- Tier 2 scenarios now include the audit-recommended scale set (deep CNode radix shape, large runnable queue, multi-endpoint IPC, depth-5 service dependency chain, boundary memory addresses),
 - Tier 2 diagnostics include scenario/risk metadata to keep failures concise and actionable,
 - Tier 4 nightly candidates now run seeded `trace_sequence_probe` sequence-diversity checks that assert IPC endpoint-state consistency across nontrivial operation streams.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.8.11"
+version = "0.8.12"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -44,3 +44,12 @@ WS-A4-IPC-05 | ipc-empty-mismatch | endpoint receive #3 (expected mismatch): SeL
 
 # Capability mint result
 WS-A4-CSPACE-02 | cspace-mint-rights-narrowing | minted cap rights: [SeLe4n.Model.AccessRight.read]
+
+# WS-A4 scale-expansion scenarios from audit recommendation set (#10)
+WS-A4-SCALE-01 | cspace-deep-radix-tree | deep cnode radix fixture: some 12
+WS-A4-SCALE-02 | scheduler-large-run-queue | large runnable queue length: 12
+WS-A4-SCALE-03 | scheduler-large-run-queue-schedule | large queue scheduled current: some 1
+WS-A4-SCALE-04 | ipc-multiple-endpoints | multi-endpoint receive senders: 4, 5
+WS-A4-SCALE-05 | service-dependency-chain-depth5 | service dependency chain depth-5 start status: some (SeLe4n.Model.ServiceStatus.running)
+WS-A4-SCALE-06 | boundary-memory-low-address | boundary memory low-address byte: 0
+WS-A4-SCALE-07 | boundary-memory-high-address | boundary memory high-address byte: 0

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -41,6 +41,7 @@ The maintained baseline keeps architecture-boundary adapter trace anchors while 
 - `adapter timer invalid-context branch`, `adapter timer unsupported branch`, and `adapter read denied branch` pin bounded failure semantics.
 - `adapter register write success path value` and `adapter register write unsupported branch` pin deterministic register boundary behavior across success/failure branches.
 - `service restart status`, `service start denied branch`, `service stop denied branch`, and dependency/isolation lines remain as M5 regression anchors to ensure no service-policy drift while M7 remediation work progresses.
+- WS-A4 scale-expansion anchors now include deep CNode radix shape, large runnable queue scheduling, multi-endpoint IPC receives, depth-5 service dependency startup, and low/high boundary memory reads.
 
 ## Historical fixture rationale notes (M4-B closeout baseline)
 


### PR DESCRIPTION
### Motivation
- Finish and harden WS-A4 (Test architecture expansion) by implementing the audit-recommended scale scenarios so Tier 2 smoke coverage exercises larger and more adversarial-style traces.
- Keep GitBook/handbook and repo-level spec/docs synchronized with the implemented evidence so M7 slice status is accurate.

### Description
- Added scale-focused executable trace scenarios in `Main.lean` to exercise: deep CNode radix shape, a large runnable queue (10+ threads), multi-endpoint IPC behavior, a depth-5 service dependency chain, and low/high boundary memory reads.
- Extended the Tier 2 fixture `tests/fixtures/main_trace_smoke.expected` with `WS-A4-SCALE-*` scenario/risk-tagged entries to anchor the new traces.
- Updated documentation and GitBook pages to reflect WS-A4 closure and the included scale scenario set in `docs/AUDIT_REMEDIATION_WORKSTREAMS.md`, `docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`, `docs/gitbook/07-testing-and-ci.md`, `docs/gitbook/06-development-workflow.md`, and `tests/scenarios/README.md`.
- Bumped project patch version in `lakefile.toml` to `0.8.12` and added release notes in `CHANGELOG.md` describing the WS-A4 completion hardening.

### Testing
- Ran `./scripts/test_smoke.sh` and the Tier 2 fixture comparison passed with the updated expectations reported as `41/41 matched` (PASS).
- Ran `./scripts/test_full.sh` which includes Tier 3 invariant/anchor checks (PASS).
- Ran `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` to execute staged Tier 4 candidates (repeat-run determinism + seeded `trace_sequence_probe`), and all staged probes passed (PASS).
- All automated test tiers executed via the repository scripts passed locally; note that invoking `lake` directly without the repository bootstrap environment may fail unless the standard toolchain sourcing (`source "$HOME/.elan/env"`) is performed, but the provided test scripts handle toolchain setup and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699416a3b1a4832ba6a349242168226d)