### PR TITLE
Finalize WS-B6: implement notification IPC, extend invariants, sync docs, and bump to 0.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [0.9.18] - 2026-02-18
+
+### WS-B6 audit hardening follow-up
+- Hardened Tier 3 documentation-synchronization guards in `scripts/test_tier3_invariant_surface.sh` so active-slice/phase-status wording for WS-B6 completion is continuously checked across README/spec/development guide/GitBook pages.
+- Re-ran fast/full/nightly validation lanes to confirm no behavioral regressions and deterministic test stability under the tightened documentation anchors.
+- Bumped patch version to **`0.9.18`** and synchronized root version marker in `README.md`.
+
+## [0.9.17] - 2026-02-18
+
+### WS-B6 post-merge synchronization audit
+- Performed a full repository audit pass after WS-B6 merge and revalidated all quality tiers, including nightly default and nightly experimental determinism lanes.
+- Fixed remaining documentation/GitBook status drift so WS-B6 completion is reflected consistently in:
+  - `docs/gitbook/01-project-overview.md`,
+  - `docs/gitbook/06-development-workflow.md`,
+  - `docs/DEVELOPMENT.md`.
+- Updated next-workstream guidance to point to WS-B7 as the next unfinished stream.
+- Bumped patch version to **`0.9.17`** and synchronized the root version marker in `README.md`.
+
+## [0.9.16] - 2026-02-18
+
+### WS-B6 IPC completeness with notifications
+- Added notification-object IPC model coverage in `SeLe4n/Model/Object.lean`: `NotificationState`, `Notification`, `KernelObject.notification`, `KernelObjectType.notification`, and `ThreadIpcState.blockedOnNotification`.
+- Implemented executable notification transitions in `SeLe4n/Kernel/IPC/Operations.lean` with `notificationWait`/`notificationSignal` semantics and explicit scheduler runnable-queue interactions.
+- Extended IPC invariant surfaces (`SeLe4n/Kernel/IPC/Invariant.lean`) so global `ipcInvariant` now covers both endpoint and notification object classes.
+- Expanded regression evidence with notification paths in `SeLe4n/Testing/MainTraceHarness.lean`, `tests/NegativeStateSuite.lean`, and `tests/fixtures/main_trace_smoke.expected`, and added WS-B6 Tier 3 anchors in `scripts/test_tier3_invariant_surface.sh`.
+- Marked WS-B6 as completed across root docs/spec/development guide and GitBook planning mirrors.
+- Bumped patch version to **`0.9.16`** and synchronized root version marker in `README.md`.
+
 ## [0.9.15] - 2026-02-18
 
 ### WS-B5 semantic-correctness refinement

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current state (authoritative snapshot)
 
-- **Active development slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed).
+- **Active development slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed).
 - **Most recently completed slice:** M7 audit remediation (WS-A1..WS-A8 complete).
 - **Previous completed slice:** M6 architecture-boundary assumptions/adapters.
-- **Current package version:** `0.9.15` (`lakefile.toml`).
+- **Current package version:** `0.9.18` (`lakefile.toml`).
 
 Normative scope and acceptance criteria live in [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md).
 
@@ -33,7 +33,7 @@ Use this as the quick index. Full contracts and dependencies are in the audit pl
 - **WS-B3:** Main trace harness refactor ✅ completed
 - **WS-B4:** Remaining type-wrapper migration ✅ completed
 - **WS-B5:** CSpace guard/radix semantics completion ✅ completed
-- **WS-B6:** Notification-object IPC completion
+- **WS-B6:** Notification-object IPC completion ✅ completed
 - **WS-B7:** Information-flow proof-track start
 - **WS-B8:** Documentation automation/consolidation
 - **WS-B9:** Threat model + security hardening

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -79,6 +79,7 @@ theorem cspaceDeleteSlot_authority_reduction
       cases obj with
       | tcb tcb => simp [cspaceDeleteSlot, hObj] at hStep
       | endpoint ep => simp [cspaceDeleteSlot, hObj] at hStep
+      | notification ntfn => simp [cspaceDeleteSlot, hObj] at hStep
       | vspaceRoot root => simp [cspaceDeleteSlot, hObj] at hStep
       | cnode cn =>
 
@@ -107,6 +108,7 @@ theorem cspaceRevoke_local_target_reduction
       cases obj with
       | tcb tcb => simp [hObj] at hStep
       | endpoint ep => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
       | cnode cn =>
 
@@ -205,6 +207,7 @@ theorem cspaceInsertSlot_lookup_eq
       cases obj with
       | tcb tcb => simp [cspaceInsertSlot, hObj] at hStep
       | endpoint ep => simp [cspaceInsertSlot, hObj] at hStep
+      | notification ntfn => simp [cspaceInsertSlot, hObj] at hStep
       | vspaceRoot root => simp [cspaceInsertSlot, hObj] at hStep
       | cnode cn =>
 
@@ -234,6 +237,7 @@ theorem cspaceDeleteSlot_lookup_eq_none
       cases obj with
       | tcb tcb => simp [cspaceDeleteSlot, hObj] at hStep
       | endpoint ep => simp [cspaceDeleteSlot, hObj] at hStep
+      | notification ntfn => simp [cspaceDeleteSlot, hObj] at hStep
       | vspaceRoot root => simp [cspaceDeleteSlot, hObj] at hStep
       | cnode cn =>
 
@@ -260,6 +264,7 @@ theorem cspaceRevoke_preserves_source
           cases obj with
           | tcb tcb => simp [hLookup, hObj] at hStep
           | endpoint ep => simp [hLookup, hObj] at hStep
+          | notification ntfn => simp [hLookup, hObj] at hStep
           | vspaceRoot root => simp [hLookup, hObj] at hStep
           | cnode cn =>
 
@@ -536,34 +541,43 @@ theorem lifecycleRetypeObject_preserves_ipcInvariant
     (newObj : KernelObject)
     (hInv : ipcInvariant st)
     (hNewObjEndpointInv : ∀ ep, newObj = .endpoint ep → endpointInvariant ep)
+    (hNewObjNotificationInv : ∀ ntfn, newObj = .notification ntfn → notificationInvariant ntfn)
     (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
     ipcInvariant st' := by
-  intro oid ep hEndpoint
-  by_cases hEq : oid = target
-  · subst hEq
-    have hObjAtTarget : st'.objects oid = some newObj := by
-      rcases lifecycleRetypeObject_ok_as_storeObject st st' authority oid newObj hStep with
-        ⟨_, _, _, _, _, _, hStore⟩
-      exact lifecycle_storeObject_objects_eq st st' oid newObj hStore
-    rw [hObjAtTarget] at hEndpoint
-    cases hNewObj : newObj with
-    | tcb _ =>
-        rw [hNewObj] at hEndpoint
-        cases hEndpoint
-    | cnode _ =>
-        rw [hNewObj] at hEndpoint
-        cases hEndpoint
-    | vspaceRoot _ =>
-        rw [hNewObj] at hEndpoint
-        cases hEndpoint
-    | endpoint newEp =>
-        rw [hNewObj] at hEndpoint
-        cases hEndpoint
-        exact hNewObjEndpointInv ep hNewObj
-  · have hPreserved : st'.objects oid = st.objects oid :=
-      lifecycleRetypeObject_ok_lookup_preserved_ne st st' authority target oid newObj hEq hStep
-    have hEndpointSt : st.objects oid = some (.endpoint ep) := by simpa [hPreserved] using hEndpoint
-    exact hInv oid ep hEndpointSt
+  rcases hInv with ⟨hEndpointInv, hNotificationInv⟩
+  refine ⟨?_, ?_⟩
+  · intro oid ep hEndpoint
+    by_cases hEq : oid = target
+    · subst hEq
+      have hObjAtTarget : st'.objects oid = some newObj := by
+        rcases lifecycleRetypeObject_ok_as_storeObject st st' authority oid newObj hStep with
+          ⟨_, _, _, _, _, _, hStore⟩
+        exact lifecycle_storeObject_objects_eq st st' oid newObj hStore
+      have hSomeEq : some newObj = some (.endpoint ep) := by
+        simpa [hObjAtTarget] using hEndpoint
+      have hNewObjEq : newObj = .endpoint ep := by
+        injection hSomeEq
+      exact hNewObjEndpointInv ep hNewObjEq
+    · have hPreserved : st'.objects oid = st.objects oid :=
+        lifecycleRetypeObject_ok_lookup_preserved_ne st st' authority target oid newObj hEq hStep
+      have hEndpointSt : st.objects oid = some (.endpoint ep) := by simpa [hPreserved] using hEndpoint
+      exact hEndpointInv oid ep hEndpointSt
+  · intro oid ntfn hNtfn
+    by_cases hEq : oid = target
+    · subst hEq
+      have hObjAtTarget : st'.objects oid = some newObj := by
+        rcases lifecycleRetypeObject_ok_as_storeObject st st' authority oid newObj hStep with
+          ⟨_, _, _, _, _, _, hStore⟩
+        exact lifecycle_storeObject_objects_eq st st' oid newObj hStore
+      have hSomeEq : some newObj = some (.notification ntfn) := by
+        simpa [hObjAtTarget] using hNtfn
+      have hNewObjEq : newObj = .notification ntfn := by
+        injection hSomeEq
+      exact hNewObjNotificationInv ntfn hNewObjEq
+    · have hPreserved : st'.objects oid = st.objects oid :=
+        lifecycleRetypeObject_ok_lookup_preserved_ne st st' authority target oid newObj hEq hStep
+      have hNtfnSt : st.objects oid = some (.notification ntfn) := by simpa [hPreserved] using hNtfn
+      exact hNotificationInv oid ntfn hNtfnSt
 
 theorem lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle
     (st st' : SystemState)
@@ -572,6 +586,7 @@ theorem lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle
     (newObj : KernelObject)
     (hInv : m3IpcSeedInvariantBundle st)
     (hNewObjEndpointInv : ∀ ep, newObj = .endpoint ep → endpointInvariant ep)
+    (hNewObjNotificationInv : ∀ ntfn, newObj = .notification ntfn → notificationInvariant ntfn)
     (hCurrentValid : currentThreadValid st')
     (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
     m3IpcSeedInvariantBundle st' := by
@@ -580,7 +595,7 @@ theorem lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle
   · exact lifecycleRetypeObject_preserves_schedulerInvariantBundle st st' authority target newObj hSched
       hCurrentValid hStep
   · exact lifecycleRetypeObject_preserves_capabilityInvariantBundle st st' authority target newObj hCap hStep
-  · exact lifecycleRetypeObject_preserves_ipcInvariant st st' authority target newObj hIpc hNewObjEndpointInv hStep
+  · exact lifecycleRetypeObject_preserves_ipcInvariant st st' authority target newObj hIpc hNewObjEndpointInv hNewObjNotificationInv hStep
 
 theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle
     (st st' : SystemState)
@@ -589,6 +604,7 @@ theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle
     (newObj : KernelObject)
     (hInv : m4aLifecycleInvariantBundle st)
     (hNewObjEndpointInv : ∀ ep, newObj = .endpoint ep → endpointInvariant ep)
+    (hNewObjNotificationInv : ∀ ntfn, newObj = .notification ntfn → notificationInvariant ntfn)
     (hCurrentValid : currentThreadValid st')
     (hCoherence' : ipcSchedulerCoherenceComponent st')
     (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
@@ -597,7 +613,7 @@ theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle
   rcases hM35 with ⟨hM3, _hCoherence⟩
   have hM3' : m3IpcSeedInvariantBundle st' :=
     lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle st st' authority target newObj hM3
-      hNewObjEndpointInv hCurrentValid hStep
+      hNewObjEndpointInv hNewObjNotificationInv hCurrentValid hStep
   have hLifecycle' : lifecycleInvariantBundle st' :=
     SeLe4n.Kernel.lifecycleRetypeObject_preserves_lifecycleInvariantBundle st st' authority target
       newObj hLifecycle hStep

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -104,6 +104,7 @@ theorem endpointSend_ok_as_storeObject
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           cases hState : ep.state with
           | idle =>
@@ -136,6 +137,7 @@ theorem endpointAwaitReceive_ok_as_storeObject
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           cases hState : ep.state <;> cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
             simp [hObj, hState, hQueue, hWait, storeObject] at hStep
@@ -158,6 +160,7 @@ theorem endpointReceive_ok_as_storeObject
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           cases hState : ep.state <;> simp [hObj, hState] at hStep
           case send =>
@@ -202,11 +205,25 @@ def endpointObjectValid (ep : Endpoint) : Prop :=
 def endpointInvariant (ep : Endpoint) : Prop :=
   endpointQueueWellFormed ep ∧ endpointObjectValid ep
 
+/-- Notification-local queue/state consistency for WS-B6. -/
+def notificationQueueWellFormed (ntfn : Notification) : Prop :=
+  match ntfn.state with
+  | .idle => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge = none
+  | .waiting => ntfn.waitingThreads ≠ [] ∧ ntfn.pendingBadge = none
+  | .active => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge.isSome
+
+/-- Notification safety bundle for IPC completeness. -/
+def notificationInvariant (ntfn : Notification) : Prop :=
+  notificationQueueWellFormed ntfn
+
 /-- Global IPC seed invariant entrypoint. -/
 def ipcInvariant (st : SystemState) : Prop :=
-  ∀ oid ep,
+  (∀ oid ep,
     st.objects oid = some (.endpoint ep) →
-    endpointInvariant ep
+    endpointInvariant ep) ∧
+  (∀ oid ntfn,
+    st.objects oid = some (.notification ntfn) →
+    notificationInvariant ntfn)
 
 /-- Scheduler contract predicate #1 for M3.5: runnable threads are explicitly IPC-ready. -/
 def runnableThreadIpcReady (st : SystemState) : Prop :=
@@ -427,6 +444,7 @@ theorem endpointSend_result_wellFormed
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           cases hState : ep.state with
           | idle =>
@@ -464,6 +482,7 @@ theorem endpointAwaitReceive_result_wellFormed
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           cases hState : ep.state <;> cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
             simp [hObj, hState, hQueue, hWait, storeObject] at hStep
@@ -487,6 +506,7 @@ theorem endpointReceive_result_wellFormed
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           cases hState : ep.state <;> simp [hObj, hState] at hStep
           case send =>
@@ -546,21 +566,33 @@ theorem endpointSend_preserves_ipcInvariant
     (hInv : ipcInvariant st)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
     ipcInvariant st' := by
-  intro oid ep hObj
-  rcases endpointSend_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, hWfNew⟩
-  by_cases hEq : oid = endpointId
-  · subst hEq
-    have hCast : ep = epNew := by
-      rw [hStored] at hObj
-      cases hObj
-      rfl
-    have hObjValidNew : endpointObjectValid epNew :=
-      endpointObjectValid_of_queueWellFormed epNew hWfNew
-    simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
-  · have hUnchanged : st'.objects oid = st.objects oid := by
-      exact endpointSend_preserves_other_objects st st' endpointId oid sender hEq hStep
-    have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
-    exact hInv oid ep hOrig
+  rcases hInv with ⟨hEndpointInv, hNotificationInv⟩
+  refine ⟨?_, ?_⟩
+  · intro oid ep hObj
+    rcases endpointSend_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, hWfNew⟩
+    by_cases hEq : oid = endpointId
+    · subst hEq
+      have hCast : ep = epNew := by
+        rw [hStored] at hObj
+        cases hObj
+        rfl
+      have hObjValidNew : endpointObjectValid epNew := endpointObjectValid_of_queueWellFormed epNew hWfNew
+      simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
+    · have hUnchanged : st'.objects oid = st.objects oid :=
+        endpointSend_preserves_other_objects st st' endpointId oid sender hEq hStep
+      have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
+      exact hEndpointInv oid ep hOrig
+  · intro oid ntfn hObj
+    by_cases hEq : oid = endpointId
+    · have hObjAtEndpoint : st'.objects endpointId = some (.notification ntfn) := by
+        simpa [hEq] using hObj
+      rcases endpointSend_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, _⟩
+      rw [hStored] at hObjAtEndpoint
+      cases hObjAtEndpoint
+    · have hUnchanged : st'.objects oid = st.objects oid :=
+        endpointSend_preserves_other_objects st st' endpointId oid sender hEq hStep
+      have hOrig : st.objects oid = some (.notification ntfn) := by simpa [hUnchanged] using hObj
+      exact hNotificationInv oid ntfn hOrig
 
 theorem endpointAwaitReceive_preserves_ipcInvariant
     (st st' : SystemState)
@@ -569,21 +601,33 @@ theorem endpointAwaitReceive_preserves_ipcInvariant
     (hInv : ipcInvariant st)
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
     ipcInvariant st' := by
-  intro oid ep hObj
-  rcases endpointAwaitReceive_result_wellFormed st st' endpointId receiver hStep with ⟨epNew, hStored, hWfNew⟩
-  by_cases hEq : oid = endpointId
-  · subst hEq
-    have hCast : ep = epNew := by
-      rw [hStored] at hObj
-      cases hObj
-      rfl
-    have hObjValidNew : endpointObjectValid epNew :=
-      endpointObjectValid_of_queueWellFormed epNew hWfNew
-    simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
-  · have hUnchanged : st'.objects oid = st.objects oid := by
-      exact endpointAwaitReceive_preserves_other_objects st st' endpointId oid receiver hEq hStep
-    have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
-    exact hInv oid ep hOrig
+  rcases hInv with ⟨hEndpointInv, hNotificationInv⟩
+  refine ⟨?_, ?_⟩
+  · intro oid ep hObj
+    rcases endpointAwaitReceive_result_wellFormed st st' endpointId receiver hStep with ⟨epNew, hStored, hWfNew⟩
+    by_cases hEq : oid = endpointId
+    · subst hEq
+      have hCast : ep = epNew := by
+        rw [hStored] at hObj
+        cases hObj
+        rfl
+      have hObjValidNew : endpointObjectValid epNew := endpointObjectValid_of_queueWellFormed epNew hWfNew
+      simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
+    · have hUnchanged : st'.objects oid = st.objects oid :=
+        endpointAwaitReceive_preserves_other_objects st st' endpointId oid receiver hEq hStep
+      have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
+      exact hEndpointInv oid ep hOrig
+  · intro oid ntfn hObj
+    by_cases hEq : oid = endpointId
+    · have hObjAtEndpoint : st'.objects endpointId = some (.notification ntfn) := by
+        simpa [hEq] using hObj
+      rcases endpointAwaitReceive_result_wellFormed st st' endpointId receiver hStep with ⟨epNew, hStored, _⟩
+      rw [hStored] at hObjAtEndpoint
+      cases hObjAtEndpoint
+    · have hUnchanged : st'.objects oid = st.objects oid :=
+        endpointAwaitReceive_preserves_other_objects st st' endpointId oid receiver hEq hStep
+      have hOrig : st.objects oid = some (.notification ntfn) := by simpa [hUnchanged] using hObj
+      exact hNotificationInv oid ntfn hOrig
 
 theorem endpointReceive_preserves_ipcInvariant
     (st st' : SystemState)
@@ -592,21 +636,33 @@ theorem endpointReceive_preserves_ipcInvariant
     (hInv : ipcInvariant st)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
     ipcInvariant st' := by
-  intro oid ep hObj
-  rcases endpointReceive_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, hWfNew⟩
-  by_cases hEq : oid = endpointId
-  · subst hEq
-    have hCast : ep = epNew := by
-      rw [hStored] at hObj
-      cases hObj
-      rfl
-    have hObjValidNew : endpointObjectValid epNew :=
-      endpointObjectValid_of_queueWellFormed epNew hWfNew
-    simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
-  · have hUnchanged : st'.objects oid = st.objects oid := by
-      exact endpointReceive_preserves_other_objects st st' endpointId oid sender hEq hStep
-    have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
-    exact hInv oid ep hOrig
+  rcases hInv with ⟨hEndpointInv, hNotificationInv⟩
+  refine ⟨?_, ?_⟩
+  · intro oid ep hObj
+    rcases endpointReceive_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, hWfNew⟩
+    by_cases hEq : oid = endpointId
+    · subst hEq
+      have hCast : ep = epNew := by
+        rw [hStored] at hObj
+        cases hObj
+        rfl
+      have hObjValidNew : endpointObjectValid epNew := endpointObjectValid_of_queueWellFormed epNew hWfNew
+      simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
+    · have hUnchanged : st'.objects oid = st.objects oid :=
+        endpointReceive_preserves_other_objects st st' endpointId oid sender hEq hStep
+      have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
+      exact hEndpointInv oid ep hOrig
+  · intro oid ntfn hObj
+    by_cases hEq : oid = endpointId
+    · have hObjAtEndpoint : st'.objects endpointId = some (.notification ntfn) := by
+        simpa [hEq] using hObj
+      rcases endpointReceive_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, _⟩
+      rw [hStored] at hObjAtEndpoint
+      cases hObjAtEndpoint
+    · have hUnchanged : st'.objects oid = st.objects oid :=
+        endpointReceive_preserves_other_objects st st' endpointId oid sender hEq hStep
+      have hOrig : st.objects oid = some (.notification ntfn) := by simpa [hUnchanged] using hObj
+      exact hNotificationInv oid ntfn hOrig
 
 theorem endpointSend_ok_implies_endpoint_object
     (st st' : SystemState)
@@ -622,6 +678,7 @@ theorem endpointSend_ok_implies_endpoint_object
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           refine ⟨ep, rfl⟩
 
@@ -639,6 +696,7 @@ theorem endpointAwaitReceive_ok_implies_endpoint_object
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           refine ⟨ep, rfl⟩
 
@@ -656,6 +714,7 @@ theorem endpointReceive_ok_implies_endpoint_object
       | tcb tcb => simp [hObj] at hStep
       | cnode cn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
+      | notification ntfn => simp [hObj] at hStep
       | endpoint ep =>
           refine ⟨ep, rfl⟩
 

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -4,6 +4,18 @@ namespace SeLe4n.Kernel
 
 open SeLe4n.Model
 
+private def removeRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
+  {
+    st with
+      scheduler := { st.scheduler with runnable := st.scheduler.runnable.filter (· ≠ tid) }
+  }
+
+private def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
+  if tid ∈ st.scheduler.runnable then
+    st
+  else
+    { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } }
+
 /-- Add a sender to an endpoint wait queue with explicit state transition. -/
 def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel Unit :=
   fun st =>
@@ -56,6 +68,57 @@ def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
         | .send, _, some _ => .error .endpointStateMismatch
         | .idle, _, _ => .error .endpointStateMismatch
         | .receive, _, _ => .error .endpointStateMismatch
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Signal a notification: wake one waiter or mark one pending badge. -/
+def notificationSignal (notificationId : SeLe4n.ObjId) (badge : SeLe4n.Badge) : Kernel Unit :=
+  fun st =>
+    match st.objects notificationId with
+    | some (.notification ntfn) =>
+        match ntfn.waitingThreads with
+        | waiter :: rest =>
+            let nextState : NotificationState := if rest.isEmpty then .idle else .waiting
+            let ntfn' : Notification := {
+              state := nextState
+              waitingThreads := rest
+              pendingBadge := none
+            }
+            match storeObject notificationId (.notification ntfn') st with
+            | .error e => .error e
+            | .ok ((), st') => .ok ((), ensureRunnable st' waiter)
+        | [] =>
+            let ntfn' : Notification := {
+              state := .active
+              waitingThreads := []
+              pendingBadge := some badge
+            }
+            storeObject notificationId (.notification ntfn') st
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Wait on a notification: consume pending badge or block the caller. -/
+def notificationWait
+    (notificationId : SeLe4n.ObjId)
+    (waiter : SeLe4n.ThreadId) : Kernel (Option SeLe4n.Badge) :=
+  fun st =>
+    match st.objects notificationId with
+    | some (.notification ntfn) =>
+        match ntfn.pendingBadge with
+        | some badge =>
+            let ntfn' : Notification := { state := .idle, waitingThreads := [], pendingBadge := none }
+            match storeObject notificationId (.notification ntfn') st with
+            | .error e => .error e
+            | .ok ((), st') => .ok (some badge, st')
+        | none =>
+            let ntfn' : Notification := {
+              state := .waiting
+              waitingThreads := ntfn.waitingThreads ++ [waiter]
+              pendingBadge := none
+            }
+            match storeObject notificationId (.notification ntfn') st with
+            | .error e => .error e
+            | .ok ((), st') => .ok (none, removeRunnable st' waiter)
     | some _ => .error .invalidCapability
     | none => .error .objectNotFound
 

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -141,6 +141,10 @@ theorem schedule_preserves_wellFormed
               simp [schedule, setCurrentThread, hRun, hObj] at hStep
               cases hStep
               simp [schedulerWellFormed, queueCurrentConsistent]
+          | notification ntfn =>
+              simp [schedule, setCurrentThread, hRun, hObj] at hStep
+              cases hStep
+              simp [schedulerWellFormed, queueCurrentConsistent]
           | cnode cn =>
               simp [schedule, setCurrentThread, hRun, hObj] at hStep
               cases hStep
@@ -182,6 +186,10 @@ theorem schedule_preserves_queueCurrentConsistent
                 (by simp [hRun])
                 (by simpa [schedule, hRun, hObj] using hStep)
           | endpoint ep =>
+              simp [schedule, setCurrentThread, hRun, hObj] at hStep
+              cases hStep
+              simp [queueCurrentConsistent]
+          | notification ntfn =>
               simp [schedule, setCurrentThread, hRun, hObj] at hStep
               cases hStep
               simp [queueCurrentConsistent]
@@ -242,6 +250,9 @@ theorem schedule_preserves_runQueueUnique
           | endpoint ep =>
               exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
                 simpa [schedule, hRun, hObj] using hStep)
+          | notification ntfn =>
+              exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
+                simpa [schedule, hRun, hObj] using hStep)
           | cnode cn =>
               exact setCurrentThread_preserves_runQueueUnique st st' none hUnique (by
                 simpa [schedule, hRun, hObj] using hStep)
@@ -269,6 +280,9 @@ theorem schedule_preserves_currentThreadValid
                 ⟨tcb, hObj⟩
                 (by simpa [schedule, hRun, hObj] using hStep)
           | endpoint ep =>
+              exact setCurrentThread_none_preserves_currentThreadValid st st' (by
+                simpa [schedule, hRun, hObj] using hStep)
+          | notification ntfn =>
               exact setCurrentThread_none_preserves_currentThreadValid st st' (by
                 simpa [schedule, hRun, hObj] using hStep)
           | cnode cn =>

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -62,6 +62,7 @@ inductive ThreadIpcState where
   | ready
   | blockedOnSend (endpoint : SeLe4n.ObjId)
   | blockedOnReceive (endpoint : SeLe4n.ObjId)
+  | blockedOnNotification (notification : SeLe4n.ObjId)
   deriving Repr, DecidableEq
 
 structure TCB where
@@ -84,6 +85,21 @@ structure Endpoint where
   state : EndpointState
   queue : List SeLe4n.ThreadId
   waitingReceiver : Option SeLe4n.ThreadId := none
+  deriving Repr, DecidableEq
+
+inductive NotificationState where
+  | idle
+  | waiting
+  | active
+  deriving Repr, DecidableEq
+
+/-- Minimal notification object model for WS-B6.
+
+`active` stores a single pending badge, while `waiting` tracks blocked receivers. -/
+structure Notification where
+  state : NotificationState
+  waitingThreads : List SeLe4n.ThreadId
+  pendingBadge : Option SeLe4n.Badge := none
   deriving Repr, DecidableEq
 
 structure CNode where
@@ -248,6 +264,7 @@ end CNode
 inductive KernelObject where
   | tcb (t : TCB)
   | endpoint (e : Endpoint)
+  | notification (n : Notification)
   | cnode (c : CNode)
   | vspaceRoot (v : VSpaceRoot)
   deriving Repr, DecidableEq
@@ -255,6 +272,7 @@ inductive KernelObject where
 inductive KernelObjectType where
   | tcb
   | endpoint
+  | notification
   | cnode
   | vspaceRoot
   deriving Repr, DecidableEq
@@ -264,6 +282,7 @@ namespace KernelObject
 def objectType : KernelObject → KernelObjectType
   | .tcb _ => .tcb
   | .endpoint _ => .endpoint
+  | .notification _ => .notification
   | .cnode _ => .cnode
   | .vspaceRoot _ => .vspaceRoot
 

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -13,6 +13,7 @@ def lifecycleAuthSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 5 }
 def mintedSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 3 }
 def siblingSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 11, slot := 4 }
 def demoEndpoint : SeLe4n.ObjId := 30
+def demoNotification : SeLe4n.ObjId := 31
 
 def svcDb : ServiceId := 100
 def svcApi : ServiceId := 101
@@ -59,6 +60,7 @@ def bootstrapState : SystemState :=
     |>.withObject 11 (.cnode CNode.empty)
     |>.withObject 20 (.vspaceRoot { asid := 1, mappings := [] })
     |>.withObject demoEndpoint (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject demoNotification (.notification { state := .idle, waitingThreads := [], pendingBadge := none })
     |>.withService svcDb {
       identity := { sid := svcDb, backingObject := 12, owner := 10 }
       status := .running
@@ -102,6 +104,7 @@ def bootstrapState : SystemState :=
     |>.withLifecycleObjectType 11 .cnode
     |>.withLifecycleObjectType 20 .vspaceRoot
     |>.withLifecycleObjectType demoEndpoint .endpoint
+    |>.withLifecycleObjectType demoNotification .notification
     |>.withLifecycleCapabilityRef rootSlot (.object 1)
     |>.withLifecycleCapabilityRef lifecycleAuthSlot (.object 12)
   ).build
@@ -391,7 +394,21 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
                                           | .error err =>
                                               IO.println s!"endpoint receive #3 (expected mismatch): {reprStr err}"
                                           | .ok (sender3, _) =>
-                                              IO.println s!"unexpected endpoint receive #3 sender: {sender3}"
+                                                IO.println s!"unexpected endpoint receive #3 sender: {sender3}"
+                                          match SeLe4n.Kernel.notificationWait demoNotification 2 st11 with
+                                          | .error err => IO.println s!"notification wait #1 error: {reprStr err}"
+                                          | .ok (badge, st12) =>
+                                              IO.println s!"notification wait #1 result: {reprStr badge}"
+                                              match SeLe4n.Kernel.notificationSignal demoNotification 99 st12 with
+                                              | .error err => IO.println s!"notification signal #1 error: {reprStr err}"
+                                              | .ok (_, st13) =>
+                                                  match SeLe4n.Kernel.notificationSignal demoNotification 123 st13 with
+                                                  | .error err => IO.println s!"notification signal #2 error: {reprStr err}"
+                                                  | .ok (_, st14) =>
+                                                      match SeLe4n.Kernel.notificationWait demoNotification 2 st14 with
+                                                      | .error err => IO.println s!"notification wait #2 error: {reprStr err}"
+                                                      | .ok (badge2, _) =>
+                                                          IO.println s!"notification wait #2 result: {reprStr badge2}"
       match SeLe4n.Kernel.cspaceLookupSlot mintedSlot st2 with
       | .error err => IO.println s!"cspace lookup error: {reprStr err}"
       | .ok (cap, _) =>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current slice**:
 
-- active: **Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed)**,
+- active: **Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed)**,
 - completed predecessor: **M7 remediation (WS-A1..WS-A8)**,
 - completed predecessor before that: **M6 architecture-boundary hardening**.
 
@@ -37,7 +37,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-B3** — `Main.lean` trace-harness refactor (**completed**)
 - **WS-B4** — remaining type wrapper migration (**completed**)
 - **WS-B5** — CSpace guard/radix completion (**completed**)
-- **WS-B6** — notification object semantics
+- **WS-B6** — notification object semantics (**completed**)
 - **WS-B7** — information-flow proof-track initiation
 - **WS-B8** — documentation automation + dedup
 - **WS-B9** — threat model/security hardening
@@ -49,7 +49,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 Use the planning phases from the workstream backbone:
 
 - **Phase P1:** WS-B4, WS-B3, WS-B8 (shape + hygiene stabilization; WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5, WS-B6, WS-B2 (semantic/model expansion; WS-B1/WS-B2/WS-B5 completed)
+- **Phase P2:** WS-B5, WS-B6, WS-B2 (semantic/model expansion; WS-B1/WS-B2/WS-B5/WS-B6 completed)
 - **Phase P3:** WS-B7, WS-B9, WS-B10, WS-B11 (assurance and operational maturity)
 
 ### 3.3 PR-to-workstream discipline
@@ -66,7 +66,7 @@ Every milestone-moving PR should include:
 
 ## 4) Daily contributor loop
 
-1. Sync branch and choose one coherent WS-B slice (prefer next unfinished stream: WS-B6 onward).
+1. Sync branch and choose one coherent WS-B slice (prefer next unfinished stream: WS-B7 onward).
 2. Implement the minimal semantic/proof/doc delta.
 3. Run smallest relevant check first, then higher tiers.
 4. Update docs in the same commit range.

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -22,7 +22,7 @@ Companion planning and execution documents:
 - **M5:** complete (service graph + policy surfaces + proof package)
 - **M6:** complete (architecture-boundary assumptions/adapters/invariant hooks)
 - **M7:** complete (audit remediation WS-A1..WS-A8)
-- **Current active slice:** post-M7 comprehensive-audit execution portfolio (WS-B6..WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 complete).
+- **Current active slice:** post-M7 comprehensive-audit execution portfolio (WS-B7..WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 complete).
 
 ---
 
@@ -53,7 +53,7 @@ proof hygiene, contributor usability, and hardware-readiness trajectory.
 - **WS-B3:** Main trace harness refactor ✅ completed
 - **WS-B4:** Remaining type-wrapper migration ✅ completed
 - **WS-B5:** CSpace semantics completion (guard/radix) ✅ completed
-- **WS-B6:** Notification-object IPC completion
+- **WS-B6:** Notification-object IPC completion ✅ completed
 - **WS-B7:** Information-flow proof-track start
 - **WS-B8:** Documentation automation + consolidation
 - **WS-B9:** Threat model and security hardening
@@ -63,7 +63,7 @@ proof hygiene, contributor usability, and hardware-readiness trajectory.
 ### 4.3 Sequencing constraints
 
 - **P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5 completed)
+- **P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 completed)
 - **P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ### 4.4 Acceptance expectations for WS-B work

--- a/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
+++ b/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
@@ -73,7 +73,7 @@ Rationale: convert expanded model coverage into long-term assurance and delivery
 ## 5) Detailed workstream execution contracts
 
 Status key: `Planned` → `In Progress` → `Completed`.
-Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 are Completed**; WS-B6..WS-B11 remain Planned/In Progress per active execution cadence.
+Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 are Completed**; WS-B7..WS-B11 remain Planned/In Progress per active execution cadence.
 
 ### WS-B1 — VSpace + memory model foundation (Completed)
 
@@ -152,7 +152,7 @@ Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 are Completed*
 - **Exit criteria:** CSpace resolution behavior is executable, tested, and invariant-preserving.
 - **Closure evidence (2026-02-18):** `SeLe4n/Model/Object.lean` now defines executable guard/radix `CNode.resolveSlot` semantics with explicit depth/guard/slot failure taxonomy; `SeLe4n/Kernel/Capability/Operations.lean` adds `CSpacePathAddr` plus `cspaceResolvePath`/`cspaceLookupPath` so pointer-path traversal is modeled separately from direct slot lookup; `tests/NegativeStateSuite.lean` adds path-resolution positive/negative checks for depth mismatch and guard mismatch failures under `scripts/test_tier2_negative.sh`; `tests/fixtures/main_trace_smoke.expected` now anchors source/deep-path guard-radix trace outputs via `scripts/test_tier2_trace.sh`; full validation gates (`scripts/test_smoke.sh`, `scripts/test_full.sh`) pass with the completed semantics.
 
-### WS-B6 — IPC completeness with notifications (Planned)
+### WS-B6 — IPC completeness with notifications (Completed)
 
 - **Goal:** add notification-object semantics so IPC model covers endpoint + notification split.
 - **Prerequisites:** WS-B3 refactor (for cleaner scenario wiring).
@@ -165,6 +165,7 @@ Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 are Completed*
   - `./scripts/test_smoke.sh`
   - `./scripts/test_full.sh`
 - **Exit criteria:** notification semantics integrated through API, proofs, and trace fixtures.
+- **Closure evidence (2026-02-18):** `SeLe4n/Model/Object.lean` now includes `NotificationState`/`Notification` plus `KernelObject.notification` and `ThreadIpcState.blockedOnNotification`; `SeLe4n/Kernel/IPC/Operations.lean` adds executable `notificationSignal` and `notificationWait` semantics with runnable-queue interactions (block on wait, wake on signal); `SeLe4n/Kernel/IPC/Invariant.lean` extends the IPC invariant surface with `notificationQueueWellFormed`/`notificationInvariant` and global endpoint+notification coverage; `tests/NegativeStateSuite.lean` adds notification negative/positive checks; and `SeLe4n/Testing/MainTraceHarness.lean` + `tests/fixtures/main_trace_smoke.expected` now exercise composed endpoint/notification trace paths under `scripts/test_smoke.sh` and `scripts/test_full.sh`.
 
 ### WS-B7 — Information-flow proof track start (Planned)
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -30,7 +30,7 @@ Closed baseline slices:
 
 Current active slice:
 
-- **Comprehensive Audit 2026-02 execution (WS-B portfolio)** with WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed and WS-B6..WS-B11 in planned/in-progress execution.
+- **Comprehensive Audit 2026-02 execution (WS-B portfolio)** with WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed and WS-B7..WS-B11 in planned/in-progress execution.
 
 ## 4. Architecture mental model
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -12,7 +12,7 @@ Current milestone state:
 - M5 complete
 - M6 complete
 - M7 complete
-- **Active:** Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed)
+- **Active:** Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed)
 
 ## 2) Stable contracts contributors must preserve
 
@@ -29,7 +29,7 @@ Current milestone state:
 - WS-B3: Main trace harness refactor ✅ completed
 - WS-B4: Remaining type-wrapper migration ✅ completed
 - WS-B5: CSpace guard/radix completion ✅ completed
-- WS-B6: Notification-object IPC completion
+- WS-B6: Notification-object IPC completion ✅ completed
 - WS-B7: Information-flow proof-track start
 - WS-B8: Documentation automation + consolidation
 - WS-B9: Threat model and security hardening
@@ -42,7 +42,7 @@ Canonical execution plan:
 ## 4) Sequencing model
 
 - **Phase P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5 complete)
+- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 complete)
 - **Phase P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ## 5) Historical context

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -39,7 +39,7 @@ For milestone-moving PRs:
 ## Workstream sequence
 
 - **Phase P1:** WS-B4, WS-B3, WS-B8
-- **Phase P2:** WS-B5, WS-B6, WS-B2 (WS-B1/WS-B2/WS-B5 completed)
+- **Phase P2:** WS-B5, WS-B6, WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 completed)
 - **Phase P3:** WS-B7, WS-B9, WS-B10, WS-B11
 
 ## Failure triage

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -21,7 +21,7 @@ This is the GitBook mirror of the canonical planning backbone:
 ### Medium priority
 
 - **WS-B5:** CSpace guard/radix semantics completion ✅ completed
-- **WS-B6:** Notification-object IPC completion
+- **WS-B6:** Notification-object IPC completion ✅ completed
 - **WS-B7:** Information-flow proof-track start
 - **WS-B8:** Documentation automation + consolidation
 - **WS-B9:** Threat model and security hardening
@@ -34,7 +34,7 @@ This is the GitBook mirror of the canonical planning backbone:
 ## 3) Sequencing
 
 - **Phase P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5 completed)
+- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 completed)
 - **Phase P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ## 4) Evidence expectations for milestone-moving PRs
@@ -88,3 +88,11 @@ When status changes, update together:
 - `SeLe4n/Kernel/Capability/Operations.lean` adds `CSpacePathAddr`, `cspaceResolvePath`, and `cspaceLookupPath` so CSpace pointer-path traversal is executable alongside direct slot lookups.
 - `tests/NegativeStateSuite.lean` now enforces WS-B5 negative-path checks for depth mismatch and guard mismatch outcomes in `scripts/test_tier2_negative.sh`.
 - `tests/fixtures/main_trace_smoke.expected` now includes source/deep CSpace path anchors enforced by `scripts/test_tier2_trace.sh`.
+
+## 11) WS-B6 closure evidence
+
+- `SeLe4n/Model/Object.lean` now includes `NotificationState` + `Notification` and extends `KernelObject` with a notification variant.
+- `SeLe4n/Kernel/IPC/Operations.lean` adds executable `notificationSignal` and `notificationWait` semantics with runnable-queue interactions (block on wait, wake on signal).
+- `SeLe4n/Kernel/IPC/Invariant.lean` now includes `notificationQueueWellFormed`/`notificationInvariant`, and `ipcInvariant` now covers both endpoint and notification object classes.
+- `SeLe4n/Testing/MainTraceHarness.lean` and `tests/fixtures/main_trace_smoke.expected` now exercise composed endpoint + notification flows.
+- `tests/NegativeStateSuite.lean` adds positive/negative notification-path checks in Tier 2 negative validation.

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form guide for architecture, workflow, and milestone co
 
 ## Current project state
 
-- **Active slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, and WS-B5 completed).
+- **Active slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed).
 - **Latest completed slice:** M7 remediation (WS-A1..WS-A8 complete).
 - **Previous completed slice:** M6 architecture-boundary hardening.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.9.15"
+version = "0.9.18"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -34,6 +34,19 @@ run_check "INVARIANT" rg -n '^def cspaceResolvePath' SeLe4n/Kernel/Capability/Op
 run_check "INVARIANT" rg -n '^def cspaceLookupPath' SeLe4n/Kernel/Capability/Operations.lean
 run_check "DOC" rg -n '^### WS-B5 — CSpace semantics completion \(Completed\)' docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
 
+# WS-B6 closure anchors: notification IPC object model and transition surface.
+run_check "INVARIANT" rg -n '^inductive NotificationState' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^structure Notification' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^def notificationSignal' SeLe4n/Kernel/IPC/Operations.lean
+run_check "INVARIANT" rg -n '^def notificationWait' SeLe4n/Kernel/IPC/Operations.lean
+run_check "INVARIANT" rg -n '^def notificationInvariant' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "DOC" rg -n '^### WS-B6 — IPC completeness with notifications \(Completed\)' docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
+run_check "DOC" rg -n '^- \*\*Active development slice:\*\* Comprehensive Audit 2026-02 execution \(WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed\)\.' README.md
+run_check "DOC" rg -n '^- \*\*Current active slice:\*\* post-M7 comprehensive-audit execution portfolio \(WS-B7\.\.WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 complete\)\.' docs/SEL4_SPEC.md
+run_check "DOC" rg -n '^- \*\*Comprehensive Audit 2026-02 execution \(WS-B portfolio\)\*\* with WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed and WS-B7\.\.WS-B11 in planned/in-progress execution\.' docs/gitbook/01-project-overview.md
+run_check "DOC" rg -n '^- \*\*Phase P2:\*\* WS-B5, WS-B6, WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 completed\)' docs/gitbook/06-development-workflow.md
+run_check "DOC" rg -n '^1\. Sync branch and choose one coherent WS-B slice \(prefer next unfinished stream: WS-B7 onward\)\.' docs/DEVELOPMENT.md
+
 # WS-B2 closure anchors: bootstrap DSL, negative suite, and nightly replay artifacts.
 run_check "INVARIANT" rg -n '^structure BootstrapBuilder' SeLe4n/Testing/StateBuilder.lean
 run_check "INVARIANT" rg -n '^def build \(builder : BootstrapBuilder\)' SeLe4n/Testing/StateBuilder.lean

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -10,6 +10,7 @@ private def cnodeId : SeLe4n.ObjId := 10
 private def wrongTypeId : SeLe4n.ObjId := 99
 private def guardedCnodeId : SeLe4n.ObjId := 55
 private def sendEmptyEndpointId : SeLe4n.ObjId := 41
+private def notificationId : SeLe4n.ObjId := 42
 private def asidPrimary : SeLe4n.ASID := 2
 private def vaddrPrimary : SeLe4n.VAddr := 4096
 private def paddrPrimary : SeLe4n.PAddr := 12288
@@ -47,12 +48,14 @@ private def baseState : SystemState :=
       ]
     })
     |>.withObject sendEmptyEndpointId (.endpoint { state := .send, queue := [], waitingReceiver := none })
+    |>.withObject notificationId (.notification { state := .idle, waitingThreads := [], pendingBadge := none })
     |>.withObject 20 (.vspaceRoot { asid := asidPrimary, mappings := [] })
     |>.withLifecycleObjectType endpointId .endpoint
     |>.withLifecycleObjectType cnodeId .cnode
     |>.withLifecycleObjectType wrongTypeId .endpoint
     |>.withLifecycleObjectType guardedCnodeId .cnode
     |>.withLifecycleObjectType sendEmptyEndpointId .endpoint
+    |>.withLifecycleObjectType notificationId .notification
     |>.withLifecycleObjectType 20 .vspaceRoot
     |>.withLifecycleCapabilityRef slot0 (.object endpointId)
     |>.build)
@@ -117,6 +120,30 @@ private def runNegativeChecks : IO Unit := do
 
   let (_, stAwait) ← expectOk "await receive handshake seed"
     (SeLe4n.Kernel.endpointAwaitReceive endpointId (SeLe4n.ThreadId.ofNat 7) baseState)
+
+  let (waitBadge, stN1) ← expectOk "notification wait blocks with none"
+    (SeLe4n.Kernel.notificationWait notificationId (SeLe4n.ThreadId.ofNat 7) baseState)
+  if waitBadge = none then
+    IO.println "positive check passed [notification wait #1 none]"
+  else
+    throw <| IO.userError "notification wait #1 expected none"
+
+  let (_, stN2) ← expectOk "notification signal wakes waiter"
+    (SeLe4n.Kernel.notificationSignal notificationId (SeLe4n.Badge.ofNat 55) stN1)
+
+  let (_, stN3) ← expectOk "notification signal stores active badge"
+    (SeLe4n.Kernel.notificationSignal notificationId (SeLe4n.Badge.ofNat 66) stN2)
+
+  let (waitBadge2, _) ← expectOk "notification wait consumes active badge"
+    (SeLe4n.Kernel.notificationWait notificationId (SeLe4n.ThreadId.ofNat 8) stN3)
+  if waitBadge2 = none then
+    throw <| IO.userError "notification wait #2 expected delivered badge"
+  else
+    IO.println "positive check passed [notification wait #2 delivered badge]"
+
+  expectError "notification wait wrong object type"
+    (SeLe4n.Kernel.notificationWait endpointId (SeLe4n.ThreadId.ofNat 1) baseState)
+    .invalidCapability
 
   expectError "await receive second waiter mismatch"
     (SeLe4n.Kernel.endpointAwaitReceive endpointId (SeLe4n.ThreadId.ofNat 8) stAwait)

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -45,4 +45,6 @@ queued two senders on endpoint
 endpoint receive #1 sender: 1
 endpoint receive #2 sender: 2
 endpoint receive #3 (expected mismatch): SeLe4n.Model.KernelError.endpointStateMismatch
+notification wait #1 result: none
+notification wait #2 result: some { val := 123 }
 minted cap rights: [SeLe4n.Model.AccessRight.read]


### PR DESCRIPTION
### Motivation
- Close WS-B6 by adding notification-object IPC semantics so the IPC model covers both endpoint and notification classes and preserves determinism. 
- Harden documentation/GitBook/README/dev-guide synchronization to prevent status-wording drift after workstream completion. 
- Ensure scheduler/IPC invariants and negative/trace evidence exercise notification flows deterministically. 

### Description
- Implemented the notification object model: added `NotificationState`, `Notification`, `KernelObject.notification`, and `ThreadIpcState.blockedOnNotification` in `SeLe4n/Model/Object.lean`. 
- Added runtime operations `notificationSignal` and `notificationWait` plus helper scheduler updates `ensureRunnable` and `removeRunnable` in `SeLe4n/Kernel/IPC/Operations.lean`. 
- Extended IPC invariants with `notificationQueueWellFormed` / `notificationInvariant`, updated `ipcInvariant`, and adjusted preservation theorems and scheduler pattern-matches to account for notification objects in `SeLe4n/Kernel/IPC/Invariant.lean`, `SeLe4n/Kernel/Scheduler/Operations.lean`, and related capability/lifecycle proofs. 
- Exercised notification flows in executable evidence: updated `SeLe4n/Testing/MainTraceHarness.lean`, added positive/negative checks in `tests/NegativeStateSuite.lean`, updated `tests/fixtures/main_trace_smoke.expected`, hardened Tier-3 doc/invariant anchors in `scripts/test_tier3_invariant_surface.sh`, and synchronized root docs/GitBook/`docs/DEVELOPMENT.md` and `README.md`. 
- Bumped package patch version to `0.9.18` in `lakefile.toml`, synchronized the README marker, and added a `CHANGELOG.md` entry documenting the hardening follow-up. 

### Testing
- Ran tiered validation locally including `./scripts/test_fast.sh`, `./scripts/test_full.sh`, `./scripts/test_nightly.sh`, and `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh`, and all automated checks passed in this environment. 
- Executed trace and fixture checks (`./scripts/test_tier2_trace.sh` / `lake exe sele4n`) with fixture comparison passing and the updated `main_trace_smoke.expected` matching observed output. 
- Ran negative-suite checks (`./scripts/test_tier2_negative.sh` / `lake exe negative_state_suite`) and observed all negative and positive notification-related checks succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952a8b8074832b9a7218e531e17a32)