### PR TITLE
docs: disambiguate SEL4_SPEC.md as upstream seL4 reference, not seLe4…

### DIFF
--- a/docs/SEL4_SPEC.md
+++ b/docs/SEL4_SPEC.md
@@ -1,9 +1,26 @@
 # seL4 Microkernel Specification Summary
 
-This document provides a detailed summary of the seL4 microkernel specification. seL4
-(Secure Embedded L4) is a third-generation, high-assurance, capability-based microkernel
-in the L4 family. It is the world's first operating-system kernel with a machine-checked
-proof of functional correctness.
+> **Scope disclaimer.** This document describes the **upstream seL4 microkernel** --
+> the production C/assembly kernel developed by the seL4 Foundation and originally by
+> NICTA/Data61 at UNSW Sydney. It is a reference summary of seL4's published
+> specification, **not** a description of the seLe4n Lean 4 formalization project
+> contained in this repository.
+>
+> For seLe4n project-specific documentation (milestones, workstreams, acceptance
+> criteria, and model scope), see:
+>
+> - Project overview and active workstreams: [`../README.md`](../README.md)
+> - Development workflow: [`DEVELOPMENT.md`](./DEVELOPMENT.md)
+> - Active audit and workstream plan: [`audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md)
+> - GitBook navigation: [`gitbook/README.md`](./gitbook/README.md)
+
+---
+
+seL4 (Secure Embedded L4) is a third-generation, high-assurance, capability-based
+microkernel in the L4 family. It is the world's first operating-system kernel with a
+machine-checked proof of functional correctness. Everything below summarizes the
+upstream seL4 specification and published reference material; it does not describe
+seLe4n's current model coverage.
 
 ---
 
@@ -741,7 +758,27 @@ seL4 and its L4 predecessors have been deployed in:
 
 ---
 
+## Relationship to seLe4n
+
+This document exists within the seLe4n repository as a reference for contributors
+working on the Lean 4 formalization. The seLe4n project incrementally models selected
+seL4 semantic surfaces (scheduler, capabilities, IPC, lifecycle, VSpace) in Lean 4 with
+the goal of machine-checked proofs of key properties. seLe4n does **not** attempt to
+replicate the full seL4 C implementation or proof corpus; it is an independent
+formalization effort.
+
+For the mapping between upstream seL4 concepts described above and seLe4n's current
+model coverage, see:
+
+- [`gitbook/02-microkernel-and-sel4-primer.md`](./gitbook/02-microkernel-and-sel4-primer.md) -- how seLe4n relates to seL4.
+- [`gitbook/05-specification-and-roadmap.md`](./gitbook/05-specification-and-roadmap.md) -- seLe4n project milestones and roadmap.
+- [`audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md) -- active workstream plan.
+
+---
+
 ## References
+
+All references below point to upstream seL4 Foundation resources, not to seLe4n.
 
 - [seL4 Reference Manual](https://sel4.systems/Info/Docs/seL4-manual-latest.pdf)
 - [seL4 Whitepaper](https://sel4.systems/About/seL4-whitepaper.pdf)

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -57,7 +57,8 @@ run_check "DOC" rg -n '^## IF-M1 — Policy lattice and labeling primitives ✅ 
 run_check "DOC" rg -n '^# IF-M1 Baseline Package \(WS-B7\)' docs/IF_M1_BASELINE_PACKAGE.md
 # shellcheck disable=SC2016
 run_check "DOC" rg -n '(^- \*\*Current completed slice:\*\* Comprehensive Audit 2026-02 execution \(WS-B portfolio; WS-B1 through WS-B11 completed\)\.$)|(^- \*\*Active findings baseline:\*\* `docs/audits/AUDIT_v0\.9\.32\.md`$)' README.md
-run_check "DOC" rg -n '(^- \*\*Current completed slice:\*\* post-M7 comprehensive-audit execution portfolio \(WS-B1 through WS-B11 complete\)\.$)|(^- \*\*Current active slice:\*\* comprehensive-audit v0\.9\.32 WS-C execution kickoff \(Phase P0/P1 transition; execution now beginning on WS-C workstreams\)\.$)' docs/SEL4_SPEC.md
+# NOTE: docs/SEL4_SPEC.md is now an upstream seL4 reference document.
+# seLe4n project milestone anchors live in README.md, DEVELOPMENT.md, and gitbook.
 run_check "DOC" rg -n '(^- \*\*Comprehensive Audit 2026-02 execution \(WS-B portfolio\)\*\* with WS-B1 through WS-B11 completed\.$)|(^Current completed slice:$)' docs/gitbook/01-project-overview.md
 run_check "DOC" rg -n '(^- \*\*Phase P2:\*\* WS-B5, WS-B6, WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)$)|(^1\. Pick one coherent WS-B target\.$)|(^1\. Pick one coherent WS-C target \(prioritize Phase P1 blockers first\)\.$)|(^- \*\*Phase P2:\*\* WS-C5 \+ remaining WS-C4 assurance expansion$)' docs/gitbook/06-development-workflow.md
 run_check "DOC" rg -n '(^- \*\*Phase P2:\*\* WS-B5 \+ WS-B6 \+ WS-B2 \(WS-B1/WS-B2/WS-B5/WS-B6 complete; WS-B7 completed\)$)|(^- \*\*WS-C1:\*\* IPC handshake correctness \(critical\)$)|(^- \*\*WS-C1:\*\* IPC handshake correctness \(critical; execution beginning\)$)' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -376,9 +377,11 @@ run_check "TRACE" rg -n 'post-revoke sibling lookup: SeLe4n.Model.KernelError.in
 run_check "TRACE" rg -n 'post-delete lookup \(expected error\): SeLe4n.Model.KernelError.invalidCapability' tests/fixtures/main_trace_smoke.expected
 
 # Active milestone docs should stay synchronized for both current and next slices.
-run_check "DOC" rg -n 'M3\.5' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md
-run_check "DOC" rg -n 'M4-A|M4-B|M5|M6|M7' docs/SEL4_SPEC.md
-run_check "DOC" rg -n 'WS-B1\.\.WS-B11|WS-B portfolio|Comprehensive Audit 2026-02' README.md docs/SEL4_SPEC.md docs/DEVELOPMENT.md docs/gitbook/README.md docs/gitbook/05-specification-and-roadmap.md docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+# NOTE: docs/SEL4_SPEC.md is now an upstream seL4 reference document;
+# seLe4n project milestone anchors are checked in the remaining files below.
+run_check "DOC" rg -n 'M3\.5' README.md docs/DEVELOPMENT.md
+run_check "DOC" rg -n 'M4-A|M4-B|M5|M6|M7' docs/gitbook/05-specification-and-roadmap.md
+run_check "DOC" rg -n 'WS-B1\.\.WS-B11|WS-B portfolio|Comprehensive Audit 2026-02' README.md docs/DEVELOPMENT.md docs/gitbook/README.md docs/gitbook/05-specification-and-roadmap.md docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
 run_check "DOC" rg -n 'Most recently completed slice:.*M7|M7 remediation is complete|M7 is complete and archived' README.md docs/gitbook/README.md docs/gitbook/23-m7-remediation-closeout-packet.md docs/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
 run_check "DOC" rg -n 'Previous completed slice:.*M6|M6 architecture-boundary|WS-M6-A through WS-M6-E|Historical baseline retained for traceability|M6 architecture-boundary assumptions/adapters' README.md docs/gitbook/README.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/05-specification-and-roadmap.md
 run_check "DOC" rg -n 'test_tier4_nightly_candidates\.sh' docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md scripts/test_nightly.sh


### PR DESCRIPTION
…n project spec

Add a scope disclaimer at the top of docs/SEL4_SPEC.md making clear the document describes the upstream seL4 microkernel (seL4 Foundation / UNSW), not the seLe4n Lean 4 formalization in this repository. Add cross-references to seLe4n-specific project docs (README, DEVELOPMENT, workstream plans) and a "Relationship to seLe4n" section before the references.

Update tier 3 tests to stop grepping SEL4_SPEC.md for seLe4n project milestones (M4-A, WS-B, etc.) that no longer belong there, redirecting those checks to the gitbook and project docs that still carry them.

https://claude.ai/code/session_019LK3tZj2ZievUWmfjLK2va

## Summary

- Workstream(s) advanced:
- Recommendation IDs closed:
- Scope notes:

## Validation evidence

- [ ] `./scripts/test_smoke.sh`
- [ ] `./scripts/test_full.sh`
- [ ] `./scripts/test_nightly.sh` (or justify omission)
- [ ] Targeted `rg -n` checks for new docs/anchors

## Documentation synchronization checklist (required)

- [ ] Canonical source docs updated first (`docs/*`, `docs/audits/*`)
- [ ] GitBook mirrors synchronized in the same PR (`docs/gitbook/*`)
- [ ] Generated navigation files refreshed (`scripts/generate_doc_navigation.py`)
- [ ] Markdown-link automation passed (`scripts/test_docs_sync.sh`)
- [ ] Active slice/workstream status synchronized across `README.md`, `docs/SEL4_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`
- [ ] Any deferrals explicitly linked to owning workstream

## Risks / follow-ups

- Residual risks:
- Deferred items + owning workstream:
