### PR TITLE
Audit follow-up: align VSpace ADR with WS-C7 behavior and bump to 0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [0.10.7] - 2026-02-19
+
+### Documentation correctness and WS-C7 refinement follow-up
+- Audited and corrected remaining ADR/GitBook drift where WS-B1 material still implied bounded ASID discovery is current behavior.
+- Amended VSpace ADR + GitBook mirror to explicitly record WS-C7 superseding the bounded scan with `SystemState.objectIndex` traversal in `resolveAsidRoot`.
+- Synchronized root/spec version markers to **`0.10.7`**.
+- Re-ran docs sync + full + nightly experimental validation to confirm end-to-end consistency.
+
+## [0.10.6] - 2026-02-19
+
+### Added
+- Added WS-C7 architecture decision record for finite object-store migration staging and compatibility notes (`docs/FINITE_OBJECT_STORE_ADR.md`) with a synced GitBook completion chapter.
+
+### Changed
+- Migrated `ServiceId` from a `Nat` alias to a typed wrapper in `SeLe4n/Prelude.lean` to restore identifier-domain separation.
+- Added finite `objectIndex` tracking to `SystemState` and `BootstrapBuilder`, and rewired VSpace ASID-root resolution to use indexed object discovery instead of bounded range scanning.
+- Consolidated shared store-object helper lemmas into `Model/State.lean` and reused them from lifecycle invariant helpers.
+- Updated active portfolio docs/GitBook to mark WS-C7 completed.
+- Bumped patch version to **`0.10.6`** and synchronized version markers.
+
 ## [0.10.5] - 2026-02-19
 
 ### WS-C6 refinement follow-up: status precision + telemetry/doc anchor tightening

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 - **Active findings baseline:** `docs/audits/AUDIT_v0.9.32.md`
 - **Active execution baseline:** `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`
-- **Current package version:** `0.10.5` (`lakefile.toml`)
-- **Current active portfolio:** WS-C1..WS-C8 (WS-C1..WS-C6 completed; WS-C7 planned; WS-C8 documentation consolidation in progress)
+- **Current package version:** `0.10.7` (`lakefile.toml`)
+- **Current active portfolio:** WS-C1..WS-C8 (WS-C1..WS-C7 completed; WS-C8 documentation consolidation in progress)
 
 ## Specifications
 

--- a/SeLe4n/Kernel/Architecture/VSpace.lean
+++ b/SeLe4n/Kernel/Architecture/VSpace.lean
@@ -13,20 +13,13 @@ namespace SeLe4n.Kernel.Architecture
 
 open SeLe4n.Model
 
-/-- WS-B1 bounded discovery window for executable ASID→VSpace-root resolution.
-
-This keeps the current model deterministic while object storage remains function-encoded.
-Follow-on map-backed state work can replace this with a direct finite map index. -/
-def vspaceDiscoveryWindow : Nat := 4096
-
 /-- Logical relation: object `rootId` is a VSpace root bound to `asid`. -/
 def asidBoundToRoot (st : SystemState) (asid : SeLe4n.ASID) (rootId : SeLe4n.ObjId) : Prop :=
   ∃ root, st.objects rootId = some (.vspaceRoot root) ∧ root.asid = asid
 
 /-- Locate one root object id carrying `asid` in the bounded discovery window. -/
 def resolveAsidRoot (st : SystemState) (asid : SeLe4n.ASID) : Option (SeLe4n.ObjId × VSpaceRoot) :=
-  let candidates : List SeLe4n.ObjId := (List.range vspaceDiscoveryWindow).map SeLe4n.ObjId.ofNat
-  candidates.findSome? (fun oid =>
+  st.objectIndex.findSome? (fun oid =>
     match st.objects oid with
     | some (.vspaceRoot root) => if root.asid = asid then some (oid, root) else none
     | _ => none)

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -123,6 +123,8 @@ theorem cspaceRevoke_local_target_reduction
                     some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target))
                   else
                     st.objects oid,
+              objectIndex :=
+                if addr.cnode ∈ st.objectIndex then st.objectIndex else addr.cnode :: st.objectIndex,
               lifecycle :=
                 {
                   st.lifecycle with
@@ -279,6 +281,8 @@ theorem cspaceRevoke_preserves_source
                         some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target))
                       else
                         st.objects oid,
+                  objectIndex :=
+                    if addr.cnode ∈ st.objectIndex then st.objectIndex else addr.cnode :: st.objectIndex,
                   lifecycle :=
                     {
                       st.lifecycle with

--- a/SeLe4n/Kernel/Lifecycle/Operations.lean
+++ b/SeLe4n/Kernel/Lifecycle/Operations.lean
@@ -79,10 +79,8 @@ theorem lifecycle_storeObject_objects_eq
     (id : SeLe4n.ObjId)
     (obj : KernelObject)
     (hStore : storeObject id obj st = .ok ((), st')) :
-    st'.objects id = some obj := by
-  unfold storeObject at hStore
-  cases hStore
-  simp
+    st'.objects id = some obj :=
+  SeLe4n.Model.storeObject_objects_eq st st' id obj hStore
 
 theorem lifecycle_storeObject_objects_ne
     (st st' : SystemState)
@@ -90,20 +88,16 @@ theorem lifecycle_storeObject_objects_ne
     (obj : KernelObject)
     (hNe : oid ≠ id)
     (hStore : storeObject id obj st = .ok ((), st')) :
-    st'.objects oid = st.objects oid := by
-  unfold storeObject at hStore
-  cases hStore
-  simp [hNe]
+    st'.objects oid = st.objects oid :=
+  SeLe4n.Model.storeObject_objects_ne st st' id oid obj hNe hStore
 
 theorem lifecycle_storeObject_scheduler_eq
     (st st' : SystemState)
     (id : SeLe4n.ObjId)
     (obj : KernelObject)
     (hStore : storeObject id obj st = .ok ((), st')) :
-    st'.scheduler = st.scheduler := by
-  unfold storeObject at hStore
-  cases hStore
-  rfl
+    st'.scheduler = st.scheduler :=
+  SeLe4n.Model.storeObject_scheduler_eq st st' id obj hStore
 
 theorem cspaceLookupSlot_ok_state_eq
     (st : SystemState)

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -2,9 +2,6 @@ import SeLe4n.Prelude
 
 namespace SeLe4n.Model
 
-/-- Identifier for modeled services in the M5 service graph layer. -/
-abbrev ServiceId := Nat
-
 /-- High-level service runtime status for orchestration-level reasoning. -/
 inductive ServiceStatus where
   | stopped

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -42,6 +42,7 @@ structure LifecycleMetadata where
 structure SystemState where
   machine : SeLe4n.MachineState
   objects : SeLe4n.ObjId → Option KernelObject
+  objectIndex : List SeLe4n.ObjId
   services : ServiceId → Option ServiceGraphEntry
   scheduler : SchedulerState
   irqHandlers : SeLe4n.Irq → Option SeLe4n.ObjId
@@ -57,6 +58,7 @@ instance : Inhabited SystemState where
   default := {
     machine := default
     objects := fun _ => none
+    objectIndex := []
     services := fun _ => none
     scheduler := default
     irqHandlers := fun _ => none
@@ -99,7 +101,8 @@ def storeObject (id : SeLe4n.ObjId) (obj : KernelObject) : Kernel Unit :=
             else
               st.lifecycle.capabilityRefs ref
       }
-    .ok ((), { st with objects := objects', lifecycle := lifecycle' })
+    let objectIndex' := if id ∈ st.objectIndex then st.objectIndex else id :: st.objectIndex
+    .ok ((), { st with objects := objects', objectIndex := objectIndex', lifecycle := lifecycle' })
 
 /-- Record or clear a slot-to-target lifecycle reference mapping. -/
 def storeCapabilityRef (ref : SlotRef) (target : Option CapTarget) : Kernel Unit :=
@@ -249,6 +252,38 @@ theorem storeCapabilityRef_lookup_eq
   simp at hStep
   cases hStep
   simp
+
+
+theorem storeObject_objects_eq
+    (st st' : SystemState)
+    (id : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hStore : storeObject id obj st = .ok ((), st')) :
+    st'.objects id = some obj := by
+  unfold storeObject at hStore
+  cases hStore
+  simp
+
+theorem storeObject_objects_ne
+    (st st' : SystemState)
+    (id oid : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hNe : oid ≠ id)
+    (hStore : storeObject id obj st = .ok ((), st')) :
+    st'.objects oid = st.objects oid := by
+  unfold storeObject at hStore
+  cases hStore
+  simp [hNe]
+
+theorem storeObject_scheduler_eq
+    (st st' : SystemState)
+    (id : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hStore : storeObject id obj st = .ok ((), st')) :
+    st'.scheduler = st.scheduler := by
+  unfold storeObject at hStore
+  cases hStore
+  rfl
 
 theorem storeObject_updates_objectTypeMeta
     (st st' : SystemState)

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -108,6 +108,27 @@ instance : ToString Irq where
 
 end Irq
 
+/-- Identifier for graph-level services in the orchestration layer. -/
+structure ServiceId where
+  val : Nat
+deriving DecidableEq, Repr, Inhabited
+
+namespace ServiceId
+
+/-- Constructor helper kept explicit for migration ergonomics. -/
+@[inline] def ofNat (n : Nat) : ServiceId := ⟨n⟩
+
+/-- Projection helper kept explicit for migration ergonomics. -/
+@[inline] def toNat (id : ServiceId) : Nat := id.val
+
+instance instOfNat (n : Nat) : OfNat ServiceId n where
+  ofNat := ⟨n⟩
+
+instance : ToString ServiceId where
+  toString id := toString id.toNat
+
+end ServiceId
+
 /-- Capability-space pointer value. -/
 structure CPtr where
   val : Nat

--- a/SeLe4n/Testing/StateBuilder.lean
+++ b/SeLe4n/Testing/StateBuilder.lean
@@ -68,6 +68,7 @@ def build (builder : BootstrapBuilder) : SystemState :=
   {
     machine := builder.machine
     objects := listLookup builder.objects
+    objectIndex := builder.objects.map Prod.fst
     services := listLookup builder.services
     scheduler := {
       runnable := builder.runnable

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current active slice**:
 
-- active: **Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 completed; WS-C8 documentation consolidation remains in progress)**,
+- active: **Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 completed; WS-C8 documentation consolidation remains in progress)**,
 - completed predecessor: **M7 remediation (WS-A1..WS-A8)**,
 - completed predecessor before that: **M6 architecture-boundary hardening**.
 
@@ -38,7 +38,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-C4** — test validity hardening (**completed**)
 - **WS-C5** — information-flow assurance (**completed: service visibility projection policy + endpoint-send low-equivalence preservation theorem**)
 - **WS-C6** — CI and supply-chain hardening (**completed: architecture-safe cache keys + toolchain-tag format validation + stronger flake probe defaults + bounded Tier-0 hygiene regex**)
-- **WS-C7** — model structure and maintainability (**Phase P3 target**)
+- **WS-C7** — model structure and maintainability (**completed**)
 - **WS-C8** — documentation/GitBook consolidation (**in progress**)
 
 ### 3.2 Sequencing model
@@ -48,7 +48,7 @@ Use the planning phases from the workstream backbone:
 - **Phase P0:** WS-C8 baseline reset/documentation synchronization (in progress)
 - **Phase P1:** WS-C4 fixture repairs completed (WS-C1 + WS-C2 + WS-C3 + WS-C4 complete)
 - **Phase P2:** WS-C5 assurance expansion (completed)
-- **Phase P3:** WS-C7 sustainability hardening (WS-C6 completed)
+- **Phase P3:** WS-C7 sustainability hardening (completed)
 
 ### 3.3 PR-to-workstream discipline
 

--- a/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+++ b/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
@@ -19,6 +19,7 @@ Use this file during planning and PR review to keep documentation status aligned
 | Tracked theorem obligations (active) | `docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` | `24-comprehensive-audit-2026-workstream-planning.md` | Keep theorem tickets and closure status in audits dir; GitBook chapter references active obligations only. |
 | Historical execution portfolio | `docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md` | archive chapters in GitBook | Keep clearly marked as historical, not active. |
 | Documentation dedup ownership | `docs/DOCS_DEDUPLICATION_MAP.md` | `27-documentation-deduplication-map.md` | Canonical dedup map stays in root docs. |
+| Finite object-store ADR (WS-C7) | `docs/FINITE_OBJECT_STORE_ADR.md` | `30-ws-c7-model-structure-and-maintainability.md` | ADR is canonical; GitBook chapter stays concise and links back. |
 | Development workflow | `docs/DEVELOPMENT.md` | `06-development-workflow.md` | Command/process changes must update both. |
 | Test tiers and CI contract | `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md` | `07-testing-and-ci.md` | Script/workflow changes require synchronized updates. |
 | Hardware-boundary contract policy | `docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md` | `10-path-to-real-hardware-mobile-first.md` | Normative constraints in policy doc; chapter links policy implications. |
@@ -51,7 +52,7 @@ For documentation/planning PRs:
 
 ## 4) Current-stage status summary
 
-- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (WS-C portfolio; WS-C1..WS-C6 completed, WS-C8 actively progressing).
+- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (WS-C portfolio; WS-C1..WS-C7 completed, WS-C8 actively progressing).
 - Active findings baseline: `AUDIT_v0.9.32.md`.
 - Historical baseline retained for traceability: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md`.
 - Quality-gate contract: Tier 0–3 required, Tier 4 nightly determinism evidence.

--- a/docs/FINITE_OBJECT_STORE_ADR.md
+++ b/docs/FINITE_OBJECT_STORE_ADR.md
@@ -1,0 +1,25 @@
+# ADR: WS-C7 Finite Object Store and ServiceId Wrapper
+
+## Status
+Accepted (WS-C7)
+
+## Context
+`SystemState` historically stored objects as a total function `ObjId → Option KernelObject` and VSpace ASID resolution scanned a fixed synthetic range (`0..4095`). This hurt maintainability and made architecture behavior depend on a hard-coded discovery window. In parallel, `ServiceId` was an `abbrev` to `Nat`, violating the typed-identifier discipline used across the rest of the model.
+
+## Decision
+1. Introduce a typed `ServiceId` wrapper in `SeLe4n/Prelude.lean` with `ofNat`, `toNat`, and `OfNat` support.
+2. Extend `SystemState` with a finite `objectIndex : List ObjId` that tracks materialized object identities.
+3. Update `storeObject` to maintain `objectIndex` deterministically (insert-once behavior).
+4. Replace `resolveAsidRoot` bounded-range scanning with `objectIndex` traversal.
+5. Keep function-based object lookup during this stage for proof compatibility; this is a staged migration endpoint, not a full finite-map replacement.
+
+## Consequences
+- Removes the linear-scan architecture hack tied to arbitrary numeric windows.
+- Provides a finite object-store frontier used by architecture lookup logic.
+- Preserves compatibility with existing proofs that reason over `objects : ObjId → Option KernelObject`.
+- Enables future migration to a concrete finite map with lower proof churn because identifiers are now consistently typed and object discovery is explicit.
+
+## Compatibility notes
+- `BootstrapBuilder.build` now seeds `objectIndex` from declared object entries.
+- Existing `ServiceId` literals continue to work via `OfNat`.
+- Invariant-surface script anchors were updated to assert `resolveAsidRoot` + `objectIndex` usage.

--- a/docs/VSPACE_MEMORY_MODEL_ADR.md
+++ b/docs/VSPACE_MEMORY_MODEL_ADR.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — 2026-02-17
+Accepted — 2026-02-17 (amended 2026-02-19 by WS-C7)
 
 ## Context
 
@@ -28,9 +28,10 @@ proof-friendly and explicitly extensible.
    - bounded-translation predicate (`boundedAddressTranslation`).
 4. Keep page-table hierarchy abstract for now; this ADR commits only to a stable
    map/unmap/lookup interface and explicit failure taxonomy.
-5. Use a bounded ASID-discovery window (`vspaceDiscoveryWindow = 4096`) while
-   object storage remains function-encoded; replace this with a direct finite-map
-   ASID index in follow-on state-model work.
+5. (Historical WS-B1 baseline) Use a bounded ASID-discovery window while object storage remains
+   function-encoded.
+6. (WS-C7 amendment) Replace bounded numeric scanning with explicit object-index traversal
+   (`SystemState.objectIndex`) for ASID-root discovery (`resolveAsidRoot`).
 
 ## Consequences
 
@@ -46,11 +47,14 @@ proof-friendly and explicitly extensible.
 - Hardware-precise MMU/TLB invalidation behavior.
 - Tight coupling to physical memory frame allocator semantics.
 
-These remain tracked as post-WS-B1 expansions, including finite-map ASID indexing.
+These remain tracked as post-WS-B1 expansions; WS-C7 has already removed the bounded
+discovery-window hack in favor of explicit object indexing, while full finite-map ASID indexing
+remains future work.
 
 ## Verification evidence
 
 - `SeLe4n/Kernel/Architecture/VSpace.lean`
 - `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`
+- `docs/FINITE_OBJECT_STORE_ADR.md` (WS-C7 object-index staging ADR)
 - `Main.lean` VSpace trace steps
 - `tests/fixtures/main_trace_smoke.expected`

--- a/docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md
@@ -206,7 +206,7 @@ Deliver a semantically faithful and evidence-backed seL4 model by:
 - **Gate G0 (planning readiness):** this file + README + GitBook chapter 24 + documentation matrix all reference `AUDIT_v0.9.32` as active baseline.
 - **Gate G1 (correctness readiness):** WS-C1/C2/C3 critical items merged with passing Tier 0–3.
 - **Gate G2 (assurance readiness):** WS-C4/C5 evidence merged; at least one nontrivial noninterference preservation theorem in tree.
-- **Gate G3 (sustainment readiness):** WS-C6/C7 merged; CI hardening and architecture ADR accepted.
+- **Gate G3 (sustainment readiness):** WS-C6/C7 merged; CI hardening and WS-C7 architecture ADR accepted.
 
 ## 7) Workstream template (apply to each WS-C*)
 
@@ -229,7 +229,7 @@ Each workstream PR must include:
 | WS-C4 | Completed | Testing | Invariant-valid fixtures, executable post-step invariant assertions, and reproducible generative probe coverage merged with smoke/full/tier4 evidence. |
 | WS-C5 | Completed | Information Flow | Added observer-scoped service visibility filtering and `endpointSend_preserves_lowEquivalent` theorem with Tier-2/Tier-3 evidence. |
 | WS-C6 | Completed | CI & Supply Chain | Architecture-safe cache keys, toolchain tag format sanitization, default 3-attempt flake probes, and bounded hygiene marker regex. |
-| WS-C7 | Planned | Unassigned | Finite store + maintainability refactor track. |
+| WS-C7 | Completed | Kernel Architecture | ServiceId wrapper migration, finite object-index tracking, VSpace lookup cleanup, and maintainability ADR evidence merged. |
 | WS-C8 | In Progress | Documentation | Documentation/GitBook re-baseline and detailed workstream specification. |
 
 ## 9) Canonical companion documents

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -36,7 +36,7 @@ Previous completed audit portfolio:
 
 Current active portfolio:
 
-- **WS-C portfolio** (v0.9.32 workstream plan): WS-C1..WS-C6 completed; WS-C7..WS-C8 in progress.
+- **WS-C portfolio** (v0.9.32 workstream plan): WS-C1..WS-C7 completed; WS-C8 in progress.
 
 ## 4. Architecture mental model
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -13,7 +13,7 @@ Current milestone state:
 - M5 complete
 - M6 complete
 - M7 complete
-- **Active:** Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 complete; WS-C8 documentation consolidation in progress)
+- **Active:** Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 complete; WS-C8 documentation consolidation in progress)
 
 ## 2) Stable contracts contributors must preserve
 
@@ -31,7 +31,7 @@ Current milestone state:
 - WS-C4: Test validity hardening (high; completed)
 - WS-C5: Information-flow assurance (critical; completed — observer-scoped service projection + endpoint-send low-equivalence preservation theorem)
 - WS-C6: CI and supply-chain hardening (medium; completed)
-- WS-C7: Model structure and maintainability (medium; Phase P3 target)
+- WS-C7: Model structure and maintainability (medium; completed)
 - WS-C8: Documentation and GitBook consolidation (high; in progress)
 
 Canonical execution plan:
@@ -45,7 +45,7 @@ Security baseline reference:
 - **Phase P0:** WS-C8 baseline reset + active-plan publication (in progress)
 - **Phase P1:** WS-C4 fixture-repair completion (WS-C1 + WS-C2 + WS-C3 + WS-C4 complete)
 - **Phase P2:** WS-C5 assurance expansion (completed)
-- **Phase P3:** WS-C7 sustainment hardening (WS-C6 completed)
+- **Phase P3:** WS-C7 sustainment hardening (completed)
 
 ## 5) Historical context
 

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -41,7 +41,7 @@ For milestone-moving PRs:
 - **Phase P0:** WS-C8 baseline reset/documentation synchronization (in progress)
 - **Phase P1:** WS-C4 fixture repairs complete (WS-C1 + WS-C2 + WS-C3 + WS-C4 complete)
 - **Phase P2:** WS-C5 assurance expansion (completed)
-- **Phase P3:** WS-C7 sustainability hardening (WS-C6 completed)
+- **Phase P3:** WS-C7 sustainability hardening (completed)
 
 ## Failure triage
 

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -1,6 +1,6 @@
 # Testing and CI
 
-Current stage context: **Comprehensive Audit v0.9.32 WS-C execution with WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 completed and WS-C8 documentation consolidation in progress; testing tiers enforce regression protection and evidence continuity across active workstreams.**
+Current stage context: **Comprehensive Audit v0.9.32 WS-C execution with WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 completed and WS-C8 documentation consolidation in progress; testing tiers enforce regression protection and evidence continuity across active workstreams.**
 
 ## Tier model
 

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -13,7 +13,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 - **Findings baseline:** `AUDIT_v0.9.32.md`
 - **Execution baseline:** `AUDIT_v0.9.32_WORKSTREAM_PLAN.md`
 - **Tracked theorem obligations:** `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`
-- **Current planning stage:** Phase P2 assurance execution (WS-C5 closed; documentation baseline maintenance remains active in WS-C8).
+- **Current planning stage:** Phase P3 sustainment closeout (WS-C7 completed; documentation baseline maintenance remains active in WS-C8).
 
 ## 2) Active workstreams (WS-C portfolio)
 
@@ -31,7 +31,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 ### Platform and sustainability
 
 - **WS-C6:** CI and supply-chain hardening (medium; completed)
-- **WS-C7:** Model structure and maintainability (medium)
+- **WS-C7:** Model structure and maintainability (medium; completed — finite object-index staging + `ServiceId` wrapper migration + VSpace lookup cleanup + ADR delivered)
 - **WS-C8:** Documentation and GitBook consolidation (high, in progress)
 
 ## 3) Updating status

--- a/docs/gitbook/26-ws-b1-vspace-memory-adr.md
+++ b/docs/gitbook/26-ws-b1-vspace-memory-adr.md
@@ -4,7 +4,7 @@ GitBook mirror of [`docs/VSPACE_MEMORY_MODEL_ADR.md`](../VSPACE_MEMORY_MODEL_ADR
 
 ## Status
 
-Accepted — 2026-02-17
+Accepted — 2026-02-17 (amended 2026-02-19 by WS-C7)
 
 ## Decision summary
 
@@ -12,9 +12,13 @@ Accepted — 2026-02-17
 - Provide deterministic `map/unmap/lookup` transition surface with explicit errors.
 - Publish VSpace invariant bundle surface for ASID-root uniqueness and non-overlap.
 - Keep hierarchical page-table specifics abstract in this slice.
-- Use a bounded ASID-discovery window (`vspaceDiscoveryWindow`) until finite-map indexing lands.
+- Historical WS-B1 baseline used bounded ASID-discovery scanning.
+- WS-C7 amended this: `resolveAsidRoot` now uses `SystemState.objectIndex` traversal; full finite-map indexing remains future work.
 
 ## Why this matters
 
 This closes the audit criticism that VSpace was only a placeholder and creates a stable
 foundation for deeper CSpace/IPC/information-flow and hardware-bound workstreams.
+
+
+See also: [`docs/FINITE_OBJECT_STORE_ADR.md`](../FINITE_OBJECT_STORE_ADR.md).

--- a/docs/gitbook/30-ws-c7-model-structure-and-maintainability.md
+++ b/docs/gitbook/30-ws-c7-model-structure-and-maintainability.md
@@ -1,0 +1,13 @@
+# WS-C7: Model Structure and Maintainability (Completed)
+
+Canonical ADR: [`docs/FINITE_OBJECT_STORE_ADR.md`](../FINITE_OBJECT_STORE_ADR.md).
+
+## Delivered changes
+- Migrated `ServiceId` to a typed wrapper in `Prelude` for identifier-discipline consistency.
+- Added finite `objectIndex` tracking to `SystemState` and deterministic maintenance in `storeObject`.
+- Replaced VSpace bounded-range object discovery with `objectIndex`-driven lookup.
+- Consolidated shared store-object helper lemmas in `Model/State` and reused them from lifecycle proofs.
+
+## Validation
+- `./scripts/test_full.sh`
+- `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh`

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -28,6 +28,7 @@
 - [WS-B1 ADR: VSpace + Bounded Memory Model Foundation](26-ws-b1-vspace-memory-adr.md)
 - [Documentation Sync and Coverage Matrix](25-documentation-sync-and-coverage-matrix.md)
 - [Documentation Deduplication Map](27-documentation-deduplication-map.md)
+- [WS-C7 Model Structure and Maintainability (Completed)](30-ws-c7-model-structure-and-maintainability.md)
 
 ## Transition and long-horizon path
 

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -116,6 +116,10 @@
         {
           "title": "Documentation Deduplication Map",
           "path": "27-documentation-deduplication-map.md"
+        },
+        {
+          "title": "WS-C7 Model Structure and Maintainability (Completed)",
+          "path": "30-ws-c7-model-structure-and-maintainability.md"
         }
       ]
     },

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -40,11 +40,11 @@ claims, and planning artifacts.
 
 ## 2. Current State Snapshot
 
-- **Current package version:** `0.10.5` (`lakefile.toml`)
+- **Current package version:** `0.10.7` (`lakefile.toml`)
 - **Active findings baseline:** [`docs/audits/AUDIT_v0.9.32.md`](../audits/AUDIT_v0.9.32.md)
 - **Active execution baseline:** [`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md)
-- **Current active portfolio:** WS-C1..WS-C8 (WS-C1..WS-C6 completed; WS-C7 planned; WS-C8 in progress)
-- **Current active slice:** comprehensive-audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 completed; WS-C7 planned; WS-C8 in progress).
+- **Current active portfolio:** WS-C1..WS-C8 (WS-C1..WS-C7 completed; WS-C8 in progress)
+- **Current active slice:** comprehensive-audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 completed; WS-C8 in progress).
 
 ---
 
@@ -76,7 +76,7 @@ on the semantic and proof foundations of the previous one.
 ### 3.3 Active Audit Portfolio
 
 - **WS-C portfolio** (v0.9.32 workstream plan): WS-C1 through WS-C5 completed;
-  WS-C7..WS-C8 in progress (WS-C6 completed).
+  WS-C8 in progress (WS-C7 completed).
 
 ---
 
@@ -97,7 +97,7 @@ on the semantic and proof foundations of the previous one.
 ### 4.2 Platform and Sustainability
 
 - **WS-C6:** CI and supply-chain hardening (medium; completed)
-- **WS-C7:** Model structure and maintainability (medium; Phase P3 target)
+- **WS-C7:** Model structure and maintainability (medium; completed)
 - **WS-C8:** Documentation and GitBook consolidation (high; **in progress**)
 
 Authoritative detail for per-workstream goals, dependencies, and evidence gates:
@@ -111,7 +111,7 @@ Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 - **Phase P1:** WS-C4 fixture-repair completion with WS-C3 already closed
   (WS-C1 + WS-C2 + WS-C3 + WS-C4 completed)
 - **Phase P2:** WS-C5 assurance expansion (completed)
-- **Phase P3:** WS-C7 sustainment hardening (WS-C6 completed)
+- **Phase P3:** WS-C7 sustainment hardening (completed)
 
 ---
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.10.5"
+version = "0.10.7"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -11,7 +11,8 @@ cd "${REPO_ROOT}"
 # M6 WS-M6-A assumption inventory anchors.
 # WS-B1 closure anchors: VSpace transitions, invariants, and ADR publication.
 run_check "INVARIANT" rg -n '^structure VSpaceRoot' SeLe4n/Model/Object.lean
-run_check "INVARIANT" rg -n '^def vspaceDiscoveryWindow' SeLe4n/Kernel/Architecture/VSpace.lean
+run_check "INVARIANT" rg -n '^def resolveAsidRoot' SeLe4n/Kernel/Architecture/VSpace.lean
+run_check "INVARIANT" rg -n '^\s*st.objectIndex.findSome\?' SeLe4n/Kernel/Architecture/VSpace.lean
 run_check "INVARIANT" rg -n '^def vspaceMapPage' SeLe4n/Kernel/Architecture/VSpace.lean
 run_check "INVARIANT" rg -n '^def vspaceUnmapPage' SeLe4n/Kernel/Architecture/VSpace.lean
 run_check "INVARIANT" rg -n '^def vspaceLookup' SeLe4n/Kernel/Architecture/VSpace.lean
@@ -30,6 +31,7 @@ run_check "INVARIANT" rg -n '^structure Badge' SeLe4n/Prelude.lean
 run_check "INVARIANT" rg -n '^structure ASID' SeLe4n/Prelude.lean
 run_check "INVARIANT" rg -n '^structure VAddr' SeLe4n/Prelude.lean
 run_check "INVARIANT" rg -n '^structure PAddr' SeLe4n/Prelude.lean
+run_check "INVARIANT" rg -n '^structure ServiceId' SeLe4n/Prelude.lean
 # WS-B5 closure anchors: CSpace guard/radix path resolution surface.
 run_check "INVARIANT" rg -n '^inductive ResolveError' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^def resolveSlot' SeLe4n/Model/Object.lean
@@ -73,7 +75,7 @@ run_check "INVARIANT" rg -n '^ELAN_INSTALLER_SHA256=' scripts/setup_lean_env.sh
 run_check "INVARIANT" rg -n '^compute_sha256\(\)' scripts/setup_lean_env.sh
 # shellcheck disable=SC2016
 # shellcheck disable=SC2016
-run_check "DOC" rg -n '(^- Active planning baseline: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md` \(WS-B11 completed\)\.$)|(^- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` \(WS-C portfolio; WS-C1..WS-C6 completed, WS-C8 actively progressing\)\.$)' docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+run_check "DOC" rg -n '(^- Active planning baseline: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md` \(WS-B11 completed\)\.$)|(^- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` \(WS-C portfolio; WS-C1..WS-C7 completed, WS-C8 actively progressing\)\.$)' docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
 run_check "DOC" rg -n '(^# Documentation Deduplication Map \(WS-B8\)$)|(^# Documentation Deduplication Map \(WS-C8\)$)' docs/DOCS_DEDUPLICATION_MAP.md
 run_check "DOC" rg -n '^# Documentation Deduplication Map' docs/gitbook/27-documentation-deduplication-map.md
 run_check "INVARIANT" rg -n '^#!/usr/bin/env python3' scripts/generate_doc_navigation.py


### PR DESCRIPTION
### Motivation
- Close a documentation truth-gap where the WS-B1 VSpace ADR (and GitBook mirror) still implied a bounded numeric ASID discovery window while the code uses explicit indexed object discovery from WS-C7. 
- Complete the WS-C7 model-structure/maintainability workstream by staging a finite object-store frontier and restoring typed identifier discipline for services.
- Ensure all validation scripts, invariant anchors, and GitBook navigation reflect the delivered runtime semantics and code-level refactors.

### Description
- Introduced a typed `ServiceId` `structure` with `ofNat`/`toNat`/`OfNat` and `ToString` helpers in `SeLe4n/Prelude.lean` to replace the prior `abbrev` alias. 
- Added `objectIndex : List SeLe4n.ObjId` to `SystemState` (and seeded it from `BootstrapBuilder.build`), updated `Inhabited` default, and changed `storeObject` to deterministically maintain `objectIndex` (insert-once behavior). 
- Rewrote `resolveAsidRoot` in `SeLe4n/Kernel/Architecture/VSpace.lean` to traverse `st.objectIndex` instead of a numeric discovery window, and kept `vspaceMapPage`/`vspaceUnmapPage` wired to the new lookup. 
- Consolidated `storeObject` helper lemmas into `SeLe4n/Model/State.lean` and refactored lifecycle helpers (e.g. `Lifecycle/Operations.lean`, `Capability/Invariant.lean`) to reuse them and update `objectIndex` where needed. 
- Updated invariant/test anchors and validation scripts (notably `scripts/test_tier3_invariant_surface.sh`) to assert `resolveAsidRoot` + `objectIndex` usage and added `docs/FINITE_OBJECT_STORE_ADR.md` plus a GitBook chapter `30-ws-c7-model-structure-and-maintainability.md`. 
- Amended `docs/VSPACE_MEMORY_MODEL_ADR.md` and its GitBook mirror to record the WS-C7 amendment (bounded scan is historical), synchronized the GitBook navigation, and bumped the package patch version to `0.10.7` in `lakefile.toml`, plus synced `README.md`, `docs/spec/SELE4N_SPEC.md`, and `CHANGELOG.md`.

### Testing
- Ran `./scripts/test_docs_sync.sh` to regenerate GitBook navigation and run markdown link checks, and it passed. 
- Ran `./scripts/test_full.sh` (Tier 0–3: hygiene, build via `lake build`, trace/negative suites, invariant anchors) and it completed successfully. 
- Ran `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` (Tier 4 nightly candidate/determinism probes) and the nightly/staged candidate runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967160ce0c832b89728f99b348d1d5)