### PR TITLE
Sync WS-C closeout docs, add claim→evidence index, and bump to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [0.11.0] - 2026-02-19
+
+### WS-C8 post-merge audit refinement and minor release
+- Performed an end-to-end documentation/codebase synchronization audit after WS-C8 completion and corrected residual status drift in the seLe4n spec (`WS-C portfolio` summary now consistently states WS-C1..WS-C8 completed).
+- Refined carried-forward proof-issue tracker wording to reflect that WS-C execution is complete and obligations remain intentionally tracked post-closeout.
+- Revalidated docs automation + smoke/full/nightly experimental gates to confirm runtime, proof-surface, and documentation anchors are synchronized.
+- Bumped minor version to **`0.11.0`** and synchronized version markers in root/spec metadata.
+
+## [0.10.8] - 2026-02-19
+
+### WS-C8 documentation and GitBook consolidation completion
+- Marked WS-C8 as completed across canonical planning docs, root guides, and GitBook mirrors so active portfolio status is consistently closed (WS-C1..WS-C8 complete).
+- Added a canonical claim/evidence audit index (`docs/CLAIM_EVIDENCE_INDEX.md`) plus a GitBook pointer chapter (`docs/gitbook/31-claim-vs-evidence-index.md`).
+- Refreshed documentation ownership/synchronization matrices and planning companion links to include the new claim/evidence index.
+- Bumped patch version to **`0.10.8`** and synchronized version markers.
+
 ## [0.10.7] - 2026-02-19
 
 ### Documentation correctness and WS-C7 refinement follow-up

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ seLe4n is a Lean 4 formalization project for an executable, machine-checked mode
 
 - **Active findings baseline:** `docs/audits/AUDIT_v0.9.32.md`
 - **Active execution baseline:** `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`
-- **Current package version:** `0.10.7` (`lakefile.toml`)
-- **Current active portfolio:** WS-C1..WS-C8 (WS-C1..WS-C7 completed; WS-C8 documentation consolidation in progress)
+- **Current package version:** `0.11.0` (`lakefile.toml`)
+- **Current active portfolio:** WS-C1..WS-C8 (all workstreams completed)
 
 ## Specifications
 
@@ -60,7 +60,7 @@ Quick index. Full contracts and dependencies are in the v0.9.32 planning backbon
 - **WS-C5:** Information-flow assurance -- completed
 - **WS-C6:** CI and supply-chain hardening -- completed
 - **WS-C7:** Model structure and maintainability -- completed
-- **WS-C8:** Documentation and GitBook consolidation (in progress)
+- **WS-C8:** Documentation and GitBook consolidation -- completed
 
 Primary references:
 - [`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md)

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -1,0 +1,22 @@
+# Claim vs Evidence Index (WS-C8)
+
+This index makes current semantic/proof/documentation claims auditable by linking each claim to executable or inspectable evidence.
+
+## Active baseline claims
+
+| Claim | Canonical source | Evidence command(s) | Evidence artifact(s) |
+|---|---|---|---|
+| Active findings baseline is `AUDIT_v0.9.32.md`. | `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` | `./scripts/test_tier3_invariant_surface.sh` | Tier-3 doc-anchor checks over README/spec/planning references. |
+| WS-C portfolio status is complete (WS-C1..WS-C8). | `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
+| Root docs and GitBook mirrors stay synchronized via canonical-first rules. | `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, `docs/DOCS_DEDUPLICATION_MAP.md` | `./scripts/test_docs_sync.sh` | Regenerated navigation + markdown link validation + doc-gen probe when available. |
+| IPC/scheduler/capability/info-flow invariants remain in active proof surface. | Kernel modules and invariant suites listed in `scripts/test_tier3_invariant_surface.sh` | `./scripts/test_tier3_invariant_surface.sh` | Direct symbol + theorem + doc anchor checks. |
+| Executable behavior remains fixture-backed and malformed-state safe. | `tests/fixtures/main_trace_smoke.expected`, negative/IF suites | `./scripts/test_tier2_trace.sh`, `./scripts/test_tier2_negative.sh` | Stable trace fragments + negative/IF runtime checks. |
+
+## Update policy
+
+When a claim changes:
+
+1. update canonical root source first,
+2. update GitBook mirror(s) in the same PR,
+3. refresh this table row(s) for changed claims,
+4. run `./scripts/test_docs_sync.sh` and at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current active slice**:
 
-- active: **Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 completed; WS-C8 documentation consolidation remains in progress)**,
+- active: **Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 + WS-C8 completed)**,
 - completed predecessor: **M7 remediation (WS-A1..WS-A8)**,
 - completed predecessor before that: **M6 architecture-boundary hardening**.
 
@@ -39,13 +39,13 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-C5** — information-flow assurance (**completed: service visibility projection policy + endpoint-send low-equivalence preservation theorem**)
 - **WS-C6** — CI and supply-chain hardening (**completed: architecture-safe cache keys + toolchain-tag format validation + stronger flake probe defaults + bounded Tier-0 hygiene regex**)
 - **WS-C7** — model structure and maintainability (**completed**)
-- **WS-C8** — documentation/GitBook consolidation (**in progress**)
+- **WS-C8** — documentation/GitBook consolidation (**completed**)
 
 ### 3.2 Sequencing model
 
 Use the planning phases from the workstream backbone:
 
-- **Phase P0:** WS-C8 baseline reset/documentation synchronization (in progress)
+- **Phase P0:** WS-C8 baseline reset/documentation synchronization (completed)
 - **Phase P1:** WS-C4 fixture repairs completed (WS-C1 + WS-C2 + WS-C3 + WS-C4 complete)
 - **Phase P2:** WS-C5 assurance expansion (completed)
 - **Phase P3:** WS-C7 sustainability hardening (completed)

--- a/docs/DOCS_DEDUPLICATION_MAP.md
+++ b/docs/DOCS_DEDUPLICATION_MAP.md
@@ -18,6 +18,7 @@ This document defines the canonical-vs-mirror split used to reduce drift between
 | Contributor workflow expectations | `docs/DEVELOPMENT.md` | `docs/gitbook/06-development-workflow.md` | Keep checklists canonical in root doc; mirror chapter keeps lightweight guidance. |
 | Test/CI evidence contract | `docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md` | `docs/gitbook/07-testing-and-ci.md` | Root docs own gate semantics and policy details; chapter links and summarizes. |
 | Documentation synchronization governance | `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, `docs/DOCS_DEDUPLICATION_MAP.md` | `docs/gitbook/25-documentation-sync-and-coverage-matrix.md`, `docs/gitbook/27-documentation-deduplication-map.md` | Keep canonical matrices in root; GitBook points readers at canonical tables. |
+| Claim/audit evidence mapping | `docs/CLAIM_EVIDENCE_INDEX.md` | `docs/gitbook/31-claim-vs-evidence-index.md` | Root file owns claim→evidence rows; GitBook chapter remains a pointer only. |
 
 ## 3) Automation hooks
 
@@ -36,4 +37,5 @@ For planning/docs workstreams (including WS-C8+), PRs should explicitly confirm:
 - GitBook mirrors were synchronized in the same PR,
 - generated navigation outputs were regenerated,
 - markdown-link checks passed,
-- active-slice status text is consistent across README/spec/development/workstream plan/chapter 24.
+- active-slice status text is consistent across README/spec/development/workstream plan/chapter 24,
+- claim/evidence rows are updated when baseline claims or validation commands change.

--- a/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+++ b/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
@@ -17,6 +17,7 @@ Use this file during planning and PR review to keep documentation status aligned
 | Active audit findings baseline | `docs/audits/AUDIT_v0.9.32.md` | `19-end-to-end-audit-and-quality-gates.md`, `24-comprehensive-audit-2026-workstream-planning.md` | Findings remain canonical in `docs/audits`; chapters provide navigation, not duplicated prose. |
 | Active workstream execution portfolio | `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` | `24-comprehensive-audit-2026-workstream-planning.md` | Status tables live in canonical plan; GitBook chapter is a concise mirror. |
 | Tracked theorem obligations (active) | `docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` | `24-comprehensive-audit-2026-workstream-planning.md` | Keep theorem tickets and closure status in audits dir; GitBook chapter references active obligations only. |
+| Claim vs evidence index (active semantics/proofs/docs) | `docs/CLAIM_EVIDENCE_INDEX.md` | `31-claim-vs-evidence-index.md` | Keep auditable claim→command mapping canonical in root; GitBook chapter points to index. |
 | Historical execution portfolio | `docs/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md` | archive chapters in GitBook | Keep clearly marked as historical, not active. |
 | Documentation dedup ownership | `docs/DOCS_DEDUPLICATION_MAP.md` | `27-documentation-deduplication-map.md` | Canonical dedup map stays in root docs. |
 | Finite object-store ADR (WS-C7) | `docs/FINITE_OBJECT_STORE_ADR.md` | `30-ws-c7-model-structure-and-maintainability.md` | ADR is canonical; GitBook chapter stays concise and links back. |
@@ -52,7 +53,7 @@ For documentation/planning PRs:
 
 ## 4) Current-stage status summary
 
-- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (WS-C portfolio; WS-C1..WS-C7 completed, WS-C8 actively progressing).
+- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (WS-C portfolio; WS-C1..WS-C8 completed).
 - Active findings baseline: `AUDIT_v0.9.32.md`.
 - Historical baseline retained for traceability: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md`.
 - Quality-gate contract: Tier 0–3 required, Tier 4 nightly determinism evidence.

--- a/docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md
+++ b/docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md
@@ -1,6 +1,6 @@
 # AUDIT v0.9.32 — Tracked Proof Issues and Follow-up Obligations
 
-This document tracks proof obligations intentionally deferred while WS-C1..WS-C8 are executed.
+This document tracks proof obligations intentionally deferred during WS-C execution and carried forward after WS-C1..WS-C8 completion.
 
 Status legend:
 

--- a/docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md
@@ -230,7 +230,7 @@ Each workstream PR must include:
 | WS-C5 | Completed | Information Flow | Added observer-scoped service visibility filtering and `endpointSend_preserves_lowEquivalent` theorem with Tier-2/Tier-3 evidence. |
 | WS-C6 | Completed | CI & Supply Chain | Architecture-safe cache keys, toolchain tag format sanitization, default 3-attempt flake probes, and bounded hygiene marker regex. |
 | WS-C7 | Completed | Kernel Architecture | ServiceId wrapper migration, finite object-index tracking, VSpace lookup cleanup, and maintainability ADR evidence merged. |
-| WS-C8 | In Progress | Documentation | Documentation/GitBook re-baseline and detailed workstream specification. |
+| WS-C8 | Completed | Documentation | Documentation/GitBook consolidation closed with claim/evidence index and root↔GitBook sync matrix refresh. |
 
 ## 9) Canonical companion documents
 
@@ -238,3 +238,4 @@ Each workstream PR must include:
 - Tracked theorem obligations: [`AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`](./AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md)
 - Prior historical plan (superseded for active planning): [`AUDIT_v0.9.0_WORKSTREAM_PLAN.md`](./AUDIT_v0.9.0_WORKSTREAM_PLAN.md)
 - Documentation synchronization policy: [`docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`](../DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md)
+- Claim/evidence audit index: [`docs/CLAIM_EVIDENCE_INDEX.md`](../CLAIM_EVIDENCE_INDEX.md)

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -36,7 +36,7 @@ Previous completed audit portfolio:
 
 Current active portfolio:
 
-- **WS-C portfolio** (v0.9.32 workstream plan): WS-C1..WS-C7 completed; WS-C8 in progress.
+- **WS-C portfolio** (v0.9.32 workstream plan): WS-C1..WS-C8 completed.
 
 ## 4. Architecture mental model
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -13,7 +13,7 @@ Current milestone state:
 - M5 complete
 - M6 complete
 - M7 complete
-- **Active:** Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 complete; WS-C8 documentation consolidation in progress)
+- **Active:** Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 + WS-C8 complete)
 
 ## 2) Stable contracts contributors must preserve
 
@@ -32,7 +32,7 @@ Current milestone state:
 - WS-C5: Information-flow assurance (critical; completed — observer-scoped service projection + endpoint-send low-equivalence preservation theorem)
 - WS-C6: CI and supply-chain hardening (medium; completed)
 - WS-C7: Model structure and maintainability (medium; completed)
-- WS-C8: Documentation and GitBook consolidation (high; in progress)
+- WS-C8: Documentation and GitBook consolidation (high; completed)
 
 Canonical execution plan:
 [Comprehensive Audit 2026 Workstream Planning](24-comprehensive-audit-2026-workstream-planning.md).
@@ -42,7 +42,7 @@ Security baseline reference:
 
 ## 4) Sequencing model
 
-- **Phase P0:** WS-C8 baseline reset + active-plan publication (in progress)
+- **Phase P0:** WS-C8 baseline reset + active-plan publication (completed)
 - **Phase P1:** WS-C4 fixture-repair completion (WS-C1 + WS-C2 + WS-C3 + WS-C4 complete)
 - **Phase P2:** WS-C5 assurance expansion (completed)
 - **Phase P3:** WS-C7 sustainment hardening (completed)

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -38,7 +38,7 @@ For milestone-moving PRs:
 
 ## Workstream sequence
 
-- **Phase P0:** WS-C8 baseline reset/documentation synchronization (in progress)
+- **Phase P0:** WS-C8 baseline reset/documentation synchronization (completed)
 - **Phase P1:** WS-C4 fixture repairs complete (WS-C1 + WS-C2 + WS-C3 + WS-C4 complete)
 - **Phase P2:** WS-C5 assurance expansion (completed)
 - **Phase P3:** WS-C7 sustainability hardening (completed)

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -1,6 +1,6 @@
 # Testing and CI
 
-Current stage context: **Comprehensive Audit v0.9.32 WS-C execution with WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 completed and WS-C8 documentation consolidation in progress; testing tiers enforce regression protection and evidence continuity across active workstreams.**
+Current stage context: **Comprehensive Audit v0.9.32 WS-C execution with WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 + WS-C8 completed; testing tiers enforce regression protection and evidence continuity across active workstreams.**
 
 ## Tier model
 

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -13,7 +13,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 - **Findings baseline:** `AUDIT_v0.9.32.md`
 - **Execution baseline:** `AUDIT_v0.9.32_WORKSTREAM_PLAN.md`
 - **Tracked theorem obligations:** `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`
-- **Current planning stage:** Phase P3 sustainment closeout (WS-C7 completed; documentation baseline maintenance remains active in WS-C8).
+- **Current planning stage:** Phase P3 sustainment closeout complete (WS-C7 + WS-C8 completed; WS-C portfolio closed).
 
 ## 2) Active workstreams (WS-C portfolio)
 
@@ -32,7 +32,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 
 - **WS-C6:** CI and supply-chain hardening (medium; completed)
 - **WS-C7:** Model structure and maintainability (medium; completed — finite object-index staging + `ServiceId` wrapper migration + VSpace lookup cleanup + ADR delivered)
-- **WS-C8:** Documentation and GitBook consolidation (high, in progress)
+- **WS-C8:** Documentation and GitBook consolidation (high, completed)
 
 ## 3) Updating status
 
@@ -42,7 +42,8 @@ When any WS-C status changes, update all of the following in the same PR:
 2. `docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` (if theorem obligations/status changed)
 3. `README.md` (current state + quick index)
 4. `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`
-5. this chapter (`24-comprehensive-audit-2026-workstream-planning.md`)
+5. `docs/CLAIM_EVIDENCE_INDEX.md` (when baseline claims/evidence mapping changes)
+6. this chapter (`24-comprehensive-audit-2026-workstream-planning.md`)
 
 ## 4) Historical references
 

--- a/docs/gitbook/25-documentation-sync-and-coverage-matrix.md
+++ b/docs/gitbook/25-documentation-sync-and-coverage-matrix.md
@@ -20,7 +20,8 @@ Use this chapter during doc/planning reviews to ensure:
 - planning docs (`docs/audits/AUDIT_v0.9.32*.md`, including tracked proof issues + chapter 24),
 - workflow/test policy docs (`docs/TESTING_FRAMEWORK_PLAN.md`, `docs/CI_POLICY.md`, chapter 07),
 - roadmap/spec docs (`docs/spec/SELE4N_SPEC.md`, `docs/spec/SEL4_SPEC.md`, chapter 05, chapter 22),
-- dedup ownership docs (`docs/DOCS_DEDUPLICATION_MAP.md`, chapter 27).
+- dedup ownership docs (`docs/DOCS_DEDUPLICATION_MAP.md`, chapter 27),
+- claim/evidence index (`docs/CLAIM_EVIDENCE_INDEX.md`, chapter 31).
 
 ## 3) Validation minimum
 

--- a/docs/gitbook/31-claim-vs-evidence-index.md
+++ b/docs/gitbook/31-claim-vs-evidence-index.md
@@ -1,0 +1,15 @@
+# Claim vs Evidence Index
+
+Canonical source document:
+
+- [`docs/CLAIM_EVIDENCE_INDEX.md`](../CLAIM_EVIDENCE_INDEX.md)
+
+This chapter is a navigation mirror. Keep the canonical claim/evidence table in the root document.
+
+## Why this chapter exists
+
+Use this chapter to quickly locate:
+
+- active baseline claims,
+- linked validation commands,
+- evidence ownership expectations for documentation and proof-surface status statements.

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Documentation Sync and Coverage Matrix](25-documentation-sync-and-coverage-matrix.md)
 - [Documentation Deduplication Map](27-documentation-deduplication-map.md)
 - [WS-C7 Model Structure and Maintainability (Completed)](30-ws-c7-model-structure-and-maintainability.md)
+- [Claim vs Evidence Index](31-claim-vs-evidence-index.md)
 
 ## Transition and long-horizon path
 

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -120,6 +120,10 @@
         {
           "title": "WS-C7 Model Structure and Maintainability (Completed)",
           "path": "30-ws-c7-model-structure-and-maintainability.md"
+        },
+        {
+          "title": "Claim vs Evidence Index",
+          "path": "31-claim-vs-evidence-index.md"
         }
       ]
     },

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -40,11 +40,11 @@ claims, and planning artifacts.
 
 ## 2. Current State Snapshot
 
-- **Current package version:** `0.10.7` (`lakefile.toml`)
+- **Current package version:** `0.11.0` (`lakefile.toml`)
 - **Active findings baseline:** [`docs/audits/AUDIT_v0.9.32.md`](../audits/AUDIT_v0.9.32.md)
 - **Active execution baseline:** [`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md)
-- **Current active portfolio:** WS-C1..WS-C8 (WS-C1..WS-C7 completed; WS-C8 in progress)
-- **Current active slice:** comprehensive-audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 completed; WS-C8 in progress).
+- **Current active portfolio:** WS-C1..WS-C8 (all workstreams completed)
+- **Current active slice:** comprehensive-audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 + WS-C8 completed).
 
 ---
 
@@ -75,8 +75,7 @@ on the semantic and proof foundations of the previous one.
 
 ### 3.3 Active Audit Portfolio
 
-- **WS-C portfolio** (v0.9.32 workstream plan): WS-C1 through WS-C5 completed;
-  WS-C8 in progress (WS-C7 completed).
+- **WS-C portfolio** (v0.9.32 workstream plan): WS-C1 through WS-C8 completed.
 
 ---
 
@@ -98,7 +97,7 @@ on the semantic and proof foundations of the previous one.
 
 - **WS-C6:** CI and supply-chain hardening (medium; completed)
 - **WS-C7:** Model structure and maintainability (medium; completed)
-- **WS-C8:** Documentation and GitBook consolidation (high; **in progress**)
+- **WS-C8:** Documentation and GitBook consolidation (high; **completed**)
 
 Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 [`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md).
@@ -107,7 +106,7 @@ Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 
 ## 5. Execution Phases
 
-- **Phase P0:** WS-C8 baseline reset + active-plan publication (in progress)
+- **Phase P0:** WS-C8 baseline reset + active-plan publication (completed)
 - **Phase P1:** WS-C4 fixture-repair completion with WS-C3 already closed
   (WS-C1 + WS-C2 + WS-C3 + WS-C4 completed)
 - **Phase P2:** WS-C5 assurance expansion (completed)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.10.7"
+version = "0.11.0"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -75,7 +75,7 @@ run_check "INVARIANT" rg -n '^ELAN_INSTALLER_SHA256=' scripts/setup_lean_env.sh
 run_check "INVARIANT" rg -n '^compute_sha256\(\)' scripts/setup_lean_env.sh
 # shellcheck disable=SC2016
 # shellcheck disable=SC2016
-run_check "DOC" rg -n '(^- Active planning baseline: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md` \(WS-B11 completed\)\.$)|(^- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` \(WS-C portfolio; WS-C1..WS-C7 completed, WS-C8 actively progressing\)\.$)' docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+run_check "DOC" rg -n '(^- Active planning baseline: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md` \(WS-B11 completed\)\.$)|(^- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` \(WS-C portfolio; WS-C1..WS-C8 completed\)\.$)' docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
 run_check "DOC" rg -n '(^# Documentation Deduplication Map \(WS-B8\)$)|(^# Documentation Deduplication Map \(WS-C8\)$)' docs/DOCS_DEDUPLICATION_MAP.md
 run_check "DOC" rg -n '^# Documentation Deduplication Map' docs/gitbook/27-documentation-deduplication-map.md
 run_check "INVARIANT" rg -n '^#!/usr/bin/env python3' scripts/generate_doc_navigation.py


### PR DESCRIPTION
### Motivation
- Finish an end-to-end post-WS-C8 audit pass to remove residual documentation drift and ensure canonical docs, GitBook mirrors, and test anchors are consistent. 
- Make claims auditable by adding a canonical claim→evidence mapping and ensure the tracked-proof wording reflects post-closeout status. 
- Bump the project minor version to reflect the post-merge refinement and synchronize version markers across metadata and docs.

### Description
- Marked WS-C as completed across canonical sources and GitBook mirrors and corrected inconsistent status wording in `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/gitbook/*` and the workstream plan. 
- Added `docs/CLAIM_EVIDENCE_INDEX.md` and a GitBook pointer chapter `docs/gitbook/31-claim-vs-evidence-index.md`, and updated `docs/DOCS_DEDUPLICATION_MAP.md`, `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, and `docs/gitbook/navigation_manifest.json` to include the new claim/evidence index. 
- Bumped the package version to `0.11.0` in `lakefile.toml` and synchronized version markers in `README.md`, `docs/spec/SELE4N_SPEC.md`, and prepended a `CHANGELOG.md` entry describing the post-merge refinement. 
- Adjusted surface-level checks and mirrors used by automation (updated `scripts/test_tier3_invariant_surface.sh` expectations and regenerated GitBook navigation output) and refined the tracked-proof intro in `docs/audits/AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md` to indicate obligations are carried forward after WS-C completion.

### Testing
- Ran `./scripts/test_docs_sync.sh` and it passed (navigation regenerated, markdown link checks passed, doc-gen probe noted as not available in this environment). 
- Ran `./scripts/test_smoke.sh` and it passed (Tier 0 hygiene + Tier 1 build + Tier 2 trace/negative suites). 
- Ran `./scripts/test_full.sh` and it passed (Tier 0–3 inclusive, invariant/doc-anchor surface checks succeeded). 
- Ran `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` and Tier 4 staged candidates executed and passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967a2506c4832bb44aa8aab6d5bc3d)