### PR TITLE
Add dark mode support for logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center">
-  <img src="assets/logo.png" alt="seLe4n logo" width="200" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo_dark.png" />
+    <img src="assets/logo.png" alt="seLe4n logo" width="200" />
+  </picture>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: Documentation/UI
- Recommendation IDs closed: N/A
- Scope notes: Updated README logo to support both light and dark color schemes using HTML `<picture>` element

## Changes

Updated the logo display in README.md to use the HTML `<picture>` element with media query support for `prefers-color-scheme: dark`. This allows the logo to automatically display `assets/logo_dark.png` when users have dark mode enabled, while falling back to `assets/logo.png` for light mode.

## Validation evidence

- [x] No functional code changes requiring test execution
- [x] Documentation-only change (README.md)
- [x] HTML/Markdown syntax is valid

## Documentation synchronization checklist

- [x] README.md updated
- [ ] N/A - No canonical docs, GitBook mirrors, or navigation generation affected by this change
- [ ] N/A - No markdown links or workstream status changes

## Risks / follow-ups

- Residual risks: None - this is a purely presentational change
- Deferred items: None

**Note:** This change assumes `assets/logo_dark.png` exists or will be added separately. If the dark logo asset is not yet available, the fallback to the standard logo will be used.

https://claude.ai/code/session_01SXHLzKjJyEq3RoakEH8g1y