### PR TITLE
Optimize project documentation for COMPREHENSIVE_AUDIT workstream execution hand off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.9.1] - 2026-02-17
+
+### Comprehensive-audit workstream execution kickoff readiness
+- Expanded `docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md` into a detailed execution contract with per-workstream goals, prerequisites, implementation slices, evidence contracts, and exit criteria for WS-B1..WS-B11.
+- Added explicit portfolio readiness gates (G0 kickoff readiness and G1 hardware-entry readiness) and clarified that the current slice is centered on WS-B execution kickoff.
+- Synchronized root README, audit index, and GitBook planning chapter wording so active-slice status consistently reflects comprehensive-audit workstream execution readiness.
+- Bumped package patch version from `0.9.0` to **`0.9.1`**.
+
 ## [0.9.0] - 2026-02-17
 
 ### CI security-scan reliability follow-up

--- a/README.md
+++ b/README.md
@@ -5,20 +5,29 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current development stage
 
-- **Active slice:** post-M7 hardware-oriented development path (next slice) with Raspberry Pi 5 as first architecture focus.
+- **Active slice:** comprehensive-audit WS-B workstream execution kickoff (planning-complete to execution-ready transition).
 - **Most recently completed slice:** M7 audit remediation workstreams (WS-A1 through WS-A8 completed).
 - **Previous completed slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-E completed).
 
 For normative milestones, acceptance criteria, and scope decisions, use
 [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md) as the source of truth.
 
-- **Current package version:** `0.9.0` (see `lakefile.toml`).
+- **Current package version:** `0.9.1` (see `lakefile.toml`).
 
 ### M7 closeout status and next-slice kickoff
 
 M7 exit-gate status is complete: WS-A1..WS-A8 are closed with CI/test/documentation evidence and the remediation handoff package published in [`docs/M7_CLOSEOUT_PACKET.md`](docs/M7_CLOSEOUT_PACKET.md).
 
 For remediation closure details, use [`docs/audits/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/audits/AUDIT_REMEDIATION_WORKSTREAMS.md) and GitBook chapter [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md).
+
+
+### Comprehensive audit planning baseline (2026-02)
+
+For planning all follow-on workstreams from the comprehensive audit, use:
+
+- Findings and recommendations: [`docs/audits/COMPREHENSIVE_AUDIT_2026_02.md`](docs/audits/COMPREHENSIVE_AUDIT_2026_02.md)
+- Canonical execution-planning matrix: [`docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`](docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md)
+- GitBook planning chapter: [`docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`](docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md)
 
 ## Start here (contributor IA)
 
@@ -33,7 +42,9 @@ For remediation closure details, use [`docs/audits/AUDIT_REMEDIATION_WORKSTREAMS
 - **Current repository audit baseline (architecture/code/test/docs/CI/security):** [`docs/audits/REPOSITORY_AUDIT.md`](docs/audits/REPOSITORY_AUDIT.md)
 - **M7 execution outcomes and workstreams (completed slice):** [`docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md`](docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md)
 - **M7 closeout packet (exit-gate artifact):** [`docs/M7_CLOSEOUT_PACKET.md`](docs/M7_CLOSEOUT_PACKET.md)
-- **Audit remediation workstreams (M7+ execution plan):** [`docs/audits/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/audits/AUDIT_REMEDIATION_WORKSTREAMS.md)
+- **Audit remediation workstreams (historical M7 plan):** [`docs/audits/AUDIT_REMEDIATION_WORKSTREAMS.md`](docs/audits/AUDIT_REMEDIATION_WORKSTREAMS.md)
+- **Comprehensive audit workstream planning backbone (active):** [`docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`](docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md)
+- **Documentation/GitBook sync + coverage matrix:** [`docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`](docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md)
 - **Long-form handbook (GitBook):** [`docs/gitbook/README.md`](docs/gitbook/README.md)
 - **M6 execution plan (completed slice):** [`docs/gitbook/18-m6-execution-plan-and-workstreams.md`](docs/gitbook/18-m6-execution-plan-and-workstreams.md)
 - **M5 closeout snapshot chapter:** [`docs/gitbook/09-m5-closeout-snapshot.md`](docs/gitbook/09-m5-closeout-snapshot.md)

--- a/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+++ b/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
@@ -1,0 +1,52 @@
+# Documentation Sync and Coverage Matrix
+
+This document is the single synchronization index for:
+
+1. canonical root documentation,
+2. GitBook chapter mirrors/navigation,
+3. test/verification coverage for the current project stage.
+
+Use this file during planning and PR review to verify that docs, GitBook, and test evidence stay aligned.
+
+## 1) Canonical source-of-truth map
+
+| Topic | Canonical document | GitBook chapter(s) | Sync rule |
+|---|---|---|---|
+| Milestones, scope, acceptance | `docs/SEL4_SPEC.md` | `05-specification-and-roadmap.md` | Update spec first; GitBook chapter summarizes and links back. |
+| Comprehensive audit findings | `docs/audits/COMPREHENSIVE_AUDIT_2026_02.md` | `19-end-to-end-audit-and-quality-gates.md`, `24-comprehensive-audit-2026-workstream-planning.md` | Keep findings canonical in audits dir; avoid duplicating full audit prose in chapters. |
+| Comprehensive audit execution portfolio | `docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md` | `24-comprehensive-audit-2026-workstream-planning.md` | Workstream status tables live in canonical plan; GitBook only navigates/summarizes. |
+| M7 historical remediation closeout | `docs/M7_CLOSEOUT_PACKET.md` + `docs/audits/AUDIT_REMEDIATION_WORKSTREAMS.md` | `21-m7-current-slice-outcomes-and-workstreams.md`, `23-m7-remediation-closeout-packet.md`, `20-repository-audit-remediation-workstreams.md` | Keep marked as historical context for post-M7 planning, not active baseline. |
+| Development workflow | `docs/DEVELOPMENT.md` | `06-development-workflow.md` | Workflow command changes must be reflected in both files in same PR. |
+| Test tiers and CI contract | `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md` | `07-testing-and-ci.md` | Script/workflow changes require root docs + GitBook updates together. |
+| Hardware-boundary contract policy | `docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md` | `10-path-to-real-hardware-mobile-first.md` | Keep normative constraints in policy doc; chapter links policy and planning implications. |
+| Security trajectory | `docs/INFORMATION_FLOW_ROADMAP.md` | `12-proof-and-invariant-map.md`, `22-next-slice-development-path.md` | Milestone shifts must update roadmap and at least one active planning chapter. |
+
+## 2) Test and verification coverage map
+
+| Validation area | Command | What it verifies |
+|---|---|---|
+| Hygiene + forbidden markers + fixture isolation | `./scripts/test_tier0_hygiene.sh` | No `sorry`/`axiom`/`TODO` debt in proof surface; no test contract leakage into production kernel modules. |
+| Lean build soundness | `./scripts/test_tier1_build.sh` | Project compiles successfully via `lake build`. |
+| End-to-end executable trace fixture | `./scripts/test_tier2_trace.sh` | Runtime trace still satisfies fixture expectations and scenario/risk-tagged entries. |
+| Invariant/doc anchor surface | `./scripts/test_tier3_invariant_surface.sh` | Critical theorem/definition/document anchors still exist after refactors. |
+| Nightly candidates / determinism replay | `./scripts/test_tier4_nightly_candidates.sh` and `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` | Multi-run determinism, nightly artifacts, and seeded stochastic probe replay. |
+| Fast lane | `./scripts/test_fast.sh` | Tier 0 + Tier 1 quick validation. |
+| Smoke lane | `./scripts/test_smoke.sh` | Tier 0 + Tier 1 + Tier 2 validation. |
+| Full lane | `./scripts/test_full.sh` | Tier 0 + Tier 1 + Tier 2 + Tier 3 validation. |
+
+## 3) PR synchronization checklist (required)
+
+For documentation/planning PRs:
+
+1. Update canonical source docs first.
+2. Update GitBook navigation and chapter links.
+3. Run at least `test_smoke.sh`; run `test_full.sh` when docs mention theorem/anchor surfaces.
+4. If planning/test policy changed, run `test_nightly.sh` (or explain why not run).
+5. Verify references with targeted `rg -n` checks for newly introduced docs/chapters.
+
+## 4) Current-stage status summary
+
+- Active planning baseline: `COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`.
+- Historical closeout baseline: M7 remediation docs (`AUDIT_REMEDIATION_WORKSTREAMS.md`, `M7_CLOSEOUT_PACKET.md`).
+- Current quality-gate contract: Tier 0–3 required, Tier 4 nightly determinism evidence.
+

--- a/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
+++ b/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
@@ -1,0 +1,284 @@
+# Comprehensive Audit 2026-02 — Workstream Planning Backbone
+
+This document is the execution-planning companion to
+[`COMPREHENSIVE_AUDIT_2026_02.md`](./COMPREHENSIVE_AUDIT_2026_02.md).
+
+It is intentionally operational: it turns the audit recommendations into
+an ordered portfolio of workstreams with dependencies, measurable evidence gates,
+and backlog-ready implementation slices.
+
+## 1) Planning objective
+
+Plan and execute workstreams that close **all recommendations and criticisms** from the 2026-02 comprehensive audit, while preserving:
+
+1. proof completeness and invariant discipline,
+2. deterministic CI and trace reproducibility,
+3. contributor usability of docs and GitBook,
+4. readiness for Raspberry Pi 5 hardware-binding milestones.
+
+## 2) Canonical planning rules
+
+See also the documentation/test synchronization index: [`docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`](../DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md).
+
+- Treat [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md) as normative scope/acceptance source.
+- Treat this file as the **portfolio planner** and each workstream as execution slices.
+- Keep root docs concise and link-forward to canonical pages (avoid duplicated long-form policy text).
+- Every workstream PR must include: recommendation IDs closed, test/proof evidence, and doc synchronization.
+- Any workstream status change must update: this file, root README active-slice text, and GitBook chapter 24.
+
+## 3) Recommendation-to-workstream matrix
+
+| Priority | Workstream ID | Recommendation coverage (from comprehensive audit) | Primary outputs |
+|---|---|---|---|
+| High | WS-B1: VSpace + memory model foundation | Architecture §2.3 #3; Priority #1 | VSpace object model, page-table semantics skeleton, bounded memory abstraction ADR |
+| High | WS-B2: Generative + negative testing expansion | Testing §4.3 #1/#2/#4/#5; Priority #2/#5 | subsystem probes, malformed-state tests, bootstrap state builder DSL |
+| High | WS-B3: Main trace harness refactor | Code Quality §3.3 #1/#2/#3; Priority #3 | extracted scenario functions, list-based bootstrap builder, assertive error checks |
+| High | WS-B4: Remaining type wrapper migration | Architecture §2.3 #1; Priority #4 | wrappers for DomainId/Priority/Irq/Badge/ASID/VAddr/PAddr + migration notes |
+| Medium | WS-B5: CSpace semantics completion | Architecture §2.3 #4; Priority #6 | CNode guard/radix resolution path and tests |
+| Medium | WS-B6: IPC completeness with notifications | Architecture §2.2 gap (notification objects); Priority #7 | Notification object model + invariant updates |
+| Medium | WS-B7: Information-flow proof track start | Priority #8 | IF-M1 formal milestone package and proof decomposition plan |
+| Medium | WS-B8: Documentation automation + consolidation | Docs §5.3 #1/#2/#4; Priority #9/#13 | doc-gen4 integration, markdown-link checks, dedup map root↔GitBook |
+| Medium | WS-B9: Threat model and security hardening | Security recommendations + Priority #10/#11/#12 | THREAT_MODEL.md, .gitignore expansion, setup script checksum verification |
+| Low | WS-B10: CI maturity upgrades | CI §7.3 #1/#2/#3/#4/#5; Priority #14/#15/#17 | CodeQL policy decision, toolchain update automation, timing/flake telemetry |
+| Low | WS-B11: Scenario framework finalization | Docs §5.3 #5; Priority #16 | populate `tests/scenarios/` or retire with explicit replacement |
+
+## 4) Dependency and sequencing model
+
+### Phase P1 — correctness foundation
+
+- WS-B4 (type wrappers)
+- WS-B3 (main harness refactor)
+- WS-B8 (doc governance + dedup rules)
+
+Rationale: stabilize API and documentation shape before deep semantic expansion.
+
+### Phase P2 — model and test depth
+
+- WS-B1 (VSpace/memory)
+- WS-B5 (CSpace guard/radix)
+- WS-B6 (notifications)
+- WS-B2 (generative + negative testing)
+
+Rationale: close architecture gaps and immediately broaden tests around each new semantic surface.
+
+### Phase P3 — assurance and operational maturity
+
+- WS-B7 (information flow)
+- WS-B9 (threat model/security baseline)
+- WS-B10 (CI maturity)
+- WS-B11 (scenario framework completion)
+
+Rationale: convert expanded model coverage into long-term assurance and delivery reliability.
+
+## 5) Detailed workstream execution contracts
+
+Status key: `Planned` → `In Progress` → `Completed`.
+Current portfolio status: all WS-B workstreams are **Planned**; this slice is dedicated to kickoff and execution.
+
+### WS-B1 — VSpace + memory model foundation (Planned)
+
+- **Goal:** formalize minimal but extensible virtual-memory semantics for page tables, ASID binding, and bounded memory access assumptions.
+- **Prerequisites:** WS-B4 wrapper migration complete for `ASID`, `VAddr`, `PAddr`.
+- **Implementation slices:**
+  1. Add object/data structures for page tables and address-space roots.
+  2. Add transition functions for map/unmap/lookups with explicit failure modes.
+  3. Add invariants for non-overlap, root validity, and bounded address translation.
+  4. Add architecture-assumption ADR documenting what remains abstract.
+- **Evidence contract:**
+  - `./scripts/test_smoke.sh`
+  - `./scripts/test_full.sh`
+  - new/updated invariant anchors in Tier 3 checks.
+- **Exit criteria:** deterministic map/unmap trace coverage, invariant preservation lemmas merged, ADR published.
+
+### WS-B2 — Generative + negative testing expansion (Planned)
+
+- **Goal:** expand fixture and stochastic tests to cover malformed states and edge-case transitions that should fail safely.
+- **Prerequisites:** WS-B3 harness extraction to make scenario composition reusable.
+- **Implementation slices:**
+  1. Build reusable bootstrap-state builder DSL for test scenarios.
+  2. Add malformed-capability and malformed-object negative tests.
+  3. Add seeded generative probes for scheduler/IPC/capability composition.
+  4. Persist replay artifacts for nightly determinism and failure triage.
+- **Evidence contract:**
+  - `./scripts/test_smoke.sh`
+  - `./scripts/test_full.sh`
+  - `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh`
+- **Exit criteria:** negative-path suite lands with deterministic seeds and documented replay procedure.
+
+### WS-B3 — Main trace harness refactor (Planned)
+
+- **Goal:** reduce `Main.lean` orchestration complexity and make scenario construction composable and auditable.
+- **Prerequisites:** none (can start immediately).
+- **Implementation slices:**
+  1. Extract scenario constructors into dedicated helper functions/modules.
+  2. Replace ad hoc bootstrap construction with list- and builder-based composition.
+  3. Add explicit error assertions at each transition boundary.
+  4. Keep fixture trace output stable or intentionally versioned.
+- **Evidence contract:**
+  - `./scripts/test_tier2_trace.sh`
+  - `./scripts/test_full.sh`
+- **Exit criteria:** harness decomposition merged with no trace-regression drift and clearer failure localization.
+
+### WS-B4 — Remaining type wrapper migration (Planned)
+
+- **Goal:** complete wrapper-typed domain separation across remaining scalar aliases.
+- **Prerequisites:** none (P1 starter).
+- **Implementation slices:**
+  1. Introduce wrappers for `DomainId`, `Priority`, `Irq`, `Badge`, `ASID`, `VAddr`, `PAddr`.
+  2. Update APIs/proofs at object-store boundaries to use explicit conversions.
+  3. Add guard checks preventing regression to implicit coercions.
+  4. Document migration notes and compatibility helpers.
+- **Evidence contract:**
+  - `./scripts/test_fast.sh`
+  - `./scripts/test_full.sh`
+- **Exit criteria:** no remaining raw alias usage in target surfaces; invariant layer compiles without coercion shortcuts.
+
+### WS-B5 — CSpace semantics completion (Planned)
+
+- **Goal:** model guard/radix-based CNode traversal and resolution outcomes with clear error branches.
+- **Prerequisites:** WS-B4 wrapper migration for capability pointers/slots stability.
+- **Implementation slices:**
+  1. Add CNode guard/radix fields and traversal helper semantics.
+  2. Implement lookup semantics with depth/guard mismatch failures.
+  3. Add preservation lemmas for capability and scheduler invariants.
+  4. Add trace scenarios that exercise deep and malformed CSpace paths.
+- **Evidence contract:**
+  - `./scripts/test_smoke.sh`
+  - `./scripts/test_full.sh`
+- **Exit criteria:** CSpace resolution behavior is executable, tested, and invariant-preserving.
+
+### WS-B6 — IPC completeness with notifications (Planned)
+
+- **Goal:** add notification-object semantics so IPC model covers endpoint + notification split.
+- **Prerequisites:** WS-B3 refactor (for cleaner scenario wiring).
+- **Implementation slices:**
+  1. Introduce notification object/state definitions.
+  2. Implement signal/wait semantics and scheduler interactions.
+  3. Extend IPC invariants to include notification safety properties.
+  4. Add traces proving endpoint and notification paths compose correctly.
+- **Evidence contract:**
+  - `./scripts/test_smoke.sh`
+  - `./scripts/test_full.sh`
+- **Exit criteria:** notification semantics integrated through API, proofs, and trace fixtures.
+
+### WS-B7 — Information-flow proof track start (Planned)
+
+- **Goal:** land IF-M1 formal baseline and decomposition plan for noninterference progression.
+- **Prerequisites:** WS-B1 and WS-B5 completion (state model and CSpace semantics available).
+- **Implementation slices:**
+  1. Define confidentiality/integrity labels and state projection helpers.
+  2. Publish IF-M1 theorem targets and assumptions ledger.
+  3. Add milestone document updates in roadmap + GitBook.
+  4. Add Tier 3 anchors for IF milestone artifacts.
+- **Evidence contract:**
+  - `./scripts/test_full.sh`
+  - `rg -n "IF-M1|information-flow" docs/INFORMATION_FLOW_ROADMAP.md docs/gitbook/12-proof-and-invariant-map.md`
+- **Exit criteria:** IF-M1 package merged with explicit theorem backlog and assumptions.
+
+### WS-B8 — Documentation automation + consolidation (Planned)
+
+- **Goal:** reduce documentation drift through generated indexes and enforceable sync checks.
+- **Prerequisites:** none (cross-cutting P1 stream).
+- **Implementation slices:**
+  1. Integrate doc-gen step for canonical navigation pages.
+  2. Add markdown-link validation in CI/test scripts.
+  3. Publish deduplication map for root docs vs GitBook mirrors.
+  4. Enforce sync checklist updates in planning PR templates.
+- **Evidence contract:**
+  - `./scripts/test_smoke.sh`
+  - `./scripts/test_full.sh`
+  - targeted link/reference scans with `rg -n`.
+- **Exit criteria:** reproducible doc synchronization workflow with automated guardrails.
+
+### WS-B9 — Threat model and security hardening (Planned)
+
+- **Goal:** formalize threat assumptions and tighten baseline supply-chain/security controls.
+- **Prerequisites:** none (can overlap P2/P3).
+- **Implementation slices:**
+  1. Add canonical `docs/THREAT_MODEL.md` (assets, actors, trust boundaries).
+  2. Expand `.gitignore` and secret-scanning posture for generated artifacts.
+  3. Add checksum/signature verification for setup/bootstrap scripts.
+  4. Sync CI policy and security workflows with documented decisions.
+- **Evidence contract:**
+  - `./scripts/test_fast.sh`
+  - `./scripts/test_full.sh`
+  - security workflow checks in CI policy anchors.
+- **Exit criteria:** threat model and hardening controls documented, testable, and linked from roadmap.
+
+### WS-B10 — CI maturity upgrades (Planned)
+
+- **Goal:** improve CI observability, policy clarity, and update cadence without destabilizing required gates.
+- **Prerequisites:** WS-B8 doc governance hooks available.
+- **Implementation slices:**
+  1. Decide and document CodeQL required-vs-informational policy.
+  2. Add automated Lean/toolchain update proposal flow.
+  3. Publish CI timing baselines and flake telemetry collection.
+  4. Ensure branch-protection documentation matches workflow reality.
+- **Evidence contract:**
+  - `./scripts/test_full.sh`
+  - `./scripts/test_nightly.sh`
+- **Exit criteria:** CI governance decisions are codified with measurable reliability baselines.
+
+### WS-B11 — Scenario framework finalization (Planned)
+
+- **Goal:** resolve `tests/scenarios/` into an active framework or retire it with explicit replacement.
+- **Prerequisites:** WS-B2 scenario DSL and negative test assets.
+- **Implementation slices:**
+  1. Define scenario metadata schema (risk tags, subsystem, determinism seed).
+  2. Populate representative scenario sets or deprecate with migration notes.
+  3. Link scenario framework into nightly replay and docs.
+  4. Add ownership and maintenance expectations.
+- **Evidence contract:**
+  - `./scripts/test_smoke.sh`
+  - `./scripts/test_nightly.sh`
+- **Exit criteria:** scenario strategy is explicit, exercised, and maintainable.
+
+## 6) Portfolio-level readiness and release gates
+
+### Gate G0 — Execution kickoff readiness (current target)
+
+Required before declaring kickoff-ready:
+
+1. WS-B backlog tickets created with owners, milestones, and recommendation IDs.
+2. Phase sequence and dependencies reviewed in weekly planning cadence.
+3. Documentation/GitBook sync contract confirmed (`docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`).
+4. Baseline quality gates pass (`test_smoke`, `test_full`, `test_nightly`).
+
+### Gate G1 — Hardware-entry readiness
+
+First hardware-facing entry gate remains:
+
+- `WS-B1 + WS-B2 + WS-B5` complete,
+- Tier 4 nightly determinism signal stable,
+- architecture assumptions and risk log updated.
+
+## 7) Workstream-ready planning template
+
+For each WS-B* planning ticket, require this minimum structure:
+
+1. **Problem statement** (quoted audit criticism/recommendation IDs)
+2. **In-scope/out-of-scope**
+3. **Architecture/proof impact**
+4. **Implementation tasks** (ordered)
+5. **Evidence contract**
+   - required Lean/test commands,
+   - expected artifacts,
+   - required docs updated.
+6. **Exit criteria**
+7. **Rollback/safety notes**
+
+## 8) Documentation and GitBook organization contract
+
+To keep docs maintainable while scaling workstreams:
+
+- Root `README.md` should remain a short navigation hub.
+- `docs/audits/*` should hold canonical audit and planning source artifacts.
+- GitBook chapters should summarize and point to canonical docs rather than duplicating full policy text.
+- Any planning status table should appear in one canonical file and be linked elsewhere.
+
+## 9) Immediate next planning actions
+
+1. Create WS-B1..WS-B11 issue backlog with owners and milestone tags.
+2. Start Phase P1 with WS-B4 + WS-B3 in parallel and WS-B8 as cross-cutting governance.
+3. Add a recurring planning review cadence (weekly) that updates only this file and milestone notes.
+4. Validate Gate G0 and then mark this portfolio as `Kickoff Ready`.

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -2,7 +2,17 @@
 
 All repository audit documents are stored in this directory and listed below from newest to oldest.
 
-1. [`COMPREHENSIVE_AUDIT_2026_02.md`](./COMPREHENSIVE_AUDIT_2026_02.md) — 2026-02-17 comprehensive repository audit (v0.9.0).
-2. [`AUDIT_REMEDIATION_WORKSTREAMS.md`](./AUDIT_REMEDIATION_WORKSTREAMS.md) — remediation execution plan linked to audit findings.
-3. [`REPOSITORY_AUDIT.md`](./REPOSITORY_AUDIT.md) — 2026-02-17 repository audit baseline (v0.8.0 snapshot).
-4. [`PROJECT_AUDIT.md`](./PROJECT_AUDIT.md) — historical end-to-end audit snapshot.
+1. [`COMPREHENSIVE_AUDIT_2026_02.md`](./COMPREHENSIVE_AUDIT_2026_02.md) — 2026-02-17 comprehensive repository audit (v0.9.1 planning baseline).
+2. [`COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`](./COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md) — canonical planning backbone to execute all recommendations/criticisms from the comprehensive audit.
+3. [`AUDIT_REMEDIATION_WORKSTREAMS.md`](./AUDIT_REMEDIATION_WORKSTREAMS.md) — historical M7 remediation execution plan and closure map.
+4. [`REPOSITORY_AUDIT.md`](./REPOSITORY_AUDIT.md) — 2026-02-17 repository audit baseline (v0.8.0 snapshot).
+5. [`PROJECT_AUDIT.md`](./PROJECT_AUDIT.md) — historical end-to-end audit snapshot.
+
+## Planning guidance
+
+For current planning, use the pair:
+
+- audit source of findings: `COMPREHENSIVE_AUDIT_2026_02.md`
+- execution portfolio map: `COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`
+
+Treat `AUDIT_REMEDIATION_WORKSTREAMS.md` as completed-slice history (M7), not the active planning baseline.

--- a/docs/gitbook/20-repository-audit-remediation-workstreams.md
+++ b/docs/gitbook/20-repository-audit-remediation-workstreams.md
@@ -1,5 +1,9 @@
 # Repository Audit Remediation Workstreams
 
+> Historical note: this chapter documents the completed M7 remediation portfolio.
+> For active planning against the 2026-02 comprehensive audit, use
+> [Comprehensive Audit 2026 Workstream Planning](24-comprehensive-audit-2026-workstream-planning.md).
+
 This chapter is the execution companion to the full repository audit in
 [`docs/audits/REPOSITORY_AUDIT.md`](../audits/REPOSITORY_AUDIT.md).
 

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -1,0 +1,48 @@
+# Comprehensive Audit 2026 Workstream Planning
+
+This chapter is the GitBook planning hub for addressing all findings from the comprehensive audit.
+
+Canonical source documents:
+
+- [`docs/audits/COMPREHENSIVE_AUDIT_2026_02.md`](../audits/COMPREHENSIVE_AUDIT_2026_02.md)
+- [`docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`](../audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md)
+
+Use this chapter as a concise navigator, not as a duplicate of those files.
+
+## 1) Current slice focus
+
+- Active slice objective is **WS-B portfolio execution kickoff**.
+- M7 remediation artifacts remain historical and complete.
+- Phase plan and recommendation mapping are canonical in the audit workstream planner.
+
+## 2) Active planning portfolio (WS-B1..WS-B11)
+
+| Phase | Workstreams |
+|---|---|
+| P1: correctness foundation | WS-B4 type wrappers, WS-B3 main harness refactor, WS-B8 docs automation/consolidation |
+| P2: model + test depth | WS-B1 VSpace/memory, WS-B5 CSpace guard/radix, WS-B6 notifications, WS-B2 generative + negative testing |
+| P3: assurance + operational maturity | WS-B7 information-flow start, WS-B9 threat/security hardening, WS-B10 CI maturity, WS-B11 scenario framework finalization |
+
+## 3) Readiness gates
+
+- **Gate G0 (kickoff readiness):** backlog ownership + dependency review + docs sync contract + baseline test lanes passing.
+- **Gate G1 (hardware entry):** WS-B1 + WS-B2 + WS-B5 complete and nightly determinism stable.
+
+For detailed workstream-level goals, prerequisites, implementation slices, and evidence contracts, use:
+[`docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`](../audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md).
+
+## 4) Planning/implementation contract
+
+Every workstream planning item should include:
+
+1. exact audit recommendation IDs closed,
+2. in-scope and out-of-scope boundaries,
+3. proof/testing/doc impact,
+4. reproducible command evidence,
+5. explicit exit criteria.
+
+## 5) How this chapter relates to M7 chapters
+
+- [`21-m7-current-slice-outcomes-and-workstreams.md`](21-m7-current-slice-outcomes-and-workstreams.md): completed-slice closure evidence.
+- [`20-repository-audit-remediation-workstreams.md`](20-repository-audit-remediation-workstreams.md): historical M7 execution map.
+- **This chapter (24):** active planning bridge from comprehensive audit findings to execution-ready WS-B kickoff.

--- a/docs/gitbook/25-documentation-sync-and-coverage-matrix.md
+++ b/docs/gitbook/25-documentation-sync-and-coverage-matrix.md
@@ -1,0 +1,34 @@
+# Documentation Sync and Coverage Matrix
+
+Canonical source document:
+
+- [`docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`](../DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md)
+
+This chapter is a concise navigation entry. Keep normative synchronization rules and coverage tables in the canonical root document.
+
+## 1) Why this chapter exists
+
+Use this chapter when reviewing or planning documentation-heavy changes to ensure:
+
+- root docs and GitBook remain in sync,
+- workstream planning references point to canonical files,
+- testing evidence expectations are applied consistently.
+
+## 2) What to update together
+
+- planning docs (`docs/audits/*` + active planning chapters),
+- workflow/test policy docs (`docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md`, chapter 07),
+- roadmap/spec docs (`docs/SEL4_SPEC.md`, chapter 05, next-slice chapter 22).
+
+## 3) Validation minimum
+
+For documentation synchronization changes:
+
+1. run `./scripts/test_smoke.sh`,
+2. run `./scripts/test_full.sh` when theorem/invariant anchors or chapter references are touched,
+3. run targeted `rg -n` link/reference checks for newly introduced docs.
+
+For release-gate or planning baseline changes, also run:
+
+- `./scripts/test_nightly.sh`.
+

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form documentation for seLe4n.
 
 ## Project stage snapshot
 
-- **Current slice:** post-M7 hardware-oriented development path (Raspberry Pi 5 first) with architecture-specific adapter and evidence expansion.
+- **Current slice:** comprehensive-audit WS-B workstream execution kickoff (execution-ready planning baseline).
 - **Most recently completed slice:** M7 audit remediation workstreams (WS-A1 through WS-A8 completed).
 - **Previous completed slice:** M6 architecture-binding interfaces and hardware-facing assumption hardening (WS-M6-A through WS-M6-E complete).
 
@@ -16,10 +16,12 @@ Root contributor-entry docs: [`CONTRIBUTING.md`](../CONTRIBUTING.md), [`CHANGELO
 
 1. [Development Workflow](06-development-workflow.md)
 2. [Testing & CI](07-testing-and-ci.md)
-3. [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
-4. [M7 Remediation Closeout Packet](23-m7-remediation-closeout-packet.md)
-5. [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
-6. [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md)
+3. [Comprehensive Audit 2026 Workstream Planning](24-comprehensive-audit-2026-workstream-planning.md)
+4. [Documentation Sync and Coverage Matrix](25-documentation-sync-and-coverage-matrix.md)
+5. [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
+6. [M7 Remediation Closeout Packet](23-m7-remediation-closeout-packet.md)
+7. [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
+8. [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md)
 
 ## Recommended navigation
 
@@ -33,30 +35,32 @@ Root contributor-entry docs: [`CONTRIBUTING.md`](../CONTRIBUTING.md), [`CHANGELO
 ### 2) Active planning and execution
 
 5. [Specification & Roadmap](05-specification-and-roadmap.md)
-6. [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
-7. [M7 Remediation Closeout Packet](23-m7-remediation-closeout-packet.md)
-8. [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
-9. [Development Workflow](06-development-workflow.md)
-10. [Testing & CI](07-testing-and-ci.md)
-11. [Codebase Reference](11-codebase-reference.md)
-12. [Proof and Invariant Map](12-proof-and-invariant-map.md)
-13. [End-to-End Audit and Quality Gates](19-end-to-end-audit-and-quality-gates.md)
+6. [Comprehensive Audit 2026 Workstream Planning](24-comprehensive-audit-2026-workstream-planning.md)
+7. [Documentation Sync and Coverage Matrix](25-documentation-sync-and-coverage-matrix.md)
+8. [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
+9. [M7 Remediation Closeout Packet](23-m7-remediation-closeout-packet.md)
+10. [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)
+11. [Development Workflow](06-development-workflow.md)
+12. [Testing & CI](07-testing-and-ci.md)
+13. [Codebase Reference](11-codebase-reference.md)
+14. [Proof and Invariant Map](12-proof-and-invariant-map.md)
+15. [End-to-End Audit and Quality Gates](19-end-to-end-audit-and-quality-gates.md)
 
 ### 3) Transition and long-horizon path
 
-14. [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md)
-15. [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)
-16. [Project Usage and Value](17-project-usage-value.md)
+16. [Next Slice Development Path (Post-M7)](22-next-slice-development-path.md)
+17. [Path to Real Hardware (Raspberry Pi 5 First)](10-path-to-real-hardware-mobile-first.md)
+18. [Project Usage and Value](17-project-usage-value.md)
 
 ### 4) Slice history archive
 
-17. [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md)
-18. [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
-19. [Completed Slice: M4-A](08-completed-slice-m4a.md)
-20. [Completed Slice: M4-B](16-completed-slice-m4b.md)
-21. [M4-B Execution Playbook](14-m4b-execution-playbook.md)
-22. [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
-23. [M5 Development Blueprint](15-m5-development-blueprint.md)
+19. [M6 Execution Plan and Workstreams](18-m6-execution-plan-and-workstreams.md)
+20. [M5 Closeout Snapshot](09-m5-closeout-snapshot.md)
+21. [Completed Slice: M4-A](08-completed-slice-m4a.md)
+22. [Completed Slice: M4-B](16-completed-slice-m4b.md)
+23. [M4-B Execution Playbook](14-m4b-execution-playbook.md)
+24. [Future Slices and Delivery Plan](13-future-slices-and-delivery-plan.md)
+25. [M5 Development Blueprint](15-m5-development-blueprint.md)
 
 ## Anti-duplication guidance
 

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -12,6 +12,8 @@
 ## Active planning and execution
 
 - [Specification & Roadmap](05-specification-and-roadmap.md)
+- [Comprehensive Audit 2026 Workstream Planning](24-comprehensive-audit-2026-workstream-planning.md)
+- [Documentation Sync and Coverage Matrix](25-documentation-sync-and-coverage-matrix.md)
 - [M7 Current Slice Outcomes and Workstreams](21-m7-current-slice-outcomes-and-workstreams.md)
 - [M7 Remediation Closeout Packet](23-m7-remediation-closeout-packet.md)
 - [Repository Audit Remediation Workstreams](20-repository-audit-remediation-workstreams.md)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.9.0"
+version = "0.9.1"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
- Expanded the comprehensive-audit workstream planner into a detailed execution document with per-workstream goals, prerequisites, implementation slices, evidence contracts, and exit criteria for WS-B1 through WS-B11, plus explicit portfolio status semantics. 

- Added portfolio readiness gates (G0 kickoff readiness and G1 hardware-entry readiness), and tightened immediate next actions so kickoff can be declared against explicit criteria. 

- Updated root and GitBook stage messaging so the active slice is now consistently described as WS-B execution kickoff readiness, and synchronized the GitBook planning chapter to mirror the new gate model. 

- Bumped patch version to 0.9.1 and documented the release in the changelog; also updated audit index labeling to reflect the new planning baseline. 


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cff9d018832b99ef94097f3afed2)