### PR TITLE
Complete WS-A6 documentation IA and contributor UX; bump version to 0.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.17] - 2026-02-17
+
+### Documentation/GitBook sync audit hardening
+- Closed remaining WS-A6-era documentation drift by marking WS-A4 as completed in `docs/AUDIT_REMEDIATION_WORKSTREAMS.md` to match existing closure evidence and the active-slice status pages.
+- Updated `docs/gitbook/13-future-slices-and-delivery-plan.md` so M7 workstream statuses are synchronized with current slice reality (WS-A1..WS-A6 completed, WS-A7 in progress, WS-A8 planned).
+- Bumped package patch version to `0.8.17` and synchronized the root README version marker.
+
 ## [0.8.16] - 2026-02-17
 
 ### WS-A6 documentation IA completion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.16] - 2026-02-17
+
+### WS-A6 documentation IA completion
+- Marked WS-A6 as completed across remediation planning and active-slice GitBook chapters with explicit closure evidence and DoD status updates.
+- Added a contributor-first 5-minute onboarding path in `CONTRIBUTING.md`, synchronized root `README.md` start-here ordering, and mirrored the same quickstart flow in `docs/gitbook/README.md`.
+- Updated M7 completion snapshot in `docs/DEVELOPMENT.md` to reflect WS-A6 closure and move active focus to WS-A7.
+
 ## [0.8.15] - 2026-02-17
 
 ### WS-A5 regression-guard refinement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 Thanks for contributing to seLe4n.
 
+## 5-minute contributor path (WS-A6)
+
+If you are new to the repository, use this order:
+
+1. **Workflow + standards:** [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
+2. **Testing tiers + expectations:** [`docs/TESTING_FRAMEWORK_PLAN.md`](docs/TESTING_FRAMEWORK_PLAN.md)
+3. **CI required checks policy:** [`docs/CI_POLICY.md`](docs/CI_POLICY.md)
+4. **Current M7 slice outcomes:** [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md)
+5. **Execution workstream definitions:** [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/AUDIT_REMEDIATION_WORKSTREAMS.md)
+
+For a full chapter map, use the handbook index in [`docs/gitbook/README.md`](docs/gitbook/README.md).
+
 The canonical development workflow, validation loop, and PR checklist live in:
 
 - [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
 
-- **Current package version:** `0.8.16` (see `lakefile.toml`).
+- **Current package version:** `0.8.17` (see `lakefile.toml`).
 
 ### Current slice target outcomes (M7)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
 
-- **Current package version:** `0.8.15` (see `lakefile.toml`).
+- **Current package version:** `0.8.16` (see `lakefile.toml`).
 
 ### Current slice target outcomes (M7)
 
@@ -25,19 +25,19 @@ For normative milestones, acceptance criteria, and scope decisions, use
 
 For workstream-level details and closure criteria, use [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/AUDIT_REMEDIATION_WORKSTREAMS.md) and GitBook chapter [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md).
 
-## Start here
+## Start here (contributor IA)
 
-- **Developer setup + workflow:** [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
-- **Contribution guide (root pointer):** [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- **Change history:** [`CHANGELOG.md`](CHANGELOG.md)
-- **Testing tiers + CI contract:** [`docs/TESTING_FRAMEWORK_PLAN.md`](docs/TESTING_FRAMEWORK_PLAN.md)
-- **Branch protection + required checks policy (WS-A1):** [`docs/CI_POLICY.md`](docs/CI_POLICY.md)
+- **1) Developer setup + workflow:** [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
+- **2) Contribution guide:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- **3) Change history:** [`CHANGELOG.md`](CHANGELOG.md)
+- **4) Testing tiers + CI contract:** [`docs/TESTING_FRAMEWORK_PLAN.md`](docs/TESTING_FRAMEWORK_PLAN.md)
+- **5) Branch protection + required checks policy (WS-A1):** [`docs/CI_POLICY.md`](docs/CI_POLICY.md)
 - **Hardware-boundary contract policy (WS-A5):** [`docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md`](docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md)
 - **Historical end-to-end audit snapshot (superseded):** [`docs/PROJECT_AUDIT.md`](docs/PROJECT_AUDIT.md)
 - **Current repository audit baseline (architecture/code/test/docs/CI/security):** [`docs/REPOSITORY_AUDIT.md`](docs/REPOSITORY_AUDIT.md)
+- **M7 execution outcomes and workstreams (active slice):** [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md)
 - **Audit remediation workstreams (M7+ execution plan):** [`docs/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/AUDIT_REMEDIATION_WORKSTREAMS.md)
 - **Long-form handbook (GitBook):** [`docs/gitbook/README.md`](docs/gitbook/README.md)
-- **M7 execution outcomes and workstreams (active slice):** [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md)
 - **M6 execution plan (completed slice):** [`docs/gitbook/18-m6-execution-plan-and-workstreams.md`](docs/gitbook/18-m6-execution-plan-and-workstreams.md)
 - **M5 closeout snapshot chapter:** [`docs/gitbook/09-m5-closeout-snapshot.md`](docs/gitbook/09-m5-closeout-snapshot.md)
 - **Completed slice archive (M4-B):** [`docs/gitbook/16-completed-slice-m4b.md`](docs/gitbook/16-completed-slice-m4b.md)

--- a/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
+++ b/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
@@ -124,20 +124,20 @@ Prevent accidental production use of permissive runtime contracts.
 
 ---
 
-### WS-A6 — Documentation IA refresh and contributor experience (Medium)
+### WS-A6 — Documentation IA refresh and contributor experience (Medium) ✅ completed
 
 **Objective**
 Improve discoverability, consistency, and onboarding speed.
 
-**Scope**
-- publish/maintain root contribution and change history artifacts,
-- synchronize root docs with GitBook navigation,
-- rebalance handbook chapters around active slice and next-slice path.
+**Closure evidence (implemented)**
+- root onboarding now includes an explicit 5-minute contributor path in `CONTRIBUTING.md` and synchronized start-here ordering in `README.md`,
+- GitBook handbook index now mirrors this path through a dedicated contributor quickstart sequence in `docs/gitbook/README.md`,
+- active-slice markers and completion snapshots are synchronized across root docs, remediation plan chapters, and current-slice chapter status.
 
-**Acceptance criteria**
-- new contributors find contribution policy from repo root,
-- slice progression is auditable in one navigation flow,
-- no conflicting active-slice markers remain.
+**Acceptance criteria status**
+- contribution policy and required workflow are discoverable from repo root ✅,
+- slice progression is auditable through one contributor-first navigation path ✅,
+- conflicting active-slice markers were removed/synchronized ✅.
 
 ---
 

--- a/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
+++ b/docs/AUDIT_REMEDIATION_WORKSTREAMS.md
@@ -89,7 +89,7 @@ Eliminate cross-domain confusion by replacing raw aliases with wrappers.
 
 ---
 
-### WS-A4 — Test architecture expansion (Medium)
+### WS-A4 — Test architecture expansion (Medium) ✅ completed
 
 **Objective**
 Scale evidence beyond fixed-path fixtures and improve behavioral confidence depth.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -230,9 +230,9 @@ Use this model for all milestone-moving work while M7 is active:
 
 ### 6.2.1 Current completion snapshot
 
-- ✅ **Completed:** WS-A1, WS-A2, WS-A3, WS-A4, WS-A5
-- ▶️ **Primary in-progress focus:** WS-A6
-- 📝 **Planned follow-on:** WS-A7, WS-A8
+- ✅ **Completed:** WS-A1, WS-A2, WS-A3, WS-A4, WS-A5, WS-A6
+- ▶️ **Primary in-progress focus:** WS-A7
+- 📝 **Planned follow-on:** WS-A8
 
 (Authoritative closure evidence remains in `docs/AUDIT_REMEDIATION_WORKSTREAMS.md` and GitBook chapter 21.)
 

--- a/docs/gitbook/13-future-slices-and-delivery-plan.md
+++ b/docs/gitbook/13-future-slices-and-delivery-plan.md
@@ -34,9 +34,11 @@ Closeout details are maintained in [M6 Execution Plan and Workstreams](18-m6-exe
 - **WS-A1:** CI hardening and quality-gate promotion ✅ completed,
 - **WS-A2:** architecture modularity and API-surface cleanup ✅ completed,
 - **WS-A3:** type-safety uplift for ID/pointer domains ✅ completed,
-- **WS-A4:** test architecture expansion,
-- **WS-A5:** hardware-boundary safety and test-only contract separation,
-- **WS-A6/WS-A7/WS-A8:** documentation, maintainability automation, and platform-security maturity preparation.
+- **WS-A4:** test architecture expansion ✅ completed,
+- **WS-A5:** hardware-boundary safety and test-only contract separation ✅ completed,
+- **WS-A6:** documentation IA and contributor UX ✅ completed,
+- **WS-A7:** proof documentation and maintainability automation (active in-progress focus),
+- **WS-A8:** platform-security maturity preparation (planned follow-on).
 
 Current closure source of truth for M7 outcomes/workstreams: [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md).
 

--- a/docs/gitbook/20-repository-audit-remediation-workstreams.md
+++ b/docs/gitbook/20-repository-audit-remediation-workstreams.md
@@ -58,10 +58,10 @@ The remediation program targets eight concrete repository outcomes:
    - document trusted-contract policy and review expectations.
    - status in active slice: **completed** (see chapter 21 closure evidence).
 
-6. **WS-A6 — Documentation IA and contributor UX**
-   - standardize root-level contributor guidance,
-   - align handbook structure with current execution flow,
-   - keep active/next slice status synchronized everywhere.
+6. **WS-A6 — Documentation IA and contributor UX** ✅ **completed**
+   - standardized root-level contributor guidance with a 5-minute path in `CONTRIBUTING.md` and synchronized ordering in `README.md`,
+   - aligned handbook structure with contributor entry flow via quickstart sequencing in `docs/gitbook/README.md`,
+   - synchronized active/next slice status markers across root docs and GitBook workstream chapters.
 
 7. **WS-A7 — Proof documentation and maintainability automation**
    - increase theorem docstring coverage,

--- a/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
+++ b/docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
@@ -126,21 +126,21 @@ Concretely, M7 should leave the repository in a state where:
 - policy is enforced by contributor checklist language ✅,
 - contract intent is unambiguous in code and docs ✅.
 
-### WS-A6 — Documentation IA and contributor UX
+### WS-A6 — Documentation IA and contributor UX ✅ completed
 
 **Intent:** make contributor onboarding and milestone navigation frictionless.
 
-**Execution focus now:**
+**Completed closure evidence:**
 
-- keep root docs and handbook chapter ordering synchronized,
-- avoid stale slice markers,
-- capture current and next-slice context in every milestone chapter.
+- root onboarding now provides an explicit 5-minute contributor path in `CONTRIBUTING.md` and synchronized start-here ordering in `README.md`,
+- GitBook handbook index (`docs/gitbook/README.md`) now includes a contributor quickstart sequence that mirrors root entrypoints and active-slice chapters,
+- M7 status markers are synchronized across development docs, remediation workstream pages, and this active-slice chapter.
 
-**DoD signals:**
+**DoD signals status:**
 
-- a new contributor can find setup/workflow/testing path from root in minutes,
-- GitBook hierarchy mirrors actual development flow,
-- active slice status is consistent across canonical docs.
+- a new contributor can find setup/workflow/testing path from root in minutes ✅,
+- GitBook hierarchy mirrors actual development flow ✅,
+- active slice status is consistent across canonical docs ✅.
 
 ### WS-A7 — Proof documentation and maintainability automation
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -12,6 +12,14 @@ Use [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as the canonical milestone/acceptance
 
 Root contributor-entry docs: [`CONTRIBUTING.md`](../CONTRIBUTING.md), [`CHANGELOG.md`](../CHANGELOG.md).
 
+## Contributor quickstart path (mirrors root README)
+
+1. [Development Workflow](06-development-workflow.md)
+2. [Testing & CI](07-testing-and-ci.md)
+3. [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
+4. [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
+5. [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md)
+
 ## Recommended navigation
 
 ### 1) Orientation

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.8.16"
+version = "0.8.17"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.8.15"
+version = "0.8.16"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation

- Close workstream WS-A6 (Documentation IA and contributor UX) by making onboarding discoverable, synchronizing root docs and GitBook, and removing conflicting active-slice markers.
- Provide a clear contributor-first quickstart so new contributors can find setup, testing, and workflow guidance in minutes.
- Record the milestone as a patch release and reflect the state in the project metadata and changelog.

### Description

- Added a 5-minute contributor quickstart to `CONTRIBUTING.md` to surface the minimal onboarding path and pointers to core docs.
- Reworked the root `README.md` "Start here" ordering to a numbered contributor-first navigation and updated the GitBook index in `docs/gitbook/README.md` to mirror the same quickstart flow.
- Marked WS-A6 as completed and added explicit closure evidence and DoD status in `docs/AUDIT_REMEDIATION_WORKSTREAMS.md`, `docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`, and `docs/gitbook/20-repository-audit-remediation-workstreams.md` and synchronized the M7 snapshot in `docs/DEVELOPMENT.md` to move active focus to WS-A7.
- Bumped the package patch version from `0.8.15` to `0.8.16` in `lakefile.toml` and added a `0.8.16` entry to `CHANGELOG.md` describing the WS-A6 completion.

### Testing

- Ran the fast validation suite with `./scripts/test_fast.sh` and it passed without failures.
- Ran smoke and full validation with `./scripts/test_smoke.sh` and `./scripts/test_full.sh` and both completed successfully with all checks green.
- Ran the nightly determinism/extension checks with `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` including seeded `trace_sequence_probe` runs and Tier 4 nightly candidate determinism checks, and all automated checks passed; a transient apt mirror warning occurred during environment setup but did not affect test outcomes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699429ecd07c832bb073b92f569af8bc)