### PR TITLE
WS-B7: Add IF‑M1 information‑flow baseline, tests and doc sync; bump to 0.9.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [0.9.21] - 2026-02-18
+
+### WS-B7 synchronization audit follow-up
+- Corrected remaining GitBook planning drift for WS-B7 completion by updating chapter 24 Phase P2 status to include WS-B7 completion state.
+- Extended Tier 3 doc anchors to enforce this chapter-24 Phase P2 synchronization in `scripts/test_tier3_invariant_surface.sh`, preventing regression in future doc updates.
+- Re-ran full and nightly validation/audit lanes to confirm repository-wide determinism and documentation consistency remain intact.
+- Bumped patch version to **`0.9.21`** and synchronized root version marker in `README.md`.
+
+## [0.9.20] - 2026-02-18
+
+### WS-B7 audit optimization and IF-M1 test-surface hardening
+- Added executable IF-M1 runtime assertions in `tests/InformationFlowSuite.lean` and wired them into Tier 2 negative validation via `lake exe information_flow_suite` in `scripts/test_tier2_negative.sh`, strengthening regression coverage for label-flow and observer-projection behavior.
+- Expanded Tier 3 invariant anchors to enforce the new IF runtime suite presence and Tier 2 wiring (`scripts/test_tier3_invariant_surface.sh`).
+- Synchronized testing/docs/GitBook evidence for the strengthened WS-B7 validation surface (`docs/TESTING_FRAMEWORK_PLAN.md`, `docs/gitbook/07-testing-and-ci.md`, `docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md`, `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`).
+- Bumped patch version to **`0.9.20`** and synchronized root version marker in `README.md`.
+
+## [0.9.19] - 2026-02-18
+
+### WS-B7 information-flow proof-track start completion
+- Implemented IF-M1 formal baseline modules in `SeLe4n/Kernel/InformationFlow/Policy.lean` and `SeLe4n/Kernel/InformationFlow/Projection.lean`, including security-label lattice primitives, flow-relation algebraic lemmas, observer projection helpers, and low-equivalence scaffolding.
+- Wired information-flow modules into the aggregate kernel API (`SeLe4n/Kernel/API.lean`) and expanded Tier 3 invariant/doc anchors in `scripts/test_tier3_invariant_surface.sh` to continuously enforce IF-M1 surface and WS-B7 status synchronization.
+- Published IF-M1 theorem targets + assumptions ledger in `docs/IF_M1_BASELINE_PACKAGE.md`, marked WS-B7 complete in canonical planning/spec/development/README/GitBook pages, and added WS-B7 closure evidence sections in planning mirrors.
+- Bumped patch version to **`0.9.19`** and synchronized root version marker in `README.md`.
+
 ## [0.9.18] - 2026-02-18
 
 ### WS-B6 audit hardening follow-up

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current state (authoritative snapshot)
 
-- **Active development slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed).
+- **Active development slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 completed).
 - **Most recently completed slice:** M7 audit remediation (WS-A1..WS-A8 complete).
 - **Previous completed slice:** M6 architecture-boundary assumptions/adapters.
-- **Current package version:** `0.9.18` (`lakefile.toml`).
+- **Current package version:** `0.9.21` (`lakefile.toml`).
 
 Normative scope and acceptance criteria live in [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md).
 
@@ -34,7 +34,7 @@ Use this as the quick index. Full contracts and dependencies are in the audit pl
 - **WS-B4:** Remaining type-wrapper migration ✅ completed
 - **WS-B5:** CSpace guard/radix semantics completion ✅ completed
 - **WS-B6:** Notification-object IPC completion ✅ completed
-- **WS-B7:** Information-flow proof-track start
+- **WS-B7:** Information-flow proof-track start ✅ completed
 - **WS-B8:** Documentation automation/consolidation
 - **WS-B9:** Threat model + security hardening
 - **WS-B10:** CI maturity upgrades

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -9,6 +9,8 @@ import SeLe4n.Kernel.Lifecycle.Operations
 import SeLe4n.Kernel.Lifecycle.Invariant
 import SeLe4n.Kernel.Service.Operations
 import SeLe4n.Kernel.Service.Invariant
+import SeLe4n.Kernel.InformationFlow.Policy
+import SeLe4n.Kernel.InformationFlow.Projection
 
 import SeLe4n.Kernel.Architecture.Assumptions
 

--- a/SeLe4n/Kernel/InformationFlow/Policy.lean
+++ b/SeLe4n/Kernel/InformationFlow/Policy.lean
@@ -1,0 +1,111 @@
+import SeLe4n.Model.State
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+/-- Confidentiality lattice for IF-M1. -/
+inductive Confidentiality where
+  | low
+  | high
+  deriving Repr, DecidableEq
+
+/-- Integrity lattice for IF-M1. -/
+inductive Integrity where
+  | untrusted
+  | trusted
+  deriving Repr, DecidableEq
+
+/-- Product security label carrying confidentiality and integrity dimensions. -/
+structure SecurityLabel where
+  confidentiality : Confidentiality
+  integrity : Integrity
+  deriving Repr, DecidableEq
+
+namespace SecurityLabel
+
+def publicLabel : SecurityLabel :=
+  { confidentiality := .low, integrity := .untrusted }
+
+def kernelTrusted : SecurityLabel :=
+  { confidentiality := .high, integrity := .trusted }
+
+end SecurityLabel
+
+/-- Confidentiality order (`≤`) used by IF-M1 policy checks. -/
+def confidentialityFlowsTo : Confidentiality → Confidentiality → Bool
+  | .low, _ => true
+  | .high, .high => true
+  | .high, .low => false
+
+/-- Integrity order (`≥`) for trusted-data flow checks. -/
+def integrityFlowsTo : Integrity → Integrity → Bool
+  | .trusted, .trusted => true
+  | .trusted, .untrusted => true
+  | .untrusted, .untrusted => true
+  | .untrusted, .trusted => false
+
+/-- Combined policy relation: confidentiality must not flow down and integrity must not flow up. -/
+def securityFlowsTo (src dst : SecurityLabel) : Bool :=
+  confidentialityFlowsTo src.confidentiality dst.confidentiality &&
+    integrityFlowsTo dst.integrity src.integrity
+
+/-- IF-M1 context: explicit label assignment entrypoints for each primary entity class. -/
+structure LabelingContext where
+  objectLabelOf : SeLe4n.ObjId → SecurityLabel
+  threadLabelOf : SeLe4n.ThreadId → SecurityLabel
+  endpointLabelOf : SeLe4n.ObjId → SecurityLabel
+
+/-- Minimal default labeling: everything is publicly observable and untrusted. -/
+def defaultLabelingContext : LabelingContext :=
+  {
+    objectLabelOf := fun _ => SecurityLabel.publicLabel
+    threadLabelOf := fun _ => SecurityLabel.publicLabel
+    endpointLabelOf := fun _ => SecurityLabel.publicLabel
+  }
+
+theorem confidentialityFlowsTo_refl (c : Confidentiality) :
+    confidentialityFlowsTo c c = true := by
+  cases c <;> rfl
+
+theorem integrityFlowsTo_refl (i : Integrity) :
+    integrityFlowsTo i i = true := by
+  cases i <;> rfl
+
+theorem securityFlowsTo_refl (l : SecurityLabel) :
+    securityFlowsTo l l = true := by
+  cases l with
+  | mk c i =>
+      simp [securityFlowsTo, confidentialityFlowsTo_refl, integrityFlowsTo_refl]
+
+theorem confidentialityFlowsTo_trans
+    (a b c : Confidentiality)
+    (h₁ : confidentialityFlowsTo a b = true)
+    (h₂ : confidentialityFlowsTo b c = true) :
+    confidentialityFlowsTo a c = true := by
+  cases a <;> cases b <;> cases c <;> simp [confidentialityFlowsTo] at h₁ h₂ ⊢
+
+theorem integrityFlowsTo_trans
+    (a b c : Integrity)
+    (h₁ : integrityFlowsTo a b = true)
+    (h₂ : integrityFlowsTo b c = true) :
+    integrityFlowsTo a c = true := by
+  cases a <;> cases b <;> cases c <;> simp [integrityFlowsTo] at h₁ h₂ ⊢
+
+theorem securityFlowsTo_trans
+    (a b c : SecurityLabel)
+    (h₁ : securityFlowsTo a b = true)
+    (h₂ : securityFlowsTo b c = true) :
+    securityFlowsTo a c = true := by
+  cases a with
+  | mk ac ai =>
+      cases b with
+      | mk bc bi =>
+          cases c with
+          | mk cc ci =>
+              simp [securityFlowsTo] at h₁ h₂ ⊢
+              exact And.intro
+                (confidentialityFlowsTo_trans ac bc cc h₁.left h₂.left)
+                (integrityFlowsTo_trans ci bi ai h₂.right h₁.right)
+
+end SeLe4n.Kernel

--- a/SeLe4n/Kernel/InformationFlow/Projection.lean
+++ b/SeLe4n/Kernel/InformationFlow/Projection.lean
@@ -1,0 +1,96 @@
+import SeLe4n.Kernel.InformationFlow.Policy
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+/-- Observer descriptor for IF-M1 projections. -/
+structure IfObserver where
+  clearance : SecurityLabel
+  deriving Repr, DecidableEq
+
+/-- Projection result used by IF-M1 low-equivalence statements. -/
+structure ObservableState where
+  objects : SeLe4n.ObjId → Option KernelObject
+  runnable : List SeLe4n.ThreadId
+  current : Option SeLe4n.ThreadId
+  services : ServiceId → Option ServiceStatus
+
+/-- Object observability gate under a labeling context. -/
+def objectObservable (ctx : LabelingContext) (observer : IfObserver) (oid : SeLe4n.ObjId) : Bool :=
+  securityFlowsTo (ctx.objectLabelOf oid) observer.clearance
+
+/-- Thread observability gate under a labeling context. -/
+def threadObservable (ctx : LabelingContext) (observer : IfObserver) (tid : SeLe4n.ThreadId) : Bool :=
+  securityFlowsTo (ctx.threadLabelOf tid) observer.clearance
+
+/-- Service projection keeps only status because service identity is carried by `ServiceId`. -/
+def projectServiceStatus (st : SystemState) : ServiceId → Option ServiceStatus :=
+  fun sid => (lookupService st sid).map ServiceGraphEntry.status
+
+/-- Project object store to observer-visible subset. -/
+def projectObjects (ctx : LabelingContext) (observer : IfObserver) (st : SystemState) :
+    SeLe4n.ObjId → Option KernelObject :=
+  fun oid =>
+    if objectObservable ctx observer oid then
+      st.objects oid
+    else
+      none
+
+/-- Project runnable queue to observer-visible threads only. -/
+def projectRunnable (ctx : LabelingContext) (observer : IfObserver) (st : SystemState) :
+    List SeLe4n.ThreadId :=
+  st.scheduler.runnable.filter (threadObservable ctx observer)
+
+/-- Project current thread to observer-visible identity. -/
+def projectCurrent (ctx : LabelingContext) (observer : IfObserver) (st : SystemState) :
+    Option SeLe4n.ThreadId :=
+  match st.scheduler.current with
+  | some tid => if threadObservable ctx observer tid then some tid else none
+  | none => none
+
+/-- Canonical IF-M1 state projection helper used by theorem targets. -/
+def projectState (ctx : LabelingContext) (observer : IfObserver) (st : SystemState) : ObservableState :=
+  {
+    objects := projectObjects ctx observer st
+    runnable := projectRunnable ctx observer st
+    current := projectCurrent ctx observer st
+    services := projectServiceStatus st
+  }
+
+/-- Two states are low-equivalent when their observer projections are equal. -/
+def lowEquivalent (ctx : LabelingContext) (observer : IfObserver) (s₁ s₂ : SystemState) : Prop :=
+  projectState ctx observer s₁ = projectState ctx observer s₂
+
+theorem projectState_deterministic
+    (ctx : LabelingContext)
+    (observer : IfObserver)
+    (st : SystemState) :
+    projectState ctx observer st = projectState ctx observer st := by
+  rfl
+
+theorem lowEquivalent_refl
+    (ctx : LabelingContext)
+    (observer : IfObserver)
+    (st : SystemState) :
+    lowEquivalent ctx observer st st := by
+  rfl
+
+theorem lowEquivalent_symm
+    (ctx : LabelingContext)
+    (observer : IfObserver)
+    (s₁ s₂ : SystemState)
+    (hEq : lowEquivalent ctx observer s₁ s₂) :
+    lowEquivalent ctx observer s₂ s₁ := by
+  simpa [lowEquivalent] using Eq.symm hEq
+
+theorem lowEquivalent_trans
+    (ctx : LabelingContext)
+    (observer : IfObserver)
+    (s₁ s₂ s₃ : SystemState)
+    (h₁₂ : lowEquivalent ctx observer s₁ s₂)
+    (h₂₃ : lowEquivalent ctx observer s₂ s₃) :
+    lowEquivalent ctx observer s₁ s₃ := by
+  simpa [lowEquivalent] using Eq.trans h₁₂ h₂₃
+
+end SeLe4n.Kernel

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current slice**:
 
-- active: **Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed)**,
+- active: **Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 completed)**,
 - completed predecessor: **M7 remediation (WS-A1..WS-A8)**,
 - completed predecessor before that: **M6 architecture-boundary hardening**.
 
@@ -38,7 +38,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-B4** — remaining type wrapper migration (**completed**)
 - **WS-B5** — CSpace guard/radix completion (**completed**)
 - **WS-B6** — notification object semantics (**completed**)
-- **WS-B7** — information-flow proof-track initiation
+- **WS-B7** — information-flow proof-track initiation (**completed**)
 - **WS-B8** — documentation automation + dedup
 - **WS-B9** — threat model/security hardening
 - **WS-B10** — CI maturity upgrades
@@ -49,7 +49,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 Use the planning phases from the workstream backbone:
 
 - **Phase P1:** WS-B4, WS-B3, WS-B8 (shape + hygiene stabilization; WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5, WS-B6, WS-B2 (semantic/model expansion; WS-B1/WS-B2/WS-B5/WS-B6 completed)
+- **Phase P2:** WS-B5, WS-B6, WS-B2 (semantic/model expansion; WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed)
 - **Phase P3:** WS-B7, WS-B9, WS-B10, WS-B11 (assurance and operational maturity)
 
 ### 3.3 PR-to-workstream discipline
@@ -66,7 +66,7 @@ Every milestone-moving PR should include:
 
 ## 4) Daily contributor loop
 
-1. Sync branch and choose one coherent WS-B slice (prefer next unfinished stream: WS-B7 onward).
+1. Sync branch and choose one coherent WS-B slice (prefer next unfinished stream: WS-B8 onward).
 2. Implement the minimal semantic/proof/doc delta.
 3. Run smallest relevant check first, then higher tiers.
 4. Update docs in the same commit range.

--- a/docs/IF_M1_BASELINE_PACKAGE.md
+++ b/docs/IF_M1_BASELINE_PACKAGE.md
@@ -1,0 +1,77 @@
+# IF-M1 Baseline Package (WS-B7)
+
+This document records the WS-B7 deliverable package for the
+**Information-flow proof track start**.
+
+## 1) Scope delivered in IF-M1
+
+WS-B7 delivers the formal baseline only:
+
+1. policy lattice primitives for confidentiality/integrity,
+2. security-label flow relation and algebraic lemmas,
+3. state projection helpers and low-equivalence scaffolding,
+4. explicit theorem-target backlog and assumptions ledger.
+
+No IF-M2+ relational transition proofs are claimed in this package.
+
+## 2) Implemented theorem entrypoints
+
+Code entrypoints:
+
+- `SeLe4n/Kernel/InformationFlow/Policy.lean`
+  - `confidentialityFlowsTo`
+  - `integrityFlowsTo`
+  - `securityFlowsTo`
+  - `securityFlowsTo_refl`
+  - `securityFlowsTo_trans`
+- `SeLe4n/Kernel/InformationFlow/Projection.lean`
+  - `projectState`
+  - `lowEquivalent`
+  - `lowEquivalent_refl`
+  - `lowEquivalent_symm`
+  - `lowEquivalent_trans`
+
+These are the canonical IF-M1 theorem and definition anchors.
+
+## 3) IF-M1 theorem targets (completed)
+
+1. **Label relation reflexivity/transitivity**
+   - complete for confidentiality, integrity, and combined security flow relation.
+2. **Deterministic observer projection API**
+   - complete via `projectState` and deterministic equality statement.
+3. **Low-equivalence relation shape**
+   - complete as an equivalence-style scaffold (`refl/symm/trans`) over projected states.
+
+## 4) Assumptions ledger
+
+The IF-M1 baseline intentionally carries the following assumptions for future milestones:
+
+1. **Trusted labeling context assumption**
+   - `LabelingContext` functions (`objectLabelOf`, `threadLabelOf`, `endpointLabelOf`) are
+     externally supplied and treated as trusted policy inputs.
+2. **Observer model simplification**
+   - observer projections currently include object visibility and scheduler-visible thread identities,
+     plus service status summaries.
+3. **No microarchitectural channel modeling**
+   - cache/timing/speculative channels remain out of scope.
+4. **No transition-level noninterference theorem claims yet**
+   - IF-M3 is where operation-level two-run theorems begin.
+
+## 5) Decomposition plan into IF-M2 and IF-M3
+
+1. **IF-M2 step:** instantiate relational projection lemmas per subsystem state carrier
+   (objects, scheduler queues, endpoints/notifications, capability metadata).
+2. **IF-M3 step:** prove seed noninterference for selected operations
+   (scheduler choose/yield, endpoint send/receive/wait, one capability mutation path).
+3. **Composition note:** retain local-first theorem naming and avoid global monolithic
+   statements until IF-M4 composition stage.
+
+## 6) Validation commands used for WS-B7 closeout
+
+```bash
+./scripts/test_fast.sh
+./scripts/test_smoke.sh
+./scripts/test_full.sh
+NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh
+lake build
+```

--- a/docs/INFORMATION_FLOW_ROADMAP.md
+++ b/docs/INFORMATION_FLOW_ROADMAP.md
@@ -34,7 +34,7 @@ Initial information-flow statements should cover:
 
 ## 4. Milestone trajectory
 
-## IF-M1 — Policy lattice and labeling primitives
+## IF-M1 — Policy lattice and labeling primitives ✅ completed (WS-B7)
 
 Deliverables:
 
@@ -47,6 +47,12 @@ Exit evidence:
 - Lean module compiles,
 - policy relation lemmas are machine-checked,
 - no regressions in existing tiered tests.
+
+Delivered anchors (WS-B7 closeout):
+
+- `SeLe4n/Kernel/InformationFlow/Policy.lean`
+- `SeLe4n/Kernel/InformationFlow/Projection.lean`
+- `docs/IF_M1_BASELINE_PACKAGE.md`
 
 ## IF-M2 — Two-run relational state framework
 

--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -22,7 +22,7 @@ Companion planning and execution documents:
 - **M5:** complete (service graph + policy surfaces + proof package)
 - **M6:** complete (architecture-boundary assumptions/adapters/invariant hooks)
 - **M7:** complete (audit remediation WS-A1..WS-A8)
-- **Current active slice:** post-M7 comprehensive-audit execution portfolio (WS-B7..WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 complete).
+- **Current active slice:** post-M7 comprehensive-audit execution portfolio (WS-B8..WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 complete).
 
 ---
 
@@ -54,7 +54,7 @@ proof hygiene, contributor usability, and hardware-readiness trajectory.
 - **WS-B4:** Remaining type-wrapper migration ✅ completed
 - **WS-B5:** CSpace semantics completion (guard/radix) ✅ completed
 - **WS-B6:** Notification-object IPC completion ✅ completed
-- **WS-B7:** Information-flow proof-track start
+- **WS-B7:** Information-flow proof-track start ✅ completed
 - **WS-B8:** Documentation automation + consolidation
 - **WS-B9:** Threat model and security hardening
 - **WS-B10:** CI maturity upgrades
@@ -63,7 +63,7 @@ proof hygiene, contributor usability, and hardware-readiness trajectory.
 ### 4.3 Sequencing constraints
 
 - **P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 completed)
+- **P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed)
 - **P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ### 4.4 Acceptance expectations for WS-B work

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -4,13 +4,13 @@
 
 This document defines the active testing baseline and near-term expansion path after M5 closeout.
 
-Current stage context: **Comprehensive Audit 2026-02 WS-B execution is active (WS-B1 through WS-B4 complete); testing now guards active workstream delivery without regressing M1–M7 contracts.**
+Current stage context: **Comprehensive Audit 2026-02 WS-B execution is active (WS-B1 through WS-B7 complete); testing now guards active workstream delivery without regressing M1–M7 contracts.**
 
 ## 2. Current enforced tiers
 
 - **Tier 0** hygiene (`scripts/test_tier0_hygiene.sh`)
 - **Tier 1** build/theorem compile (`scripts/test_tier1_build.sh`)
-- **Tier 2** executable smoke (`scripts/test_tier2_trace.sh` + `scripts/test_tier2_negative.sh`)
+- **Tier 2** executable smoke (`scripts/test_tier2_trace.sh` + `scripts/test_tier2_negative.sh`, including `negative_state_suite` + `information_flow_suite`)
 - **Tier 3** invariant/doc-surface checks (`scripts/test_tier3_invariant_surface.sh`, via full suite),
   including M4-A executable-anchor checks for lifecycle unauthorized/illegal-state/success trace fragments.
 - **Tier 4** staged nightly candidates (`scripts/test_tier4_nightly_candidates.sh` via `scripts/test_nightly.sh`; explicit opt-in extension point with mode-aware status messaging for default vs enabled runs)

--- a/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
+++ b/docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
@@ -73,7 +73,7 @@ Rationale: convert expanded model coverage into long-term assurance and delivery
 ## 5) Detailed workstream execution contracts
 
 Status key: `Planned` → `In Progress` → `Completed`.
-Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 are Completed**; WS-B7..WS-B11 remain Planned/In Progress per active execution cadence.
+Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 are Completed**; WS-B8..WS-B11 remain Planned/In Progress per active execution cadence.
 
 ### WS-B1 — VSpace + memory model foundation (Completed)
 
@@ -167,7 +167,7 @@ Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 are Com
 - **Exit criteria:** notification semantics integrated through API, proofs, and trace fixtures.
 - **Closure evidence (2026-02-18):** `SeLe4n/Model/Object.lean` now includes `NotificationState`/`Notification` plus `KernelObject.notification` and `ThreadIpcState.blockedOnNotification`; `SeLe4n/Kernel/IPC/Operations.lean` adds executable `notificationSignal` and `notificationWait` semantics with runnable-queue interactions (block on wait, wake on signal); `SeLe4n/Kernel/IPC/Invariant.lean` extends the IPC invariant surface with `notificationQueueWellFormed`/`notificationInvariant` and global endpoint+notification coverage; `tests/NegativeStateSuite.lean` adds notification negative/positive checks; and `SeLe4n/Testing/MainTraceHarness.lean` + `tests/fixtures/main_trace_smoke.expected` now exercise composed endpoint/notification trace paths under `scripts/test_smoke.sh` and `scripts/test_full.sh`.
 
-### WS-B7 — Information-flow proof track start (Planned)
+### WS-B7 — Information-flow proof track start (Completed)
 
 - **Goal:** land IF-M1 formal baseline and decomposition plan for noninterference progression.
 - **Prerequisites:** WS-B1 and WS-B5 completion (state model and CSpace semantics available). ✅ satisfied
@@ -180,6 +180,7 @@ Current portfolio status: **WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 are Com
   - `./scripts/test_full.sh`
   - `rg -n "IF-M1|information-flow" docs/INFORMATION_FLOW_ROADMAP.md docs/gitbook/12-proof-and-invariant-map.md`
 - **Exit criteria:** IF-M1 package merged with explicit theorem backlog and assumptions.
+- **Closure evidence (2026-02-18):** IF-M1 formal primitives are now implemented in `SeLe4n/Kernel/InformationFlow/Policy.lean` (`SecurityLabel`, `securityFlowsTo`, reflexive/transitive policy lemmas) and `SeLe4n/Kernel/InformationFlow/Projection.lean` (`projectState`, `lowEquivalent`, equivalence-style helper lemmas); theorem targets and assumptions ledger are published in `docs/IF_M1_BASELINE_PACKAGE.md`; milestone roadmap + GitBook proof map are synchronized in `docs/INFORMATION_FLOW_ROADMAP.md` and `docs/gitbook/12-proof-and-invariant-map.md`; Tier 2 negative coverage now includes `tests/InformationFlowSuite.lean` via `lake exe information_flow_suite` in `scripts/test_tier2_negative.sh`; Tier 3 anchors enforce IF-M1 entrypoint/doc presence via `scripts/test_tier3_invariant_surface.sh`; and full validation gates (`scripts/test_fast.sh`, `scripts/test_smoke.sh`, `scripts/test_full.sh`, `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh`, `lake build`) pass with WS-B7 integrated.
 
 ### WS-B8 — Documentation automation + consolidation (Planned)
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -30,7 +30,7 @@ Closed baseline slices:
 
 Current active slice:
 
-- **Comprehensive Audit 2026-02 execution (WS-B portfolio)** with WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed and WS-B7..WS-B11 in planned/in-progress execution.
+- **Comprehensive Audit 2026-02 execution (WS-B portfolio)** with WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 completed and WS-B8..WS-B11 in planned/in-progress execution.
 
 ## 4. Architecture mental model
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -12,7 +12,7 @@ Current milestone state:
 - M5 complete
 - M6 complete
 - M7 complete
-- **Active:** Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed)
+- **Active:** Comprehensive Audit 2026-02 workstream execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 completed)
 
 ## 2) Stable contracts contributors must preserve
 
@@ -30,7 +30,7 @@ Current milestone state:
 - WS-B4: Remaining type-wrapper migration ✅ completed
 - WS-B5: CSpace guard/radix completion ✅ completed
 - WS-B6: Notification-object IPC completion ✅ completed
-- WS-B7: Information-flow proof-track start
+- WS-B7: Information-flow proof-track start ✅ completed
 - WS-B8: Documentation automation + consolidation
 - WS-B9: Threat model and security hardening
 - WS-B10: CI maturity upgrades
@@ -42,7 +42,7 @@ Canonical execution plan:
 ## 4) Sequencing model
 
 - **Phase P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 complete)
+- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 complete)
 - **Phase P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ## 5) Historical context

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -39,7 +39,7 @@ For milestone-moving PRs:
 ## Workstream sequence
 
 - **Phase P1:** WS-B4, WS-B3, WS-B8
-- **Phase P2:** WS-B5, WS-B6, WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 completed)
+- **Phase P2:** WS-B5, WS-B6, WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed)
 - **Phase P3:** WS-B7, WS-B9, WS-B10, WS-B11
 
 ## Failure triage

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -1,6 +1,6 @@
 # Testing and CI
 
-Current stage context: **Comprehensive Audit 2026-02 WS-B execution is active (WS-B1 through WS-B4 complete), with testing tiers enforcing regression protection and evidence continuity.**
+Current stage context: **Comprehensive Audit 2026-02 WS-B execution is active (WS-B1 through WS-B7 complete), with testing tiers enforcing regression protection and evidence continuity.**
 
 ## Tier model
 
@@ -11,6 +11,7 @@ Current stage context: **Comprehensive Audit 2026-02 WS-B execution is active (W
   - full `lake build` to verify definitions, theorem scripts, and module integration.
 - **Tier 2 (trace/behavior)**
   - executable scenario (`lake exe sele4n`) checked against stable fixture fragments,
+  - malformed/negative and IF-M1 runtime suites (`lake exe negative_state_suite`, `lake exe information_flow_suite`) run under `scripts/test_tier2_negative.sh`,
   - fixture lines support scenario/risk tags (`scenario_id | risk_class | expected_trace_fragment`) for audit traceability.
   - fixtures include WS-A4 scale scenarios for deep CNode radix, large runnable queues, multi-endpoint IPC, depth-5 service dependencies, and boundary memory addresses.
 - **Tier 3 (invariant and documentation anchor surface)**
@@ -74,6 +75,6 @@ stories remain visible and intentional, especially for milestone claims tied to 
 
 - **Tier 0 fails:** remove placeholder markers or fix script-level lint/hygiene issues.
 - **Tier 1 fails:** resolve first Lean compile/proof failure before chasing downstream errors.
-- **Tier 2 fails:** if `test_tier2_trace.sh` fails, inspect missing fixture lines; if `test_tier2_negative.sh` fails, inspect malformed-state guard semantics and expected error branches.
+- **Tier 2 fails:** if `test_tier2_trace.sh` fails, inspect missing fixture lines; if `test_tier2_negative.sh` fails, inspect malformed-state or IF-M1 runtime assertions (`negative_state_suite` / `information_flow_suite`) and expected branch behavior.
 - **Tier 3 fails (`./scripts/test_tier3_invariant_surface.sh`):** verify theorem/bundle/doc anchor names are still present after refactor, then repair the exact missing anchor in the referenced file.
 - **Tier 4 fails (`./scripts/test_nightly.sh` / `./scripts/test_tier4_nightly_candidates.sh`):** inspect `tests/artifacts/nightly/` traces + determinism diff and decide whether the drift is semantic regression or an intentional behavior change that needs fixture/doc updates.

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -142,3 +142,19 @@ Proof-package entrypoints now extend the M5 policy surface to full local + compo
 This keeps the M5 theorem surface aligned with the local-first composition rule:
 prove per-transition preservation first, then expose cross-subsystem bundle preservation with
 explicit failure-path statements.
+
+## 10. IF-M1 information-flow baseline layering (WS-B7 complete)
+
+Information-flow proof-track entrypoints now exist with explicit local decomposition:
+
+- policy lattice/labels:
+  - `Confidentiality`, `Integrity`, `SecurityLabel`,
+  - `confidentialityFlowsTo`, `integrityFlowsTo`, `securityFlowsTo`,
+  - algebraic lemmas: `securityFlowsTo_refl`, `securityFlowsTo_trans`.
+- observer projection helpers:
+  - `projectState`, `projectObjects`, `projectRunnable`, `projectCurrent`,
+  - relation scaffold: `lowEquivalent` with `refl/symm/trans` lemmas.
+
+This keeps IF-M1 aligned with the repository's local-first theorem discipline:
+first provide reusable policy + projection primitives, then stage transition-level
+noninterference claims in IF-M2/IF-M3.

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -22,7 +22,7 @@ This is the GitBook mirror of the canonical planning backbone:
 
 - **WS-B5:** CSpace guard/radix semantics completion ✅ completed
 - **WS-B6:** Notification-object IPC completion ✅ completed
-- **WS-B7:** Information-flow proof-track start
+- **WS-B7:** Information-flow proof-track start ✅ completed
 - **WS-B8:** Documentation automation + consolidation
 - **WS-B9:** Threat model and security hardening
 
@@ -34,7 +34,7 @@ This is the GitBook mirror of the canonical planning backbone:
 ## 3) Sequencing
 
 - **Phase P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4 completed)
-- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 completed)
+- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed)
 - **Phase P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11
 
 ## 4) Evidence expectations for milestone-moving PRs
@@ -96,3 +96,16 @@ When status changes, update together:
 - `SeLe4n/Kernel/IPC/Invariant.lean` now includes `notificationQueueWellFormed`/`notificationInvariant`, and `ipcInvariant` now covers both endpoint and notification object classes.
 - `SeLe4n/Testing/MainTraceHarness.lean` and `tests/fixtures/main_trace_smoke.expected` now exercise composed endpoint + notification flows.
 - `tests/NegativeStateSuite.lean` adds positive/negative notification-path checks in Tier 2 negative validation.
+
+## 12) WS-B7 closure evidence
+
+- IF-M1 baseline primitives are implemented in:
+  - `SeLe4n/Kernel/InformationFlow/Policy.lean` (labels + flow relation + algebraic lemmas),
+  - `SeLe4n/Kernel/InformationFlow/Projection.lean` (observer projection + low-equivalence scaffold).
+- theorem targets and assumptions ledger are published in [`docs/IF_M1_BASELINE_PACKAGE.md`](../IF_M1_BASELINE_PACKAGE.md).
+- roadmap/proof-map sync now includes IF-M1 completion markers in:
+  - `docs/INFORMATION_FLOW_ROADMAP.md`,
+  - `docs/gitbook/12-proof-and-invariant-map.md`.
+- Tier 2 includes IF-M1 runtime sanity checks via `tests/InformationFlowSuite.lean` (`lake exe information_flow_suite`) in `scripts/test_tier2_negative.sh`.
+- Tier 3 invariant/doc anchors now check IF-M1 surfaces in `scripts/test_tier3_invariant_surface.sh`.
+

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ This GitBook is the long-form guide for architecture, workflow, and milestone co
 
 ## Current project state
 
-- **Active slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed).
+- **Active slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 completed).
 - **Latest completed slice:** M7 remediation (WS-A1..WS-A8 complete).
 - **Previous completed slice:** M6 architecture-boundary hardening.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.9.18"
+version = "0.9.21"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]
@@ -16,3 +16,7 @@ root = "tests.TraceSequenceProbe"
 [[lean_exe]]
 name = "negative_state_suite"
 root = "tests.NegativeStateSuite"
+
+[[lean_exe]]
+name = "information_flow_suite"
+root = "tests.InformationFlowSuite"

--- a/scripts/test_tier2_negative.sh
+++ b/scripts/test_tier2_negative.sh
@@ -11,5 +11,6 @@ cd "${REPO_ROOT}"
 ensure_lake_available
 
 run_check "TRACE" lake exe negative_state_suite
+run_check "TRACE" lake exe information_flow_suite
 
 finalize_report

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -41,11 +41,26 @@ run_check "INVARIANT" rg -n '^def notificationSignal' SeLe4n/Kernel/IPC/Operatio
 run_check "INVARIANT" rg -n '^def notificationWait' SeLe4n/Kernel/IPC/Operations.lean
 run_check "INVARIANT" rg -n '^def notificationInvariant' SeLe4n/Kernel/IPC/Invariant.lean
 run_check "DOC" rg -n '^### WS-B6 — IPC completeness with notifications \(Completed\)' docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
-run_check "DOC" rg -n '^- \*\*Active development slice:\*\* Comprehensive Audit 2026-02 execution \(WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed\)\.' README.md
-run_check "DOC" rg -n '^- \*\*Current active slice:\*\* post-M7 comprehensive-audit execution portfolio \(WS-B7\.\.WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 complete\)\.' docs/SEL4_SPEC.md
-run_check "DOC" rg -n '^- \*\*Comprehensive Audit 2026-02 execution \(WS-B portfolio\)\*\* with WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, and WS-B6 completed and WS-B7\.\.WS-B11 in planned/in-progress execution\.' docs/gitbook/01-project-overview.md
-run_check "DOC" rg -n '^- \*\*Phase P2:\*\* WS-B5, WS-B6, WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 completed\)' docs/gitbook/06-development-workflow.md
-run_check "DOC" rg -n '^1\. Sync branch and choose one coherent WS-B slice \(prefer next unfinished stream: WS-B7 onward\)\.' docs/DEVELOPMENT.md
+
+# WS-B7 closure anchors: information-flow policy/projection baseline and milestone docs.
+run_check "INVARIANT" rg -n '^inductive Confidentiality' SeLe4n/Kernel/InformationFlow/Policy.lean
+run_check "INVARIANT" rg -n '^structure SecurityLabel' SeLe4n/Kernel/InformationFlow/Policy.lean
+run_check "INVARIANT" rg -n '^def securityFlowsTo' SeLe4n/Kernel/InformationFlow/Policy.lean
+run_check "INVARIANT" rg -n '^theorem securityFlowsTo_trans' SeLe4n/Kernel/InformationFlow/Policy.lean
+run_check "INVARIANT" rg -n '^def projectState' SeLe4n/Kernel/InformationFlow/Projection.lean
+run_check "INVARIANT" rg -n '^def lowEquivalent' SeLe4n/Kernel/InformationFlow/Projection.lean
+run_check "INVARIANT" rg -n '^theorem lowEquivalent_trans' SeLe4n/Kernel/InformationFlow/Projection.lean
+run_check "INVARIANT" rg -n '^private def runInformationFlowChecks' tests/InformationFlowSuite.lean
+run_check "INVARIANT" rg -n '^run_check "TRACE" lake exe information_flow_suite' scripts/test_tier2_negative.sh
+run_check "DOC" rg -n '^### WS-B7 — Information-flow proof track start \(Completed\)' docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md
+run_check "DOC" rg -n '^## IF-M1 — Policy lattice and labeling primitives ✅ completed \(WS-B7\)' docs/INFORMATION_FLOW_ROADMAP.md
+run_check "DOC" rg -n '^# IF-M1 Baseline Package \(WS-B7\)' docs/IF_M1_BASELINE_PACKAGE.md
+run_check "DOC" rg -n '^- \*\*Active development slice:\*\* Comprehensive Audit 2026-02 execution \(WS-B portfolio; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 completed\)\.' README.md
+run_check "DOC" rg -n '^- \*\*Current active slice:\*\* post-M7 comprehensive-audit execution portfolio \(WS-B8\.\.WS-B11 pending/in progress; WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 complete\)\.' docs/SEL4_SPEC.md
+run_check "DOC" rg -n '^- \*\*Comprehensive Audit 2026-02 execution \(WS-B portfolio\)\*\* with WS-B1, WS-B2, WS-B3, WS-B4, WS-B5, WS-B6, and WS-B7 completed and WS-B8\.\.WS-B11 in planned/in-progress execution\.' docs/gitbook/01-project-overview.md
+run_check "DOC" rg -n '^- \*\*Phase P2:\*\* WS-B5, WS-B6, WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)' docs/gitbook/06-development-workflow.md
+run_check "DOC" rg -n '^- \*\*Phase P2:\*\* WS-B5 \+ WS-B6 \+ WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+run_check "DOC" rg -n '^1\. Sync branch and choose one coherent WS-B slice \(prefer next unfinished stream: WS-B8 onward\)\.' docs/DEVELOPMENT.md
 
 # WS-B2 closure anchors: bootstrap DSL, negative suite, and nightly replay artifacts.
 run_check "INVARIANT" rg -n '^structure BootstrapBuilder' SeLe4n/Testing/StateBuilder.lean

--- a/tests/InformationFlowSuite.lean
+++ b/tests/InformationFlowSuite.lean
@@ -1,0 +1,92 @@
+import SeLe4n
+import SeLe4n.Testing.StateBuilder
+
+open SeLe4n.Model
+
+namespace SeLe4n.Testing
+
+private def expect (label : String) (cond : Bool) : IO Unit := do
+  if cond then
+    IO.println s!"information-flow check passed [{label}]"
+  else
+    throw <| IO.userError s!"information-flow check failed [{label}]"
+
+private def publicLabel : SeLe4n.Kernel.SecurityLabel :=
+  { confidentiality := .low, integrity := .untrusted }
+
+private def secretLabel : SeLe4n.Kernel.SecurityLabel :=
+  { confidentiality := .high, integrity := .trusted }
+
+private def reviewer : SeLe4n.Kernel.IfObserver :=
+  { clearance := publicLabel }
+
+private def admin : SeLe4n.Kernel.IfObserver :=
+  { clearance := secretLabel }
+
+private def sampleServiceEntry : ServiceGraphEntry :=
+  {
+    identity := { sid := 1, backingObject := 1, owner := 1 }
+    status := .running
+    dependencies := []
+    isolatedFrom := []
+  }
+
+private def sampleState : SystemState :=
+  (BootstrapBuilder.empty
+    |>.withObject 1 (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject 2 (.notification { state := .active, waitingThreads := [], pendingBadge := some 7 })
+    |>.withService 1 sampleServiceEntry
+    |>.withRunnable [1, 2]
+    |>.withCurrent (some 2)
+    |>.build)
+
+private def sampleLabeling : SeLe4n.Kernel.LabelingContext :=
+  {
+    objectLabelOf := fun oid => if oid = 2 then secretLabel else publicLabel
+    threadLabelOf := fun tid => if tid = 2 then secretLabel else publicLabel
+    endpointLabelOf := fun _ => publicLabel
+  }
+
+private def runInformationFlowChecks : IO Unit := do
+  expect "security flow is reflexive"
+    (SeLe4n.Kernel.securityFlowsTo secretLabel secretLabel)
+
+  expect "public can flow to secret"
+    (SeLe4n.Kernel.securityFlowsTo publicLabel secretLabel)
+
+  expect "secret cannot flow to public"
+    (!(SeLe4n.Kernel.securityFlowsTo secretLabel publicLabel))
+
+  let publicProjection := SeLe4n.Kernel.projectState sampleLabeling reviewer sampleState
+  let adminProjection := SeLe4n.Kernel.projectState sampleLabeling admin sampleState
+
+  expect "public observer cannot see secret object"
+    ((publicProjection.objects 2).isNone)
+
+  expect "public observer cannot see secret current thread"
+    ((publicProjection.current).isNone)
+
+  expect "admin observer can see secret object"
+    ((adminProjection.objects 2).isSome)
+
+  expect "admin observer can see current thread"
+    (adminProjection.current = some 2)
+
+  let _baselineEq : SeLe4n.Kernel.lowEquivalent sampleLabeling reviewer sampleState sampleState := by
+    rfl
+  IO.println "information-flow check passed [lowEquivalent reflexive proof witness]"
+
+  let redactedState : SystemState :=
+    { sampleState with services := fun _ => none }
+
+  let serviceBefore := (SeLe4n.Kernel.projectState sampleLabeling reviewer sampleState).services 1
+  let serviceAfter := (SeLe4n.Kernel.projectState sampleLabeling reviewer redactedState).services 1
+
+  -- service projection is intentionally status-only and independent from security labels.
+  expect "service-only mutation is visible in observer projection"
+    (decide (serviceBefore ≠ serviceAfter))
+
+end SeLe4n.Testing
+
+def main : IO Unit :=
+  SeLe4n.Testing.runInformationFlowChecks


### PR DESCRIPTION
### Motivation
- Close the remaining WS-B7 workstream gap by publishing the IF‑M1 formal baseline (policy lattice + observer projection) and ensuring all planning/docs reflect WS‑B7 as completed.
- Harden regression protection so future refactors cannot silently desynchronize GitBook/README/spec/development pages from the canonical audit plan.
- Deliver executable, tiered test coverage for the new IF surface so the information‑flow anchors are enforced by the existing validation lanes.

### Description
- Added IF‑M1 implementation modules: `SeLe4n/Kernel/InformationFlow/Policy.lean` (labels, confidentiality/integrity lattices, `securityFlowsTo` and lemmas) and `SeLe4n/Kernel/InformationFlow/Projection.lean` (observer projection API, `projectState`, `lowEquivalent` and equivalence lemmas), and wired them into the kernel API via `SeLe4n/Kernel/API.lean` imports.
- Added executable IF runtime checks in `tests/InformationFlowSuite.lean` and registered an `information_flow_suite` executable in `lakefile.toml` so it runs as part of Tier‑2 negative checks, with `scripts/test_tier2_negative.sh` invoking `lake exe information_flow_suite`.
- Synchronized documentation and planning artifacts to mark WS‑B7 complete and describe IF‑M1: updated `README.md`, `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/INFORMATION_FLOW_ROADMAP.md`, `docs/IF_M1_BASELINE_PACKAGE.md`, `docs/gitbook/*` chapters, and `docs/audits/COMPREHENSIVE_AUDIT_2026_02_WORKSTREAM_PLAN.md` to reflect closure evidence and the IF‑M1 package.
- Hardened Tier‑3 invariant/doc anchors by extending `scripts/test_tier3_invariant_surface.sh` with checks for IF‑M1 theorem anchors, the presence of the `information_flow_suite` invocation, and the chapter‑24 Phase P2 wording; bumped package patch version to `0.9.21` (`lakefile.toml`, `README.md`, `CHANGELOG.md`).

### Testing
- Ran full validation: `./scripts/test_full.sh` completed with all tiers passing (Tier 0 hygiene, `lake build`, Tier 2 trace/negative suites, Tier 3 invariant anchors) and the build succeeded via `lake build`.
- Ran nightly determinism lane: `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` (Tier 4 staged candidates executed) and determinism replay checks passed.
- Ran the audit entrypoint: `./scripts/audit_testing_framework.sh`, which executed the same tiered checks and confirmed expected control-data mismatch behavior in the audit harness while reporting audit success.
- Confirmed `lake exe information_flow_suite` and `scripts/test_tier2_negative.sh` invocations succeed and print all information-flow checks as passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699531db4394832bab996a2ba3ac0c96)