### PR TITLE
 Implement and finalize workstream WS-B5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [0.9.15] - 2026-02-18
+
+### WS-B5 semantic-correctness refinement
+- Corrected `CNode.resolveSlot` semantics so `depth` is interpreted as consumed bits with `depth >= radix`, guard width `depth - radix`, and guard comparison against extracted guard bits; removed the unreachable `slotOutOfRange` branch.
+- Updated `cspaceResolvePath` error mapping to the refined `ResolveError` space and realigned WS-B5 negative tests (`tests/NegativeStateSuite.lean`) to validate true depth-mismatch and guard-mismatch paths under the corrected semantics.
+- Refined main trace WS-B5 coverage to assert meaningful behaviors only: removed impossible radix-0 depth-mismatch source branch and strengthened deep CNode success/guard-mismatch paths with valid pointers/depths.
+- Bumped patch version to **`0.9.15`** and synchronized root version marker in `README.md`.
+
+## [0.9.14] - 2026-02-18
+
+### WS-B5 trace/invariant hardening follow-up
+- Fixed WS-B5 trace semantics to avoid misleading "unexpected" alias output by making alias-path behavior explicit in `SeLe4n/Testing/MainTraceHarness.lean` and anchoring deep-path success with a valid guard/radix CPtr.
+- Expanded Tier 2 fixture coverage by adding source/deep CSpace path expectations in `tests/fixtures/main_trace_smoke.expected` so WS-B5 path traversal outputs are regression-checked.
+- Added Tier 3 invariant/doc anchors for WS-B5 (`ResolveError`, `resolveSlot`, `cspaceResolvePath`, `cspaceLookupPath`, and canonical WS-B5 completion header) in `scripts/test_tier3_invariant_surface.sh`.
+- Bumped package patch version to **`0.9.14`** and synchronized root version marker in `README.md`.
+
+## [0.9.13] - 2026-02-18
+
+### WS-B5 CSpace guard/radix semantics completion
+- Implemented executable guard/radix pointer traversal for CNodes via `CNode.resolveSlot` in `SeLe4n/Model/Object.lean`, including explicit depth mismatch and guard mismatch failure branches.
+- Added path-addressed CSpace APIs (`CSpacePathAddr`, `cspaceResolvePath`, `cspaceLookupPath`) in `SeLe4n/Kernel/Capability/Operations.lean` so resolution semantics are exercised independently from direct slot lookup.
+- Extended malformed-state coverage in `tests/NegativeStateSuite.lean` with WS-B5 path-resolution success + failure checks, and synchronized active-slice status/closure evidence in README/spec/development/workstream-plan/GitBook docs.
+- Bumped package patch version to **`0.9.13`** and synchronized root version marker in `README.md`.
+
 ## [0.9.12] - 2026-02-18
 
 ### WS-B documentation/test-sync audit hardening

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current state (authoritative snapshot)
 
-- **Active development slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, and WS-B4 completed).
+- **Active development slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed).
 - **Most recently completed slice:** M7 audit remediation (WS-A1..WS-A8 complete).
 - **Previous completed slice:** M6 architecture-boundary assumptions/adapters.
-- **Current package version:** `0.9.12` (`lakefile.toml`).
+- **Current package version:** `0.9.15` (`lakefile.toml`).
 
 Normative scope and acceptance criteria live in [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md).
 
@@ -32,7 +32,7 @@ Use this as the quick index. Full contracts and dependencies are in the audit pl
 - **WS-B2:** Generative + negative testing expansion ✅ completed
 - **WS-B3:** Main trace harness refactor ✅ completed
 - **WS-B4:** Remaining type-wrapper migration ✅ completed
-- **WS-B5:** CSpace guard/radix semantics completion
+- **WS-B5:** CSpace guard/radix semantics completion ✅ completed
 - **WS-B6:** Notification-object IPC completion
 - **WS-B7:** Information-flow proof-track start
 - **WS-B8:** Documentation automation/consolidation

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -7,6 +7,13 @@ open SeLe4n.Model
 /-- Address of a capability slot in the modeled CSpace. -/
 abbrev CSpaceAddr := SlotRef
 
+/-- Address of a guard/radix resolved pointer in the modeled CSpace. -/
+structure CSpacePathAddr where
+  cnode : SeLe4n.ObjId
+  cptr : SeLe4n.CPtr
+  depth : Nat
+  deriving Repr, DecidableEq
+
 /-- Rights attenuation policy for the M2 foundation slice.
 
 `derived.rights` must be a subset of `parent.rights`; targets are preserved by mint-like
@@ -23,6 +30,24 @@ def cspaceLookupSlot (addr : CSpaceAddr) : Kernel Capability :=
         match st.objects addr.cnode with
         | some (.cnode _) => .error .invalidCapability
         | _ => .error .objectNotFound
+
+/-- Resolve a CSpace path address into a concrete slot using CNode guard/radix semantics. -/
+def cspaceResolvePath (addr : CSpacePathAddr) : Kernel CSpaceAddr :=
+  fun st =>
+    match st.objects addr.cnode with
+    | some (.cnode cn) =>
+        match cn.resolveSlot addr.cptr addr.depth with
+        | .ok slot => .ok ({ cnode := addr.cnode, slot := slot }, st)
+        | .error .depthMismatch => .error .illegalState
+        | .error .guardMismatch => .error .invalidCapability
+    | _ => .error .objectNotFound
+
+/-- Lookup a capability via guard/radix resolution from a CSpace pointer path. -/
+def cspaceLookupPath (addr : CSpacePathAddr) : Kernel Capability :=
+  fun st =>
+    match cspaceResolvePath addr st with
+    | .error e => .error e
+    | .ok (resolved, st') => cspaceLookupSlot resolved st'
 
 /-- Insert or replace a capability in `(cnode, slot)`. -/
 def cspaceInsertSlot (addr : CSpaceAddr) (cap : Capability) : Kernel Unit :=

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -162,8 +162,36 @@ end VSpaceRoot
 
 namespace CNode
 
+inductive ResolveError where
+  | depthMismatch
+  | guardMismatch
+  deriving Repr, DecidableEq
+
 def empty : CNode :=
   { guard := 0, radix := 0, slots := [] }
+
+/-- Number of addressable slots represented by this CNode radix width. -/
+def slotCount (node : CNode) : Nat :=
+  2 ^ node.radix
+
+/-- Resolve a CPtr/depth pair into the local slot index using guard/radix semantics.
+
+`depth` is interpreted as the number of low-order bits consumed at this CNode level.
+Those bits split into:
+- `radix` slot-index bits,
+- `depth - radix` guard bits, which must equal `node.guard`. -/
+def resolveSlot (node : CNode) (cptr : SeLe4n.CPtr) (depth : Nat) : Except ResolveError SeLe4n.Slot :=
+  if depth < node.radix then
+    .error .depthMismatch
+  else
+    let guardWidth := depth - node.radix
+    let slotCount := node.slotCount
+    let slotNat := cptr.toNat % slotCount
+    let guardBits := (cptr.toNat / slotCount) % (2 ^ guardWidth)
+    if guardBits = node.guard then
+      .ok (SeLe4n.Slot.ofNat slotNat)
+    else
+      .error .guardMismatch
 
 def lookup (node : CNode) (slot : SeLe4n.Slot) : Option Capability :=
   (node.slots.find? (fun entry => entry.fst = slot)).map Prod.snd
@@ -190,6 +218,15 @@ theorem lookup_remove_eq_none (node : CNode) (slot : SeLe4n.Slot) :
     (node.remove slot).lookup slot = none := by
   unfold remove lookup
   simp
+
+theorem resolveSlot_depthMismatch
+    (node : CNode)
+    (cptr : SeLe4n.CPtr)
+    (depth : Nat)
+    (hDepth : depth < node.radix) :
+    node.resolveSlot cptr depth = .error .depthMismatch := by
+  unfold resolveSlot
+  simp [hDepth]
 
 theorem lookup_revokeTargetLocal_source_eq_lookup
     (node : CNode)

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -7,6 +7,8 @@ open SeLe4n.Model
 namespace SeLe4n.Testing
 
 def rootSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 0 }
+def rootPath : SeLe4n.Kernel.CSpacePathAddr := { cnode := 10, cptr := 0, depth := 0 }
+def rootPathAlias : SeLe4n.Kernel.CSpacePathAddr := { cnode := 10, cptr := 1, depth := 0 }
 def lifecycleAuthSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 5 }
 def mintedSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 3 }
 def siblingSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 4 }
@@ -199,6 +201,15 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
         if oid = 200 then some (.cnode deepRadixCNode) else st1.objects oid
     }
   IO.println s!"deep cnode radix fixture: {reprStr <| (stDeepCNode.objects 200).map (fun obj => match obj with | .cnode cn => cn.radix | _ => 0)}"
+  match SeLe4n.Kernel.cspaceLookupPath { cnode := 200, cptr := 13312, depth := 14 } stDeepCNode with
+  | .error err => IO.println s!"deep cnode path lookup error: {reprStr err}"
+  | .ok (cap, _) => IO.println s!"deep cnode path lookup rights: {reprStr cap.rights}"
+  match SeLe4n.Kernel.cspaceLookupPath { cnode := 200, cptr := 1024, depth := 4 } stDeepCNode with
+  | .error err => IO.println s!"deep cnode path bad-depth branch: {reprStr err}"
+  | .ok (cap, _) => IO.println s!"unexpected deep cnode path bad-depth success: {reprStr cap}"
+  match SeLe4n.Kernel.cspaceLookupPath { cnode := 200, cptr := 9216, depth := 14 } stDeepCNode with
+  | .error err => IO.println s!"deep cnode path guard-mismatch branch: {reprStr err}"
+  | .ok (cap, _) => IO.println s!"unexpected deep cnode path guard success: {reprStr cap}"
 
   let largeRunnable : List SeLe4n.ThreadId :=
     (List.range 12).map (fun i => SeLe4n.ThreadId.ofNat (i + 1))
@@ -391,6 +402,12 @@ def runMainTraceFrom (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"source lookup error: {reprStr err}"
   | .ok (srcCap, _) =>
       IO.println s!"source cap rights before mint: {reprStr srcCap.rights}"
+  match SeLe4n.Kernel.cspaceLookupPath rootPath st1 with
+  | .error err => IO.println s!"source path lookup error: {reprStr err}"
+  | .ok (srcCap, _) => IO.println s!"source path lookup rights: {reprStr srcCap.rights}"
+  match SeLe4n.Kernel.cspaceLookupPath rootPathAlias st1 with
+  | .error err => IO.println s!"source path alias branch error: {reprStr err}"
+  | .ok (srcCap, _) => IO.println s!"source path alias lookup rights: {reprStr srcCap.rights}"
 
   runCapabilityAndArchitectureTrace st1
   runServiceAndStressTrace st1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current slice**:
 
-- active: **Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, and WS-B4 completed)**,
+- active: **Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed)**,
 - completed predecessor: **M7 remediation (WS-A1..WS-A8)**,
 - completed predecessor before that: **M6 architecture-boundary hardening**.
 
@@ -36,7 +36,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-B2** — generative + negative testing expansion (**completed**)
 - **WS-B3** — `Main.lean` trace-harness refactor (**completed**)
 - **WS-B4** — remaining type wrapper migration (**completed**)
-- **WS-B5** — CSpace guard/radix completion
+- **WS-B5** — CSpace guard/radix completion (**completed**)
 - **WS-B6** — notification object semantics
 - **WS-B7** — information-flow proof-track initiation
 - **WS-B8** — documentation automation + dedup
@@ -49,7 +49,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 Use the planning phases from the workstream backbone:
 
 - **Phase P1:** WS-B4, WS-B3, WS-B8 (shape + hygiene stabilization; WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5, WS-B6, WS-B2 (semantic/model expansion; WS-B1/WS-B2 completed)
+- **Phase P2:** WS-B5, WS-B6, WS-B2 (semantic/model expansion; WS-B1/WS-B2/WS-B5 completed)
 - **Phase P3:** WS-B7, WS-B9, WS-B10, WS-B11 (assurance and operational maturity)
 
 ### 3.3 PR-to-workstream discipline
@@ -66,7 +66,7 @@ Every milestone-moving PR should include:
 
 ## 4) Daily contributor loop
 
-1. Sync branch and choose one coherent WS-B slice (prefer next unfinished stream: WS-B5 onward).
+1. Sync branch and choose one coherent WS-B slice (prefer next unfinished stream: WS-B6 onward).
 2. Implement the minimal semantic/proof/doc delta.
 3. Run smallest relevant check first, then higher tiers.
 4. Update docs in the same commit range.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -22,7 +22,7 @@ Companion planning and execution documents:
 - **M5:** complete (service graph + policy surfaces + proof package)
 - **M6:** complete (architecture-boundary assumptions/adapters/invariant hooks)
 - **M7:** complete (audit remediation WS-A1..WS-A8)
-- **Current active slice:** post-M7 comprehensive-audit execution portfolio (WS-B5..WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, and WS-B4 complete).
+- **Current active slice:** post-M7 comprehensive-audit execution portfolio (WS-B6..WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 complete).
 
 ---
 
@@ -52,7 +52,7 @@ proof hygiene, contributor usability, and hardware-readiness trajectory.
 - **WS-B2:** Generative + negative testing expansion ✅ completed
 - **WS-B3:** Main trace harness refactor ✅ completed
 - **WS-B4:** Remaining type-wrapper migration ✅ completed
-- **WS-B5:** CSpace semantics completion (guard/radix)
+- **WS-B5:** CSpace semantics completion (guard/radix) ✅ completed
 - **WS-B6:** Notification-object IPC completion
 - **WS-B7:** Information-flow proof-track start
 - **WS-B8:** Documentation automation + consolidation
@@ -63,7 +63,7 @@ proof hygiene, contributor usability, and hardware-readiness trajectory.
 ### 4.3 Sequencing constraints
 
 - **P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2 completed)
+- **P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5 completed)
 - **P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ### 4.4 Acceptance expectations for WS-B work

--- a/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
+++ b/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
@@ -73,7 +73,7 @@ Rationale: convert expanded model coverage into long-term assurance and delivery
 ## 5) Detailed workstream execution contracts
 
 Status key: `Planned` → `In Progress` → `Completed`.
-Current portfolio status: **WS-B1, WS-B2, WS-B3, and WS-B4 are Completed**; WS-B5..WS-B11 remain Planned/In Progress per active execution cadence.
+Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 are Completed**; WS-B6..WS-B11 remain Planned/In Progress per active execution cadence.
 
 ### WS-B1 — VSpace + memory model foundation (Completed)
 
@@ -137,7 +137,7 @@ Current portfolio status: **WS-B1, WS-B2, WS-B3, and WS-B4 are Completed**; WS-B
 - **Exit criteria:** no remaining raw alias usage in target surfaces; invariant layer compiles without coercion shortcuts.
 - **Closure evidence (2026-02-18):** `SeLe4n/Prelude.lean` now upgrades `DomainId`, `Priority`, `Irq`, `Badge`, `ASID`, `VAddr`, and `PAddr` from `Nat` aliases to wrapper structures with `ofNat`/`toNat` helpers and explicit `ToString`/`OfNat` compatibility instances; `scripts/test_tier0_hygiene.sh` now fails if any of these regress to `abbrev ... := Nat`; full validation gates pass under `scripts/test_fast.sh` and `scripts/test_full.sh`.
 
-### WS-B5 — CSpace semantics completion (Planned)
+### WS-B5 — CSpace semantics completion (Completed)
 
 - **Goal:** model guard/radix-based CNode traversal and resolution outcomes with clear error branches.
 - **Prerequisites:** WS-B4 wrapper migration for capability pointers/slots stability.
@@ -150,6 +150,7 @@ Current portfolio status: **WS-B1, WS-B2, WS-B3, and WS-B4 are Completed**; WS-B
   - `./scripts/test_smoke.sh`
   - `./scripts/test_full.sh`
 - **Exit criteria:** CSpace resolution behavior is executable, tested, and invariant-preserving.
+- **Closure evidence (2026-02-18):** `SeLe4n/Model/Object.lean` now defines executable guard/radix `CNode.resolveSlot` semantics with explicit depth/guard/slot failure taxonomy; `SeLe4n/Kernel/Capability/Operations.lean` adds `CSpacePathAddr` plus `cspaceResolvePath`/`cspaceLookupPath` so pointer-path traversal is modeled separately from direct slot lookup; `tests/NegativeStateSuite.lean` adds path-resolution positive/negative checks for depth mismatch and guard mismatch failures under `scripts/test_tier2_negative.sh`; `tests/fixtures/main_trace_smoke.expected` now anchors source/deep-path guard-radix trace outputs via `scripts/test_tier2_trace.sh`; full validation gates (`scripts/test_smoke.sh`, `scripts/test_full.sh`) pass with the completed semantics.
 
 ### WS-B6 — IPC completeness with notifications (Planned)
 
@@ -168,7 +169,7 @@ Current portfolio status: **WS-B1, WS-B2, WS-B3, and WS-B4 are Completed**; WS-B
 ### WS-B7 — Information-flow proof track start (Planned)
 
 - **Goal:** land IF-M1 formal baseline and decomposition plan for noninterference progression.
-- **Prerequisites:** WS-B1 and WS-B5 completion (state model and CSpace semantics available).
+- **Prerequisites:** WS-B1 and WS-B5 completion (state model and CSpace semantics available). ✅ satisfied
 - **Implementation slices:**
   1. Define confidentiality/integrity labels and state projection helpers.
   2. Publish IF-M1 theorem targets and assumptions ledger.
@@ -252,7 +253,7 @@ Required before declaring kickoff-ready:
 
 First hardware-facing entry gate remains:
 
-- `WS-B1 + WS-B2 + WS-B5` complete,
+- `WS-B1 + WS-B2 + WS-B5` complete ✅,
 - Tier 4 nightly determinism signal stable,
 - architecture assumptions and risk log updated.
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -30,7 +30,7 @@ Closed baseline slices:
 
 Current active slice:
 
-- **Comprehensive Audit 2026-02 execution (WS-B portfolio)** with WS-B1, WS-B2, WS-B3, and WS-B4 completed and WS-B5..WS-B11 in planned/in-progress execution.
+- **Comprehensive Audit 2026-02 execution (WS-B portfolio)** with WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed and WS-B6..WS-B11 in planned/in-progress execution.
 
 ## 4. Architecture mental model
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -12,7 +12,7 @@ Current milestone state:
 - M5 complete
 - M6 complete
 - M7 complete
-- **Active:** Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, and WS-B4 completed)
+- **Active:** Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed)
 
 ## 2) Stable contracts contributors must preserve
 
@@ -28,7 +28,7 @@ Current milestone state:
 - WS-B2: Generative + negative testing expansion ✅ completed
 - WS-B3: Main trace harness refactor ✅ completed
 - WS-B4: Remaining type-wrapper migration ✅ completed
-- WS-B5: CSpace guard/radix completion
+- WS-B5: CSpace guard/radix completion ✅ completed
 - WS-B6: Notification-object IPC completion
 - WS-B7: Information-flow proof-track start
 - WS-B8: Documentation automation + consolidation
@@ -42,7 +42,7 @@ Canonical execution plan:
 ## 4) Sequencing model
 
 - **Phase P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2 complete)
+- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5 complete)
 - **Phase P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ## 5) Historical context

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -39,7 +39,7 @@ For milestone-moving PRs:
 ## Workstream sequence
 
 - **Phase P1:** WS-B4, WS-B3, WS-B8
-- **Phase P2:** WS-B5, WS-B6, WS-B2 (WS-B1/WS-B2 completed)
+- **Phase P2:** WS-B5, WS-B6, WS-B2 (WS-B1/WS-B2/WS-B5 completed)
 - **Phase P3:** WS-B7, WS-B9, WS-B10, WS-B11
 
 ## Failure triage

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -20,7 +20,7 @@ This is the GitBook mirror of the canonical planning backbone:
 
 ### Medium priority
 
-- **WS-B5:** CSpace guard/radix semantics completion
+- **WS-B5:** CSpace guard/radix semantics completion ✅ completed
 - **WS-B6:** Notification-object IPC completion
 - **WS-B7:** Information-flow proof-track start
 - **WS-B8:** Documentation automation + consolidation
@@ -34,7 +34,7 @@ This is the GitBook mirror of the canonical planning backbone:
 ## 3) Sequencing
 
 - **Phase P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2 completed)
+- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5 completed)
 - **Phase P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ## 4) Evidence expectations for milestone-moving PRs
@@ -80,3 +80,11 @@ When status changes, update together:
 - `SeLe4n/Prelude.lean` upgrades `DomainId`, `Priority`, `Irq`, `Badge`, `ASID`, `VAddr`, and `PAddr` from `Nat` aliases to dedicated wrapper structures with explicit `ofNat`/`toNat` helpers.
 - Compatibility ergonomics are preserved via targeted `OfNat` and `ToString` instances, so existing deterministic fixtures remain readable while retaining type separation.
 - Tier 0 now includes a WS-B4 regression guard in `scripts/test_tier0_hygiene.sh` that fails if any of the migrated wrappers revert to `abbrev ... := Nat`.
+
+
+## 10) WS-B5 closure evidence
+
+- `SeLe4n/Model/Object.lean` now includes `CNode.resolveSlot` with explicit guard/radix resolution and depth/guard failure branches.
+- `SeLe4n/Kernel/Capability/Operations.lean` adds `CSpacePathAddr`, `cspaceResolvePath`, and `cspaceLookupPath` so CSpace pointer-path traversal is executable alongside direct slot lookups.
+- `tests/NegativeStateSuite.lean` now enforces WS-B5 negative-path checks for depth mismatch and guard mismatch outcomes in `scripts/test_tier2_negative.sh`.
+- `tests/fixtures/main_trace_smoke.expected` now includes source/deep CSpace path anchors enforced by `scripts/test_tier2_trace.sh`.

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form guide for architecture, workflow, and milestone co
 
 ## Current project state
 
-- **Active slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, and WS-B4 completed).
+- **Active slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed).
 - **Latest completed slice:** M7 remediation (WS-A1..WS-A8 complete).
 - **Previous completed slice:** M6 architecture-boundary hardening.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.9.12"
+version = "0.9.15"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -27,6 +27,13 @@ run_check "INVARIANT" rg -n '^structure Badge' SeLe4n/Prelude.lean
 run_check "INVARIANT" rg -n '^structure ASID' SeLe4n/Prelude.lean
 run_check "INVARIANT" rg -n '^structure VAddr' SeLe4n/Prelude.lean
 run_check "INVARIANT" rg -n '^structure PAddr' SeLe4n/Prelude.lean
+# WS-B5 closure anchors: CSpace guard/radix path resolution surface.
+run_check "INVARIANT" rg -n '^inductive ResolveError' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^def resolveSlot' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^def cspaceResolvePath' SeLe4n/Kernel/Capability/Operations.lean
+run_check "INVARIANT" rg -n '^def cspaceLookupPath' SeLe4n/Kernel/Capability/Operations.lean
+run_check "DOC" rg -n '^### WS-B5 — CSpace semantics completion \(Completed\)' docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
+
 # WS-B2 closure anchors: bootstrap DSL, negative suite, and nightly replay artifacts.
 run_check "INVARIANT" rg -n '^structure BootstrapBuilder' SeLe4n/Testing/StateBuilder.lean
 run_check "INVARIANT" rg -n '^def build \(builder : BootstrapBuilder\)' SeLe4n/Testing/StateBuilder.lean

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -8,13 +8,17 @@ namespace SeLe4n.Testing
 private def endpointId : SeLe4n.ObjId := 40
 private def cnodeId : SeLe4n.ObjId := 10
 private def wrongTypeId : SeLe4n.ObjId := 99
+private def guardedCnodeId : SeLe4n.ObjId := 55
 private def sendEmptyEndpointId : SeLe4n.ObjId := 41
 private def asidPrimary : SeLe4n.ASID := 2
 private def vaddrPrimary : SeLe4n.VAddr := 4096
 private def paddrPrimary : SeLe4n.PAddr := 12288
 
 private def slot0 : SeLe4n.Kernel.CSpaceAddr := { cnode := cnodeId, slot := 0 }
+private def slot0Path : SeLe4n.Kernel.CSpacePathAddr := { cnode := cnodeId, cptr := 0, depth := 0 }
+private def guardedPathBadDepth : SeLe4n.Kernel.CSpacePathAddr := { cnode := guardedCnodeId, cptr := 0, depth := 1 }
 private def badSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := wrongTypeId, slot := 0 }
+private def guardedPathBadGuard : SeLe4n.Kernel.CSpacePathAddr := { cnode := guardedCnodeId, cptr := 0, depth := 3 }
 
 private def baseState : SystemState :=
   (BootstrapBuilder.empty
@@ -31,11 +35,23 @@ private def baseState : SystemState :=
       ]
     })
     |>.withObject wrongTypeId (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject guardedCnodeId (.cnode {
+      guard := 1
+      radix := 2
+      slots := [
+        (1, {
+          target := .object endpointId
+          rights := [.read]
+          badge := none
+        })
+      ]
+    })
     |>.withObject sendEmptyEndpointId (.endpoint { state := .send, queue := [], waitingReceiver := none })
     |>.withObject 20 (.vspaceRoot { asid := asidPrimary, mappings := [] })
     |>.withLifecycleObjectType endpointId .endpoint
     |>.withLifecycleObjectType cnodeId .cnode
     |>.withLifecycleObjectType wrongTypeId .endpoint
+    |>.withLifecycleObjectType guardedCnodeId .cnode
     |>.withLifecycleObjectType sendEmptyEndpointId .endpoint
     |>.withLifecycleObjectType 20 .vspaceRoot
     |>.withLifecycleCapabilityRef slot0 (.object endpointId)
@@ -68,6 +84,17 @@ private def runNegativeChecks : IO Unit := do
   expectError "lookup wrong object type"
     (SeLe4n.Kernel.cspaceLookupSlot badSlot baseState)
     .objectNotFound
+  let _ ← expectOk "lookup path resolved"
+    (SeLe4n.Kernel.cspaceLookupPath slot0Path baseState)
+
+  expectError "lookup path depth mismatch"
+    (SeLe4n.Kernel.cspaceLookupPath guardedPathBadDepth baseState)
+    .illegalState
+
+  expectError "lookup path guard mismatch"
+    (SeLe4n.Kernel.cspaceLookupPath guardedPathBadGuard baseState)
+    .invalidCapability
+
 
   expectError "endpoint receive idle-state mismatch"
     (SeLe4n.Kernel.endpointReceive endpointId baseState)

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -1,5 +1,7 @@
 scheduled thread: some 1
 source cap rights before mint: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]
+source path lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]
+source path alias lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]
 adapter timer success path value: 2
 adapter timer invalid-context branch: SeLe4n.Model.KernelError.illegalState
 adapter timer unsupported branch: SeLe4n.Model.KernelError.notImplemented
@@ -20,6 +22,9 @@ service restart start-stage failure: SeLe4n.Model.KernelError.dependencyViolatio
 service isolation api↔denied: true
 service isolation api↔db: false
 deep cnode radix fixture: some 12
+deep cnode path lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write]
+deep cnode path bad-depth branch: SeLe4n.Model.KernelError.illegalState
+deep cnode path guard-mismatch branch: SeLe4n.Model.KernelError.invalidCapability
 large runnable queue length: 12
 large queue scheduled current: some 1
 multi-endpoint receive senders: 4, 5


### PR DESCRIPTION
- Completed WS-B5 by adding executable CNode guard/radix traversal semantics: CNode.ResolveError, slotCount, and resolveSlot (plus a depth-mismatch theorem) in the model layer. 

- Added path-based CSpace APIs in kernel capability operations: new CSpacePathAddr, cspaceResolvePath (with explicit depth/guard error mapping), and cspaceLookupPath on top of existing slot lookup. 

- Expanded negative-state validation with WS-B5 path-resolution coverage (success path + depth mismatch + guard mismatch) using a guarded CNode fixture. 

- Updated trace harness scenarios to exercise deep-radix CSpace path lookups and source-path branches for expected mismatch behavior. 

- Marked WS-B5 as completed across canonical planning and synced project docs/GitBook active-slice status. 

- Bumped patch version to 0.9.13 and recorded the WS-B5 changelog entry. 

----

- Performed a full WS-B5 hardening pass on top of the prior PR and fixed the biggest quality issue in the trace surface: radix-0 alias behavior is now modeled explicitly (rootPathAlias) instead of being emitted as an “unexpected guard-mismatch success,” and deep CNode path lookup now uses a valid guard/radix-resolving pointer (cptr := 13312) so the positive deep-path branch is meaningful. 

- Tightened Tier 2 regression coverage by updating the canonical smoke trace fixture to assert the WS-B5 source-path and deep-path outputs (including alias-path success, bad-depth failure, and guard-mismatch failure). This closes the previous gap where extra log lines could drift without fixture enforcement. 

- Strengthened Tier 3 invariant/doc guardrails by adding explicit WS-B5 anchors for ResolveError, resolveSlot, cspaceResolvePath, cspaceLookupPath, and canonical WS-B5 completed status text. 

- Updated WS-B5 closure evidence text in canonical planning + GitBook to explicitly include trace-fixture anchoring as part of completion evidence. 

- Bumped patch version to 0.9.14, synchronized README version marker, and added a changelog entry documenting this follow-up hardening pass.


----

- Refined WS-B5 core semantics to remove a modeling bug: resolveSlot now interprets depth as consumed bits with depth >= radix, computes guard width as depth - radix, and compares extracted guard bits against the CNode guard value. This replaced the prior depth/guard conflation and removed an unreachable error branch. 

- Updated path resolution error mapping to the corrected ResolveError set (depth mismatch and guard mismatch only) in the kernel CSpace path resolver. 

- Fixed WS-B5 negative tests so they validate real failure modes under corrected semantics:

- depth mismatch now targets a guarded/radix CNode with insufficient depth,

- guard mismatch now uses a depth where guard bits are actually checked. 

- Refined main trace harness WS-B5 scenarios to remove impossible radix-0 “bad depth” expectations and to use valid deep CSpace pointers/depths for success + guard mismatch checks. 

- Synced the smoke fixture with the refined trace semantics (48/48 stable expectations). 

- Bumped patch version to 0.9.15, synced README version marker, and added a changelog entry documenting this semantic-correctness refinement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952125c1b4832bb1f3d5241f1bec65)