### PR TITLE
WS-D3: Close F-06, F-08, F-16 proof gaps (badge safety, VSpace preservation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.11.3] - 2026-02-21
+
+### WS-D3 proof gap closure (F-06, F-08, F-16)
+- **F-06 (Badge-override safety):** Added three badge-safety theorems to `SeLe4n/Kernel/Capability/Invariant.lean`: `mintDerivedCap_rights_attenuated_with_badge_override` (rights attenuation holds regardless of badge), `mintDerivedCap_target_preserved_with_badge_override` (target identity preserved regardless of badge), and `cspaceMint_badge_override_safe` (composed kernel-operation-level proof that badge override cannot escalate privilege). TPI-D04 closed.
+- **F-08 (VSpace success preservation):** Added `vspaceMapPage_success_preserves_vspaceInvariantBundle` and `vspaceUnmapPage_success_preserves_vspaceInvariantBundle` to `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`. Supporting infrastructure: `resolveAsidRoot_some_implies`, `resolveAsidRoot_of_unique_root`, `storeObject_objectIndex_eq_of_mem`, and `vspaceAsidRootsUnique` moved to `VSpace.lean`; seven VSpaceRoot helper theorems added to `Model/Object.lean` (`mapPage_asid_eq`, `unmapPage_asid_eq`, `lookup_eq_none_not_mem`, `mapPage_noVirtualOverlap`, `unmapPage_noVirtualOverlap`, `lookup_mapPage_ne`, `lookup_unmapPage_ne`). TPI-D05 closed.
+- **TPI-001 (VSpace round-trip theorems):** Four round-trip theorems proved in `VSpaceInvariant.lean`: `vspaceLookup_after_map`, `vspaceLookup_map_other`, `vspaceLookup_after_unmap`, `vspaceLookup_unmap_other`. All proved without `sorry`. TPI-001 obligation from WS-C fully discharged.
+- **F-16 (Proof classification docstrings):** Added module-level `/-! ... -/` docstrings to all seven `Invariant.lean` files (Scheduler, IPC, Capability, Lifecycle, InformationFlow, Service, Architecture) and `VSpaceInvariant.lean`, classifying every theorem as substantive, error-case (trivially true), non-interference, badge-safety, structural/bridge, or round-trip.
+- Updated Tier-3 invariant surface script with 20 new anchor checks for WS-D3 theorem symbols and docstring presence.
+- Updated all canonical planning docs, tracked proof issues, claim-evidence index, development guide, spec, GitBook chapters (12, 32), and documentation sync matrix to reflect WS-D3 completion.
+- Bumped patch version to **`0.11.3`**.
+
 ## [0.11.1] - 2026-02-19
 
 ### WS-D2 information-flow enforcement and proof completion

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.11.1-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.11.3-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.27.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License" /></a>
 </p>
@@ -22,7 +22,7 @@
 
 - **Active findings baseline:** `docs/audits/AUDIT_v0.11.0.md`
 - **Active execution baseline:** `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md`
-- **Current package version:** `0.11.1` (`lakefile.toml`)
+- **Current package version:** `0.11.3` (`lakefile.toml`)
 - **Current active portfolio:** WS-D1..WS-D6 (v0.11.0 audit remediation)
 - **Prior completed portfolio:** WS-C1..WS-C8 (all completed)
 

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -1,6 +1,31 @@
 import SeLe4n.Kernel.Architecture.Adapter
 import SeLe4n.Kernel.Service.Invariant
 
+/-!
+# Architecture Boundary Invariant Proofs (M6)
+
+This module defines the composed `proofLayerInvariantBundle` entrypoint that composes
+all active subsystem invariant bundles, and the `AdapterProofHooks` structure that
+ties architecture-adapter transitions to invariant preservation.
+
+## Proof scope qualification (F-16)
+
+Theorems in this module compose the subsystem-level invariants into global
+architecture-boundary bundles. Preservation is inherited from the subsystem modules
+(IPC, Capability, Lifecycle, Service, Scheduler, VSpace). See individual subsystem
+invariant modules for per-theorem classification.
+
+| Category | Theorems |
+|---|---|
+| **Substantive preservation** | `adapterAdvanceTimer_ok_preserves_proofLayerInvariantBundle`, `adapterWriteRegister_ok_preserves_proofLayerInvariantBundle`, `adapterReadMemory_ok_preserves_proofLayerInvariantBundle` |
+| **Error-case preservation** | `adapterAdvanceTimer_error_invalidContext_preserves_proofLayerInvariantBundle`, `adapterAdvanceTimer_error_unsupportedBinding_preserves_proofLayerInvariantBundle`, `adapterWriteRegister_error_unsupportedBinding_preserves_proofLayerInvariantBundle`, `adapterReadMemory_error_unsupportedBinding_preserves_proofLayerInvariantBundle` |
+
+The error-case preservation theorems are trivially true (the state is unchanged on
+error). The success-path theorems are substantive: they prove that adapter transitions
+satisfying the `RuntimeBoundaryContract` and `AdapterProofHooks` obligations preserve
+the composed invariant bundle over genuinely changed state.
+-/
+
 namespace SeLe4n.Kernel.Architecture
 
 open SeLe4n.Model

--- a/SeLe4n/Kernel/Architecture/VSpace.lean
+++ b/SeLe4n/Kernel/Architecture/VSpace.lean
@@ -56,4 +56,106 @@ def vspaceLookup (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr) : Kernel SeLe4n.PAd
         | none => .error .translationFault
         | some paddr => .ok (paddr, st)
 
+-- ============================================================================
+-- resolveAsidRoot extraction and characterization lemmas (F-08 / TPI-001)
+-- ============================================================================
+
+/-- ASID roots in the bounded discovery window are unique. -/
+def vspaceAsidRootsUnique (st : SystemState) : Prop :=
+  ∀ oid₁ oid₂ root₁ root₂,
+    st.objects oid₁ = some (.vspaceRoot root₁) →
+    st.objects oid₂ = some (.vspaceRoot root₂) →
+    root₁.asid = root₂.asid →
+    oid₁ = oid₂
+
+/-- Extract concrete object-store facts from a successful `resolveAsidRoot` result. -/
+theorem resolveAsidRoot_some_implies
+    (st : SystemState) (asid : SeLe4n.ASID)
+    (rootId : SeLe4n.ObjId) (root : VSpaceRoot)
+    (hResolve : resolveAsidRoot st asid = some (rootId, root)) :
+    st.objects rootId = some (.vspaceRoot root) ∧ root.asid = asid ∧ rootId ∈ st.objectIndex := by
+  unfold resolveAsidRoot at hResolve
+  generalize st.objectIndex = idx at hResolve ⊢
+  induction idx with
+  | nil => simp [List.findSome?_nil] at hResolve
+  | cons a rest ih =>
+      simp only [List.findSome?_cons] at hResolve
+      split at hResolve
+      · next hMatch =>
+        cases hObjA : st.objects a with
+        | none => simp [hObjA] at hMatch
+        | some obj =>
+            cases obj with
+            | vspaceRoot r =>
+                simp only [hObjA] at hMatch
+                split at hMatch
+                · next hAsidEq =>
+                  simp at hMatch
+                  rcases hMatch with ⟨rfl, rfl⟩
+                  simp at hResolve
+                  rcases hResolve with ⟨rfl, rfl⟩
+                  exact ⟨hObjA, hAsidEq, List.mem_cons_self⟩
+                · simp at hMatch
+            | tcb _ | cnode _ | endpoint _ | notification _ =>
+                simp [hObjA] at hMatch
+      · next hNone =>
+        rcases ih hResolve with ⟨hObj, hAsid, hMem⟩
+        exact ⟨hObj, hAsid, List.mem_cons_of_mem a hMem⟩
+
+/-- Characterization lemma: given ASID-uniqueness, object-store membership, and objectIndex
+    membership, `resolveAsidRoot` returns exactly the expected root.
+
+    This is the key lemma enabling round-trip theorems for VSpace operations. -/
+theorem resolveAsidRoot_of_unique_root
+    (st : SystemState) (asid : SeLe4n.ASID)
+    (rootId : SeLe4n.ObjId) (root : VSpaceRoot)
+    (hObj : st.objects rootId = some (.vspaceRoot root))
+    (hAsid : root.asid = asid)
+    (hMem : rootId ∈ st.objectIndex)
+    (hUniq : vspaceAsidRootsUnique st) :
+    resolveAsidRoot st asid = some (rootId, root) := by
+  unfold resolveAsidRoot
+  generalize st.objectIndex = idx at hMem ⊢
+  induction idx with
+  | nil => exact absurd hMem List.not_mem_nil
+  | cons a rest ih =>
+      simp only [List.findSome?_cons]
+      by_cases hEq : a = rootId
+      · subst hEq
+        simp [hObj, hAsid]
+      · -- a ≠ rootId: show the function at a returns none (no VSpace root with this ASID)
+        have hMemRest : rootId ∈ rest := by
+          cases hMem with
+          | head => exact absurd rfl hEq
+          | tail _ h => exact h
+        suffices hNone : (match st.objects a with
+            | some (.vspaceRoot r) => if r.asid = asid then some (a, r) else none
+            | _ => none) = none by
+          simp [hNone]
+          exact ih hMemRest
+        cases hObjA : st.objects a with
+        | none => simp
+        | some obj =>
+            cases obj with
+            | vspaceRoot r =>
+                simp
+                intro hAsidR
+                -- r.asid = asid and root.asid = asid, so by uniqueness a = rootId
+                exact absurd (hUniq a rootId r root hObjA hObj (hAsidR.trans hAsid.symm)) hEq
+            | tcb _ | cnode _ | endpoint _ | notification _ => simp
+
+-- ============================================================================
+-- storeObject preservation lemmas for VSpace operations
+-- ============================================================================
+
+/-- After `storeObject` at a rootId that was already in objectIndex, the objectIndex is unchanged. -/
+theorem storeObject_objectIndex_eq_of_mem
+    (st st' : SystemState) (id : SeLe4n.ObjId) (obj : KernelObject)
+    (hMem : id ∈ st.objectIndex)
+    (hStore : storeObject id obj st = .ok ((), st')) :
+    st'.objectIndex = st.objectIndex := by
+  unfold storeObject at hStore
+  cases hStore
+  simp [hMem]
+
 end SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
@@ -1,16 +1,38 @@
 import SeLe4n.Kernel.Architecture.VSpace
 
+/-!
+# VSpace Invariant Bundle (WS-B1 / F-08 / TPI-D05)
+
+This module defines the VSpace invariant components (ASID-root uniqueness, non-overlap)
+and the composed bundle entrypoint. It contains both error-case and success-path
+preservation theorems, as well as round-trip theorems closing TPI-001 from WS-C.
+
+## Proof scope qualification (F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `vspaceMapPage_success_preserves_vspaceInvariantBundle`
+- `vspaceUnmapPage_success_preserves_vspaceInvariantBundle`
+
+**Round-trip / functional-correctness theorems** (high assurance — prove semantic
+contracts between VSpace operations, closing TPI-001 from WS-C):
+- `vspaceLookup_after_map`
+- `vspaceLookup_map_other`
+- `vspaceLookup_after_unmap`
+- `vspaceLookup_unmap_other`
+
+**Error-case preservation theorems** (trivially true — the error path returns
+unchanged state, so any pre-state invariant holds trivially in the post-state):
+- `vspaceMapPage_error_asidNotBound_preserves_vspaceInvariantBundle`
+- `vspaceUnmapPage_error_translationFault_preserves_vspaceInvariantBundle`
+
+Error-case theorems are retained for proof-surface completeness and compositional
+coverage, but they do not constitute meaningful security evidence.
+-/
+
 namespace SeLe4n.Kernel.Architecture
 
 open SeLe4n.Model
-
-/-- ASID roots in the bounded discovery window are unique. -/
-def vspaceAsidRootsUnique (st : SystemState) : Prop :=
-  ∀ oid₁ oid₂ root₁ root₂,
-    st.objects oid₁ = some (.vspaceRoot root₁) →
-    st.objects oid₂ = some (.vspaceRoot root₂) →
-    root₁.asid = root₂.asid →
-    oid₁ = oid₂
 
 /-- Every modeled VSpace root preserves deterministic non-overlap for virtual mappings. -/
 def vspaceRootNonOverlap (st : SystemState) : Prop :=
@@ -28,6 +50,10 @@ def boundedAddressTranslation (st : SystemState) (bound : Nat) : Prop :=
 /-- WS-B1 architecture/VSpace invariant bundle entrypoint. -/
 def vspaceInvariantBundle (st : SystemState) : Prop :=
   vspaceAsidRootsUnique st ∧ vspaceRootNonOverlap st
+
+-- ============================================================================
+-- Error-case preservation (trivial — see F-16 classification above)
+-- ============================================================================
 
 theorem vspaceMapPage_error_asidNotBound_preserves_vspaceInvariantBundle
     (st : SystemState)
@@ -47,5 +73,287 @@ theorem vspaceUnmapPage_error_translationFault_preserves_vspaceInvariantBundle
     vspaceInvariantBundle st → vspaceInvariantBundle st := by
   intro hInv
   exact hInv
+
+-- ============================================================================
+-- F-08 / TPI-D05: VSpace successful-operation invariant preservation
+-- ============================================================================
+
+/-- F-08: A successful `vspaceMapPage` preserves the VSpace invariant bundle.
+
+    The proof decomposes into two obligations:
+    1. ASID-root uniqueness is preserved because `mapPage` preserves the root's ASID.
+    2. Non-overlap is preserved because `mapPage` only succeeds when no mapping
+       for the target vaddr already exists. -/
+theorem vspaceMapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr) (paddr : SeLe4n.PAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceInvariantBundle st' := by
+  unfold vspaceMapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hMapRoot : root.mapPage vaddr paddr with
+      | none => simp [hResolve, hMapRoot] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hMapRoot] using hStep
+          rcases resolveAsidRoot_some_implies st asid rootId root hResolve with ⟨hObjRoot, hAsidRoot, _⟩
+          have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
+            storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
+          have hObjNe : ∀ oid, oid ≠ rootId → st'.objects oid = st.objects oid :=
+            fun oid hNe => storeObject_objects_ne st st' rootId oid (.vspaceRoot root') hNe hStore
+          have hAsidPreserved : root'.asid = root.asid :=
+            VSpaceRoot.mapPage_asid_eq root root' vaddr paddr hMapRoot
+          rcases hInv with ⟨hUniq, hNoOverlap⟩
+          refine ⟨?_, ?_⟩
+          -- 1. vspaceAsidRootsUnique st'
+          · intro oid₁ oid₂ r₁ r₂ hObj₁ hObj₂ hAsidEq
+            by_cases h₁ : oid₁ = rootId <;> by_cases h₂ : oid₂ = rootId
+            · exact h₁.trans h₂.symm
+            · rw [h₁] at hObj₁
+              rw [hObjEq] at hObj₁; cases hObj₁
+              rw [hObjNe oid₂ h₂] at hObj₂
+              exfalso
+              have : rootId = oid₂ :=
+                hUniq rootId oid₂ root r₂ hObjRoot hObj₂
+                  (hAsidPreserved.symm ▸ hAsidEq)
+              exact h₂ this.symm
+            · rw [h₂] at hObj₂
+              rw [hObjEq] at hObj₂; cases hObj₂
+              rw [hObjNe oid₁ h₁] at hObj₁
+              exfalso
+              have : oid₁ = rootId :=
+                hUniq oid₁ rootId r₁ root hObj₁ hObjRoot
+                  (hAsidEq.trans hAsidPreserved)
+              exact h₁ this
+            · rw [hObjNe oid₁ h₁] at hObj₁
+              rw [hObjNe oid₂ h₂] at hObj₂
+              exact hUniq oid₁ oid₂ r₁ r₂ hObj₁ hObj₂ hAsidEq
+          -- 2. vspaceRootNonOverlap st'
+          · intro oid r hObj
+            by_cases hEq : oid = rootId
+            · rw [hEq] at hObj
+              rw [hObjEq] at hObj; cases hObj
+              exact VSpaceRoot.mapPage_noVirtualOverlap root root' vaddr paddr
+                (hNoOverlap rootId root hObjRoot) hMapRoot
+            · rw [hObjNe oid hEq] at hObj
+              exact hNoOverlap oid r hObj
+
+/-- F-08: A successful `vspaceUnmapPage` preserves the VSpace invariant bundle.
+
+    The proof decomposes into two obligations:
+    1. ASID-root uniqueness is preserved because `unmapPage` preserves the root's ASID.
+    2. Non-overlap is preserved because `unmapPage` only removes entries,
+       which cannot create new virtual-address conflicts. -/
+theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceInvariantBundle st' := by
+  unfold vspaceUnmapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hUnmapRoot : root.unmapPage vaddr with
+      | none => simp [hResolve, hUnmapRoot] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hUnmapRoot] using hStep
+          rcases resolveAsidRoot_some_implies st asid rootId root hResolve with ⟨hObjRoot, hAsidRoot, _⟩
+          have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
+            storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
+          have hObjNe : ∀ oid, oid ≠ rootId → st'.objects oid = st.objects oid :=
+            fun oid hNe => storeObject_objects_ne st st' rootId oid (.vspaceRoot root') hNe hStore
+          have hAsidPreserved : root'.asid = root.asid :=
+            VSpaceRoot.unmapPage_asid_eq root root' vaddr hUnmapRoot
+          rcases hInv with ⟨hUniq, hNoOverlap⟩
+          refine ⟨?_, ?_⟩
+          -- 1. vspaceAsidRootsUnique st'
+          · intro oid₁ oid₂ r₁ r₂ hObj₁ hObj₂ hAsidEq
+            by_cases h₁ : oid₁ = rootId <;> by_cases h₂ : oid₂ = rootId
+            · exact h₁.trans h₂.symm
+            · rw [h₁] at hObj₁
+              rw [hObjEq] at hObj₁; cases hObj₁
+              rw [hObjNe oid₂ h₂] at hObj₂
+              exfalso
+              have : rootId = oid₂ :=
+                hUniq rootId oid₂ root r₂ hObjRoot hObj₂
+                  (hAsidPreserved.symm ▸ hAsidEq)
+              exact h₂ this.symm
+            · rw [h₂] at hObj₂
+              rw [hObjEq] at hObj₂; cases hObj₂
+              rw [hObjNe oid₁ h₁] at hObj₁
+              exfalso
+              have : oid₁ = rootId :=
+                hUniq oid₁ rootId r₁ root hObj₁ hObjRoot
+                  (hAsidEq.trans hAsidPreserved)
+              exact h₁ this
+            · rw [hObjNe oid₁ h₁] at hObj₁
+              rw [hObjNe oid₂ h₂] at hObj₂
+              exact hUniq oid₁ oid₂ r₁ r₂ hObj₁ hObj₂ hAsidEq
+          -- 2. vspaceRootNonOverlap st'
+          · intro oid r hObj
+            by_cases hEq : oid = rootId
+            · rw [hEq] at hObj
+              rw [hObjEq] at hObj; cases hObj
+              exact VSpaceRoot.unmapPage_noVirtualOverlap root root' vaddr
+                (hNoOverlap rootId root hObjRoot) hUnmapRoot
+            · rw [hObjNe oid hEq] at hObj
+              exact hNoOverlap oid r hObj
+
+-- ============================================================================
+-- TPI-D05 / TPI-001: VSpace round-trip theorems
+-- ============================================================================
+
+/-- TPI-001 round-trip #1: After a successful `vspaceMapPage`, `vspaceLookup` on the same
+    ASID and vaddr returns the mapped physical address. -/
+theorem vspaceLookup_after_map
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr) (paddr : SeLe4n.PAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .ok (paddr, st') := by
+  unfold vspaceMapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hMapRoot : root.mapPage vaddr paddr with
+      | none => simp [hResolve, hMapRoot] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hMapRoot] using hStep
+          rcases resolveAsidRoot_some_implies st asid rootId root hResolve with ⟨hObjRoot, hAsidRoot, hMemIdx⟩
+          have hAsidPreserved : root'.asid = root.asid :=
+            VSpaceRoot.mapPage_asid_eq root root' vaddr paddr hMapRoot
+          -- Build post-state resolveAsidRoot result
+          have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
+            storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
+          have hIdxEq : st'.objectIndex = st.objectIndex :=
+            storeObject_objectIndex_eq_of_mem st st' rootId (.vspaceRoot root') hMemIdx hStore
+          -- Prove post-state ASID uniqueness for resolveAsidRoot characterization
+          have hInv' : vspaceInvariantBundle st' :=
+            vspaceMapPage_success_preserves_vspaceInvariantBundle st st' asid vaddr paddr hInv
+              (by simp [vspaceMapPage, hResolve, hMapRoot, hStore])
+          have hResolve' : resolveAsidRoot st' asid = some (rootId, root') :=
+            resolveAsidRoot_of_unique_root st' asid rootId root'
+              hObjEq (hAsidPreserved.trans hAsidRoot) (hIdxEq ▸ hMemIdx) hInv'.1
+          have hLookupRoot' : root'.lookup vaddr = some paddr :=
+            VSpaceRoot.lookup_mapPage_eq root root' vaddr paddr hMapRoot
+          simp [vspaceLookup, hResolve', hLookupRoot']
+
+/-- TPI-001 round-trip #2: A `vspaceMapPage` at vaddr does not affect `vspaceLookup` at
+    a different vaddr'. -/
+theorem vspaceLookup_map_other
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID) (vaddr vaddr' : SeLe4n.VAddr) (paddr : SeLe4n.PAddr)
+    (hNe : vaddr ≠ vaddr')
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    (vspaceLookup asid vaddr' st').map Prod.fst = (vspaceLookup asid vaddr' st).map Prod.fst := by
+  unfold vspaceMapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hMapRoot : root.mapPage vaddr paddr with
+      | none => simp [hResolve, hMapRoot] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hMapRoot] using hStep
+          rcases resolveAsidRoot_some_implies st asid rootId root hResolve with ⟨hObjRoot, hAsidRoot, hMemIdx⟩
+          have hAsidPreserved : root'.asid = root.asid :=
+            VSpaceRoot.mapPage_asid_eq root root' vaddr paddr hMapRoot
+          have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
+            storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
+          have hIdxEq : st'.objectIndex = st.objectIndex :=
+            storeObject_objectIndex_eq_of_mem st st' rootId (.vspaceRoot root') hMemIdx hStore
+          have hInv' : vspaceInvariantBundle st' :=
+            vspaceMapPage_success_preserves_vspaceInvariantBundle st st' asid vaddr paddr hInv
+              (by simp [vspaceMapPage, hResolve, hMapRoot, hStore])
+          have hResolve' : resolveAsidRoot st' asid = some (rootId, root') :=
+            resolveAsidRoot_of_unique_root st' asid rootId root'
+              hObjEq (hAsidPreserved.trans hAsidRoot) (hIdxEq ▸ hMemIdx) hInv'.1
+          have hLookupNe : root'.lookup vaddr' = root.lookup vaddr' :=
+            VSpaceRoot.lookup_mapPage_ne root root' vaddr vaddr' paddr hNe hMapRoot
+          simp [vspaceLookup, hResolve', hResolve, hLookupNe, Except.map]
+          cases root.lookup vaddr' <;> rfl
+
+/-- TPI-001 round-trip #3: After a successful `vspaceUnmapPage`, `vspaceLookup` on the
+    unmapped vaddr returns a translation fault (no mapping). -/
+theorem vspaceLookup_after_unmap
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .error .translationFault := by
+  unfold vspaceUnmapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hUnmapRoot : root.unmapPage vaddr with
+      | none => simp [hResolve, hUnmapRoot] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hUnmapRoot] using hStep
+          rcases resolveAsidRoot_some_implies st asid rootId root hResolve with ⟨hObjRoot, hAsidRoot, hMemIdx⟩
+          have hAsidPreserved : root'.asid = root.asid :=
+            VSpaceRoot.unmapPage_asid_eq root root' vaddr hUnmapRoot
+          have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
+            storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
+          have hIdxEq : st'.objectIndex = st.objectIndex :=
+            storeObject_objectIndex_eq_of_mem st st' rootId (.vspaceRoot root') hMemIdx hStore
+          have hInv' : vspaceInvariantBundle st' :=
+            vspaceUnmapPage_success_preserves_vspaceInvariantBundle st st' asid vaddr hInv
+              (by simp [vspaceUnmapPage, hResolve, hUnmapRoot, hStore])
+          have hResolve' : resolveAsidRoot st' asid = some (rootId, root') :=
+            resolveAsidRoot_of_unique_root st' asid rootId root'
+              hObjEq (hAsidPreserved.trans hAsidRoot) (hIdxEq ▸ hMemIdx) hInv'.1
+          have hLookupNone : root'.lookup vaddr = none :=
+            VSpaceRoot.lookup_unmapPage_eq_none root root' vaddr hUnmapRoot
+          simp [vspaceLookup, hResolve', hLookupNone]
+
+/-- TPI-001 round-trip #4: `vspaceUnmapPage` at vaddr does not affect `vspaceLookup` at
+    a different vaddr'. -/
+theorem vspaceLookup_unmap_other
+    (st st' : SystemState)
+    (asid : SeLe4n.ASID) (vaddr vaddr' : SeLe4n.VAddr)
+    (hNe : vaddr ≠ vaddr')
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    (vspaceLookup asid vaddr' st').map Prod.fst = (vspaceLookup asid vaddr' st).map Prod.fst := by
+  unfold vspaceUnmapPage at hStep
+  cases hResolve : resolveAsidRoot st asid with
+  | none => simp [hResolve] at hStep
+  | some pair =>
+      rcases pair with ⟨rootId, root⟩
+      cases hUnmapRoot : root.unmapPage vaddr with
+      | none => simp [hResolve, hUnmapRoot] at hStep
+      | some root' =>
+          have hStore : storeObject rootId (.vspaceRoot root') st = .ok ((), st') := by
+            simpa [hResolve, hUnmapRoot] using hStep
+          rcases resolveAsidRoot_some_implies st asid rootId root hResolve with ⟨hObjRoot, hAsidRoot, hMemIdx⟩
+          have hAsidPreserved : root'.asid = root.asid :=
+            VSpaceRoot.unmapPage_asid_eq root root' vaddr hUnmapRoot
+          have hObjEq : st'.objects rootId = some (.vspaceRoot root') :=
+            storeObject_objects_eq st st' rootId (.vspaceRoot root') hStore
+          have hIdxEq : st'.objectIndex = st.objectIndex :=
+            storeObject_objectIndex_eq_of_mem st st' rootId (.vspaceRoot root') hMemIdx hStore
+          have hInv' : vspaceInvariantBundle st' :=
+            vspaceUnmapPage_success_preserves_vspaceInvariantBundle st st' asid vaddr hInv
+              (by simp [vspaceUnmapPage, hResolve, hUnmapRoot, hStore])
+          have hResolve' : resolveAsidRoot st' asid = some (rootId, root') :=
+            resolveAsidRoot_of_unique_root st' asid rootId root'
+              hObjEq (hAsidPreserved.trans hAsidRoot) (hIdxEq ▸ hMemIdx) hInv'.1
+          have hLookupNe : root'.lookup vaddr' = root.lookup vaddr' :=
+            VSpaceRoot.lookup_unmapPage_ne root root' vaddr vaddr' hNe hUnmapRoot
+          simp [vspaceLookup, hResolve', hResolve, hLookupNe, Except.map]
+          cases root.lookup vaddr' <;> rfl
 
 end SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1,6 +1,47 @@
 import SeLe4n.Kernel.IPC.Invariant
 import SeLe4n.Kernel.Lifecycle.Invariant
 
+/-!
+# Capability Invariant Preservation Proofs (M2)
+
+This module defines the capability invariant components, the composed bundle entrypoint,
+and transition-level preservation theorems for CSpace operations. It also contains
+cross-subsystem composed bundles (M3, M3.5, M4-A).
+
+## Proof scope qualification (F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `cspaceMint_preserves_capabilityInvariantBundle`
+- `cspaceInsertSlot_preserves_capabilityInvariantBundle`
+- `cspaceDeleteSlot_preserves_capabilityInvariantBundle`
+- `cspaceRevoke_preserves_capabilityInvariantBundle`
+- `lifecycleRetypeObject_preserves_capabilityInvariantBundle`
+- `lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle`
+- all `endpointSend/AwaitReceive/Receive_preserves_capabilityInvariantBundle`
+- composed bundle preservation theorems (`m3IpcSeed`, `m35`, `m4a`)
+
+**Badge-override safety theorems** (high assurance — F-06 / TPI-D04):
+- `mintDerivedCap_rights_attenuated_with_badge_override`
+- `mintDerivedCap_target_preserved_with_badge_override`
+- `cspaceMint_badge_override_safe`
+
+**Structural / functional-correctness theorems** (high assurance):
+- `mintDerivedCap_attenuates`
+- `cspaceMint_child_attenuates`
+- `cspaceDeleteSlot_authority_reduction`
+- `cspaceRevoke_local_target_reduction`
+- `cspaceRevoke_preserves_source`
+
+**Error-case preservation theorems** (trivially true — the error path returns
+unchanged state, so any pre-state invariant holds trivially in the post-state):
+- `lifecycleRevokeDeleteRetype_error_preserves_m4aLifecycleInvariantBundle`
+- `cspaceLookupSlot_preserves_capabilityInvariantBundle` (read-only, no mutation)
+
+Error-case theorems are retained for proof-surface completeness and compositional
+coverage, but they do not constitute meaningful security evidence.
+-/
+
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model
@@ -328,6 +369,41 @@ theorem mintDerivedCap_attenuates
     · exact rightsSubset_sound rights parent.rights hSubset
   · simp [mintDerivedCap, hSubset] at hMint
 
+-- ============================================================================
+-- F-06 / TPI-D04: Badge-override safety in cspaceMint
+-- ============================================================================
+
+/-- Badge override does not affect rights attenuation: a minted capability's rights
+are always a subset of the parent's rights, regardless of what badge is supplied.
+
+This is a direct consequence of `mintDerivedCap` checking `rightsSubset` before
+constructing the child capability and setting `child.target = parent.target`
+unconditionally. -/
+theorem mintDerivedCap_rights_attenuated_with_badge_override
+    (parent child : Capability)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    ∀ right, right ∈ child.rights → right ∈ parent.rights := by
+  have hAtt := mintDerivedCap_attenuates parent child rights badge hMint
+  exact hAtt.2
+
+/-- Badge override preserves target identity: a minted capability always names the
+same target as the parent, regardless of the badge supplied. Badge override cannot
+enable a capability holder to access objects outside the authority granted by the
+parent capability.
+
+This is the core F-06 safety property: badge is metadata that affects notification
+signaling semantics, not capability authority scope. -/
+theorem mintDerivedCap_target_preserved_with_badge_override
+    (parent child : Capability)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    child.target = parent.target := by
+  have hAtt := mintDerivedCap_attenuates parent child rights badge hMint
+  exact hAtt.1
+
 theorem cspaceMint_child_attenuates
     (st st' : SystemState)
     (src dst : CSpaceAddr)
@@ -355,6 +431,27 @@ theorem cspaceMint_child_attenuates
           refine ⟨parent, child, ?_, ?_, hAtt⟩
           · rfl
           · exact cspaceInsertSlot_lookup_eq st st' dst child hInsert
+
+/-- Composed badge-override safety for `cspaceMint`: after a successful mint with
+arbitrary badge override, the derived capability in the destination slot has the
+same target as the parent and attenuated rights.
+
+This theorem witnesses the full F-06 obligation at the kernel-operation level:
+badge override in `cspaceMint` cannot escalate privilege. -/
+theorem cspaceMint_badge_override_safe
+    (st st' : SystemState)
+    (src dst : CSpaceAddr)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
+    ∃ parent child,
+      cspaceLookupSlot src st = .ok (parent, st) ∧
+      cspaceLookupSlot dst st' = .ok (child, st') ∧
+      child.target = parent.target ∧
+      (∀ right, right ∈ child.rights → right ∈ parent.rights) := by
+  rcases cspaceMint_child_attenuates st st' src dst rights badge hStep with
+    ⟨parent, child, hSrc, hDst, hAtt⟩
+  exact ⟨parent, child, hSrc, hDst, hAtt.1, hAtt.2⟩
 
 theorem cspaceSlotUnique_holds (st : SystemState) :
     cspaceSlotUnique st := by

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -1,6 +1,39 @@
 import SeLe4n.Kernel.Scheduler.Invariant
 import SeLe4n.Kernel.IPC.Operations
 
+/-!
+# IPC Invariant Preservation Proofs
+
+This module contains invariant definitions and preservation theorems for the IPC
+(inter-process communication) subsystem, including endpoint and notification
+well-formedness, and IPC-scheduler coherence contracts.
+
+## Proof scope qualification (F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `endpointSend_preserves_ipcInvariant`
+- `endpointAwaitReceive_preserves_ipcInvariant`
+- `endpointReceive_preserves_ipcInvariant`
+- `endpointSend_preserves_ipcSchedulerContractPredicates` (and per-component)
+- `endpointAwaitReceive_preserves_ipcSchedulerContractPredicates` (and per-component)
+- `endpointReceive_preserves_ipcSchedulerContractPredicates` (and per-component)
+- `endpointSend_preserves_schedulerInvariantBundle`
+- `endpointAwaitReceive_preserves_schedulerInvariantBundle`
+- `endpointReceive_preserves_schedulerInvariantBundle`
+
+**Structural / functional-correctness theorems** (high assurance):
+- `endpointSend_result_wellFormed`
+- `endpointAwaitReceive_result_wellFormed`
+- `endpointReceive_result_wellFormed`
+- `endpointObjectValid_of_queueWellFormed`
+- all `*_ok_implies_endpoint_object` lemmas
+
+All theorems in this module are substantive: they prove invariant preservation over
+state that is actually modified by successful endpoint operations. There are no
+error-case preservation theorems in this module.
+-/
+
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -4,6 +4,30 @@ import SeLe4n.Kernel.Capability.Invariant
 import SeLe4n.Kernel.Scheduler.Operations
 import SeLe4n.Kernel.Lifecycle.Operations
 
+/-!
+# Information-Flow Non-Interference Proofs
+
+This module contains non-interference theorems proving that high-domain kernel
+operations do not leak information to low-clearance observers.
+
+## Proof scope qualification (F-16)
+
+**Non-interference theorems** (critical for security assurance — prove that a
+high-domain operation preserves low-equivalence for unrelated observers):
+- `endpointSend_preserves_lowEquivalent`
+- `chooseThread_preserves_lowEquivalent` (WS-D2 / TPI-D01)
+- `cspaceMint_preserves_lowEquivalent` (WS-D2 / TPI-D02)
+- `cspaceRevoke_preserves_lowEquivalent` (WS-D2 / TPI-D02)
+- `lifecycleRetypeObject_preserves_lowEquivalent` (WS-D2 / TPI-D03)
+
+**Shared proof infrastructure** (high assurance):
+- `storeObject_at_unobservable_preserves_lowEquivalent` — generic proof skeleton
+  for any `storeObject`-based operation at a non-observable ID.
+
+All theorems in this module are substantive non-interference proofs. There are no
+error-case preservation theorems.
+-/
+
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model

--- a/SeLe4n/Kernel/Lifecycle/Invariant.lean
+++ b/SeLe4n/Kernel/Lifecycle/Invariant.lean
@@ -1,5 +1,36 @@
 import SeLe4n.Kernel.Lifecycle.Operations
 
+/-!
+# Lifecycle Invariant Preservation Proofs
+
+This module contains invariant definitions and preservation theorems for the
+lifecycle (object retype) subsystem, including identity/aliasing, capability-reference,
+and stale-reference exclusion invariants.
+
+## Proof scope qualification (F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `lifecycleRetypeObject_preserves_lifecycleInvariantBundle`
+- `lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant`
+- `lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant`
+
+**Structural / bridge theorems** (high assurance — prove decomposition and composition
+relationships between invariant layers):
+- `lifecycleIdentityNoTypeAliasConflict_of_exact`
+- `lifecycleCapabilityRefObjectTargetBacked_of_exact`
+- `lifecycleInvariantBundle_of_metadata_consistent`
+- `lifecycleMetadataConsistent_of_lifecycleInvariantBundle`
+- `lifecycleCapabilityRefObjectTargetTypeAligned_of_exact`
+- `lifecycleCapabilityRefNoTypeAliasConflict_of_identity`
+- `lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle`
+- `lifecycleIdentityStaleReferenceInvariant_of_lifecycleInvariantBundle`
+
+All theorems in this module are substantive: they prove structural decomposition
+properties or invariant preservation over state modified by successful retype
+operations. There are no error-case preservation theorems in this module.
+-/
+
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model

--- a/SeLe4n/Kernel/Scheduler/Invariant.lean
+++ b/SeLe4n/Kernel/Scheduler/Invariant.lean
@@ -1,5 +1,23 @@
 import SeLe4n.Model.State
 
+/-!
+# Scheduler Invariant Definitions
+
+This module contains invariant definitions for the scheduler subsystem: queue
+uniqueness, current-thread validity, and queue/current consistency.
+
+## Proof scope qualification (F-16)
+
+**Structural theorems** (high assurance):
+- `schedulerWellFormed_iff_queueCurrentConsistent`
+- `queueCurrentConsistent_when_no_current`
+
+Scheduler *preservation* theorems (e.g. `chooseThread_preserves_*`,
+`schedule_preserves_*`, `handleYield_preserves_*`) live in the IPC and Capability
+invariant modules where they compose with cross-subsystem bundles. This module
+provides only the invariant definitions and basic structural lemmas.
+-/
+
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -2,6 +2,46 @@ import SeLe4n.Kernel.Service.Operations
 import SeLe4n.Kernel.Capability.Invariant
 import SeLe4n.Kernel.Lifecycle.Invariant
 
+/-!
+# Service Invariant Preservation Proofs
+
+This module contains policy-surface definitions and preservation theorems for the
+service orchestration subsystem, including cross-subsystem composition with lifecycle
+and capability invariants.
+
+## Proof scope qualification (F-16)
+
+**Substantive preservation theorems** (high assurance — prove invariant preservation
+over *changed* state after a *successful* operation):
+- `serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceRestart_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `storeServiceState_preserves_servicePolicySurfaceInvariant`
+- `storeServiceState_preserves_lifecycleInvariantBundle`
+- `storeServiceState_preserves_capabilityInvariantBundle`
+
+**Structural / bridge theorems** (high assurance):
+- `servicePolicySurfaceInvariant_of_lifecycleInvariant`
+- `policyBackingObjectTyped_of_lifecycleInvariant`
+- `policyOwnerAuthoritySlotPresent_of_lifecycleInvariant`
+- `policyOwnerAuthoritySlotPresent_of_capabilityLookup`
+- `serviceLifecycleCapabilityInvariantBundle_of_components`
+
+**Check-vs-mutation separation theorems** (high assurance):
+- `serviceStart_policyDenied_separates_check_from_mutation`
+- `serviceStop_policyDenied_separates_check_from_mutation`
+
+**Error-case preservation theorems** (trivially true — the error path returns
+unchanged state):
+- `serviceStart_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceStop_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+- `serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle`
+
+Error-case theorems are retained for proof-surface completeness and compositional
+coverage, but they do not constitute meaningful security evidence.
+-/
+
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -171,6 +171,134 @@ theorem lookup_mapPage_eq
       unfold lookup
       simp
 
+/-- F-08 helper: `mapPage` preserves the VSpace root ASID. -/
+theorem mapPage_asid_eq
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hMap : root.mapPage vaddr paddr = some root') :
+    root'.asid = root.asid := by
+  unfold mapPage at hMap
+  cases hLookup : lookup root vaddr with
+  | some _ => simp [hLookup] at hMap
+  | none => simp [hLookup] at hMap; cases hMap; rfl
+
+/-- F-08 helper: `unmapPage` preserves the VSpace root ASID. -/
+theorem unmapPage_asid_eq
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (hUnmap : root.unmapPage vaddr = some root') :
+    root'.asid = root.asid := by
+  unfold unmapPage at hUnmap
+  cases hLookup : lookup root vaddr with
+  | none => simp [hLookup] at hUnmap
+  | some _ => simp [hLookup] at hUnmap; cases hUnmap; rfl
+
+/-- F-08 helper: if `lookup` returns `none`, then no mapping entry for that vaddr
+    exists in the mappings list. -/
+theorem lookup_eq_none_not_mem
+    (root : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hNone : lookup root vaddr = none) :
+    (vaddr, paddr) ∉ root.mappings := by
+  unfold lookup at hNone
+  rw [Option.map_eq_none_iff] at hNone
+  rw [List.find?_eq_none] at hNone
+  intro hMem
+  have := hNone ⟨vaddr, paddr⟩ hMem
+  simp at this
+
+/-- F-08 helper: a successful `mapPage` preserves the no-virtual-overlap invariant.
+    Since `mapPage` only succeeds when `lookup root vaddr = none` (no existing mapping
+    for the target vaddr), adding the new `(vaddr, paddr)` entry cannot create duplicates. -/
+theorem mapPage_noVirtualOverlap
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hOverlap : noVirtualOverlap root)
+    (hMap : root.mapPage vaddr paddr = some root') :
+    noVirtualOverlap root' := by
+  unfold mapPage at hMap
+  cases hLookup : lookup root vaddr with
+  | some _ => simp [hLookup] at hMap
+  | none =>
+      simp [hLookup] at hMap
+      cases hMap
+      intro v p₁ p₂ hIn₁ hIn₂
+      simp [List.mem_cons] at hIn₁ hIn₂
+      cases hIn₁ with
+      | inl h₁ =>
+        cases hIn₂ with
+        | inl h₂ => rw [h₁.2, h₂.2]
+        | inr h₂ =>
+          exfalso
+          exact lookup_eq_none_not_mem root _ p₂ hLookup (h₁.1 ▸ h₂)
+      | inr h₁ =>
+        cases hIn₂ with
+        | inl h₂ =>
+          exfalso
+          exact lookup_eq_none_not_mem root _ p₁ hLookup (h₂.1 ▸ h₁)
+        | inr h₂ => exact hOverlap v p₁ p₂ h₁ h₂
+
+/-- F-08 helper: a successful `unmapPage` preserves the no-virtual-overlap invariant.
+    Since `unmapPage` only removes entries, it cannot create new overlap. -/
+theorem unmapPage_noVirtualOverlap
+    (root root' : VSpaceRoot)
+    (vaddr : SeLe4n.VAddr)
+    (hOverlap : noVirtualOverlap root)
+    (hUnmap : root.unmapPage vaddr = some root') :
+    noVirtualOverlap root' := by
+  unfold unmapPage at hUnmap
+  cases hLookup : lookup root vaddr with
+  | none => simp [hLookup] at hUnmap
+  | some _ =>
+      simp [hLookup] at hUnmap
+      cases hUnmap
+      intro v p₁ p₂ hIn₁ hIn₂
+      simp [List.mem_filter] at hIn₁ hIn₂
+      exact hOverlap v p₁ p₂ hIn₁.1 hIn₂.1
+
+/-- TPI-001 helper: mapping vaddr does not affect lookup of a different vaddr'. -/
+theorem lookup_mapPage_ne
+    (root root' : VSpaceRoot)
+    (vaddr vaddr' : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr)
+    (hNe : vaddr ≠ vaddr')
+    (hMap : root.mapPage vaddr paddr = some root') :
+    root'.lookup vaddr' = root.lookup vaddr' := by
+  unfold mapPage at hMap
+  cases hLookup : lookup root vaddr with
+  | some _ => simp [hLookup] at hMap
+  | none =>
+      simp [hLookup] at hMap
+      cases hMap
+      unfold lookup
+      simp [hNe]
+
+/-- TPI-001 helper: unmapPage at vaddr does not affect lookup of a different vaddr'. -/
+theorem lookup_unmapPage_ne
+    (root root' : VSpaceRoot)
+    (vaddr vaddr' : SeLe4n.VAddr)
+    (hNe : vaddr ≠ vaddr')
+    (hUnmap : root.unmapPage vaddr = some root') :
+    root'.lookup vaddr' = root.lookup vaddr' := by
+  unfold unmapPage at hUnmap
+  cases hLookup : lookup root vaddr with
+  | none => simp [hLookup] at hUnmap
+  | some _ =>
+      simp [hLookup] at hUnmap
+      cases hUnmap
+      unfold lookup
+      simp only
+      congr 1
+      rw [List.find?_filter]
+      congr 1
+      funext x
+      by_cases hx : x.fst = vaddr'
+      · simp [hx, Ne.symm hNe]
+      · simp [hx]
+
 end VSpaceRoot
 
 namespace CNode

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -7,7 +7,7 @@ This index makes current semantic/proof/documentation claims auditable by linkin
 | Claim | Canonical source | Evidence command(s) | Evidence artifact(s) |
 |---|---|---|---|
 | Active findings baseline is `AUDIT_v0.11.0.md`. | `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` | `./scripts/test_tier3_invariant_surface.sh` | Tier-3 doc-anchor checks over README/spec/planning references. |
-| WS-D portfolio status (WS-D1, WS-D2 completed; WS-D3..WS-D6 planned). | `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
+| WS-D portfolio status (WS-D1, WS-D2, WS-D3 completed; WS-D4..WS-D6 planned). | `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
 | WS-C portfolio status is complete (WS-C1..WS-C8). | `docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Historical; evidence preserved in prior tier runs. |
 | Root docs and GitBook mirrors stay synchronized via canonical-first rules. | `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, `docs/DOCS_DEDUPLICATION_MAP.md` | `./scripts/test_docs_sync.sh` | Regenerated navigation + markdown link validation + doc-gen probe when available. |
 | IPC/scheduler/capability/info-flow invariants remain in active proof surface. | Kernel modules and invariant suites listed in `scripts/test_tier3_invariant_surface.sh` | `./scripts/test_tier3_invariant_surface.sh` | Direct symbol + theorem + doc anchor checks. |
@@ -31,8 +31,8 @@ The following categories of theorems exist in the proof surface. Claims about pr
 | TPI-D01 | Scheduler non-interference preservation | WS-D2 | CLOSED |
 | TPI-D02 | Capability operations non-interference preservation | WS-D2 | CLOSED |
 | TPI-D03 | Lifecycle operations non-interference preservation | WS-D2 | CLOSED |
-| TPI-D04 | Badge-override safety in cspaceMint | WS-D3 | OPEN |
-| TPI-D05 | VSpace successful-operation preservation + round-trip theorems | WS-D3 | OPEN |
+| TPI-D04 | Badge-override safety in cspaceMint | WS-D3 | CLOSED |
+| TPI-D05 | VSpace successful-operation preservation + round-trip theorems | WS-D3 | CLOSED |
 | TPI-D06 | Waiting-list uniqueness invariant | WS-D4 | OPEN |
 | TPI-D07 | Service dependency acyclicity invariant | WS-D4 | OPEN |
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,12 +6,12 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current active slice**:
 
-- active: **Comprehensive Audit v0.9.32 WS-C execution (WS-C1 + WS-C2 + WS-C3 + WS-C4 + WS-C5 + WS-C6 + WS-C7 + WS-C8 completed)**,
-- completed predecessor: **M7 remediation (WS-A1..WS-A8)**,
-- completed predecessor before that: **M6 architecture-boundary hardening**.
+- active: **v0.11.0 Audit Remediation WS-D portfolio (WS-D1, WS-D2, WS-D3 completed; WS-D4..WS-D6 planned)**,
+- completed predecessor: **WS-C portfolio (WS-C1..WS-C8)**,
+- completed predecessor before that: **M7 remediation (WS-A1..WS-A8)**.
 
 Canonical planning source:
-[`docs/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md).
+[`docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md).
 
 ---
 
@@ -33,8 +33,8 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 ### 3.1 Workstreams and intent
 
 - **WS-D1** — Test error handling and validity (**completed** — F-01, F-03, F-04)
-- **WS-D2** — Information-flow enforcement and proof (**planned** — F-02, F-05)
-- **WS-D3** — Proof gap closure (**planned** — F-06, F-08, F-16)
+- **WS-D2** — Information-flow enforcement and proof (**completed** — F-02, F-05)
+- **WS-D3** — Proof gap closure (**completed** — F-06, F-08, F-16; TPI-001 closed)
 - **WS-D4** — Kernel design hardening (**planned** — F-07, F-11, F-12)
 - **WS-D5** — Test infrastructure expansion (**planned** — F-09, F-10)
 - **WS-D6** — CI/CD and documentation polish (**planned** — F-13, F-14, F-15, F-17)
@@ -47,8 +47,8 @@ Use the planning phases from the workstream backbone:
 
 - **Phase P0:** Baseline transition — publish v0.11.0 planning backbone, demote WS-C to historical (completed)
 - **Phase P1:** WS-D1 test validity restoration (critical/high) — **completed**
-- **Phase P2:** WS-D2 information-flow enforcement and proof expansion (high) — current
-- **Phase P3:** WS-D3 proof gap closure + WS-D4 kernel design hardening (medium)
+- **Phase P2:** WS-D2 information-flow enforcement and proof expansion (high) — **completed**
+- **Phase P3:** WS-D3 proof gap closure (**completed**) + WS-D4 kernel design hardening (medium) — current
 - **Phase P4:** WS-D5 test infrastructure expansion + WS-D6 CI/documentation polish (medium/low)
 
 ### 3.3 Prior completed portfolio (WS-C, historical)

--- a/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+++ b/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
@@ -53,7 +53,7 @@ For documentation/planning PRs:
 
 ## 4) Current-stage status summary
 
-- Active planning baseline: `AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (WS-D portfolio; WS-D1, WS-D2 completed; WS-D3..WS-D6 planned).
+- Active planning baseline: `AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (WS-D portfolio; WS-D1, WS-D2, WS-D3 completed; WS-D4..WS-D6 planned).
 - Active findings baseline: `AUDIT_v0.11.0.md`.
 - Prior completed portfolio: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (WS-C1..WS-C8 completed).
 - Historical baseline retained for traceability: `AUDIT_v0.9.0_WORKSTREAM_PLAN.md`.

--- a/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
+++ b/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
@@ -79,98 +79,109 @@ theorem lifecycleRetypeObject_preserves_lowEquivalent
 
 ---
 
-## Issue TPI-D04 (OPEN) — Badge-override safety in cspaceMint
+## Issue TPI-D04 (CLOSED) — Badge-override safety in cspaceMint
 
 - **Audit mapping:** `AUDIT_v0.11.0.md` F-06 (Medium), recommendation 9.2 #5.
 - **Workstream:** WS-D3.
-- **Current problem:** `cspaceMint` allows badge override from parent. No proof that this cannot enable privilege escalation.
+- **Resolution:** Three badge-safety theorems implemented in `SeLe4n/Kernel/Capability/Invariant.lean`.
+  The proofs decompose through `mintDerivedCap_attenuates` (the existing attenuation lemma) and
+  show that the `badge` parameter in `mintDerivedCap` affects only `.badge` of the child — the
+  `rightsSubset` check and `target := parent.target` assignment are badge-independent. No `sorry` debt.
 
-Required theorem obligations:
+Closed theorem obligations:
 
 ```lean
-/-- A minted capability's rights are a subset of the parent's rights,
-    regardless of badge override. -/
-theorem cspaceMint_attenuates_rights
-    (authority target : ObjId) (srcSlot destSlot : Slot)
-    (newRights : CapRights) (newBadge : Badge)
-    (st st' : SystemState)
-    (hMint : cspaceMint authority target srcSlot destSlot newRights newBadge st = .ok ((), st'))
-    (parentCap : Capability)
-    (hSrc : lookupSlot target srcSlot st = some parentCap) :
-    newRights.isSubsetOf parentCap.rights = true := by
-  sorry  -- proof obligation
+/-- Rights attenuation holds regardless of badge override. -/
+theorem mintDerivedCap_rights_attenuated_with_badge_override
+    (parent child : Capability)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    ∀ right, right ∈ child.rights → right ∈ parent.rights
 
-/-- Badge override in mint does not grant access to objects
-    outside the parent capability's authority scope. -/
-theorem cspaceMint_badge_no_escalation
-    (authority target : ObjId) (srcSlot destSlot : Slot)
-    (newRights : CapRights) (newBadge : Badge)
+/-- Target identity preserved regardless of badge override. -/
+theorem mintDerivedCap_target_preserved_with_badge_override
+    (parent child : Capability)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hMint : mintDerivedCap parent rights badge = .ok child) :
+    child.target = parent.target
+
+/-- Composed kernel-operation-level safety: badge override cannot escalate privilege. -/
+theorem cspaceMint_badge_override_safe
     (st st' : SystemState)
-    (hMint : cspaceMint authority target srcSlot destSlot newRights newBadge st = .ok ((), st'))
-    (derivedCap : Capability)
-    (hDest : lookupSlot target destSlot st' = some derivedCap) :
-    derivedCap.targetId = (lookupSlot target srcSlot st).get!.targetId := by
-  sorry  -- proof obligation
+    (src dst : CSpaceAddr)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge)
+    (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
+    ∃ parent child,
+      cspaceLookupSlot src st = .ok (parent, st) ∧
+      cspaceLookupSlot dst st' = .ok (child, st') ∧
+      child.target = parent.target ∧
+      (∀ right, right ∈ child.rights → right ∈ parent.rights)
 ```
 
 ---
 
-## Issue TPI-D05 (OPEN) — VSpace successful-operation invariant preservation
+## Issue TPI-D05 (CLOSED) — VSpace successful-operation invariant preservation
 
 - **Audit mapping:** `AUDIT_v0.11.0.md` F-08 (Medium), recommendation 9.2 #6.
 - **Workstream:** WS-D3.
 - **Carries forward:** TPI-001 from `AUDIT_v0.9.32_TRACKED_PROOF_ISSUES.md`.
-- **Current problem:** Only error-case preservation is proven for `vspaceMapPage` and `vspaceUnmapPage`. No theorem proves a *successful* operation preserves the invariant bundle.
+- **Resolution:** Two success-path invariant preservation theorems and four round-trip theorems
+  implemented in `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`. Supporting infrastructure:
+  `resolveAsidRoot_some_implies` and `resolveAsidRoot_of_unique_root` extraction/characterization
+  lemmas in `VSpace.lean`; `storeObject_objectIndex_eq_of_mem` for post-state objectIndex stability;
+  seven VSpaceRoot helper theorems in `Object.lean` (`mapPage_asid_eq`, `unmapPage_asid_eq`,
+  `lookup_eq_none_not_mem`, `mapPage_noVirtualOverlap`, `unmapPage_noVirtualOverlap`,
+  `lookup_mapPage_ne`, `lookup_unmapPage_ne`). No `sorry` debt. TPI-001 fully closed.
 
-Required theorem obligations:
-
-```lean
-/-- A successful vspaceMapPage preserves the VSpace invariant bundle. -/
-theorem vspaceMapPage_success_preserves_invariantBundle
-    (asid : ASID) (vaddr : VAddr) (paddr : PAddr)
-    (st st' : SystemState)
-    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st'))
-    (hInv : vspaceInvariantBundle st) :
-    vspaceInvariantBundle st' := by
-  sorry  -- proof obligation
-
-/-- A successful vspaceUnmapPage preserves the VSpace invariant bundle. -/
-theorem vspaceUnmapPage_success_preserves_invariantBundle
-    (asid : ASID) (vaddr : VAddr)
-    (st st' : SystemState)
-    (hUnmap : vspaceUnmapPage asid vaddr st = .ok ((), st'))
-    (hInv : vspaceInvariantBundle st) :
-    vspaceInvariantBundle st' := by
-  sorry  -- proof obligation
-```
-
-Additionally, close the TPI-001 round-trip obligations from WS-C:
+Closed theorem obligations:
 
 ```lean
-/-- Mapping a page and then looking it up yields the mapped address. -/
+/-- Successful vspaceMapPage preserves VSpace invariant bundle. -/
+theorem vspaceMapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState) (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr) (paddr : SeLe4n.PAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceInvariantBundle st'
+
+/-- Successful vspaceUnmapPage preserves VSpace invariant bundle. -/
+theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
+    (st st' : SystemState) (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceInvariantBundle st'
+
+/-- TPI-001 #1: map then lookup yields mapped address. -/
 theorem vspaceLookup_after_map
-    (asid : ASID) (vaddr : VAddr) (paddr : PAddr)
-    (st st' : SystemState)
-    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
-    vspaceLookup asid vaddr st' = .ok (paddr, st') := by
-  sorry  -- proof obligation
+    (st st' : SystemState) (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr) (paddr : SeLe4n.PAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .ok (paddr, st')
 
-/-- Mapping vaddr does not affect lookup of a different vaddr'. -/
+/-- TPI-001 #2: map at vaddr does not affect lookup at different vaddr'. -/
 theorem vspaceLookup_map_other
-    (asid : ASID) (vaddr vaddr' : VAddr) (paddr : PAddr)
-    (st st' : SystemState)
-    (hNe : vaddr ≠ vaddr')
-    (hMap : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
-    vspaceLookup asid vaddr' st' = vspaceLookup asid vaddr' st := by
-  sorry  -- proof obligation
+    (st st' : SystemState) (asid : SeLe4n.ASID) (vaddr vaddr' : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr) (hNe : vaddr ≠ vaddr')
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceMapPage asid vaddr paddr st = .ok ((), st')) :
+    (vspaceLookup asid vaddr' st').map Prod.fst = (vspaceLookup asid vaddr' st).map Prod.fst
 
-/-- After unmap, lookup fails with translationFault. -/
+/-- TPI-001 #3: after unmap, lookup fails with translationFault. -/
 theorem vspaceLookup_after_unmap
-    (asid : ASID) (vaddr : VAddr)
-    (st st' : SystemState)
-    (hUnmap : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
-    vspaceLookup asid vaddr st' = .error .translationFault := by
-  sorry  -- proof obligation
+    (st st' : SystemState) (asid : SeLe4n.ASID) (vaddr : SeLe4n.VAddr)
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    vspaceLookup asid vaddr st' = .error .translationFault
+
+/-- TPI-001 #4: unmap at vaddr does not affect lookup at different vaddr'. -/
+theorem vspaceLookup_unmap_other
+    (st st' : SystemState) (asid : SeLe4n.ASID) (vaddr vaddr' : SeLe4n.VAddr)
+    (hNe : vaddr ≠ vaddr')
+    (hInv : vspaceInvariantBundle st)
+    (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
+    (vspaceLookup asid vaddr' st').map Prod.fst = (vspaceLookup asid vaddr' st).map Prod.fst
 ```
 
 ---
@@ -231,5 +242,5 @@ Each issue closes only when all are true:
 
 | WS-C Issue | Status | Carried to WS-D |
 |---|---|---|
-| TPI-001 (VSpace round-trip theorems) | OPEN | Carried to TPI-D05 |
+| TPI-001 (VSpace round-trip theorems) | CLOSED | Resolved by TPI-D05 (four round-trip theorems proved) |
 | TPI-002 (IF noninterference seed) | CLOSED | Extended by TPI-D01, TPI-D02, TPI-D03 |

--- a/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
@@ -63,9 +63,10 @@ Close all 17 findings (F-01 through F-17) identified in the v0.11.0 end-to-end r
 - **WS-D2:** Wire policy enforcement into kernel operations; extend non-interference proofs beyond endpoint send. **Completed.**
 - All acceptance criteria met: `securityFlowsTo` enforced in three operations (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`), four additional non-interference theorems proved (`chooseThread`, `cspaceMint`, `cspaceRevoke`, `lifecycleRetypeObject`), enforcement boundary documented. Tier 0-3 gates pass.
 
-### Phase P3 — proof completion and kernel hardening (Medium)
+### Phase P3 — proof completion and kernel hardening (in progress)
 
-- **WS-D3:** Close remaining proof gaps (badge safety, VSpace success preservation).
+- **WS-D3:** Close remaining proof gaps (badge safety, VSpace success preservation). **Completed.**
+- All three findings (F-06, F-08, F-16) resolved. TPI-D04 and TPI-D05 closed. TPI-001 obligations from WS-C fully discharged. Four round-trip theorems proved. Seven Invariant.lean files annotated with proof-scope docstrings. Tier 0-3 gates pass.
 - **WS-D4:** Harden kernel design (cycle detection, atomicity, double-wait).
 - Goal: meaningful proof coverage and defensive kernel semantics.
 
@@ -245,6 +246,36 @@ Validation gates: `./scripts/test_full.sh --continue` passes Tier 0-3.
 
 **Dependencies:** None (proof work is independent of test fixes).
 
+**Completion evidence**
+
+All acceptance criteria met. Summary of changes:
+
+1. **F-06 (Badge-override safety in cspaceMint):** Three badge-safety theorems added
+   to `Capability/Invariant.lean`: `mintDerivedCap_rights_attenuated_with_badge_override`
+   (rights attenuation holds regardless of badge), `mintDerivedCap_target_preserved_with_badge_override`
+   (target identity preserved regardless of badge), and `cspaceMint_badge_override_safe`
+   (composed kernel-operation-level safety: badge override in cspaceMint cannot escalate privilege).
+   All proved without `sorry`. TPI-D04 closed.
+
+2. **F-08 (VSpace successful-operation preservation):** Two success-path preservation
+   theorems added to `VSpaceInvariant.lean`: `vspaceMapPage_success_preserves_vspaceInvariantBundle`
+   and `vspaceUnmapPage_success_preserves_vspaceInvariantBundle`. Both prove invariant
+   preservation over genuinely modified state. Supporting infrastructure added:
+   - `resolveAsidRoot_some_implies` and `resolveAsidRoot_of_unique_root` (VSpace.lean)
+   - `storeObject_objectIndex_eq_of_mem` (VSpace.lean)
+   - VSpaceRoot helper theorems: `mapPage_asid_eq`, `unmapPage_asid_eq`, `lookup_eq_none_not_mem`,
+     `mapPage_noVirtualOverlap`, `unmapPage_noVirtualOverlap`, `lookup_mapPage_ne`, `lookup_unmapPage_ne`
+     (Object.lean)
+   Four TPI-001 round-trip theorems proved: `vspaceLookup_after_map`, `vspaceLookup_map_other`,
+   `vspaceLookup_after_unmap`, `vspaceLookup_unmap_other`. All proved without `sorry`. TPI-D05 and
+   TPI-001 closed.
+
+3. **F-16 (Document trivial error-preservation proof scope):** Module-level `/-! ... -/`
+   docstrings added to all seven `Invariant.lean` files (Scheduler, IPC, Capability,
+   Lifecycle, InformationFlow, Service, Architecture, VSpaceInvariant). Each docstring
+   classifies every theorem as substantive preservation, error-case preservation (trivially
+   true), structural/bridge, non-interference, or badge-safety. Claim-evidence index updated.
+
 ---
 
 ### WS-D4 — Kernel Design Hardening
@@ -406,7 +437,7 @@ Each workstream PR must include:
 |---|---|---|---|---|
 | WS-D1 | **Completed** | Critical/High | F-01, F-03, F-04 | Test error handling and validity restoration. Gate G1 passed: Tier 0-3 clean. |
 | WS-D2 | **Completed** | High | F-02, F-05 | Information-flow enforcement and non-interference proof expansion. Gate G2 passed: enforcement in 3 operations, 4 additional non-interference theorems. |
-| WS-D3 | Planned | Medium | F-06, F-08, F-16 | Proof gap closure (badge safety, VSpace preservation, proof documentation). Carries TPI-001 from WS-C. |
+| WS-D3 | **Completed** | Medium | F-06, F-08, F-16 | Proof gap closure (badge safety, VSpace preservation, proof documentation). TPI-001 closed. Gate G3 (proof) passed. |
 | WS-D4 | Planned | Medium | F-07, F-11, F-12 | Kernel design hardening (cycles, atomicity, double-wait). |
 | WS-D5 | Planned | Medium | F-09, F-10 | Test infrastructure expansion (fixtures, ID bounds). |
 | WS-D6 | Planned | Low | F-13, F-14, F-15, F-17 | CI/CD polish and documentation governance. F-13 likely already resolved. |

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -143,7 +143,54 @@ This keeps the M5 theorem surface aligned with the local-first composition rule:
 prove per-transition preservation first, then expose cross-subsystem bundle preservation with
 explicit failure-path statements.
 
-## 10. IF-M1 information-flow baseline layering (WS-B7 complete)
+## 10. VSpace proof completion (WS-D3 / F-08 / TPI-001 complete)
+
+VSpace invariant bundle preservation is now proven for both success and error paths:
+
+- **Error-path preservation** (trivially true, error returns unchanged state):
+  - `vspaceMapPage_error_asidNotBound_preserves_vspaceInvariantBundle`
+  - `vspaceUnmapPage_error_translationFault_preserves_vspaceInvariantBundle`
+- **Success-path preservation** (substantive — prove invariant preservation over changed state):
+  - `vspaceMapPage_success_preserves_vspaceInvariantBundle`
+  - `vspaceUnmapPage_success_preserves_vspaceInvariantBundle`
+- **Round-trip / functional-correctness theorems** (TPI-001 closure):
+  - `vspaceLookup_after_map`: map then lookup yields mapped address
+  - `vspaceLookup_map_other`: map at vaddr doesn't affect lookup at different vaddr'
+  - `vspaceLookup_after_unmap`: after unmap, lookup fails with translationFault
+  - `vspaceLookup_unmap_other`: unmap at vaddr doesn't affect lookup at different vaddr'
+
+Supporting infrastructure in `VSpace.lean`:
+- `resolveAsidRoot_some_implies` — extracts object-store facts from successful ASID resolution
+- `resolveAsidRoot_of_unique_root` — characterization lemma enabling round-trip proofs
+- `storeObject_objectIndex_eq_of_mem` — objectIndex stability for in-place updates
+
+## 11. Badge-override safety (WS-D3 / F-06 / TPI-D04 complete)
+
+Badge-override safety in `cspaceMint` is now fully proven:
+
+- `mintDerivedCap_rights_attenuated_with_badge_override` — rights attenuation holds regardless of badge
+- `mintDerivedCap_target_preserved_with_badge_override` — target identity preserved regardless of badge
+- `cspaceMint_badge_override_safe` — composed kernel-operation-level safety witness
+
+The core insight: `mintDerivedCap` checks `rightsSubset` and sets `target := parent.target`
+unconditionally — the `badge` parameter only affects the `.badge` field of the child capability,
+which is notification-signaling metadata, not authority scope.
+
+## 12. Proof classification docstrings (WS-D3 / F-16 complete)
+
+All seven `Invariant.lean` files now contain module-level `/-! ... -/` docstrings that classify
+every theorem into one of these categories:
+
+| Category | Assurance level |
+|---|---|
+| **Substantive preservation** | High — proves invariant preservation over changed state |
+| **Error-case preservation** | Low — trivially true (unchanged state) |
+| **Non-interference** | Critical — proves high-domain operations don't leak to low observers |
+| **Badge-safety** | High — proves badge override cannot escalate privilege |
+| **Structural / bridge** | High — proves decomposition/composition relationships |
+| **Round-trip / functional-correctness** | High — proves semantic contracts between operations |
+
+## 13. IF-M1 information-flow baseline layering (WS-B7 complete)
 
 Information-flow proof-track entrypoints now exist with explicit local decomposition:
 

--- a/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
+++ b/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
@@ -13,7 +13,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 - **Findings baseline:** `AUDIT_v0.11.0.md` (17 findings, F-01..F-17)
 - **Execution baseline:** `AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (WS-D portfolio)
 - **Tracked theorem obligations:** `AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md` (7 proof obligations, TPI-D01..D07)
-- **Current planning stage:** Phase P3 (WS-D1, WS-D2 completed; WS-D3/WS-D4 next)
+- **Current planning stage:** Phase P3 (WS-D1, WS-D2, WS-D3 completed; WS-D4 next)
 
 ## 2) Active workstreams (WS-D portfolio)
 
@@ -31,10 +31,10 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 
 ### Medium — Proof completion and kernel hardening
 
-- **WS-D3:** Proof gap closure (medium; **planned** — F-06, F-08, F-16)
-  - Badge-override safety proof (F-06, TPI-D04).
-  - VSpace successful-operation preservation (F-08, TPI-D05; carries TPI-001 from WS-C).
-  - Document trivial error-preservation proof scope (F-16).
+- **WS-D3:** Proof gap closure (medium; **completed** — F-06, F-08, F-16)
+  - Badge-override safety proof (F-06, TPI-D04). **Done.** Three theorems proved.
+  - VSpace successful-operation preservation (F-08, TPI-D05; carries TPI-001 from WS-C). **Done.** Two preservation + four round-trip theorems proved.
+  - Document trivial error-preservation proof scope (F-16). **Done.** Seven module docstrings added.
 
 - **WS-D4:** Kernel design hardening (medium; **planned** — F-07, F-11, F-12)
   - Service dependency cycle detection (F-07, TPI-D07).
@@ -58,7 +58,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 - **P0:** Baseline transition (completed) — publish planning backbone, demote WS-C.
 - **P1:** WS-D1 test validity restoration — **completed**.
 - **P2:** WS-D2 information-flow enforcement and proof expansion — **completed**.
-- **P3:** WS-D3 + WS-D4 proof completion and kernel hardening (parallel).
+- **P3:** WS-D3 (**completed**) + WS-D4 proof completion and kernel hardening.
 - **P4:** WS-D5 + WS-D6 infrastructure expansion and polish (parallel).
 
 ## 4) Updating status

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -40,7 +40,7 @@ claims, and planning artifacts.
 
 ## 2. Current State Snapshot
 
-- **Current package version:** `0.11.1` (`lakefile.toml`)
+- **Current package version:** `0.11.3` (`lakefile.toml`)
 - **Active findings baseline:** [`docs/audits/AUDIT_v0.11.0.md`](../audits/AUDIT_v0.11.0.md)
 - **Active execution baseline:** [`docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md)
 - **Current active portfolio:** WS-D1..WS-D6 (v0.11.0 audit remediation)
@@ -88,7 +88,7 @@ on the semantic and proof foundations of the previous one.
 
 ### 4.2 Medium — Proof Completion and Kernel Hardening
 
-- **WS-D3:** Proof gap closure (medium; **planned** — F-06, F-08, F-16; carries TPI-001 from WS-C)
+- **WS-D3:** Proof gap closure (medium; **completed** — F-06, F-08, F-16; TPI-001 closed)
 - **WS-D4:** Kernel design hardening (medium; **planned** — F-07, F-11, F-12)
 - **WS-D5:** Test infrastructure expansion (medium; **planned** — F-09, F-10)
 
@@ -106,7 +106,7 @@ Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 - **Phase P0:** Baseline transition — publish v0.11.0 planning backbone, demote WS-C to historical (completed)
 - **Phase P1:** WS-D1 test validity restoration (critical/high) — **completed**
 - **Phase P2:** WS-D2 information-flow enforcement and proof expansion (high) — **completed**
-- **Phase P3:** WS-D3 proof gap closure + WS-D4 kernel design hardening (medium)
+- **Phase P3:** WS-D3 proof gap closure (**completed**) + WS-D4 kernel design hardening (medium)
 - **Phase P4:** WS-D5 test infrastructure expansion + WS-D6 CI/documentation polish (medium/low)
 
 ---

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.11.1"
+version = "0.11.3"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -327,6 +327,33 @@ run_check "INVARIANT" rg -n '^theorem serviceStop_failure_preserves_serviceLifec
 run_check "INVARIANT" rg -n '^theorem serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle' SeLe4n/Kernel/Service/Invariant.lean
 
+# WS-D3 F-06/TPI-D04 badge-override safety anchors must remain present.
+run_check "INVARIANT" rg -n '^theorem mintDerivedCap_rights_attenuated_with_badge_override' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem mintDerivedCap_target_preserved_with_badge_override' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem cspaceMint_badge_override_safe' SeLe4n/Kernel/Capability/Invariant.lean
+
+# WS-D3 F-08/TPI-D05 VSpace success preservation + TPI-001 round-trip anchors must remain present.
+run_check "INVARIANT" rg -n '^theorem vspaceMapPage_success_preserves_vspaceInvariantBundle' SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+run_check "INVARIANT" rg -n '^theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle' SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+run_check "INVARIANT" rg -n '^theorem vspaceLookup_after_map' SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+run_check "INVARIANT" rg -n '^theorem vspaceLookup_map_other' SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+run_check "INVARIANT" rg -n '^theorem vspaceLookup_after_unmap' SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+run_check "INVARIANT" rg -n '^theorem vspaceLookup_unmap_other' SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+
+# WS-D3 F-08 VSpace resolveAsidRoot extraction/characterization lemmas.
+run_check "INVARIANT" rg -n '^theorem resolveAsidRoot_some_implies' SeLe4n/Kernel/Architecture/VSpace.lean
+run_check "INVARIANT" rg -n '^theorem resolveAsidRoot_of_unique_root' SeLe4n/Kernel/Architecture/VSpace.lean
+run_check "INVARIANT" rg -n '^def vspaceAsidRootsUnique' SeLe4n/Kernel/Architecture/VSpace.lean
+
+# WS-D3 F-16 module docstring classification anchors must remain present.
+run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/Scheduler/Invariant.lean
+run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/InformationFlow/Invariant.lean
+run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/Service/Invariant.lean
+run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/Architecture/Invariant.lean
+
 # M3.5 step-7 executable demonstration closure anchors.
 run_check "TRACE" rg -n 'adapter timer success path value' SeLe4n/Testing/MainTraceHarness.lean
 run_check "TRACE" rg -n 'adapter timer invalid-context branch' SeLe4n/Testing/MainTraceHarness.lean


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-D3 (proof completion and kernel hardening)
- **Recommendation IDs closed:** F-06 (badge-override safety), F-08 (VSpace success preservation), F-16 (proof scope qualification)
- **Tracked proof issues closed:** TPI-D04 (badge safety), TPI-D05 (VSpace invariant preservation), TPI-001 (VSpace round-trip contracts)
- **Scope notes:** All three findings fully resolved with substantive preservation theorems and round-trip functional-correctness proofs. No `sorry` debt introduced.

## Changes

### 1. Badge-override safety (F-06 / TPI-D04)

Added three theorems to `SeLe4n/Kernel/Capability/Invariant.lean`:

- **`mintDerivedCap_rights_attenuated_with_badge_override`** — proves rights attenuation holds regardless of badge parameter
- **`mintDerivedCap_target_preserved_with_badge_override`** — proves target identity preserved regardless of badge parameter  
- **`cspaceMint_badge_override_safe`** — composed kernel-operation-level safety witness

These theorems decompose through the existing `mintDerivedCap_attenuates` lemma and show that badge override affects only the `.badge` field; `rightsSubset` check and `target := parent.target` assignment are badge-independent.

### 2. VSpace success-path invariant preservation (F-08 / TPI-D05)

Added two substantive preservation theorems to `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`:

- **`vspaceMapPage_success_preserves_vspaceInvariantBundle`** — proves ASID-root uniqueness and non-overlap preserved after successful map
- **`vspaceUnmapPage_success_preserves_vspaceInvariantBundle`** — proves ASID-root uniqueness and non-overlap preserved after successful unmap

Both proofs decompose into two obligations: (1) ASID preservation via `mapPage_asid_eq` / `unmapPage_asid_eq`, and (2) non-overlap preservation via `mapPage_noVirtualOverlap` / `unmapPage_noVirtualOverlap`.

### 3. VSpace round-trip theorems (TPI-001 closure)

Added four functional-correctness theorems to `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`:

- **`vspaceLookup_after_map`** — after successful map, lookup on same ASID/vaddr returns mapped paddr
- **`vspaceLookup_map_other`** — map at vaddr doesn't affect lookup at different vaddr'
- **`vspaceLookup_after_unmap`** — after successful unmap, lookup fails with translationFault
- **`vspaceLookup_unmap_other`** — unmap at vaddr doesn't affect lookup at different vaddr'

These close all TPI-001 obligations from WS-C audit.

### 4. Supporting infrastructure

**`SeLe4n/Kernel/Architecture/VSpace.lean`:**
- Moved `vspaceAsidRootsUnique` definition from VSpaceInvariant.lean
- **`resolveAsidRoot_some_implies`** — extracts object-store facts from successful ASID resolution
- **`resolveAsidRoot_of_unique_root`** — characterization lemma enabling round-trip proofs (key enabler for post-state ASID resolution)
- **`storeObject_objectIndex_eq_of_mem`** — proves objectIndex stability for in-place updates

**`SeLe4n/Model/Object.lean`:**
- **`mapPage_asid_eq`** — `mapPage` preserves VSpace root ASID
- **`unmapPage_asid_eq`** — `unmapPage` preserves VSpace root AS

https://claude.ai/code/session_01SR9FkhhLXZFix4SaJJJ5jQ