### PR TITLE
docs: refine WS-C workstreams and add tracked proof obligations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 ## Current state (authoritative snapshot)
 
-- **Current completed slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1 through WS-B11 completed).
-- **Most recently completed slice:** M7 audit remediation (WS-A1..WS-A8 complete).
-- **Previous completed slice:** M6 architecture-boundary assumptions/adapters.
-- **Current package version:** `0.9.32` (`lakefile.toml`).
+- **Active findings baseline:** `docs/audits/AUDIT_v0.9.32.md`
+- **Active execution baseline:** `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`
+- **Current package version:** `0.9.32` (`lakefile.toml`)
+- **Current active portfolio:** WS-C1..WS-C8 (WS-C8 documentation consolidation in progress)
 
 Normative scope and acceptance criteria live in [`docs/SEL4_SPEC.md`](docs/SEL4_SPEC.md).
 
@@ -16,37 +16,34 @@ Normative scope and acceptance criteria live in [`docs/SEL4_SPEC.md`](docs/SEL4_
 
 1. **Development workflow:** [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
 2. **Testing and CI contract:** [`docs/TESTING_FRAMEWORK_PLAN.md`](docs/TESTING_FRAMEWORK_PLAN.md)
-3. **Comprehensive audit workstream plan (current slice):**
-   [`docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md)
+3. **Current audit workstream plan:**
+   [`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md)
 4. **GitBook navigation hub:** [`docs/gitbook/README.md`](docs/gitbook/README.md)
 5. **Contribution mechanics:**
 
 - Contribution guide (root pointer): [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Change history: [`CHANGELOG.md`](CHANGELOG.md)
 
-## Current slice workstreams (WS-B)
+## Active workstreams (WS-C)
 
-Use this as the quick index. Full contracts and dependencies are in the audit planning backbone.
+Use this as a quick index. Full contracts and dependencies are in the v0.9.32 planning backbone.
 
-- **WS-B1:** VSpace + memory model foundation ✅ completed
-- **WS-B2:** Generative + negative testing expansion ✅ completed
-- **WS-B3:** Main trace harness refactor ✅ completed
-- **WS-B4:** Remaining type-wrapper migration ✅ completed
-- **WS-B5:** CSpace guard/radix semantics completion ✅ completed
-- **WS-B6:** Notification-object IPC completion ✅ completed
-- **WS-B7:** Information-flow proof-track start ✅ completed
-- **WS-B8:** Documentation automation/consolidation ✅ completed
-- **WS-B9:** Threat model + security hardening ✅ completed
-- **WS-B10:** CI maturity upgrades ✅ completed
-- **WS-B11:** Scenario framework finalization ✅ completed
+- **WS-C1:** IPC handshake correctness
+- **WS-C2:** Scheduler semantic fidelity
+- **WS-C3:** Proof-surface de-tautologization (remove tautological `_deterministic` theorems and track semantic replacements)
+- **WS-C4:** Test validity hardening
+- **WS-C5:** Information-flow assurance
+- **WS-C6:** CI and supply-chain hardening
+- **WS-C7:** Model structure and maintainability
+- **WS-C8:** Documentation and GitBook consolidation (in progress)
 
-Primary reference:
-[`docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md).
+Primary references:
+- [`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md)
+- [`docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`](docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md)
 
+## Historical note
 
-## Legacy semantic anchor note
-
-The M3.5 IPC-scheduler handshake semantics remain part of the stable regression surface and are still exercised through `Main.lean` trace fixtures and Tier 3 anchor checks.
+WS-B (`docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md`) and earlier M7/M6/M5/M4 slices remain available for historical traceability, but are not the active planning baseline.
 
 ## Quick setup
 
@@ -79,4 +76,3 @@ lake exe sele4n
 - `Main.lean` — executable trace/demo harness
 - `tests/fixtures/main_trace_smoke.expected` — stable trace expectation anchors
 - `scripts/test_tier*.sh` — tiered quality gates used by CI and local workflows
-

--- a/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+++ b/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
@@ -1,32 +1,33 @@
 # Documentation Sync and Coverage Matrix
 
-This document is the single synchronization index for:
+This document is the synchronization index for:
 
 1. canonical root documentation,
 2. GitBook chapter mirrors/navigation,
-3. test/verification coverage for the current project stage.
+3. test/verification coverage for active planning.
 
-Use this file during planning and PR review to verify that docs, GitBook, and test evidence stay aligned.
+Use this file during planning and PR review to keep documentation status aligned with code reality.
 
 ## 1) Canonical source-of-truth map
 
 | Topic | Canonical document | GitBook chapter(s) | Sync rule |
 |---|---|---|---|
-| Milestones, scope, acceptance | `docs/SEL4_SPEC.md` | `05-specification-and-roadmap.md` | Update spec first; GitBook chapter summarizes and links back. |
-| Comprehensive audit findings | `docs/audits/AUDIT_v0.9.0.md` | `19-end-to-end-audit-and-quality-gates.md`, `24-comprehensive-audit-2026-workstream-planning.md` | Keep findings canonical in audits dir; avoid duplicating full audit prose in chapters. |
-| Comprehensive audit execution portfolio | `docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md` | `24-comprehensive-audit-2026-workstream-planning.md` | Workstream status tables live in canonical plan; GitBook only navigates/summarizes. |
-| Documentation dedup ownership | `docs/DOCS_DEDUPLICATION_MAP.md` | `27-documentation-deduplication-map.md` | Canonical dedup map lives in root docs; chapter is entrypoint only. |
-| M7 historical remediation closeout | `docs/M7_CLOSEOUT_PACKET.md` | `21-m7-current-slice-outcomes-and-workstreams.md`, `23-m7-remediation-closeout-packet.md`, `20-repository-audit-remediation-workstreams.md` | Keep marked as historical context for post-M7 planning, not active baseline. |
-| Development workflow | `docs/DEVELOPMENT.md` | `06-development-workflow.md` | Workflow command changes must be reflected in both files in same PR. |
-| Test tiers and CI contract | `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md` | `07-testing-and-ci.md` | Script/workflow changes require root docs + GitBook updates together. |
-| Hardware-boundary contract policy | `docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md` | `10-path-to-real-hardware-mobile-first.md` | Keep normative constraints in policy doc; chapter links policy and planning implications. |
-| Security trajectory | `docs/INFORMATION_FLOW_ROADMAP.md` | `12-proof-and-invariant-map.md`, `22-next-slice-development-path.md` | Milestone shifts must update roadmap and at least one active planning chapter. |
+| Milestones, scope, acceptance | `docs/SEL4_SPEC.md` | `05-specification-and-roadmap.md` | Update spec first; GitBook summarizes and links back. |
+| Active audit findings baseline | `docs/audits/AUDIT_v0.9.32.md` | `19-end-to-end-audit-and-quality-gates.md`, `24-comprehensive-audit-2026-workstream-planning.md` | Findings remain canonical in `docs/audits`; chapters provide navigation, not duplicated prose. |
+| Active workstream execution portfolio | `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` | `24-comprehensive-audit-2026-workstream-planning.md` | Status tables live in canonical plan; GitBook chapter is a concise mirror. |
+| Tracked theorem obligations (active) | `docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` | `24-comprehensive-audit-2026-workstream-planning.md` | Keep theorem tickets and closure status in audits dir; GitBook chapter references active obligations only. |
+| Historical execution portfolio | `docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md` | archive chapters in GitBook | Keep clearly marked as historical, not active. |
+| Documentation dedup ownership | `docs/DOCS_DEDUPLICATION_MAP.md` | `27-documentation-deduplication-map.md` | Canonical dedup map stays in root docs. |
+| Development workflow | `docs/DEVELOPMENT.md` | `06-development-workflow.md` | Command/process changes must update both. |
+| Test tiers and CI contract | `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md` | `07-testing-and-ci.md` | Script/workflow changes require synchronized updates. |
+| Hardware-boundary contract policy | `docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md` | `10-path-to-real-hardware-mobile-first.md` | Normative constraints in policy doc; chapter links policy implications. |
+| Security trajectory | `docs/INFORMATION_FLOW_ROADMAP.md`, `docs/THREAT_MODEL.md` | `12-proof-and-invariant-map.md`, `22-next-slice-development-path.md`, `28-threat-model-and-security-hardening.md` | Milestone shifts must update roadmap and at least one active planning chapter. |
 
 ## 2) Test and verification coverage map
 
 | Validation area | Command | What it verifies |
 |---|---|---|
-| Hygiene + forbidden markers + fixture isolation | `./scripts/test_tier0_hygiene.sh` | No `sorry`/`axiom`/`TODO` debt in proof surface; no test contract leakage into production kernel modules. |
+| Hygiene + forbidden markers + fixture isolation | `./scripts/test_tier0_hygiene.sh` | No `sorry`/`axiom` debt in proof surface; no test contract leakage into production kernel modules. |
 | Documentation sync automation | `./scripts/test_docs_sync.sh` | GitBook navigation generation is reproducible/committed and local markdown links resolve. |
 | Lean build soundness | `./scripts/test_tier1_build.sh` | Project compiles successfully via `lake build`. |
 | End-to-end executable trace fixture | `./scripts/test_tier2_trace.sh` | Runtime trace still satisfies fixture expectations and scenario/risk-tagged entries. |
@@ -42,14 +43,14 @@ Use this file during planning and PR review to verify that docs, GitBook, and te
 For documentation/planning PRs:
 
 1. Update canonical source docs first.
-2. Update GitBook navigation and chapter links.
-3. Run at least `test_smoke.sh`; run `test_full.sh` when docs mention theorem/anchor surfaces.
-4. If planning/test policy changed, run `test_nightly.sh` (or explain why not run).
+2. Update GitBook mirror/navigation references.
+3. Run at least `test_smoke.sh`; run `test_full.sh` when theorem/invariant anchors or policy text changes.
+4. If planning baseline or test policy changes, run `test_nightly.sh` (or explain why not run).
 5. Verify references with targeted `rg -n` checks for newly introduced docs/chapters.
 
 ## 4) Current-stage status summary
 
-- Active planning baseline: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md` (WS-B11 completed).
-- Historical closeout baseline: `M7_CLOSEOUT_PACKET.md` and its mirrored GitBook summaries.
-- Current quality-gate contract: Tier 0–3 required, Tier 4 nightly determinism evidence.
-
+- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (WS-C portfolio).
+- Active findings baseline: `AUDIT_v0.9.32.md`.
+- Historical baseline retained for traceability: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md`.
+- Quality-gate contract: Tier 0–3 required, Tier 4 nightly determinism evidence.

--- a/docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md
+++ b/docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md
@@ -1,0 +1,86 @@
+# AUDIT v0.9.32 — Tracked Proof Issues and Follow-up Obligations
+
+This document tracks proof obligations intentionally deferred while WS-C1..WS-C8 are executed.
+
+Status legend:
+
+- `OPEN`: accepted obligation, not yet implemented.
+- `IN PROGRESS`: implementation/proof branch exists.
+- `CLOSED`: theorem is implemented in Lean and covered by tiered tests/anchors.
+
+## Issue TPI-001 (OPEN) — Replace tautological VSpace determinism theorem with round-trip properties
+
+- **Audit mapping:** `AUDIT_v0.9.32.md` Immediate recommendation #4.
+- **Current problem:** `vspaceLookup_deterministic` is tautological (`f x = f x`) and does not establish semantic correctness.
+- **Planned WS-C3 action:**
+  1. remove the tautological `_deterministic` theorem,
+  2. add a module docstring in the VSpace proof module explaining that determinism of pure Lean functions is a meta-property and should not be encoded as tautological object-level theorems,
+  3. replace with explicit semantic theorems below.
+
+Required theorem obligations to implement:
+
+```lean
+/-- Mapping a page and then looking it up yields the mapped address. -/
+theorem vspaceLookup_after_map
+    (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr) (paddr : SeLe4n.PAddr)
+    (st st' : SystemState)
+    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .ok (paddr, st') := by
+  sorry  -- actual proof obligation
+
+/-- Mapping vaddr does not affect lookup of a different vaddr'. -/
+theorem vspaceLookup_map_other
+    (asid : SeLe4n.ASID) (vaddr vaddr' : SeLe4n.VAddr) (paddr : SeLe4n.PAddr)
+    (st st' : SystemState)
+    (hNe : vaddr ≠ vaddr')
+    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr' st' = vspaceLookup asid vaddr' st := by
+  sorry  -- actual proof obligation
+
+/-- After unmap, lookup fails with translationFault. -/
+theorem vspaceLookup_after_unmap
+    (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr)
+    (st st' : SystemState)
+    (hUnmap : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .error .translationFault := by
+  sorry  -- actual proof obligation
+```
+
+## Issue TPI-002 (OPEN) — Replace tautological IF projection determinism theorem with noninterference preservation theorem
+
+- **Audit mapping:** `AUDIT_v0.9.32.md` Immediate recommendation #4 and #5.
+- **Current problem:** `projectState_deterministic` is tautological and does not prove security preservation.
+- **Planned WS-C3/WS-C5 action:**
+  1. remove the tautological `_deterministic` theorem,
+  2. add a module docstring in the InformationFlow projection/proof module clarifying determinism-as-meta-property,
+  3. implement operation-level noninterference preservation theorem(s), beginning with endpoint send.
+
+Required theorem obligation to implement:
+
+```lean
+/-- If two states are indistinguishable to an observer, then running
+    a high-domain operation leaves them indistinguishable.
+    This is the actual noninterference property. -/
+theorem endpointSend_preserves_lowEquivalent
+    (ctx : LabelingContext) (observer : IfObserver)
+    (tid : SeLe4n.ThreadId) (epId : SeLe4n.ObjId)
+    (badge : SeLe4n.Badge)
+    (s₁ s₂ : SystemState)
+    (hLow : lowEquivalent ctx observer s₁ s₂)
+    (hHigh : ¬ threadObservable ctx observer tid)  -- sender is above observer
+    (hR1 : ∃ r1, endpointSend tid epId badge s₁ = .ok r1)
+    (hR2 : ∃ r2, endpointSend tid epId badge s₂ = .ok r2) :
+    lowEquivalent ctx observer
+      (endpointSend tid epId badge s₁).toOption.get!.2
+      (endpointSend tid epId badge s₂).toOption.get!.2 := by
+  sorry  -- this is where the real security proof lives
+```
+
+## Integration requirements before closure
+
+Each issue closes only when all are true:
+
+1. theorem is implemented without `sorry` in production proof surface,
+2. old tautological theorem is removed or explicitly marked historical/deprecated with migration notes,
+3. tiered checks (`test_tier3_invariant_surface.sh`, plus relevant tier 2/4 evidence) are updated,
+4. `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` status table is updated from planned to completed for the corresponding WS-C objective.

--- a/docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md
@@ -1,0 +1,240 @@
+# AUDIT v0.9.32 — Workstream Planning Backbone
+
+This document is the canonical execution plan for closing every recommendation and criticism in [`AUDIT_v0.9.32.md`](./AUDIT_v0.9.32.md).
+
+## 1) Planning objective
+
+Deliver a semantically faithful and evidence-backed seL4 model by:
+
+1. closing all **critical/high** correctness gaps first,
+2. restoring confidence in proof/test claims,
+3. tightening CI/documentation governance so status and reality stay aligned,
+4. preserving deterministic execution and contributor ergonomics.
+
+## 2) Planning principles
+
+- **Truth over optimism:** statuses must reflect current code behavior, not intent.
+- **Canonical-first docs:** this file is authoritative for current workstream sequencing and status.
+- **Evidence-gated completion:** no workstream can move to completed without linked code/proof/tests.
+- **Invariant-valid test entry:** new tests must begin from states satisfying baseline invariants unless explicitly testing invariant violations.
+- **No claim without theorem:** security/semantic claims require executable checks or machine-checked theorems.
+
+## 3) Recommendation-to-workstream matrix
+
+| Workstream | Priority | Recommendation coverage from `AUDIT_v0.9.32.md` | Exit evidence |
+|---|---|---|---|
+| WS-C1 IPC handshake correctness | Critical | Immediate #1, #2, #3 | endpoint/notification semantics implemented; ipcState transitions wired; invariant proofs updated; trace + negative tests updated. |
+| WS-C2 Scheduler semantic fidelity | High | Immediate #5 (noninterference dependency), Medium #10, Low #15 | priority-aware `chooseThread`; `handleYield` queue semantics; proofs/tests for runnable ordering. |
+| WS-C3 Proof-surface de-tautologization | Critical | Immediate #4 | remove/relabel tautological theorems and replace with meaningful statements over changed state or relation. |
+| WS-C4 Test validity hardening | High | High Priority #6, #7, #9 | invariant-valid fixtures, post-step invariant assertions, generative state exploration with reproducible seeds. |
+| WS-C5 Information-flow assurance | Critical | Immediate #5, Medium #13 | at least one real `operation_preserves_lowEquivalent` theorem; service filtering by observer clearance in projection; regression tests. |
+| WS-C6 CI and supply-chain hardening | Medium | Medium #14, CI §5.2, §5.4, §5.3 | architecture-safe cache keys, toolchain tag sanitization, stronger flake probe defaults, bounded TODO regex. |
+| WS-C7 Model structure and maintainability | Medium | Architecture §1.2 (finite map migration, ServiceId wrapper, do-notation adoption, vspace lookup cleanup), Medium #11, #12 | finite object-store design ADR, `ServiceId` wrapper migration, shared lemmas consolidated, kernel op readability improvements. |
+| WS-C8 Documentation and GitBook consolidation | High | Low #16, Docs §6.1, §6.2 | right-sized docs hierarchy, explicit “current vs historical” split, claim-audit table, root↔GitBook sync matrix refreshed. |
+
+## 4) Execution phases
+
+### Phase P0 — documentation baseline reset (now)
+
+- Activate WS-C8.
+- Publish this v0.9.32 planning backbone.
+- Demote prior completed-status claims to historical records.
+
+### Phase P1 — correctness blockers
+
+- WS-C1, WS-C3, WS-C2 (core scheduling semantics), WS-C4 (fixture repairs).
+- Goal: eliminate critical correctness and vacuous-proof claims.
+
+### Phase P2 — assurance depth
+
+- WS-C5 + remaining WS-C4 property-based/generative expansion.
+- Goal: establish nontrivial information-flow and invariant-preservation evidence.
+
+### Phase P3 — sustainability
+
+- WS-C6 + WS-C7.
+- Goal: operational reliability and maintainable model architecture.
+
+## 5) Detailed execution contracts
+
+### WS-C1 — IPC handshake correctness
+
+**Scope**
+
+- implement complete endpoint fast-path semantics (waiting receiver wakeup + runnable queue integration + payload/badge propagation model),
+- wire all IPC state transitions on sender/receiver/waiter TCBs,
+- correct notification active-state badge semantics (accumulation instead of overwrite).
+
+**Code and proof targets**
+
+- `SeLe4n/Kernel/IPC/Operations.lean`
+- `SeLe4n/Kernel/IPC/Invariant.lean`
+- scheduler/IPC contract preservation lemmas affected by real `ipcState` updates.
+
+**Validation gates**
+
+- `./scripts/test_tier2_trace.sh`
+- `./scripts/test_tier2_negative.sh`
+- `./scripts/test_tier3_invariant_surface.sh`
+
+### WS-C2 — Scheduler semantic fidelity
+
+**Scope**
+
+- make `chooseThread` priority-aware,
+- implement proper yield behavior (move current thread within runnable queue),
+- preserve deterministic tie-breaking and explicit invalid-state failure modes.
+
+**Code and proof targets**
+
+- `SeLe4n/Kernel/Scheduler/Operations.lean`
+- `SeLe4n/Kernel/Scheduler/Invariant.lean`
+- trace harness expectations dependent on runnable order.
+
+**Validation gates**
+
+- `./scripts/test_tier1_build.sh`
+- `./scripts/test_tier2_trace.sh`
+- `./scripts/test_tier2_negative.sh`
+
+### WS-C3 — Proof-surface de-tautologization
+
+**Required changes**
+
+1. remove the two tautological `_deterministic` theorems (`vspaceLookup_deterministic`, `projectState_deterministic`),
+2. add module-level docstrings in the affected proof modules stating that determinism of pure Lean definitions is a meta-property and tautological `f(x)=f(x)` theorems are non-evidence,
+3. replace with tracked semantic obligations and milestone-owned theorem tickets.
+
+**Tracked obligations**
+
+- See [`AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`](./AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md):
+  - TPI-001 (VSpace round-trip theorem suite),
+  - TPI-002 (noninterference preservation theorem seed).
+
+**Validation gates**
+
+- `./scripts/test_tier0_hygiene.sh`
+- `./scripts/test_tier1_build.sh`
+- `./scripts/test_tier3_invariant_surface.sh`
+
+### WS-C4 — Test validity hardening
+
+**Scope**
+
+- repair fixture initialization so baseline traces begin from invariant-valid states,
+- enforce post-operation invariant assertions in harness/probes,
+- add reproducible generative exploration for valid-state transitions.
+
+**Code and proof targets**
+
+- `SeLe4n/Testing/StateBuilder.lean`
+- `SeLe4n/Testing/MainTraceHarness.lean`
+- `tests/NegativeStateSuite.lean`, `tests/TraceSequenceProbe.lean`, and fixture contracts.
+
+**Validation gates**
+
+- `./scripts/test_smoke.sh`
+- `./scripts/test_full.sh`
+- `./scripts/test_tier4_nightly_candidates.sh`
+
+### WS-C5 — Information-flow assurance
+
+**Scope**
+
+- introduce real operation-preservation theorems over `lowEquivalent`,
+- align observer projection with service-visibility policy,
+- provide at least one nontrivial noninterference theorem accepted into Tier-3 anchors.
+
+**Tracked obligation seed**
+
+- TPI-002 in [`AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`](./AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md).
+
+**Validation gates**
+
+- `./scripts/test_tier2_negative.sh`
+- `./scripts/test_tier3_invariant_surface.sh`
+- `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh`
+
+### WS-C6 — CI and supply-chain hardening
+
+**Scope**
+
+- normalize CI cache-key architecture isolation,
+- sanitize toolchain/tag inputs in automation workflows,
+- raise flake probe iterations and improve hygiene regex precision.
+
+**Validation gates**
+
+- `./scripts/test_fast.sh`
+- `./scripts/test_full.sh`
+- CI workflow dry-run checks as applicable.
+
+### WS-C7 — Model structure and maintainability
+
+**Scope**
+
+- design and execute finite object-store migration plan,
+- migrate `ServiceId` to typed wrapper,
+- consolidate shared lemmas and reduce nested operation structure (do-notation adoption where appropriate),
+- remove linear-scan architecture hacks where model allows.
+
+**Outputs**
+
+- ADR + staged migration plan + compatibility notes,
+- proof and benchmark deltas for changed data model.
+
+**Validation gates**
+
+- `./scripts/test_full.sh`
+- `./scripts/test_nightly.sh`
+
+### WS-C8 — Documentation and GitBook consolidation
+
+**Scope**
+
+- keep active-vs-historical planning boundaries explicit,
+- add auditable “claim vs evidence” index for semantics/proofs,
+- reduce duplication between root docs and GitBook chapters.
+
+**Validation gates**
+
+- `./scripts/test_docs_sync.sh`
+- `./scripts/test_smoke.sh`
+
+## 6) Milestone gates
+
+- **Gate G0 (planning readiness):** this file + README + GitBook chapter 24 + documentation matrix all reference `AUDIT_v0.9.32` as active baseline.
+- **Gate G1 (correctness readiness):** WS-C1/C2/C3 critical items merged with passing Tier 0–3.
+- **Gate G2 (assurance readiness):** WS-C4/C5 evidence merged; at least one nontrivial noninterference preservation theorem in tree.
+- **Gate G3 (sustainment readiness):** WS-C6/C7 merged; CI hardening and architecture ADR accepted.
+
+## 7) Workstream template (apply to each WS-C*)
+
+Each workstream PR must include:
+
+1. **Audit mapping:** exact recommendation IDs closed.
+2. **Code diff summary:** semantic changes and failure-mode behavior.
+3. **Proof delta:** new/changed theorems and assumptions.
+4. **Test evidence:** command outputs from relevant tier scripts.
+5. **Doc sync:** updates to root docs + GitBook mirrors.
+6. **Deferred items:** explicit carry-forward list.
+
+## 8) Current status dashboard
+
+| Workstream | Status | Owner | Notes |
+|---|---|---|---|
+| WS-C1 | Planned | Unassigned | Critical fast-path and ipcState correctness. |
+| WS-C2 | Planned | Unassigned | Priority scheduling and yield semantics. |
+| WS-C3 | Planned | Unassigned | Remove tautological determinism theorems and publish tracked theorem obligations. |
+| WS-C4 | Planned | Unassigned | Invariant-valid tests + post-op checks + generators. |
+| WS-C5 | Planned | Unassigned | First noninterference preservation theorem. |
+| WS-C6 | Planned | Unassigned | CI cache/sanitization/flake/hygiene tightening. |
+| WS-C7 | Planned | Unassigned | Finite store + maintainability refactor track. |
+| WS-C8 | In Progress | Documentation | Documentation/GitBook re-baseline and detailed workstream specification. |
+
+## 9) Canonical companion documents
+
+- Findings source: [`AUDIT_v0.9.32.md`](./AUDIT_v0.9.32.md)
+- Tracked theorem obligations: [`AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`](./AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md)
+- Prior historical plan (superseded for active planning): [`AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](./AUDIT_v0.9.0_WORKSTREAM_PLAN.md)
+- Documentation synchronization policy: [`docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`](../DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md)

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -2,16 +2,19 @@
 
 All repository audit documents are stored in this directory and listed below from newest to oldest.
 
-1. [`AUDIT_v0.9.0.md`](./AUDIT_v0.9.0.md) — 2026-02-17 comprehensive repository audit (v0.9.2 WS-B1-complete baseline).
-2. [`AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](./AUDIT_v0.9.0_WORKSTREAM_PLAN.md) — canonical planning backbone to execute all recommendations/criticisms from the comprehensive audit.
-3. [`AUDIT_v0.9.32.md`](./AUDIT_v0.9.32.md) — independent audit companion snapshot.
-4. [`AUDIT_v0.8.0.md`](./AUDIT_v0.8.0.md) — 2026-02-17 repository audit baseline (v0.8.0 snapshot).
+1. [`AUDIT_v0.9.32.md`](./AUDIT_v0.9.32.md) — 2026-02-18 independent full-repository audit (active findings baseline).
+2. [`AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](./AUDIT_v0.9.32_WORKSTREAM_PLAN.md) — canonical active execution plan for closing v0.9.32 recommendations.
+3. [`AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`](./AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md) — tracked theorem obligations (VSpace round-trips, noninterference preservation) and closure criteria.
+4. [`AUDIT_v0.9.0.md`](./AUDIT_v0.9.0.md) — 2026-02-17 comprehensive repository audit (historical baseline).
+5. [`AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](./AUDIT_v0.9.0_WORKSTREAM_PLAN.md) — historical WS-B execution portfolio (retained for traceability).
+6. [`AUDIT_v0.8.0.md`](./AUDIT_v0.8.0.md) — 2026-02-17 repository audit baseline.
 
 ## Planning guidance
 
-For current planning, use the pair:
+For current planning, use the trio:
 
-- audit source of findings: `AUDIT_v0.9.0.md`
-- execution portfolio map: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md`
+- audit source of findings: `AUDIT_v0.9.32.md`
+- execution portfolio map: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md`
+- theorem obligation tracker: `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`
 
-Treat `M7_CLOSEOUT_PACKET.md` plus GitBook M7 chapters as completed-slice history, not the active planning baseline.
+Treat `AUDIT_v0.9.0_WORKSTREAM_PLAN.md`, `M7_CLOSEOUT_PACKET.md`, and GitBook M7/M6/M5/M4 chapters as historical context rather than active execution status.

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -1,144 +1,49 @@
 # Comprehensive Audit 2026 Workstream Planning
 
-This is the GitBook mirror of the canonical planning backbone:
-[`docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md).
+Canonical planning source:
+[`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md).
 
-## 1) Why this chapter exists
+Tracked proof obligations source:
+[`docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`](../audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md).
 
-- make the active slice obvious for new contributors,
-- provide one-page navigation for WS-B workstreams,
-- keep handbook structure aligned with the normative/audit docs.
+This chapter is intentionally concise and navigational. It summarizes active workstream status and points to canonical details.
 
-## 2) Active workstream index (WS-B)
+## 1) Active planning baseline
 
-### High priority
+- **Findings baseline:** `AUDIT_v0.9.32.md`
+- **Execution baseline:** `AUDIT_v0.9.32_WORKSTREAM_PLAN.md`
+- **Tracked theorem obligations:** `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`
+- **Current planning stage:** Phase P0/P1 transition (documentation baseline reset, correctness blockers next).
 
-- **WS-B1:** VSpace + memory model foundation ✅ completed
-- **WS-B2:** Generative + negative testing expansion ✅ completed
-- **WS-B3:** Main trace harness refactor ✅ completed
-- **WS-B4:** Remaining type-wrapper migration ✅ completed
+## 2) Active workstreams (WS-C portfolio)
 
-### Medium priority
+### Critical/high correctness and assurance
 
-- **WS-B5:** CSpace guard/radix semantics completion ✅ completed
-- **WS-B6:** Notification-object IPC completion ✅ completed
-- **WS-B7:** Information-flow proof-track start ✅ completed
-- **WS-B8:** Documentation automation + consolidation ✅ completed
-- **WS-B9:** Threat model and security hardening ✅ completed
+- **WS-C1:** IPC handshake correctness (critical)
+- **WS-C2:** Scheduler semantic fidelity (high)
+- **WS-C3:** Proof-surface de-tautologization (critical)
+  - remove tautological `vspaceLookup_deterministic` and `projectState_deterministic`,
+  - add module docstrings clarifying determinism as a meta-property of pure Lean,
+  - track replacement theorem obligations in `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`.
+- **WS-C4:** Test validity hardening (high)
+- **WS-C5:** Information-flow assurance (critical)
 
-### Low priority
+### Platform and sustainability
 
-- **WS-B10:** CI maturity upgrades ✅ completed
-- **WS-B11:** Scenario framework finalization ✅ completed
+- **WS-C6:** CI and supply-chain hardening (medium)
+- **WS-C7:** Model structure and maintainability (medium)
+- **WS-C8:** Documentation and GitBook consolidation (high, in progress)
 
-## 3) Sequencing
+## 3) Updating status
 
-- **Phase P1:** WS-B4 + WS-B3 + WS-B8 (WS-B3/WS-B4/WS-B8 completed)
-- **Phase P2:** WS-B5 + WS-B6 + WS-B2 (WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed)
-- **Phase P3:** WS-B7 + WS-B9 + WS-B10 + WS-B11 (WS-B7/WS-B9/WS-B10/WS-B11 completed)
+When any WS-C status changes, update all of the following in the same PR:
 
-## 4) Evidence expectations for milestone-moving PRs
+1. `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (canonical source)
+2. `docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` (if theorem obligations/status changed)
+3. `README.md` (current state + quick index)
+4. `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`
+5. this chapter (`24-comprehensive-audit-2026-workstream-planning.md`)
 
-- workstream ID mapping,
-- implementation/proof/test evidence,
-- docs synchronization,
-- explicit deferred items,
-- no regression of stable M4–M7 baseline contracts.
+## 4) Historical references
 
-## 5) Where to update status
-
-When status changes, update together:
-
-1. `docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md` (canonical)
-2. `README.md` active-slice snapshot
-3. `docs/SEL4_SPEC.md` milestone state
-4. this chapter
-
-
-## 6) WS-B1 closure evidence
-
-- executable VSpace transitions: `SeLe4n/Kernel/Architecture/VSpace.lean`,
-- VSpace invariant bundle and preservation anchors: `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`,
-- deterministic map/unmap trace path in `Main.lean` + fixture update,
-- ADR published: [`docs/VSPACE_MEMORY_MODEL_ADR.md`](../VSPACE_MEMORY_MODEL_ADR.md).
-
-## 7) WS-B2 closure evidence
-
-- bootstrap-state builder DSL published in `SeLe4n/Testing/StateBuilder.lean`,
-- malformed-state negative suite published in `tests/NegativeStateSuite.lean` and enforced in smoke/full gates via `scripts/test_tier2_negative.sh`,
-- nightly experimental replay now persists stochastic seed logs and `trace_sequence_probe_manifest.csv` for deterministic triage.
-
-## 8) WS-B3 closure evidence
-
-- `Main.lean` now provides a minimal executable entrypoint and delegates trace orchestration to `SeLe4n/Testing/MainTraceHarness.lean` (with dedicated scenario functions),
-- bootstrap state construction moved to list/builder composition via `SeLe4n/Testing/StateBuilder.lean`,
-- Tier 2 trace fixture expectations remain stable (`tests/fixtures/main_trace_smoke.expected`) under `scripts/test_tier2_trace.sh` and full-suite execution.
-
-
-## 9) WS-B4 closure evidence
-
-- `SeLe4n/Prelude.lean` upgrades `DomainId`, `Priority`, `Irq`, `Badge`, `ASID`, `VAddr`, and `PAddr` from `Nat` aliases to dedicated wrapper structures with explicit `ofNat`/`toNat` helpers.
-- Compatibility ergonomics are preserved via targeted `OfNat` and `ToString` instances, so existing deterministic fixtures remain readable while retaining type separation.
-- Tier 0 now includes a WS-B4 regression guard in `scripts/test_tier0_hygiene.sh` that fails if any of the migrated wrappers revert to `abbrev ... := Nat`.
-
-
-## 10) WS-B5 closure evidence
-
-- `SeLe4n/Model/Object.lean` now includes `CNode.resolveSlot` with explicit guard/radix resolution and depth/guard failure branches.
-- `SeLe4n/Kernel/Capability/Operations.lean` adds `CSpacePathAddr`, `cspaceResolvePath`, and `cspaceLookupPath` so CSpace pointer-path traversal is executable alongside direct slot lookups.
-- `tests/NegativeStateSuite.lean` now enforces WS-B5 negative-path checks for depth mismatch and guard mismatch outcomes in `scripts/test_tier2_negative.sh`.
-- `tests/fixtures/main_trace_smoke.expected` now includes source/deep CSpace path anchors enforced by `scripts/test_tier2_trace.sh`.
-
-## 11) WS-B6 closure evidence
-
-- `SeLe4n/Model/Object.lean` now includes `NotificationState` + `Notification` and extends `KernelObject` with a notification variant.
-- `SeLe4n/Kernel/IPC/Operations.lean` adds executable `notificationSignal` and `notificationWait` semantics with runnable-queue interactions (block on wait, wake on signal).
-- `SeLe4n/Kernel/IPC/Invariant.lean` now includes `notificationQueueWellFormed`/`notificationInvariant`, and `ipcInvariant` now covers both endpoint and notification object classes.
-- `SeLe4n/Testing/MainTraceHarness.lean` and `tests/fixtures/main_trace_smoke.expected` now exercise composed endpoint + notification flows.
-- `tests/NegativeStateSuite.lean` adds positive/negative notification-path checks in Tier 2 negative validation.
-
-## 12) WS-B7 closure evidence
-
-- IF-M1 baseline primitives are implemented in:
-  - `SeLe4n/Kernel/InformationFlow/Policy.lean` (labels + flow relation + algebraic lemmas),
-  - `SeLe4n/Kernel/InformationFlow/Projection.lean` (observer projection + low-equivalence scaffold).
-- theorem targets and assumptions ledger are published in [`docs/IF_M1_BASELINE_PACKAGE.md`](../IF_M1_BASELINE_PACKAGE.md).
-- roadmap/proof-map sync now includes IF-M1 completion markers in:
-  - `docs/INFORMATION_FLOW_ROADMAP.md`,
-  - `docs/gitbook/12-proof-and-invariant-map.md`.
-- Tier 2 includes IF-M1 runtime sanity checks via `tests/InformationFlowSuite.lean` (`lake exe information_flow_suite`) in `scripts/test_tier2_negative.sh`.
-- Tier 3 invariant/doc anchors now check IF-M1 surfaces in `scripts/test_tier3_invariant_surface.sh`.
-
-
-
-## 13) WS-B8 closure evidence
-
-- GitBook navigation pages are generated from `docs/gitbook/navigation_manifest.json` via `scripts/generate_doc_navigation.py` (`docs/gitbook/README.md`, `docs/gitbook/SUMMARY.md`).
-- Markdown link validation now runs in `scripts/check_markdown_links.py` through `scripts/test_docs_sync.sh`, and Tier 0 executes it by default via `scripts/test_tier0_hygiene.sh`.
-- CI now includes a docs lane (`Docs Automation / Navigation + Links + DocGen Probe`) in `.github/workflows/lean_action_ci.yml` to enforce documentation automation before smoke/full lanes.
-- Root↔GitBook dedup ownership is captured in [`docs/DOCS_DEDUPLICATION_MAP.md`](../DOCS_DEDUPLICATION_MAP.md) and mirrored in chapter 27.
-- Planning/doc PR checklist enforcement is codified in `.github/pull_request_template.md`.
-
-
-## 14) WS-B9 closure evidence
-
-- Threat assumptions/trust boundaries are now canonicalized in [`docs/THREAT_MODEL.md`](../THREAT_MODEL.md) with GitBook mirror [Threat Model and Security Hardening (WS-B9)](28-threat-model-and-security-hardening.md).
-- Repository hygiene now excludes common local secret/config and scanner artifacts via `.gitignore` denylist expansion.
-- `scripts/setup_lean_env.sh` now enforces installer integrity by downloading elan installer content to a temporary file and validating `ELAN_INSTALLER_SHA256` before execution.
-- CI policy linkage is synchronized in [`docs/CI_POLICY.md`](../CI_POLICY.md), and Tier 3 invariant/doc anchors continuously enforce WS-B9 security-surface markers.
-
-## 15) WS-B10 closure evidence
-
-- CodeQL required-vs-informational policy is explicitly documented in [`docs/CI_POLICY.md`](../CI_POLICY.md) and reflected in workflow step naming at `.github/workflows/platform_security_baseline.yml`.
-- Lean/toolchain update automation now includes Dependabot for GitHub Actions (`.github/dependabot.yml`) and scheduled Lean release drift proposals via `.github/workflows/lean_toolchain_update_proposal.yml`.
-- CI timing + flake telemetry is now collected by `scripts/ci_capture_timing.sh` and `scripts/ci_flake_probe.sh`, wired into Lean CI and nightly workflows.
-- Canonical telemetry interpretation guidance is published in [`docs/CI_TELEMETRY_BASELINE.md`](../CI_TELEMETRY_BASELINE.md) with GitBook mirror [CI Maturity and Telemetry Baseline (WS-B10)](29-ci-maturity-and-telemetry-baseline.md).
-
-## 16) WS-B11 closure evidence
-
-- scenario metadata is now canonicalized in `tests/scenarios/scenario_catalog.json` with explicit fields for scenario IDs, subsystem ownership, risk tags, replay tier, deterministic seeds, and fixture anchors.
-- `scripts/scenario_catalog.py` enforces schema and fixture-anchor validation (`validate`) and exports nightly deterministic seeds (`nightly-seeds`).
-- smoke and nightly paths now exercise the scenario framework directly:
-  - `scripts/test_smoke.sh` runs catalog validation,
-  - `scripts/test_tier4_nightly_candidates.sh` materializes nightly seeds from the catalog and replays `trace_sequence_probe` from generated metadata.
-- maintenance ownership and cadence are documented in `tests/scenarios/README.md` (`testing-maintainers`, `per-slice` review).
+The WS-B portfolio (`AUDIT_v0.9.0_WORKSTREAM_PLAN.md`) is retained for provenance and completed-history context only; it is no longer the active planning baseline.

--- a/docs/gitbook/25-documentation-sync-and-coverage-matrix.md
+++ b/docs/gitbook/25-documentation-sync-and-coverage-matrix.md
@@ -8,18 +8,18 @@ This chapter is a concise navigation entry. Keep normative synchronization rules
 
 ## 1) Why this chapter exists
 
-Use this chapter when reviewing or planning documentation-heavy changes to ensure:
+Use this chapter during doc/planning reviews to ensure:
 
-- current workstream status remains synchronized through WS-B11 completion,
-- root docs and GitBook remain in sync,
-- workstream planning references point to canonical files,
+- active planning references point to the `AUDIT_v0.9.32` baseline,
+- root docs and GitBook remain synchronized,
+- historical WS-B content is clearly separated from active WS-C planning,
 - testing evidence expectations are applied consistently.
 
 ## 2) What to update together
 
-- planning docs (`docs/audits/*` + active planning chapters),
+- planning docs (`docs/audits/AUDIT_v0.9.32*.md`, including tracked proof issues + chapter 24),
 - workflow/test policy docs (`docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md`, chapter 07),
-- roadmap/spec docs (`docs/SEL4_SPEC.md`, chapter 05, next-slice chapter 22).
+- roadmap/spec docs (`docs/SEL4_SPEC.md`, chapter 05, chapter 22),
 - dedup ownership docs (`docs/DOCS_DEDUPLICATION_MAP.md`, chapter 27).
 
 ## 3) Validation minimum
@@ -27,10 +27,9 @@ Use this chapter when reviewing or planning documentation-heavy changes to ensur
 For documentation synchronization changes:
 
 1. run `./scripts/test_smoke.sh`,
-2. run `./scripts/test_full.sh` when theorem/invariant anchors or chapter references are touched,
-3. run targeted `rg -n` link/reference checks for newly introduced docs.
+2. run `./scripts/test_full.sh` when theorem/invariant anchors or planning policies are touched,
+3. run targeted `rg -n` reference checks for newly introduced docs.
 
-For release-gate or planning baseline changes, also run:
+For baseline planning changes, also run:
 
 - `./scripts/test_nightly.sh`.
-

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -5,9 +5,9 @@
 This GitBook is the long-form guide for architecture, workflow, and milestone context.
 
 ## Current project state
-- **Current completed slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1 through WS-B11 completed).
-- **Latest completed slice:** M7 remediation (WS-A1..WS-A8 complete).
-- **Previous completed slice:** M6 architecture-boundary hardening.
+- **Active findings baseline:** AUDIT v0.9.32 (independent audit).
+- **Active execution baseline:** WS-C portfolio (v0.9.32 workstream plan).
+- **Historical baseline retained for traceability:** WS-B portfolio (v0.9.0 plan).
 
 Normative scope and acceptance source:
 [`docs/SEL4_SPEC.md`](../SEL4_SPEC.md).
@@ -28,7 +28,7 @@ Normative scope and acceptance source:
 ## Where to find current workstream detail
 
 - Canonical execution matrix:
-  [`docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md)
+  [`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md)
 - GitBook planning chapter:
   [Comprehensive Audit 2026 Workstream Planning](24-comprehensive-audit-2026-workstream-planning.md)
 

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -1,9 +1,9 @@
 {
   "description": "This GitBook is the long-form guide for architecture, workflow, and milestone context.",
   "current_state_bullets": [
-    "**Current completed slice:** Comprehensive Audit 2026-02 execution (WS-B portfolio; WS-B1 through WS-B11 completed).",
-    "**Latest completed slice:** M7 remediation (WS-A1..WS-A8 complete).",
-    "**Previous completed slice:** M6 architecture-boundary hardening."
+    "**Active findings baseline:** AUDIT v0.9.32 (independent audit).",
+    "**Active execution baseline:** WS-C portfolio (v0.9.32 workstream plan).",
+    "**Historical baseline retained for traceability:** WS-B portfolio (v0.9.0 plan)."
   ],
   "recommended_reading": [
     {
@@ -184,5 +184,13 @@
         }
       ]
     }
-  ]
+  ],
+  "current_workstream_doc": {
+    "label": "docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md",
+    "path": "../audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md"
+  },
+  "current_workstream_chapter": {
+    "title": "Comprehensive Audit 2026 Workstream Planning",
+    "path": "24-comprehensive-audit-2026-workstream-planning.md"
+  }
 }

--- a/scripts/generate_doc_navigation.py
+++ b/scripts/generate_doc_navigation.py
@@ -41,9 +41,17 @@ def format_readme(manifest: dict) -> str:
     lines.append("## Where to find current workstream detail")
     lines.append("")
     lines.append("- Canonical execution matrix:")
-    lines.append("  [`docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md)")
+    workstream_doc = manifest.get("current_workstream_doc", {
+        "label": "docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md",
+        "path": "../audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md",
+    })
+    lines.append(f"  [`{workstream_doc['label']}`]({workstream_doc['path']})")
     lines.append("- GitBook planning chapter:")
-    lines.append("  [Comprehensive Audit 2026 Workstream Planning](24-comprehensive-audit-2026-workstream-planning.md)")
+    planning_chapter = manifest.get("current_workstream_chapter", {
+        "title": "Comprehensive Audit 2026 Workstream Planning",
+        "path": "24-comprehensive-audit-2026-workstream-planning.md",
+    })
+    lines.append(f"  [{planning_chapter['title']}]({planning_chapter['path']})")
     lines.append("")
     lines.append("## Historical slice archive")
     lines.append("")

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -55,12 +55,13 @@ run_check "INVARIANT" rg -n '^run_check "TRACE" lake exe information_flow_suite'
 run_check "DOC" rg -n '^### WS-B7 — Information-flow proof track start \(Completed\)' docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
 run_check "DOC" rg -n '^## IF-M1 — Policy lattice and labeling primitives ✅ completed \(WS-B7\)' docs/INFORMATION_FLOW_ROADMAP.md
 run_check "DOC" rg -n '^# IF-M1 Baseline Package \(WS-B7\)' docs/IF_M1_BASELINE_PACKAGE.md
-run_check "DOC" rg -n '^- \*\*Current completed slice:\*\* Comprehensive Audit 2026-02 execution \(WS-B portfolio; WS-B1 through WS-B11 completed\)\.' README.md
+# shellcheck disable=SC2016
+run_check "DOC" rg -n '(^- \*\*Current completed slice:\*\* Comprehensive Audit 2026-02 execution \(WS-B portfolio; WS-B1 through WS-B11 completed\)\.$)|(^- \*\*Active findings baseline:\*\* `docs/audits/AUDIT_v0\.9\.32\.md`$)' README.md
 run_check "DOC" rg -n '^- \*\*Current completed slice:\*\* post-M7 comprehensive-audit execution portfolio \(WS-B1 through WS-B11 complete\)\.' docs/SEL4_SPEC.md
-run_check "DOC" rg -n '^- \*\*Comprehensive Audit 2026-02 execution \(WS-B portfolio\)\*\* with WS-B1 through WS-B11 completed\.' docs/gitbook/01-project-overview.md
-run_check "DOC" rg -n '^- \*\*Phase P2:\*\* WS-B5, WS-B6, WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)' docs/gitbook/06-development-workflow.md
-run_check "DOC" rg -n '^- \*\*Phase P2:\*\* WS-B5 \+ WS-B6 \+ WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
-run_check "DOC" rg -n '^1\. Sync branch and choose one coherent WS-B slice \(prefer the next documented priority in the active plan \(all WS-B streams are complete\)\)\.' docs/DEVELOPMENT.md
+run_check "DOC" rg -n '(^- \*\*Comprehensive Audit 2026-02 execution \(WS-B portfolio\)\*\* with WS-B1 through WS-B11 completed\.$)|(^Current completed slice:$)' docs/gitbook/01-project-overview.md
+run_check "DOC" rg -n '(^- \*\*Phase P2:\*\* WS-B5, WS-B6, WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)$)|(^1\. Pick one coherent WS-B target\.$)' docs/gitbook/06-development-workflow.md
+run_check "DOC" rg -n '(^- \*\*Phase P2:\*\* WS-B5 \+ WS-B6 \+ WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)$)|(^- \*\*WS-C1:\*\* IPC handshake correctness \(critical\)$)' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+run_check "DOC" rg -n '(^1\. Sync branch and choose one coherent WS-B slice \(prefer the next documented priority in the active plan \(all WS-B streams are complete\)\)\.$)|(^## 3\) Current execution slice \(WS-B portfolio\)$)' docs/DEVELOPMENT.md
 run_check "DOC" rg -n '^### WS-B8 — Documentation automation \+ consolidation \(Completed\)' docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
 run_check "DOC" rg -n '^### WS-B9 — Threat model and security hardening \(Completed\)' docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
 run_check "DOC" rg -n '^# Threat Model and Security Hardening Baseline \(WS-B9\)' docs/THREAT_MODEL.md
@@ -68,7 +69,8 @@ run_check "DOC" rg -n '^# Threat Model and Security Hardening \(WS-B9\)' docs/gi
 run_check "INVARIANT" rg -n '^ELAN_INSTALLER_SHA256=' scripts/setup_lean_env.sh
 run_check "INVARIANT" rg -n '^compute_sha256\(\)' scripts/setup_lean_env.sh
 # shellcheck disable=SC2016
-run_check "DOC" rg -n '^- Active planning baseline: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md` \(WS-B11 completed\)\.' docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+# shellcheck disable=SC2016
+run_check "DOC" rg -n '(^- Active planning baseline: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md` \(WS-B11 completed\)\.$)|(^- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` \(WS-C portfolio\)\.$)' docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
 run_check "DOC" rg -n '^# Documentation Deduplication Map \(WS-B8\)' docs/DOCS_DEDUPLICATION_MAP.md
 run_check "DOC" rg -n '^# Documentation Deduplication Map' docs/gitbook/27-documentation-deduplication-map.md
 run_check "INVARIANT" rg -n '^#!/usr/bin/env python3' scripts/generate_doc_navigation.py
@@ -378,7 +380,7 @@ run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
 run_check "DOC" rg -n 'M4-A|M4-B|M5|M6|M7' docs/SEL4_SPEC.md
 run_check "DOC" rg -n 'WS-B1\.\.WS-B11|WS-B portfolio|Comprehensive Audit 2026-02' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/gitbook/README.md docs/gitbook/05-specification-and-roadmap.md docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
 run_check "DOC" rg -n 'Most recently completed slice:.*M7|M7 remediation is complete|M7 is complete and archived' README.md docs/gitbook/README.md docs/gitbook/23-m7-remediation-closeout-packet.md docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
-run_check "DOC" rg -n 'Previous completed slice:.*M6|M6 architecture-boundary|WS-M6-A through WS-M6-E' README.md docs/gitbook/README.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/05-specification-and-roadmap.md
+run_check "DOC" rg -n 'Previous completed slice:.*M6|M6 architecture-boundary|WS-M6-A through WS-M6-E|Historical baseline retained for traceability|M6 architecture-boundary assumptions/adapters' README.md docs/gitbook/README.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/05-specification-and-roadmap.md
 run_check "DOC" rg -n 'test_tier4_nightly_candidates\.sh' docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md scripts/test_nightly.sh
 # shellcheck disable=SC2016
 run_check "DOC" rg -n 'Tier 3 fails \(`\./scripts/test_tier3_invariant_surface\.sh`\)' docs/gitbook/07-testing-and-ci.md
@@ -406,7 +408,7 @@ run_check "DOC" rg -n '^# CI Maturity and Telemetry Baseline \(WS-B10\)' docs/gi
 run_check "DOC" rg -n 'WS-B10 — CI maturity upgrades \(Completed\)|WS-B11 — Scenario framework finalization \(Completed\)' docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
 
 run_check "DOC" rg -n '^# Scenario framework \(WS-B11\)' tests/scenarios/README.md
-run_check "DOC" rg -n '^## 16\) WS-B11 closure evidence' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+run_check "DOC" rg -n '(^## 16\) WS-B11 closure evidence$)|(^## 2\) Active workstreams \(WS-C portfolio\)$)' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
 run_check "INVARIANT" rg -n '^\s*"schema_version": "1\.0\.0"' tests/scenarios/scenario_catalog.json
 run_check "INVARIANT" rg -n '^def validate_catalog' scripts/scenario_catalog.py
 run_check "INVARIANT" rg -n '^def nightly_seeds' scripts/scenario_catalog.py


### PR DESCRIPTION
### Motivation

- Clarify and rebaseline the active v0.9.32 audit execution portfolio so planning, claims, and tracked proof work are authoritative and discoverable. 
- Remove reliance on tautological `_deterministic` theorems as evidence and replace them with explicitly tracked semantic obligations for VSpace and information-flow proofs. 
- Make GitBook mirrors and navigation generation manifest-driven so the canonical plan and its tracked obligations are visible in handbook mirrors.

### Description

- Add a new canonical tracked-theorem tracker `docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` that records the requested VSpace round-trip theorem stubs and the `endpointSend_preserves_lowEquivalent` noninterference seed. 
- Expand `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` with detailed WS-C execution contracts (scope, code/proof targets, and validation gates) and explicit WS-C3 instructions to remove tautological determinism theorems and document determinism as a Lean meta-property. 
- Update root and mirror docs to surface the tracked obligations by changing `README.md`, `docs/audits/README.md`, `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, and GitBook chapter files `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md` and `docs/gitbook/25-documentation-sync-and-coverage-matrix.md`. 
- Make navigation generation robust by adding `current_workstream_doc` / `current_workstream_chapter` manifest keys in `docs/gitbook/navigation_manifest.json` and updating `scripts/generate_doc_navigation.py` to read them and render `docs/gitbook/README.md` and `docs/gitbook/SUMMARY.md` accordingly.

### Testing

- Ran `./scripts/test_docs_sync.sh`, which generated `docs/gitbook/README.md` and `docs/gitbook/SUMMARY.md`, performed markdown link checks, and completed successfully. 
- Ran `./scripts/test_smoke.sh`, which includes Tier-0 hygiene checks, docs-sync, `lake build`, scenario/catalog validation, Tier-2 trace & negative checks, and the information-flow suite; all subchecks passed in this environment. 
- Note: the recorded theorem stubs are documented in `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` as future obligations and no production Lean modules were changed to introduce `sorry`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962584c080832b8311d4a323a8d1a2)