### PR TITLE
Harden smoke and nightly scenario seed checks

### DIFF
--- a/scripts/test_smoke.sh
+++ b/scripts/test_smoke.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/test_lib.sh"
 
 parse_common_args "$@"
+cd "${REPO_ROOT}"
 
 sub_args=()
 if [[ "${CONTINUE_MODE}" -eq 1 ]]; then

--- a/scripts/test_tier4_nightly_candidates.sh
+++ b/scripts/test_tier4_nightly_candidates.sh
@@ -21,6 +21,7 @@ mkdir -p "${ARTIFACT_DIR}"
 
 run_check "META" python3 "${SCRIPT_DIR}/scenario_catalog.py" validate
 run_check "META" bash -lc "python3 '${SCRIPT_DIR}/scenario_catalog.py' nightly-seeds > '${ARTIFACT_DIR}/scenario_seeds.txt'"
+run_check "META" bash -lc "if [[ ! -s '${ARTIFACT_DIR}/scenario_seeds.txt' ]] || ! rg -q '[0-9]' '${ARTIFACT_DIR}/scenario_seeds.txt'; then echo 'error: no nightly seeds found in scenario catalog' >&2; exit 1; fi"
 
 run_check "TRACE" bash -lc 'lake exe sele4n > tests/artifacts/nightly/sele4n_run1.trace'
 run_check "TRACE" bash -lc 'lake exe sele4n > tests/artifacts/nightly/sele4n_run2.trace'


### PR DESCRIPTION
### Motivation
- Ensure `scenario_catalog.py validate` and other checks in the smoke pipeline are location-independent when `scripts/test_smoke.sh` is invoked from outside the repository root.
- Fail fast in the nightly candidates flow when no nightly seeds are produced so a catalog change cannot silently remove nightly seeds and cause the nightly checks to be skipped.

### Description
- Added `cd "${REPO_ROOT}"` to `scripts/test_smoke.sh` immediately after `parse_common_args` so relative defaults in `scenario_catalog.py` resolve correctly.
- Added an explicit guard in `scripts/test_tier4_nightly_candidates.sh` after generating `scenario_seeds.txt` that exits with an error if the file is empty or contains no numeric seeds (`rg -q '[0-9]'`).

### Testing
- Ran `bash -n scripts/test_smoke.sh scripts/test_tier4_nightly_candidates.sh` for syntax checking, which succeeded.
- Executed `cd /tmp && bash -lc 'SCRIPT_DIR="/workspace/seLe4n/scripts"; source "${SCRIPT_DIR}/test_lib.sh"; parse_common_args; cd "${REPO_ROOT}"; python3 "${SCRIPT_DIR}/scenario_catalog.py" validate'` to validate the fix for running from outside the repo, which reported success.
- Verified the nightly-seeds guard with a small tmpdir test that returns non-zero for an empty file and zero for a file containing a numeric seed, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699566476250832ba51bd93a6a5439aa)