### PR TITLE
WS-D3: Close F-06 (badge-override safety) and F-08 (VSpace preservation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Quick index. Full contracts and dependencies are in the v0.11.0 planning backbon
 
 - **WS-D1:** Test error handling and validity -- **completed** (Critical/High; F-01, F-03, F-04)
 - **WS-D2:** Information-flow enforcement and proof -- **completed** (High; F-02, F-05)
-- **WS-D3:** Proof gap closure -- planned (Medium; F-06, F-08, F-16)
+- **WS-D3:** Proof gap closure -- **completed** (Medium; F-06, F-08, F-16)
 - **WS-D4:** Kernel design hardening -- planned (Medium; F-07, F-11, F-12)
 - **WS-D5:** Test infrastructure expansion -- planned (Medium; F-09, F-10)
 - **WS-D6:** CI/CD and documentation polish -- planned (Low; F-13, F-14, F-15, F-17)

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -1,3 +1,17 @@
+/-!
+# Architecture Boundary Invariant Proofs
+
+This module contains architecture-boundary invariant definitions and theorems for
+the adapter/architecture boundary subsystem, including hardware-boundary contracts
+and global invariant composition.
+
+## Proof classification (WS-D3 / F-16)
+
+Theorems in this module compose the subsystem-level invariants into global
+architecture-boundary bundles. Preservation is inherited from the subsystem modules
+(IPC, Capability, Lifecycle, Service, Scheduler, VSpace). See individual subsystem
+invariant modules for per-theorem classification.
+-/
 import SeLe4n.Kernel.Architecture.Adapter
 import SeLe4n.Kernel.Service.Invariant
 

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -1,3 +1,6 @@
+import SeLe4n.Kernel.Architecture.Adapter
+import SeLe4n.Kernel.Service.Invariant
+
 /-!
 # Architecture Boundary Invariant Proofs
 
@@ -12,8 +15,6 @@ architecture-boundary bundles. Preservation is inherited from the subsystem modu
 (IPC, Capability, Lifecycle, Service, Scheduler, VSpace). See individual subsystem
 invariant modules for per-theorem classification.
 -/
-import SeLe4n.Kernel.Architecture.Adapter
-import SeLe4n.Kernel.Service.Invariant
 
 namespace SeLe4n.Kernel.Architecture
 

--- a/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
@@ -177,7 +177,7 @@ theorem vspaceMapPage_success_preserves_vspaceInvariantBundle
           -- Extract the old root from resolveAsidRoot
           have hOldObj : st.objects rootId = some (.vspaceRoot root) := by
             unfold resolveAsidRoot at hResolve
-            have := List.findSome?_eq_some.mp hResolve
+            have := List.exists_of_findSome?_eq_some hResolve
             rcases this with ⟨_, _, hBody⟩
             split at hBody <;> simp_all
             split at hBody <;> simp_all
@@ -215,7 +215,7 @@ theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
             simpa [hResolve, hUnmap] using hStep
           have hOldObj : st.objects rootId = some (.vspaceRoot root) := by
             unfold resolveAsidRoot at hResolve
-            have := List.findSome?_eq_some.mp hResolve
+            have := List.exists_of_findSome?_eq_some hResolve
             rcases this with ⟨_, _, hBody⟩
             split at hBody <;> simp_all
             split at hBody <;> simp_all
@@ -243,37 +243,36 @@ private theorem resolveAsidRoot_after_storeObject
     (hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st')) :
     resolveAsidRoot st' root.asid = some (rootId, root') := by
   unfold resolveAsidRoot at hResolve ⊢
-  have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
-    storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
   unfold storeObject at hStore
   cases hStore
-  -- st'.objectIndex is either st.objectIndex or rootId :: st.objectIndex
-  simp only
-  -- We need to show findSome? returns (rootId, root') on the new objectIndex
-  have hOrigFound := List.findSome?_eq_some.mp hResolve
-  rcases hOrigFound with ⟨oid, hOidMem, hBody⟩
-  -- The original resolveAsidRoot found rootId in the original objectIndex
+  -- Extract list decomposition from original resolve
+  obtain ⟨l₁, oid, l₂, hDecomp, hFoid, hNoneBefore⟩ :=
+    List.findSome?_eq_some_iff.mp hResolve
+  -- oid = rootId (since f oid returned some (rootId, root))
   have hOidIsRoot : oid = rootId := by
-    split at hBody <;> simp_all
-    split at hBody <;> simp_all
+    split at hFoid <;> simp_all
+    split at hFoid <;> simp_all
     rename_i r _ _ hObj _ hAsidCheck
-    have hRootInOld : st.objects oid = some (.vspaceRoot r) := hObj
-    -- From the resolve, r.asid = root.asid and the found root is `root`
     have : (oid, r) = (rootId, root) := by
-      simp at hBody; exact hBody
+      simp at hFoid; exact hFoid
     exact this.1
   subst hOidIsRoot
-  -- Now show findSome? on new index finds rootId with root'
-  apply List.findSome?_eq_some.mpr
+  -- Reconstruct findSome? for the new state using the full decomposition
+  rw [List.findSome?_eq_some_iff]
   by_cases hMem : rootId ∈ st.objectIndex
-  · -- objectIndex unchanged
+  · -- objectIndex unchanged (= l₁ ++ rootId :: l₂)
     simp [hMem]
-    refine ⟨rootId, hOidMem, ?_⟩
-    simp [hObjEq, hAsid]
+    refine ⟨l₁, rootId, l₂, hDecomp, ?_, ?_⟩
+    · simp [hAsid]
+    · intro x hx
+      have hNe : x ≠ rootId := by intro heq; subst heq; simp_all
+      simp [hNe]
+      exact hNoneBefore x hx
   · -- objectIndex = rootId :: st.objectIndex
     simp [hMem]
-    refine ⟨rootId, List.mem_cons_self _ _, ?_⟩
-    simp [hObjEq, hAsid]
+    refine ⟨[], rootId, st.objectIndex, rfl, ?_, ?_⟩
+    · simp [hAsid]
+    · intro x hx; exact absurd hx (List.not_mem_nil x)
 
 /-- Mapping a page and then looking it up yields the mapped physical address.
 

--- a/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
@@ -1,3 +1,30 @@
+/-!
+# VSpace Invariant Preservation Proofs
+
+This module contains invariant definitions and preservation theorems for the VSpace
+(virtual address space) subsystem.
+
+## Proof classification (WS-D3 / F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `vspaceMapPage_success_preserves_vspaceInvariantBundle`
+- `vspaceUnmapPage_success_preserves_vspaceInvariantBundle`
+
+**Round-trip / functional-correctness theorems** (high assurance — prove semantic
+contracts between VSpace operations):
+- `vspaceLookup_after_map`
+- `vspaceLookup_map_other`
+- `vspaceLookup_after_unmap`
+
+**Error-case preservation theorems** (trivially true — the error path returns
+unchanged state, so any pre-state invariant holds trivially in the post-state):
+- `vspaceMapPage_error_asidNotBound_preserves_vspaceInvariantBundle`
+- `vspaceUnmapPage_error_translationFault_preserves_vspaceInvariantBundle`
+
+Error-case theorems are retained for proof-surface completeness and compositional
+coverage, but they do not constitute meaningful security evidence.
+-/
 import SeLe4n.Kernel.Architecture.VSpace
 
 namespace SeLe4n.Kernel.Architecture
@@ -29,6 +56,10 @@ def boundedAddressTranslation (st : SystemState) (bound : Nat) : Prop :=
 def vspaceInvariantBundle (st : SystemState) : Prop :=
   vspaceAsidRootsUnique st ∧ vspaceRootNonOverlap st
 
+-- ============================================================================
+-- Error-case preservation (trivial — see F-16 classification above)
+-- ============================================================================
+
 theorem vspaceMapPage_error_asidNotBound_preserves_vspaceInvariantBundle
     (st : SystemState)
     (asid : SeLe4n.ASID)
@@ -47,5 +78,286 @@ theorem vspaceUnmapPage_error_translationFault_preserves_vspaceInvariantBundle
     vspaceInvariantBundle st → vspaceInvariantBundle st := by
   intro hInv
   exact hInv
+
+-- ============================================================================
+-- F-08 / TPI-D05: VSpace success-path invariant preservation
+-- ============================================================================
+
+/-- Helper: `storeObject` at `rootId` with a VSpace root preserves ASID uniqueness
+when the new root has the same ASID as the original. -/
+private theorem storeObject_vspaceRoot_preserves_asidRootsUnique
+    (st st' : SystemState)
+    (rootId : SeLe4n.ObjId)
+    (oldRoot newRoot : VSpaceRoot)
+    (hAsid : newRoot.asid = oldRoot.asid)
+    (hOldObj : st.objects rootId = some (.vspaceRoot oldRoot))
+    (hStore : storeObject rootId (.vspaceRoot newRoot) st = .ok ((), st'))
+    (hUnique : vspaceAsidRootsUnique st) :
+    vspaceAsidRootsUnique st' := by
+  intro oid₁ oid₂ r₁ r₂ hObj₁ hObj₂ hAsidEq
+  by_cases h₁ : oid₁ = rootId <;> by_cases h₂ : oid₂ = rootId
+  · rw [h₁, h₂]
+  · subst h₁
+    have hR₁ : r₁ = newRoot := by
+      have := storeObject_objects_eq st st' rootId (.vspaceRoot newRoot) hStore
+      rw [this] at hObj₁; cases hObj₁; rfl
+    have hR₂Orig : st.objects oid₂ = some (.vspaceRoot r₂) := by
+      rw [storeObject_objects_ne st st' rootId oid₂ (.vspaceRoot newRoot) h₂ hStore] at hObj₂
+      exact hObj₂
+    subst hR₁
+    rw [hAsid] at hAsidEq
+    exact hUnique rootId oid₂ oldRoot r₂ hOldObj hR₂Orig hAsidEq
+  · subst h₂
+    have hR₂ : r₂ = newRoot := by
+      have := storeObject_objects_eq st st' rootId (.vspaceRoot newRoot) hStore
+      rw [this] at hObj₂; cases hObj₂; rfl
+    have hR₁Orig : st.objects oid₁ = some (.vspaceRoot r₁) := by
+      rw [storeObject_objects_ne st st' rootId oid₁ (.vspaceRoot newRoot) h₁ hStore] at hObj₁
+      exact hObj₁
+    subst hR₂
+    rw [hAsid] at hAsidEq
+    exact hUnique oid₁ rootId r₁ oldRoot hR₁Orig hOldObj hAsidEq
+  · have hR₁Orig : st.objects oid₁ = some (.vspaceRoot r₁) := by
+      rw [storeObject_objects_ne st st' rootId oid₁ (.vspaceRoot newRoot) h₁ hStore] at hObj₁
+      exact hObj₁
+    have hR₂Orig : st.objects oid₂ = some (.vspaceRoot r₂) := by
+      rw [storeObject_objects_ne st st' rootId oid₂ (.vspaceRoot newRoot) h₂ hStore] at hObj₂
+      exact hObj₂
+    exact hUnique oid₁ oid₂ r₁ r₂ hR₁Orig hR₂Orig hAsidEq
+
+/-- Helper: `storeObject` at `rootId` with a VSpace root preserves non-overlap when
+the new root satisfies `noVirtualOverlap`. -/
+private theorem storeObject_vspaceRoot_preserves_rootNonOverlap
+    (st st' : SystemState)
+    (rootId : SeLe4n.ObjId)
+    (newRoot : VSpaceRoot)
+    (hNewOverlap : VSpaceRoot.noVirtualOverlap newRoot)
+    (hStore : storeObject rootId (.vspaceRoot newRoot) st = .ok ((), st'))
+    (hNonOverlap : vspaceRootNonOverlap st) :
+    vspaceRootNonOverlap st' := by
+  intro oid root hObj
+  by_cases hEq : oid = rootId
+  · subst hEq
+    have hR : root = newRoot := by
+      have := storeObject_objects_eq st st' rootId (.vspaceRoot newRoot) hStore
+      rw [this] at hObj; cases hObj; rfl
+    subst hR
+    exact hNewOverlap
+  · have hOrig : st.objects oid = some (.vspaceRoot root) := by
+      rw [storeObject_objects_ne st st' rootId oid (.vspaceRoot newRoot) hEq hStore] at hObj
+      exact hObj
+    exact hNonOverlap oid root hOrig
+
+/-- A successful `vspaceMapPage` preserves the VSpace invariant bundle.
+
+The proof decomposes the operation into `resolveAsidRoot` + `VSpaceRoot.mapPage` +
+`storeObject`, then shows:
+1. ASID uniqueness: the new root has the same ASID as the old root (by `mapPage_preserves_asid`).
+2. Non-overlap: `mapPage` only succeeds when no existing mapping exists at `vaddr`,
+   so adding the new entry preserves `noVirtualOverlap` (by `mapPage_preserves_noVirtualOverlap`). -/
+theorem vspaceMapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceInvariantBundle st' := by
+  rcases hInv with ⟨hUnique, hNonOverlap⟩
+  unfold vspaceMapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hMap : root.mapPage vaddr paddr with
+      | none => simp [hResolve, hMap] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hMap] using hStep
+          -- Extract the old root from resolveAsidRoot
+          have hOldObj : st.objects rootId = some (.vspaceRoot root) := by
+            unfold resolveAsidRoot at hResolve
+            have := List.findSome?_eq_some.mp hResolve
+            rcases this with ⟨_, _, hBody⟩
+            split at hBody <;> simp_all
+            split at hBody <;> simp_all
+          have hAsid := VSpaceRoot.mapPage_preserves_asid root root' vaddr paddr hMap
+          have hNewOverlap := VSpaceRoot.mapPage_preserves_noVirtualOverlap
+            root root' vaddr paddr (hNonOverlap rootId root hOldObj) hMap
+          refine ⟨?_, ?_⟩
+          · exact storeObject_vspaceRoot_preserves_asidRootsUnique
+              st st' rootId root root' hAsid hOldObj hStore hUnique
+          · exact storeObject_vspaceRoot_preserves_rootNonOverlap
+              st st' rootId root' hNewOverlap hStore hNonOverlap
+
+/-- A successful `vspaceUnmapPage` preserves the VSpace invariant bundle.
+
+The proof follows the same decomposition as the map case. Filtering the mapping list
+preserves both ASID uniqueness and non-overlap (removing entries cannot create new
+virtual-address conflicts). -/
+theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID)
+    (vaddr : SeLe4n.VAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceInvariantBundle st' := by
+  rcases hInv with ⟨hUnique, hNonOverlap⟩
+  unfold vspaceUnmapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hUnmap : root.unmapPage vaddr with
+      | none => simp [hResolve, hUnmap] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hUnmap] using hStep
+          have hOldObj : st.objects rootId = some (.vspaceRoot root) := by
+            unfold resolveAsidRoot at hResolve
+            have := List.findSome?_eq_some.mp hResolve
+            rcases this with ⟨_, _, hBody⟩
+            split at hBody <;> simp_all
+            split at hBody <;> simp_all
+          have hAsid := VSpaceRoot.unmapPage_preserves_asid root root' vaddr hUnmap
+          have hNewOverlap := VSpaceRoot.unmapPage_preserves_noVirtualOverlap
+            root root' vaddr (hNonOverlap rootId root hOldObj) hUnmap
+          refine ⟨?_, ?_⟩
+          · exact storeObject_vspaceRoot_preserves_asidRootsUnique
+              st st' rootId root root' hAsid hOldObj hStore hUnique
+          · exact storeObject_vspaceRoot_preserves_rootNonOverlap
+              st st' rootId root' hNewOverlap hStore hNonOverlap
+
+-- ============================================================================
+-- TPI-001 / TPI-D05: VSpace round-trip theorems
+-- ============================================================================
+
+/-- Helper: `resolveAsidRoot` after `storeObject` at the same rootId resolves to
+the new root object. -/
+private theorem resolveAsidRoot_after_storeObject
+    (st st' : SystemState)
+    (rootId : SeLe4n.ObjId)
+    (root root' : VSpaceRoot)
+    (hAsid : root'.asid = root.asid)
+    (hResolve : resolveAsidRoot st root.asid = some (rootId, root))
+    (hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st')) :
+    resolveAsidRoot st' root.asid = some (rootId, root') := by
+  unfold resolveAsidRoot at hResolve ⊢
+  have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
+    storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
+  unfold storeObject at hStore
+  cases hStore
+  -- st'.objectIndex is either st.objectIndex or rootId :: st.objectIndex
+  simp only
+  -- We need to show findSome? returns (rootId, root') on the new objectIndex
+  have hOrigFound := List.findSome?_eq_some.mp hResolve
+  rcases hOrigFound with ⟨oid, hOidMem, hBody⟩
+  -- The original resolveAsidRoot found rootId in the original objectIndex
+  have hOidIsRoot : oid = rootId := by
+    split at hBody <;> simp_all
+    split at hBody <;> simp_all
+    rename_i r _ _ hObj _ hAsidCheck
+    have hRootInOld : st.objects oid = some (.vspaceRoot r) := hObj
+    -- From the resolve, r.asid = root.asid and the found root is `root`
+    have : (oid, r) = (rootId, root) := by
+      simp at hBody; exact hBody
+    exact this.1
+  subst hOidIsRoot
+  -- Now show findSome? on new index finds rootId with root'
+  apply List.findSome?_eq_some.mpr
+  by_cases hMem : rootId ∈ st.objectIndex
+  · -- objectIndex unchanged
+    simp [hMem]
+    refine ⟨rootId, hOidMem, ?_⟩
+    simp [hObjEq, hAsid]
+  · -- objectIndex = rootId :: st.objectIndex
+    simp [hMem]
+    refine ⟨rootId, List.mem_cons_self _ _, ?_⟩
+    simp [hObjEq, hAsid]
+
+/-- Mapping a page and then looking it up yields the mapped physical address.
+
+This is the first TPI-001 round-trip obligation carried forward from WS-C. -/
+theorem vspaceLookup_after_map
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .ok (paddr, st') := by
+  unfold vspaceMapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hMap : root.mapPage vaddr paddr with
+      | none => simp [hResolve, hMap] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hMap] using hStep
+          have hAsid := VSpaceRoot.mapPage_preserves_asid root root' vaddr paddr hMap
+          have hLookupRoot := VSpaceRoot.lookup_mapPage_eq root root' vaddr paddr hMap
+          have hResolve' := resolveAsidRoot_after_storeObject
+            st st' rootId root root' hAsid hResolve hStore
+          unfold vspaceLookup
+          rw [hResolve']
+          simp [hLookupRoot]
+
+/-- Mapping at `vaddr` does not affect lookup of a different virtual address `vaddr'`.
+
+This is the second TPI-001 round-trip obligation carried forward from WS-C. -/
+theorem vspaceLookup_map_other
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID)
+    (vaddr vaddr' : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hNe : vaddr ≠ vaddr')
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr' st' = vspaceLookup asid vaddr' st := by
+  unfold vspaceMapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hMap : root.mapPage vaddr paddr with
+      | none => simp [hResolve, hMap] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hMap] using hStep
+          have hAsid := VSpaceRoot.mapPage_preserves_asid root root' vaddr paddr hMap
+          have hLookupOther := VSpaceRoot.lookup_mapPage_other
+            root root' vaddr vaddr' paddr hNe hMap
+          have hResolve' := resolveAsidRoot_after_storeObject
+            st st' rootId root root' hAsid hResolve hStore
+          unfold vspaceLookup
+          rw [hResolve, hResolve']
+          simp [hLookupOther]
+
+/-- After unmapping a page, looking up the same virtual address fails with `translationFault`.
+
+This is the third TPI-001 round-trip obligation carried forward from WS-C. -/
+theorem vspaceLookup_after_unmap
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID)
+    (vaddr : SeLe4n.VAddr)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .error .translationFault := by
+  unfold vspaceUnmapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hUnmap : root.unmapPage vaddr with
+      | none => simp [hResolve, hUnmap] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hUnmap] using hStep
+          have hAsid := VSpaceRoot.unmapPage_preserves_asid root root' vaddr hUnmap
+          have hLookupNone := VSpaceRoot.lookup_unmapPage_eq_none root root' vaddr hUnmap
+          have hResolve' := resolveAsidRoot_after_storeObject
+            st st' rootId root root' hAsid hResolve hStore
+          unfold vspaceLookup
+          rw [hResolve']
+          simp [hLookupNone]
 
 end SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
@@ -1,3 +1,5 @@
+import SeLe4n.Kernel.Architecture.VSpace
+
 /-!
 # VSpace Invariant Preservation Proofs
 
@@ -25,7 +27,6 @@ unchanged state, so any pre-state invariant holds trivially in the post-state):
 Error-case theorems are retained for proof-surface completeness and compositional
 coverage, but they do not constitute meaningful security evidence.
 -/
-import SeLe4n.Kernel.Architecture.VSpace
 
 namespace SeLe4n.Kernel.Architecture
 
@@ -99,24 +100,24 @@ private theorem storeObject_vspaceRoot_preserves_asidRootsUnique
   · rw [h₁, h₂]
   · subst h₁
     have hR₁ : r₁ = newRoot := by
-      have := storeObject_objects_eq st st' rootId (.vspaceRoot newRoot) hStore
+      have := storeObject_objects_eq st st' oid₁ (.vspaceRoot newRoot) hStore
       rw [this] at hObj₁; cases hObj₁; rfl
     have hR₂Orig : st.objects oid₂ = some (.vspaceRoot r₂) := by
-      rw [storeObject_objects_ne st st' rootId oid₂ (.vspaceRoot newRoot) h₂ hStore] at hObj₂
+      rw [storeObject_objects_ne st st' oid₁ oid₂ (.vspaceRoot newRoot) h₂ hStore] at hObj₂
       exact hObj₂
     subst hR₁
     rw [hAsid] at hAsidEq
-    exact hUnique rootId oid₂ oldRoot r₂ hOldObj hR₂Orig hAsidEq
+    exact hUnique oid₁ oid₂ oldRoot r₂ hOldObj hR₂Orig hAsidEq
   · subst h₂
     have hR₂ : r₂ = newRoot := by
-      have := storeObject_objects_eq st st' rootId (.vspaceRoot newRoot) hStore
+      have := storeObject_objects_eq st st' oid₂ (.vspaceRoot newRoot) hStore
       rw [this] at hObj₂; cases hObj₂; rfl
     have hR₁Orig : st.objects oid₁ = some (.vspaceRoot r₁) := by
-      rw [storeObject_objects_ne st st' rootId oid₁ (.vspaceRoot newRoot) h₁ hStore] at hObj₁
+      rw [storeObject_objects_ne st st' oid₂ oid₁ (.vspaceRoot newRoot) h₁ hStore] at hObj₁
       exact hObj₁
     subst hR₂
     rw [hAsid] at hAsidEq
-    exact hUnique oid₁ rootId r₁ oldRoot hR₁Orig hOldObj hAsidEq
+    exact hUnique oid₁ oid₂ r₁ oldRoot hR₁Orig hOldObj hAsidEq
   · have hR₁Orig : st.objects oid₁ = some (.vspaceRoot r₁) := by
       rw [storeObject_objects_ne st st' rootId oid₁ (.vspaceRoot newRoot) h₁ hStore] at hObj₁
       exact hObj₁
@@ -139,7 +140,7 @@ private theorem storeObject_vspaceRoot_preserves_rootNonOverlap
   by_cases hEq : oid = rootId
   · subst hEq
     have hR : root = newRoot := by
-      have := storeObject_objects_eq st st' rootId (.vspaceRoot newRoot) hStore
+      have := storeObject_objects_eq st st' oid (.vspaceRoot newRoot) hStore
       rw [this] at hObj; cases hObj; rfl
     subst hR
     exact hNewOverlap
@@ -180,7 +181,6 @@ theorem vspaceMapPage_success_preserves_vspaceInvariantBundle
             have := List.exists_of_findSome?_eq_some hResolve
             rcases this with ⟨_, _, hBody⟩
             split at hBody <;> simp_all
-            split at hBody <;> simp_all
           have hAsid := VSpaceRoot.mapPage_preserves_asid root root' vaddr paddr hMap
           have hNewOverlap := VSpaceRoot.mapPage_preserves_noVirtualOverlap
             root root' vaddr paddr (hNonOverlap rootId root hOldObj) hMap
@@ -218,7 +218,6 @@ theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
             have := List.exists_of_findSome?_eq_some hResolve
             rcases this with ⟨_, _, hBody⟩
             split at hBody <;> simp_all
-            split at hBody <;> simp_all
           have hAsid := VSpaceRoot.unmapPage_preserves_asid root root' vaddr hUnmap
           have hNewOverlap := VSpaceRoot.unmapPage_preserves_noVirtualOverlap
             root root' vaddr (hNonOverlap rootId root hOldObj) hUnmap
@@ -236,43 +235,39 @@ theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
 the new root object. -/
 private theorem resolveAsidRoot_after_storeObject
     (st st' : SystemState)
+    (asid : SeLe4n.ASID)
     (rootId : SeLe4n.ObjId)
     (root root' : VSpaceRoot)
     (hAsid : root'.asid = root.asid)
-    (hResolve : resolveAsidRoot st root.asid = some (rootId, root))
+    (hResolve : resolveAsidRoot st asid = some (rootId, root))
     (hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st')) :
-    resolveAsidRoot st' root.asid = some (rootId, root') := by
+    resolveAsidRoot st' asid = some (rootId, root') := by
+  have hRootAsid : root.asid = asid := by
+    unfold resolveAsidRoot at hResolve
+    have ⟨_, _, hBody⟩ := List.exists_of_findSome?_eq_some hResolve
+    split at hBody <;> simp_all
+    obtain ⟨h1, -, rfl⟩ := hBody
+    exact h1
   unfold resolveAsidRoot at hResolve ⊢
   unfold storeObject at hStore
   cases hStore
-  -- Extract list decomposition from original resolve
   obtain ⟨l₁, oid, l₂, hDecomp, hFoid, hNoneBefore⟩ :=
     List.findSome?_eq_some_iff.mp hResolve
-  -- oid = rootId (since f oid returned some (rootId, root))
   have hOidIsRoot : oid = rootId := by
     split at hFoid <;> simp_all
-    split at hFoid <;> simp_all
-    rename_i r _ _ hObj _ hAsidCheck
-    have : (oid, r) = (rootId, root) := by
-      simp at hFoid; exact hFoid
-    exact this.1
   subst hOidIsRoot
-  -- Reconstruct findSome? for the new state using the full decomposition
+  have hMemIndex : oid ∈ st.objectIndex := by
+    rw [hDecomp]; exact List.mem_append_right l₁ List.mem_cons_self
+  simp [hMemIndex]
   rw [List.findSome?_eq_some_iff]
-  by_cases hMem : rootId ∈ st.objectIndex
-  · -- objectIndex unchanged (= l₁ ++ rootId :: l₂)
-    simp [hMem]
-    refine ⟨l₁, rootId, l₂, hDecomp, ?_, ?_⟩
-    · simp [hAsid]
-    · intro x hx
-      have hNe : x ≠ rootId := by intro heq; subst heq; simp_all
-      simp [hNe]
-      exact hNoneBefore x hx
-  · -- objectIndex = rootId :: st.objectIndex
-    simp [hMem]
-    refine ⟨[], rootId, st.objectIndex, rfl, ?_, ?_⟩
-    · simp [hAsid]
-    · intro x hx; exact absurd hx (List.not_mem_nil x)
+  refine ⟨l₁, oid, l₂, hDecomp, ?_, ?_⟩
+  · simp [hAsid, hRootAsid]
+  · intro x hx
+    have hNe : x ≠ oid := by
+      intro heq; subst heq
+      rw [hNoneBefore x hx] at hFoid; simp at hFoid
+    simp [hNe]
+    exact hNoneBefore x hx
 
 /-- Mapping a page and then looking it up yields the mapped physical address.
 
@@ -297,7 +292,7 @@ theorem vspaceLookup_after_map
           have hAsid := VSpaceRoot.mapPage_preserves_asid root root' vaddr paddr hMap
           have hLookupRoot := VSpaceRoot.lookup_mapPage_eq root root' vaddr paddr hMap
           have hResolve' := resolveAsidRoot_after_storeObject
-            st st' rootId root root' hAsid hResolve hStore
+            st st' asid rootId root root' hAsid hResolve hStore
           unfold vspaceLookup
           rw [hResolve']
           simp [hLookupRoot]
@@ -312,7 +307,8 @@ theorem vspaceLookup_map_other
     (paddr : SeLe4n.PAddr)
     (hNe : vaddr ≠ vaddr')
     (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
-    vspaceLookup asid vaddr' st' = vspaceLookup asid vaddr' st := by
+    (vspaceLookup asid vaddr' st').map Prod.fst =
+    (vspaceLookup asid vaddr' st).map Prod.fst := by
   unfold vspaceMapPage at hStep
   cases hResolve : resolveAsidRoot st asid with
   | none => simp [hResolve] at hStep
@@ -327,10 +323,11 @@ theorem vspaceLookup_map_other
           have hLookupOther := VSpaceRoot.lookup_mapPage_other
             root root' vaddr vaddr' paddr hNe hMap
           have hResolve' := resolveAsidRoot_after_storeObject
-            st st' rootId root root' hAsid hResolve hStore
+            st st' asid rootId root root' hAsid hResolve hStore
           unfold vspaceLookup
           rw [hResolve, hResolve']
           simp [hLookupOther]
+          cases root.lookup vaddr' <;> simp [Except.map]
 
 /-- After unmapping a page, looking up the same virtual address fails with `translationFault`.
 
@@ -354,7 +351,7 @@ theorem vspaceLookup_after_unmap
           have hAsid := VSpaceRoot.unmapPage_preserves_asid root root' vaddr hUnmap
           have hLookupNone := VSpaceRoot.lookup_unmapPage_eq_none root root' vaddr hUnmap
           have hResolve' := resolveAsidRoot_after_storeObject
-            st st' rootId root root' hAsid hResolve hStore
+            st st' asid rootId root root' hAsid hResolve hStore
           unfold vspaceLookup
           rw [hResolve']
           simp [hLookupNone]

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1,3 +1,42 @@
+/-!
+# Capability Invariant Preservation Proofs
+
+This module contains invariant definitions and preservation theorems for the
+capability (CSpace) subsystem.
+
+## Proof classification (WS-D3 / F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `cspaceMint_preserves_capabilityInvariantBundle`
+- `cspaceInsertSlot_preserves_capabilityInvariantBundle`
+- `cspaceDeleteSlot_preserves_capabilityInvariantBundle`
+- `cspaceRevoke_preserves_capabilityInvariantBundle`
+- `lifecycleRetypeObject_preserves_capabilityInvariantBundle`
+- `lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle`
+- all `endpointSend/AwaitReceive/Receive_preserves_capabilityInvariantBundle`
+- composed bundle preservation theorems (`m3IpcSeed`, `m35`, `m4a`)
+
+**Badge-override safety theorems** (high assurance — F-06 / TPI-D04):
+- `mintDerivedCap_rights_attenuated_with_badge_override`
+- `mintDerivedCap_target_preserved_with_badge_override`
+- `cspaceMint_badge_override_safe`
+
+**Structural / functional-correctness theorems** (high assurance):
+- `mintDerivedCap_attenuates`
+- `cspaceMint_child_attenuates`
+- `cspaceDeleteSlot_authority_reduction`
+- `cspaceRevoke_local_target_reduction`
+- `cspaceRevoke_preserves_source`
+
+**Error-case preservation theorems** (trivially true — the error path returns
+unchanged state, so any pre-state invariant holds trivially in the post-state):
+- `lifecycleRevokeDeleteRetype_error_preserves_m4aLifecycleInvariantBundle`
+- `cspaceLookupSlot_preserves_capabilityInvariantBundle` (read-only, no mutation)
+
+Error-case theorems are retained for proof-surface completeness and compositional
+coverage, but they do not constitute meaningful security evidence.
+-/
 import SeLe4n.Kernel.IPC.Invariant
 import SeLe4n.Kernel.Lifecycle.Invariant
 
@@ -327,6 +366,62 @@ theorem mintDerivedCap_attenuates
     · rfl
     · exact rightsSubset_sound rights parent.rights hSubset
   · simp [mintDerivedCap, hSubset] at hMint
+
+-- ============================================================================
+-- F-06 / TPI-D04: Badge-override safety in cspaceMint
+-- ============================================================================
+
+/-- Badge override does not affect rights attenuation: a minted capability's rights
+are always a subset of the parent's rights, regardless of what badge is supplied.
+
+This is a direct consequence of `mintDerivedCap` checking `rightsSubset` before
+constructing the child capability and setting `child.target = parent.target`
+unconditionally. -/
+theorem mintDerivedCap_rights_attenuated_with_badge_override
+    (parent child : Capability)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    ∀ right, right ∈ child.rights → right ∈ parent.rights := by
+  have hAtt := mintDerivedCap_attenuates parent child rights badge hMint
+  exact hAtt.2
+
+/-- Badge override preserves target identity: a minted capability always names the
+same target as the parent, regardless of the badge supplied. Badge override cannot
+enable a capability holder to access objects outside the authority granted by the
+parent capability.
+
+This is the core F-06 safety property: badge is metadata that affects notification
+signaling semantics, not capability authority scope. -/
+theorem mintDerivedCap_target_preserved_with_badge_override
+    (parent child : Capability)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    child.target = parent.target := by
+  have hAtt := mintDerivedCap_attenuates parent child rights badge hMint
+  exact hAtt.1
+
+/-- Composed badge-override safety for `cspaceMint`: after a successful mint with
+arbitrary badge override, the derived capability in the destination slot has the
+same target as the parent and attenuated rights.
+
+This theorem witnesses the full F-06 obligation at the kernel-operation level:
+badge override in `cspaceMint` cannot escalate privilege. -/
+theorem cspaceMint_badge_override_safe
+    (st st' : SystemState)
+    (src dst : CSpaceAddr)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
+    ∃ parent child,
+      cspaceLookupSlot src st = .ok (parent, st) ∧
+      cspaceLookupSlot dst st' = .ok (child, st') ∧
+      child.target = parent.target ∧
+      (∀ right, right ∈ child.rights → right ∈ parent.rights) := by
+  rcases cspaceMint_child_attenuates st st' src dst rights badge hStep with
+    ⟨parent, child, hSrc, hDst, hAtt⟩
+  exact ⟨parent, child, hSrc, hDst, hAtt.1, hAtt.2⟩
 
 theorem cspaceMint_child_attenuates
     (st st' : SystemState)

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1,3 +1,6 @@
+import SeLe4n.Kernel.IPC.Invariant
+import SeLe4n.Kernel.Lifecycle.Invariant
+
 /-!
 # Capability Invariant Preservation Proofs
 
@@ -37,8 +40,6 @@ unchanged state, so any pre-state invariant holds trivially in the post-state):
 Error-case theorems are retained for proof-surface completeness and compositional
 coverage, but they do not constitute meaningful security evidence.
 -/
-import SeLe4n.Kernel.IPC.Invariant
-import SeLe4n.Kernel.Lifecycle.Invariant
 
 namespace SeLe4n.Kernel
 

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -402,27 +402,6 @@ theorem mintDerivedCap_target_preserved_with_badge_override
   have hAtt := mintDerivedCap_attenuates parent child rights badge hMint
   exact hAtt.1
 
-/-- Composed badge-override safety for `cspaceMint`: after a successful mint with
-arbitrary badge override, the derived capability in the destination slot has the
-same target as the parent and attenuated rights.
-
-This theorem witnesses the full F-06 obligation at the kernel-operation level:
-badge override in `cspaceMint` cannot escalate privilege. -/
-theorem cspaceMint_badge_override_safe
-    (st st' : SystemState)
-    (src dst : CSpaceAddr)
-    (rights : List AccessRight)
-    (badge : Option SeLe4n.Badge)
-    (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
-    ∃ parent child,
-      cspaceLookupSlot src st = .ok (parent, st) ∧
-      cspaceLookupSlot dst st' = .ok (child, st') ∧
-      child.target = parent.target ∧
-      (∀ right, right ∈ child.rights → right ∈ parent.rights) := by
-  rcases cspaceMint_child_attenuates st st' src dst rights badge hStep with
-    ⟨parent, child, hSrc, hDst, hAtt⟩
-  exact ⟨parent, child, hSrc, hDst, hAtt.1, hAtt.2⟩
-
 theorem cspaceMint_child_attenuates
     (st st' : SystemState)
     (src dst : CSpaceAddr)
@@ -450,6 +429,27 @@ theorem cspaceMint_child_attenuates
           refine ⟨parent, child, ?_, ?_, hAtt⟩
           · rfl
           · exact cspaceInsertSlot_lookup_eq st st' dst child hInsert
+
+/-- Composed badge-override safety for `cspaceMint`: after a successful mint with
+arbitrary badge override, the derived capability in the destination slot has the
+same target as the parent and attenuated rights.
+
+This theorem witnesses the full F-06 obligation at the kernel-operation level:
+badge override in `cspaceMint` cannot escalate privilege. -/
+theorem cspaceMint_badge_override_safe
+    (st st' : SystemState)
+    (src dst : CSpaceAddr)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
+    ∃ parent child,
+      cspaceLookupSlot src st = .ok (parent, st) ∧
+      cspaceLookupSlot dst st' = .ok (child, st') ∧
+      child.target = parent.target ∧
+      (∀ right, right ∈ child.rights → right ∈ parent.rights) := by
+  rcases cspaceMint_child_attenuates st st' src dst rights badge hStep with
+    ⟨parent, child, hSrc, hDst, hAtt⟩
+  exact ⟨parent, child, hSrc, hDst, hAtt.1, hAtt.2⟩
 
 theorem cspaceSlotUnique_holds (st : SystemState) :
     cspaceSlotUnique st := by

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -1,3 +1,35 @@
+/-!
+# IPC Invariant Preservation Proofs
+
+This module contains invariant definitions and preservation theorems for the IPC
+(inter-process communication) subsystem, including endpoint and notification
+well-formedness, and IPC-scheduler coherence contracts.
+
+## Proof classification (WS-D3 / F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `endpointSend_preserves_ipcInvariant`
+- `endpointAwaitReceive_preserves_ipcInvariant`
+- `endpointReceive_preserves_ipcInvariant`
+- `endpointSend_preserves_ipcSchedulerContractPredicates` (and per-component)
+- `endpointAwaitReceive_preserves_ipcSchedulerContractPredicates` (and per-component)
+- `endpointReceive_preserves_ipcSchedulerContractPredicates` (and per-component)
+- `endpointSend_preserves_schedulerInvariantBundle`
+- `endpointAwaitReceive_preserves_schedulerInvariantBundle`
+- `endpointReceive_preserves_schedulerInvariantBundle`
+
+**Structural / functional-correctness theorems** (high assurance):
+- `endpointSend_result_wellFormed`
+- `endpointAwaitReceive_result_wellFormed`
+- `endpointReceive_result_wellFormed`
+- `endpointObjectValid_of_queueWellFormed`
+- all `*_ok_implies_endpoint_object` lemmas
+
+All theorems in this module are substantive: they prove invariant preservation over
+state that is actually modified by successful endpoint operations. There are no
+error-case preservation theorems in this module.
+-/
 import SeLe4n.Kernel.Scheduler.Invariant
 import SeLe4n.Kernel.IPC.Operations
 

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -1,3 +1,6 @@
+import SeLe4n.Kernel.Scheduler.Invariant
+import SeLe4n.Kernel.IPC.Operations
+
 /-!
 # IPC Invariant Preservation Proofs
 
@@ -30,8 +33,6 @@ All theorems in this module are substantive: they prove invariant preservation o
 state that is actually modified by successful endpoint operations. There are no
 error-case preservation theorems in this module.
 -/
-import SeLe4n.Kernel.Scheduler.Invariant
-import SeLe4n.Kernel.IPC.Operations
 
 namespace SeLe4n.Kernel
 

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -1,3 +1,26 @@
+/-!
+# Information-Flow Non-Interference Proofs
+
+This module contains non-interference theorems proving that high-domain kernel
+operations do not leak information to low-clearance observers.
+
+## Proof classification (WS-D3 / F-16)
+
+**Non-interference theorems** (critical for security assurance — prove that a
+high-domain operation preserves low-equivalence for unrelated observers):
+- `endpointSend_preserves_lowEquivalent`
+- `chooseThread_preserves_lowEquivalent` (WS-D2 / TPI-D01)
+- `cspaceMint_preserves_lowEquivalent` (WS-D2 / TPI-D02)
+- `cspaceRevoke_preserves_lowEquivalent` (WS-D2 / TPI-D02)
+- `lifecycleRetypeObject_preserves_lowEquivalent` (WS-D2 / TPI-D03)
+
+**Shared proof infrastructure** (high assurance):
+- `storeObject_at_unobservable_preserves_lowEquivalent` — generic proof skeleton
+  for any `storeObject`-based operation at a non-observable ID.
+
+All theorems in this module are substantive non-interference proofs. There are no
+error-case preservation theorems.
+-/
 import SeLe4n.Kernel.InformationFlow.Projection
 import SeLe4n.Kernel.IPC.Invariant
 import SeLe4n.Kernel.Capability.Invariant

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -1,3 +1,9 @@
+import SeLe4n.Kernel.InformationFlow.Projection
+import SeLe4n.Kernel.IPC.Invariant
+import SeLe4n.Kernel.Capability.Invariant
+import SeLe4n.Kernel.Scheduler.Operations
+import SeLe4n.Kernel.Lifecycle.Operations
+
 /-!
 # Information-Flow Non-Interference Proofs
 
@@ -21,11 +27,6 @@ high-domain operation preserves low-equivalence for unrelated observers):
 All theorems in this module are substantive non-interference proofs. There are no
 error-case preservation theorems.
 -/
-import SeLe4n.Kernel.InformationFlow.Projection
-import SeLe4n.Kernel.IPC.Invariant
-import SeLe4n.Kernel.Capability.Invariant
-import SeLe4n.Kernel.Scheduler.Operations
-import SeLe4n.Kernel.Lifecycle.Operations
 
 namespace SeLe4n.Kernel
 

--- a/SeLe4n/Kernel/Lifecycle/Invariant.lean
+++ b/SeLe4n/Kernel/Lifecycle/Invariant.lean
@@ -1,3 +1,33 @@
+/-!
+# Lifecycle Invariant Preservation Proofs
+
+This module contains invariant definitions and preservation theorems for the
+lifecycle (object retype) subsystem, including identity/aliasing, capability-reference,
+and stale-reference exclusion invariants.
+
+## Proof classification (WS-D3 / F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `lifecycleRetypeObject_preserves_lifecycleInvariantBundle`
+- `lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant`
+- `lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant`
+
+**Structural / bridge theorems** (high assurance — prove decomposition and composition
+relationships between invariant layers):
+- `lifecycleIdentityNoTypeAliasConflict_of_exact`
+- `lifecycleCapabilityRefObjectTargetBacked_of_exact`
+- `lifecycleInvariantBundle_of_metadata_consistent`
+- `lifecycleMetadataConsistent_of_lifecycleInvariantBundle`
+- `lifecycleCapabilityRefObjectTargetTypeAligned_of_exact`
+- `lifecycleCapabilityRefNoTypeAliasConflict_of_identity`
+- `lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle`
+- `lifecycleIdentityStaleReferenceInvariant_of_lifecycleInvariantBundle`
+
+All theorems in this module are substantive: they prove structural decomposition
+properties or invariant preservation over state modified by successful retype
+operations. There are no error-case preservation theorems in this module.
+-/
 import SeLe4n.Kernel.Lifecycle.Operations
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Lifecycle/Invariant.lean
+++ b/SeLe4n/Kernel/Lifecycle/Invariant.lean
@@ -1,3 +1,5 @@
+import SeLe4n.Kernel.Lifecycle.Operations
+
 /-!
 # Lifecycle Invariant Preservation Proofs
 
@@ -28,7 +30,6 @@ All theorems in this module are substantive: they prove structural decomposition
 properties or invariant preservation over state modified by successful retype
 operations. There are no error-case preservation theorems in this module.
 -/
-import SeLe4n.Kernel.Lifecycle.Operations
 
 namespace SeLe4n.Kernel
 

--- a/SeLe4n/Kernel/Scheduler/Invariant.lean
+++ b/SeLe4n/Kernel/Scheduler/Invariant.lean
@@ -1,3 +1,5 @@
+import SeLe4n.Model.State
+
 /-!
 # Scheduler Invariant Definitions
 
@@ -15,7 +17,6 @@ Scheduler *preservation* theorems (e.g. `chooseThread_preserves_*`,
 invariant modules where they compose with cross-subsystem bundles. This module
 provides only the invariant definitions and basic structural lemmas.
 -/
-import SeLe4n.Model.State
 
 namespace SeLe4n.Kernel
 

--- a/SeLe4n/Kernel/Scheduler/Invariant.lean
+++ b/SeLe4n/Kernel/Scheduler/Invariant.lean
@@ -1,3 +1,20 @@
+/-!
+# Scheduler Invariant Definitions
+
+This module contains invariant definitions for the scheduler subsystem: queue
+uniqueness, current-thread validity, and queue/current consistency.
+
+## Proof classification (WS-D3 / F-16)
+
+**Structural theorems** (high assurance):
+- `schedulerWellFormed_iff_queueCurrentConsistent`
+- `queueCurrentConsistent_when_no_current`
+
+Scheduler *preservation* theorems (e.g. `chooseThread_preserves_*`,
+`schedule_preserves_*`, `handleYield_preserves_*`) live in the IPC and Capability
+invariant modules where they compose with cross-subsystem bundles. This module
+provides only the invariant definitions and basic structural lemmas.
+-/
 import SeLe4n.Model.State
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -1,3 +1,7 @@
+import SeLe4n.Kernel.Service.Operations
+import SeLe4n.Kernel.Capability.Invariant
+import SeLe4n.Kernel.Lifecycle.Invariant
+
 /-!
 # Service Invariant Preservation Proofs
 
@@ -37,9 +41,6 @@ unchanged state):
 Error-case theorems are retained for proof-surface completeness and compositional
 coverage, but they do not constitute meaningful security evidence.
 -/
-import SeLe4n.Kernel.Service.Operations
-import SeLe4n.Kernel.Capability.Invariant
-import SeLe4n.Kernel.Lifecycle.Invariant
 
 namespace SeLe4n.Kernel
 

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -1,3 +1,42 @@
+/-!
+# Service Invariant Preservation Proofs
+
+This module contains policy-surface definitions and preservation theorems for the
+service orchestration subsystem, including cross-subsystem composition with lifecycle
+and capability invariants.
+
+## Proof classification (WS-D3 / F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceRestart_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `storeServiceState_preserves_servicePolicySurfaceInvariant`
+- `storeServiceState_preserves_lifecycleInvariantBundle`
+- `storeServiceState_preserves_capabilityInvariantBundle`
+
+**Structural / bridge theorems** (high assurance):
+- `servicePolicySurfaceInvariant_of_lifecycleInvariant`
+- `policyBackingObjectTyped_of_lifecycleInvariant`
+- `policyOwnerAuthoritySlotPresent_of_lifecycleInvariant`
+- `policyOwnerAuthoritySlotPresent_of_capabilityLookup`
+- `serviceLifecycleCapabilityInvariantBundle_of_components`
+
+**Check-vs-mutation separation theorems** (high assurance):
+- `serviceStart_policyDenied_separates_check_from_mutation`
+- `serviceStop_policyDenied_separates_check_from_mutation`
+
+**Error-case preservation theorems** (trivially true — the error path returns
+unchanged state):
+- `serviceStart_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceStop_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+
+Error-case theorems are retained for proof-surface completeness and compositional
+coverage, but they do not constitute meaningful security evidence.
+-/
 import SeLe4n.Kernel.Service.Operations
 import SeLe4n.Kernel.Capability.Invariant
 import SeLe4n.Kernel.Lifecycle.Invariant

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -218,21 +218,17 @@ theorem mapPage_preserves_noVirtualOverlap
       intro v p₁ p₂ hIn₁ hIn₂
       simp at hIn₁ hIn₂
       rcases hIn₁ with ⟨rfl, rfl⟩ | hIn₁
-      · rcases hIn₂ with ⟨rfl, rfl⟩ | hIn₂
+      · rcases hIn₂ with ⟨_, rfl⟩ | hIn₂
         · rfl
         · -- v = vaddr, p₂ from old list: contradicts lookup = none
           unfold lookup at hLookup
-          have hFound := List.find?_isSome.mpr ⟨(vaddr, p₂), hIn₂, by simp⟩
           simp at hLookup
-          rw [hLookup] at hFound
-          simp at hFound
+          exact absurd rfl (hLookup v p₂ hIn₂)
       · rcases hIn₂ with ⟨rfl, rfl⟩ | hIn₂
         · -- v = vaddr, p₁ from old list: contradicts lookup = none
           unfold lookup at hLookup
-          have hFound := List.find?_isSome.mpr ⟨(vaddr, p₁), hIn₁, by simp⟩
           simp at hLookup
-          rw [hLookup] at hFound
-          simp at hFound
+          exact absurd rfl (hLookup v p₁ hIn₁)
         · exact hOverlap v p₁ p₂ hIn₁ hIn₂
 
 /-- Unmapping a page preserves the no-virtual-overlap invariant.
@@ -253,7 +249,7 @@ theorem unmapPage_preserves_noVirtualOverlap
       cases hUnmap
       intro v p₁ p₂ hIn₁ hIn₂
       simp at hIn₁ hIn₂
-      exact hOverlap v p₁ p₂ hIn₁.2 hIn₂.2
+      exact hOverlap v p₁ p₂ hIn₁.1 hIn₂.1
 
 /-- Mapping at `vaddr` does not affect lookup of a different virtual address `vaddr'`. -/
 theorem lookup_mapPage_other

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -171,6 +171,107 @@ theorem lookup_mapPage_eq
       unfold lookup
       simp
 
+/-- `mapPage` preserves the ASID identity of the VSpace root. -/
+theorem mapPage_preserves_asid
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hMap : root.mapPage vaddr paddr = some root') :
+    root'.asid = root.asid := by
+  unfold mapPage at hMap
+  cases hLookup : lookup root vaddr with
+  | some _ => simp [hLookup] at hMap
+  | none => simp [hLookup] at hMap; cases hMap; rfl
+
+/-- `unmapPage` preserves the ASID identity of the VSpace root. -/
+theorem unmapPage_preserves_asid
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (hUnmap : root.unmapPage vaddr = some root') :
+    root'.asid = root.asid := by
+  unfold unmapPage at hUnmap
+  cases hLookup : lookup root vaddr with
+  | none => simp [hLookup] at hUnmap
+  | some _ => simp [hLookup] at hUnmap; cases hUnmap; rfl
+
+/-- Mapping a fresh page preserves the no-virtual-overlap invariant.
+
+When `mapPage` succeeds, `lookup root vaddr = none` meaning no existing mapping at
+`vaddr`. The new mappings list is `(vaddr, paddr) :: root.mappings`. For any virtual
+address `v`, if two physical addresses are in the new list, they must agree because:
+- if `v = vaddr`, the only mapping at `v` is the new `(vaddr, paddr)` entry (the old
+  list had no mapping at `vaddr`),
+- if `v ≠ vaddr`, both mappings come from the original list where `noVirtualOverlap` held. -/
+theorem mapPage_preserves_noVirtualOverlap
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hOverlap : noVirtualOverlap root)
+    (hMap : root.mapPage vaddr paddr = some root') :
+    noVirtualOverlap root' := by
+  unfold mapPage at hMap
+  cases hLookup : lookup root vaddr with
+  | some _ => simp [hLookup] at hMap
+  | none =>
+      simp [hLookup] at hMap
+      cases hMap
+      intro v p₁ p₂ hIn₁ hIn₂
+      simp at hIn₁ hIn₂
+      rcases hIn₁ with ⟨rfl, rfl⟩ | hIn₁
+      · rcases hIn₂ with ⟨rfl, rfl⟩ | hIn₂
+        · rfl
+        · -- v = vaddr, p₂ from old list: contradicts lookup = none
+          unfold lookup at hLookup
+          have hFound := List.find?_isSome.mpr ⟨(vaddr, p₂), hIn₂, by simp⟩
+          simp at hLookup
+          rw [hLookup] at hFound
+          simp at hFound
+      · rcases hIn₂ with ⟨rfl, rfl⟩ | hIn₂
+        · -- v = vaddr, p₁ from old list: contradicts lookup = none
+          unfold lookup at hLookup
+          have hFound := List.find?_isSome.mpr ⟨(vaddr, p₁), hIn₁, by simp⟩
+          simp at hLookup
+          rw [hLookup] at hFound
+          simp at hFound
+        · exact hOverlap v p₁ p₂ hIn₁ hIn₂
+
+/-- Unmapping a page preserves the no-virtual-overlap invariant.
+
+Filtering removes entries; any two remaining entries with the same virtual address
+were also both present in the original list where `noVirtualOverlap` held. -/
+theorem unmapPage_preserves_noVirtualOverlap
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (hOverlap : noVirtualOverlap root)
+    (hUnmap : root.unmapPage vaddr = some root') :
+    noVirtualOverlap root' := by
+  unfold unmapPage at hUnmap
+  cases hLookup : lookup root vaddr with
+  | none => simp [hLookup] at hUnmap
+  | some _ =>
+      simp [hLookup] at hUnmap
+      cases hUnmap
+      intro v p₁ p₂ hIn₁ hIn₂
+      simp at hIn₁ hIn₂
+      exact hOverlap v p₁ p₂ hIn₁.2 hIn₂.2
+
+/-- Mapping at `vaddr` does not affect lookup of a different virtual address `vaddr'`. -/
+theorem lookup_mapPage_other
+    (root root' : VSpaceRoot)
+    (vaddr vaddr' : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hNe : vaddr ≠ vaddr')
+    (hMap : root.mapPage vaddr paddr = some root') :
+    root'.lookup vaddr' = root.lookup vaddr' := by
+  unfold mapPage at hMap
+  cases hLookup : lookup root vaddr with
+  | some _ => simp [hLookup] at hMap
+  | none =>
+      simp [hLookup] at hMap
+      cases hMap
+      unfold lookup
+      simp [hNe]
+
 end VSpaceRoot
 
 namespace CNode

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -7,7 +7,7 @@ This index makes current semantic/proof/documentation claims auditable by linkin
 | Claim | Canonical source | Evidence command(s) | Evidence artifact(s) |
 |---|---|---|---|
 | Active findings baseline is `AUDIT_v0.11.0.md`. | `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` | `./scripts/test_tier3_invariant_surface.sh` | Tier-3 doc-anchor checks over README/spec/planning references. |
-| WS-D portfolio status (WS-D1, WS-D2 completed; WS-D3..WS-D6 planned). | `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
+| WS-D portfolio status (WS-D1, WS-D2, WS-D3 completed; WS-D4..WS-D6 planned). | `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
 | WS-C portfolio status is complete (WS-C1..WS-C8). | `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Historical; evidence preserved in prior tier runs. |
 | Root docs and GitBook mirrors stay synchronized via canonical-first rules. | `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, `docs/DOCS_DEDUPLICATION_MAP.md` | `./scripts/test_docs_sync.sh` | Regenerated navigation + markdown link validation + doc-gen probe when available. |
 | IPC/scheduler/capability/info-flow invariants remain in active proof surface. | Kernel modules and invariant suites listed in `scripts/test_tier3_invariant_surface.sh` | `./scripts/test_tier3_invariant_surface.sh` | Direct symbol + theorem + doc anchor checks. |
@@ -31,8 +31,8 @@ The following categories of theorems exist in the proof surface. Claims about pr
 | TPI-D01 | Scheduler non-interference preservation | WS-D2 | CLOSED |
 | TPI-D02 | Capability operations non-interference preservation | WS-D2 | CLOSED |
 | TPI-D03 | Lifecycle operations non-interference preservation | WS-D2 | CLOSED |
-| TPI-D04 | Badge-override safety in cspaceMint | WS-D3 | OPEN |
-| TPI-D05 | VSpace successful-operation preservation + round-trip theorems | WS-D3 | OPEN |
+| TPI-D04 | Badge-override safety in cspaceMint | WS-D3 | CLOSED |
+| TPI-D05 | VSpace successful-operation preservation + round-trip theorems | WS-D3 | CLOSED |
 | TPI-D06 | Waiting-list uniqueness invariant | WS-D4 | OPEN |
 | TPI-D07 | Service dependency acyclicity invariant | WS-D4 | OPEN |
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,8 +33,8 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 ### 3.1 Workstreams and intent
 
 - **WS-D1** — Test error handling and validity (**completed** — F-01, F-03, F-04)
-- **WS-D2** — Information-flow enforcement and proof (**planned** — F-02, F-05)
-- **WS-D3** — Proof gap closure (**planned** — F-06, F-08, F-16)
+- **WS-D2** — Information-flow enforcement and proof (**completed** — F-02, F-05)
+- **WS-D3** — Proof gap closure (**completed** — F-06, F-08, F-16)
 - **WS-D4** — Kernel design hardening (**planned** — F-07, F-11, F-12)
 - **WS-D5** — Test infrastructure expansion (**planned** — F-09, F-10)
 - **WS-D6** — CI/CD and documentation polish (**planned** — F-13, F-14, F-15, F-17)
@@ -47,8 +47,8 @@ Use the planning phases from the workstream backbone:
 
 - **Phase P0:** Baseline transition — publish v0.11.0 planning backbone, demote WS-C to historical (completed)
 - **Phase P1:** WS-D1 test validity restoration (critical/high) — **completed**
-- **Phase P2:** WS-D2 information-flow enforcement and proof expansion (high) — current
-- **Phase P3:** WS-D3 proof gap closure + WS-D4 kernel design hardening (medium)
+- **Phase P2:** WS-D2 information-flow enforcement and proof expansion (high) — **completed**
+- **Phase P3:** WS-D3 proof gap closure + WS-D4 kernel design hardening (medium) — WS-D3 **completed**, WS-D4 next
 - **Phase P4:** WS-D5 test infrastructure expansion + WS-D6 CI/documentation polish (medium/low)
 
 ### 3.3 Prior completed portfolio (WS-C, historical)

--- a/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
+++ b/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
@@ -79,98 +79,89 @@ theorem lifecycleRetypeObject_preserves_lowEquivalent
 
 ---
 
-## Issue TPI-D04 (OPEN) — Badge-override safety in cspaceMint
+## Issue TPI-D04 (CLOSED) — Badge-override safety in cspaceMint
 
 - **Audit mapping:** `AUDIT_v0.11.0.md` F-06 (Medium), recommendation 9.2 #5.
 - **Workstream:** WS-D3.
-- **Current problem:** `cspaceMint` allows badge override from parent. No proof that this cannot enable privilege escalation.
+- **Resolution:** Implemented three badge-override safety theorems in `SeLe4n/Kernel/Capability/Invariant.lean`. The proofs delegate to the existing `mintDerivedCap_attenuates` theorem, which shows that `mintDerivedCap` unconditionally sets `child.target = parent.target` and checks `rightsSubset` before constructing the child capability. Badge is metadata affecting notification semantics, not capability authority scope. No `sorry` debt.
 
-Required theorem obligations:
+Closed theorem obligations:
 
 ```lean
-/-- A minted capability's rights are a subset of the parent's rights,
-    regardless of badge override. -/
-theorem cspaceMint_attenuates_rights
-    (authority target : ObjId) (srcSlot destSlot : Slot)
-    (newRights : CapRights) (newBadge : Badge)
-    (st st' : SystemState)
-    (hMint : cspaceMint authority target srcSlot destSlot newRights newBadge st = .ok ((), st'))
-    (parentCap : Capability)
-    (hSrc : lookupSlot target srcSlot st = some parentCap) :
-    newRights.isSubsetOf parentCap.rights = true := by
-  sorry  -- proof obligation
+/-- Badge override does not affect rights attenuation. -/
+theorem mintDerivedCap_rights_attenuated_with_badge_override
+    (parent child : Capability) (rights : List AccessRight)
+    (badge : Option Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    ∀ right, right ∈ child.rights → right ∈ parent.rights
 
-/-- Badge override in mint does not grant access to objects
-    outside the parent capability's authority scope. -/
-theorem cspaceMint_badge_no_escalation
-    (authority target : ObjId) (srcSlot destSlot : Slot)
-    (newRights : CapRights) (newBadge : Badge)
-    (st st' : SystemState)
-    (hMint : cspaceMint authority target srcSlot destSlot newRights newBadge st = .ok ((), st'))
-    (derivedCap : Capability)
-    (hDest : lookupSlot target destSlot st' = some derivedCap) :
-    derivedCap.targetId = (lookupSlot target srcSlot st).get!.targetId := by
-  sorry  -- proof obligation
+/-- Badge override preserves target identity. -/
+theorem mintDerivedCap_target_preserved_with_badge_override
+    (parent child : Capability) (rights : List AccessRight)
+    (badge : Option Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    child.target = parent.target
+
+/-- Composed badge-override safety at the kernel-operation level. -/
+theorem cspaceMint_badge_override_safe
+    (st st' : SystemState) (src dst : CSpaceAddr)
+    (rights : List AccessRight) (badge : Option Badge)
+    (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
+    ∃ parent child,
+      cspaceLookupSlot src st = .ok (parent, st) ∧
+      cspaceLookupSlot dst st' = .ok (child, st') ∧
+      child.target = parent.target ∧
+      (∀ right, right ∈ child.rights → right ∈ parent.rights)
 ```
 
 ---
 
-## Issue TPI-D05 (OPEN) — VSpace successful-operation invariant preservation
+## Issue TPI-D05 (CLOSED) — VSpace successful-operation invariant preservation
 
 - **Audit mapping:** `AUDIT_v0.11.0.md` F-08 (Medium), recommendation 9.2 #6.
 - **Workstream:** WS-D3.
 - **Carries forward:** TPI-001 from `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`.
-- **Current problem:** Only error-case preservation is proven for `vspaceMapPage` and `vspaceUnmapPage`. No theorem proves a *successful* operation preserves the invariant bundle.
+- **Resolution:** Implemented success-path preservation for both `vspaceMapPage` and `vspaceUnmapPage`, plus all three TPI-001 round-trip theorems, in `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`. Supporting VSpaceRoot-level helper lemmas (`mapPage_preserves_asid`, `unmapPage_preserves_asid`, `mapPage_preserves_noVirtualOverlap`, `unmapPage_preserves_noVirtualOverlap`, `lookup_mapPage_other`) were added to `SeLe4n/Model/Object.lean`. No `sorry` debt.
 
-Required theorem obligations:
+Closed theorem obligations (invariant preservation):
 
 ```lean
 /-- A successful vspaceMapPage preserves the VSpace invariant bundle. -/
-theorem vspaceMapPage_success_preserves_invariantBundle
-    (asid : ASID) (vaddr : VAddr) (paddr : PAddr)
-    (st st' : SystemState)
-    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st'))
-    (hInv : vspaceInvariantBundle st) :
-    vspaceInvariantBundle st' := by
-  sorry  -- proof obligation
+theorem vspaceMapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState) (asid : ASID) (vaddr : VAddr) (paddr : PAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceInvariantBundle st'
 
 /-- A successful vspaceUnmapPage preserves the VSpace invariant bundle. -/
-theorem vspaceUnmapPage_success_preserves_invariantBundle
-    (asid : ASID) (vaddr : VAddr)
-    (st st' : SystemState)
-    (hUnmap : vspaceUnmapPage asid vaddr st = .ok ((), st'))
-    (hInv : vspaceInvariantBundle st) :
-    vspaceInvariantBundle st' := by
-  sorry  -- proof obligation
+theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState) (asid : ASID) (vaddr : VAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceInvariantBundle st'
 ```
 
-Additionally, close the TPI-001 round-trip obligations from WS-C:
+Closed theorem obligations (TPI-001 round-trip):
 
 ```lean
 /-- Mapping a page and then looking it up yields the mapped address. -/
 theorem vspaceLookup_after_map
-    (asid : ASID) (vaddr : VAddr) (paddr : PAddr)
-    (st st' : SystemState)
-    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
-    vspaceLookup asid vaddr st' = .ok (paddr, st') := by
-  sorry  -- proof obligation
+    (st st' : SystemState) (asid : ASID) (vaddr : VAddr) (paddr : PAddr)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .ok (paddr, st')
 
 /-- Mapping vaddr does not affect lookup of a different vaddr'. -/
 theorem vspaceLookup_map_other
-    (asid : ASID) (vaddr vaddr' : VAddr) (paddr : PAddr)
-    (st st' : SystemState)
+    (st st' : SystemState) (asid : ASID) (vaddr vaddr' : VAddr) (paddr : PAddr)
     (hNe : vaddr ≠ vaddr')
-    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
-    vspaceLookup asid vaddr' st' = vspaceLookup asid vaddr' st := by
-  sorry  -- proof obligation
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr' st' = vspaceLookup asid vaddr' st
 
 /-- After unmap, lookup fails with translationFault. -/
 theorem vspaceLookup_after_unmap
-    (asid : ASID) (vaddr : VAddr)
-    (st st' : SystemState)
-    (hUnmap : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
-    vspaceLookup asid vaddr st' = .error .translationFault := by
-  sorry  -- proof obligation
+    (st st' : SystemState) (asid : ASID) (vaddr : VAddr)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .error .translationFault
 ```
 
 ---

--- a/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
@@ -245,6 +245,40 @@ Validation gates: `./scripts/test_full.sh --continue` passes Tier 0-3.
 
 **Dependencies:** None (proof work is independent of test fixes).
 
+**Completion evidence**
+
+All acceptance criteria met. Summary of changes:
+
+1. **F-06 (Badge-override safety):** Added three badge-override safety theorems to
+   `SeLe4n/Kernel/Capability/Invariant.lean`:
+   - `mintDerivedCap_rights_attenuated_with_badge_override`: rights attenuation holds
+     regardless of badge supplied.
+   - `mintDerivedCap_target_preserved_with_badge_override`: target identity is always
+     preserved by `mintDerivedCap`, so badge override cannot redirect authority.
+   - `cspaceMint_badge_override_safe`: composed kernel-operation-level theorem witnessing
+     that derived capability has same target and attenuated rights regardless of badge.
+   All proofs delegate to `mintDerivedCap_attenuates` (no `sorry`). TPI-D04 closed.
+
+2. **F-08 (VSpace success preservation + TPI-001 round-trip):** Added five VSpaceRoot-level
+   helper lemmas to `SeLe4n/Model/Object.lean` (`mapPage_preserves_asid`,
+   `unmapPage_preserves_asid`, `mapPage_preserves_noVirtualOverlap`,
+   `unmapPage_preserves_noVirtualOverlap`, `lookup_mapPage_other`). Added two success-path
+   invariant preservation theorems and three round-trip theorems to
+   `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`:
+   - `vspaceMapPage_success_preserves_vspaceInvariantBundle`
+   - `vspaceUnmapPage_success_preserves_vspaceInvariantBundle`
+   - `vspaceLookup_after_map` (TPI-001 obligation 1)
+   - `vspaceLookup_map_other` (TPI-001 obligation 2)
+   - `vspaceLookup_after_unmap` (TPI-001 obligation 3)
+   All proofs are complete without `sorry`. TPI-D05 and TPI-001 closed.
+
+3. **F-16 (Proof scope documentation):** Added `/-! ... -/` module-level docstrings to all
+   8 `Invariant.lean` files classifying every theorem into one of four categories:
+   substantive preservation, non-interference, structural/bridge, or error-case (trivially
+   true). Updated `docs/CLAIM_EVIDENCE_INDEX.md` proof claim qualification table.
+
+Validation gates: `./scripts/test_full.sh` passes Tier 0-3.
+
 ---
 
 ### WS-D4 — Kernel Design Hardening
@@ -406,7 +440,7 @@ Each workstream PR must include:
 |---|---|---|---|---|
 | WS-D1 | **Completed** | Critical/High | F-01, F-03, F-04 | Test error handling and validity restoration. Gate G1 passed: Tier 0-3 clean. |
 | WS-D2 | **Completed** | High | F-02, F-05 | Information-flow enforcement and non-interference proof expansion. Gate G2 passed: enforcement in 3 operations, 4 additional non-interference theorems. |
-| WS-D3 | Planned | Medium | F-06, F-08, F-16 | Proof gap closure (badge safety, VSpace preservation, proof documentation). Carries TPI-001 from WS-C. |
+| WS-D3 | **Completed** | Medium | F-06, F-08, F-16 | Proof gap closure (badge safety, VSpace preservation, proof documentation). TPI-D04, TPI-D05, TPI-001 all closed. |
 | WS-D4 | Planned | Medium | F-07, F-11, F-12 | Kernel design hardening (cycles, atomicity, double-wait). |
 | WS-D5 | Planned | Medium | F-09, F-10 | Test infrastructure expansion (fixtures, ID bounds). |
 | WS-D6 | Planned | Low | F-13, F-14, F-15, F-17 | CI/CD polish and documentation governance. F-13 likely already resolved. |

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -47,6 +47,16 @@ Preservation shape:
 
 - operation-level `*_preserves_capabilityInvariantBundle` for lookup/insert/mint/delete/revoke.
 
+Badge-override safety (WS-D3 / F-06 / TPI-D04):
+
+- `mintDerivedCap_rights_attenuated_with_badge_override`
+- `mintDerivedCap_target_preserved_with_badge_override`
+- `cspaceMint_badge_override_safe`
+
+These theorems prove that badge override in `cspaceMint` cannot escalate privilege:
+the derived capability always has the same target as the parent and attenuated rights,
+regardless of what badge is supplied.
+
 ## 4. IPC invariants (M3)
 
 Component level:
@@ -143,7 +153,26 @@ This keeps the M5 theorem surface aligned with the local-first composition rule:
 prove per-transition preservation first, then expose cross-subsystem bundle preservation with
 explicit failure-path statements.
 
-## 10. IF-M1 information-flow baseline layering (WS-B7 complete)
+## 10. VSpace invariant preservation and round-trip theorems (WS-D3 complete)
+
+VSpace invariant preservation is now proven for both success and error paths:
+
+- `vspaceMapPage_success_preserves_vspaceInvariantBundle`
+- `vspaceUnmapPage_success_preserves_vspaceInvariantBundle`
+- `vspaceMapPage_error_asidNotBound_preserves_vspaceInvariantBundle` (trivial)
+- `vspaceUnmapPage_error_translationFault_preserves_vspaceInvariantBundle` (trivial)
+
+Round-trip functional-correctness theorems (TPI-001 / TPI-D05):
+
+- `vspaceLookup_after_map`: mapping then looking up yields the mapped address.
+- `vspaceLookup_map_other`: mapping does not affect lookup of a different virtual address.
+- `vspaceLookup_after_unmap`: after unmap, lookup fails with `translationFault`.
+
+Supporting VSpaceRoot-level lemmas in `Model/Object.lean`:
+`mapPage_preserves_asid`, `unmapPage_preserves_asid`, `mapPage_preserves_noVirtualOverlap`,
+`unmapPage_preserves_noVirtualOverlap`, `lookup_mapPage_other`.
+
+## 11. IF-M1 information-flow baseline layering (WS-B7 complete)
 
 Information-flow proof-track entrypoints now exist with explicit local decomposition:
 

--- a/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
+++ b/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
@@ -13,7 +13,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 - **Findings baseline:** `AUDIT_v0.11.0.md` (17 findings, F-01..F-17)
 - **Execution baseline:** `AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (WS-D portfolio)
 - **Tracked theorem obligations:** `AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md` (7 proof obligations, TPI-D01..D07)
-- **Current planning stage:** Phase P3 (WS-D1, WS-D2 completed; WS-D3/WS-D4 next)
+- **Current planning stage:** Phase P3 (WS-D1, WS-D2, WS-D3 completed; WS-D4 next)
 
 ## 2) Active workstreams (WS-D portfolio)
 
@@ -31,10 +31,10 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 
 ### Medium — Proof completion and kernel hardening
 
-- **WS-D3:** Proof gap closure (medium; **planned** — F-06, F-08, F-16)
-  - Badge-override safety proof (F-06, TPI-D04).
-  - VSpace successful-operation preservation (F-08, TPI-D05; carries TPI-001 from WS-C).
-  - Document trivial error-preservation proof scope (F-16).
+- **WS-D3:** Proof gap closure (medium; **completed** — F-06, F-08, F-16)
+  - Badge-override safety proof (F-06, TPI-D04). **Done.**
+  - VSpace successful-operation preservation (F-08, TPI-D05; carries TPI-001 from WS-C). **Done.**
+  - Document trivial error-preservation proof scope (F-16). **Done.**
 
 - **WS-D4:** Kernel design hardening (medium; **planned** — F-07, F-11, F-12)
   - Service dependency cycle detection (F-07, TPI-D07).

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -88,7 +88,7 @@ on the semantic and proof foundations of the previous one.
 
 ### 4.2 Medium — Proof Completion and Kernel Hardening
 
-- **WS-D3:** Proof gap closure (medium; **planned** — F-06, F-08, F-16; carries TPI-001 from WS-C)
+- **WS-D3:** Proof gap closure (medium; **completed** — F-06, F-08, F-16; TPI-001/TPI-D04/TPI-D05 closed)
 - **WS-D4:** Kernel design hardening (medium; **planned** — F-07, F-11, F-12)
 - **WS-D5:** Test infrastructure expansion (medium; **planned** — F-09, F-10)
 
@@ -106,7 +106,7 @@ Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 - **Phase P0:** Baseline transition — publish v0.11.0 planning backbone, demote WS-C to historical (completed)
 - **Phase P1:** WS-D1 test validity restoration (critical/high) — **completed**
 - **Phase P2:** WS-D2 information-flow enforcement and proof expansion (high) — **completed**
-- **Phase P3:** WS-D3 proof gap closure + WS-D4 kernel design hardening (medium)
+- **Phase P3:** WS-D3 proof gap closure (**completed**) + WS-D4 kernel design hardening (medium)
 - **Phase P4:** WS-D5 test infrastructure expansion + WS-D6 CI/documentation polish (medium/low)
 
 ---


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-D3 (Proof gap closure)
- **Recommendation IDs closed:** F-06 (TPI-D04), F-08 (TPI-D05), F-16 (proof scope documentation)
- **Scope notes:** Implements three badge-override safety theorems for `cspaceMint`, two success-path VSpace invariant preservation theorems, three TPI-001 round-trip theorems, and supporting VSpaceRoot-level lemmas. Adds module-level proof-classification docstrings to all 8 `Invariant.lean` files per F-16 audit recommendation.

## Changes

### 1. Badge-override safety (F-06 / TPI-D04)

**File:** `SeLe4n/Kernel/Capability/Invariant.lean`

Added three theorems proving that badge override in `cspaceMint` cannot escalate privilege:

- `mintDerivedCap_rights_attenuated_with_badge_override`: Rights attenuation holds regardless of badge supplied (delegates to `mintDerivedCap_attenuates`).
- `mintDerivedCap_target_preserved_with_badge_override`: Target identity is always preserved by `mintDerivedCap`, so badge override cannot redirect authority.
- `cspaceMint_badge_override_safe`: Composed kernel-operation-level theorem witnessing that the derived capability has the same target and attenuated rights regardless of badge.

All proofs are complete without `sorry`. Badge is metadata affecting notification semantics, not capability authority scope.

### 2. VSpace success-path preservation and round-trip theorems (F-08 / TPI-D05 / TPI-001)

**Files:** `SeLe4n/Model/Object.lean`, `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`

#### VSpaceRoot-level helper lemmas (Object.lean)

Added five lemmas supporting the success-path preservation proofs:

- `mapPage_preserves_asid`: `mapPage` preserves the ASID identity of the VSpace root.
- `unmapPage_preserves_asid`: `unmapPage` preserves the ASID identity.
- `mapPage_preserves_noVirtualOverlap`: Mapping a fresh page preserves the no-virtual-overlap invariant (new entry cannot conflict with old list where invariant held).
- `unmapPage_preserves_noVirtualOverlap`: Unmapping preserves no-virtual-overlap (filtering cannot create new conflicts).
- `lookup_mapPage_other`: Mapping at `vaddr` does not affect lookup of a different virtual address.

#### Success-path preservation (VSpaceInvariant.lean)

- `vspaceMapPage_success_preserves_vspaceInvariantBundle`: A successful `vspaceMapPage` preserves the VSpace invariant bundle (ASID uniqueness + non-overlap).
- `vspaceUnmapPage_success_preserves_vspaceInvariantBundle`: A successful `vspaceUnmapPage` preserves the VSpace invariant bundle.

Both proofs decompose the operation into `resolveAsidRoot` + `VSpaceRoot.mapPage/unmapPage` + `storeObject`, then show ASID uniqueness and non-overlap are preserved using the helper lemmas.

#### Round-trip functional-correctness theorems (TPI-001)

- `vspaceLookup_after_map`: Mapping a page and then looking it up yields the mapped physical address.
- `vspaceLookup_map_other`: Mapping at `vaddr` does not affect lookup of a different virtual address `vaddr'`.
- `vspaceLookup_after_unmap`: After unmapping a page, looking up the same virtual address fails with `translationFault`.

All proofs are complete without `sorry`.

### 3. Proof scope documentation (F-16)

Added module-level `/-! ... -/` docstrings to all 8 `Invariant.lean

https://claude.ai/code/session_01EfpwNrEctzXC6AY5ud1WpF