### PR TITLE
Sync DEVELOPMENT.md and GitBook overview to reflect WS-D1 completion

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,12 +6,12 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current active slice**:
 
-- active: **Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 + WS-C8 completed)**,
-- completed predecessor: **M7 remediation (WS-A1..WS-A8)**,
-- completed predecessor before that: **M6 architecture-boundary hardening**.
+- active: **v0.11.0 WS-D execution (WS-D1 completed; WS-D2..WS-D6 planned)**,
+- completed predecessor: **WS-C portfolio (WS-C1..WS-C8 completed)**,
+- completed predecessor before that: **M7 remediation (WS-A1..WS-A8)**.
 
 Canonical planning source:
-[`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md).
+[`docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md).
 
 ---
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -37,7 +37,7 @@ Completed audit portfolios:
 
 Current active portfolio:
 
-- **WS-D portfolio** (v0.11.0 workstream plan): WS-D1..WS-D6 planned.
+- **WS-D portfolio** (v0.11.0 workstream plan): WS-D1 completed; WS-D2..WS-D6 planned.
 
 ## 4. Architecture mental model
 
@@ -50,11 +50,11 @@ The codebase is organized as layered contracts:
 - **Executable evidence** (`Main.lean`): scenario traces used by fixture checks.
 - **Validation scripts** (`scripts/test_*.sh`): tiered CI contract from hygiene to nightly lanes.
 
-## 5. Current-slice outcomes (WS-C portfolio)
+## 5. Current-slice outcomes (WS-D portfolio)
 
 The active slice is successful when contributors deliver all of the following:
 
-1. closure of comprehensive-audit recommendations via WS-C workstreams,
+1. closure of v0.11.0 audit findings via WS-D workstreams,
 2. deterministic CI + trace reproducibility preserved through every workstream increment,
 3. theorem/invariant surfaces remain discoverable and preservation-focused,
 4. synchronized updates across README/spec/development guide/GitBook + audit planning artifacts.


### PR DESCRIPTION
The introductory active-slice reference in DEVELOPMENT.md still pointed to the historical WS-C portfolio (v0.9.32). Updated to reference the current v0.11.0 WS-D execution with WS-D1 completed status.

The GitBook project overview listed all WS-D workstreams as "planned" and referenced WS-C as the current slice. Updated to show WS-D1 as completed and WS-D as the active portfolio.

https://claude.ai/code/session_01MJn6zivdrDjdbixm8Vxmiv

## Summary

- Workstream(s) advanced:
- Recommendation IDs closed:
- Scope notes:

## Validation evidence

- [ ] `./scripts/test_smoke.sh`
- [ ] `./scripts/test_full.sh`
- [ ] `./scripts/test_nightly.sh` (or justify omission)
- [ ] Targeted `rg -n` checks for new docs/anchors

## Documentation synchronization checklist (required)

- [ ] Canonical source docs updated first (`docs/*`, `docs/audits/*`)
- [ ] GitBook mirrors synchronized in the same PR (`docs/gitbook/*`)
- [ ] Generated navigation files refreshed (`scripts/generate_doc_navigation.py`)
- [ ] Markdown-link automation passed (`scripts/test_docs_sync.sh`)
- [ ] Active slice/workstream status synchronized across `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`
- [ ] Any deferrals explicitly linked to owning workstream

## Risks / follow-ups

- Residual risks:
- Deferred items + owning workstream:
