### PR TITLE
docs: add comprehensive guide for editing large files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,53 @@ When editing large files, read the specific region around the target lines
 first (e.g., `offset=380, limit=40`) rather than the whole file. This avoids
 context-window pressure and "file too large" errors.
 
+## Writing and editing large files
+
+The Write tool replaces an entire file in one call. For files over ~200 lines
+this is error-prone: content gets silently truncated, sections are accidentally
+dropped, and the context window fills up. **Prefer the Edit tool for all
+changes to existing files**, regardless of size.
+
+**Rules for large-file changes:**
+
+1. **Never rewrite a large file with Write.** Use Edit with a precise
+   `old_string`/`new_string` pair targeting only the lines that change. This is
+   safer and uses far less context.
+2. **One logical change per Edit call.** If you need to change three separate
+   functions, make three Edit calls rather than one giant replacement that spans
+   the whole file.
+3. **Read before you edit.** Always Read the specific region first
+   (e.g., `offset=350, limit=50`) so the `old_string` matches exactly,
+   including indentation and whitespace.
+4. **Adding large new sections.** If you must insert more than ~80 new lines
+   into an existing file, break the insertion into multiple sequential Edit
+   calls (each ≤80 lines), anchoring each one to context already present in the
+   file.
+5. **Creating new large files.** When a new file must exceed ~200 lines, build
+   it incrementally:
+   - Write an initial skeleton (imports, structure, first section) with Write.
+   - Use successive Edit calls to append remaining sections, using the end of
+     the previously written content as the `old_string` anchor.
+   - Verify the final line count with `wc -l` via Bash.
+6. **Post-write verification.** After any large write or series of edits, spot-
+   check the result by reading the modified region (and the file's last few
+   lines) to confirm nothing was truncated or duplicated.
+
+**Example — appending a new theorem block to an invariant file:**
+
+```
+# Step 1: Read the anchor region at the end of the file
+Read("SeLe4n/Kernel/Capability/Invariant.lean", offset=880, limit=20)
+
+# Step 2: Edit using the last lines as old_string, appending new content
+Edit(file_path="SeLe4n/Kernel/Capability/Invariant.lean",
+     old_string="<last 2-3 lines of file>",
+     new_string="<those same lines>\n<new theorem block>")
+
+# Step 3: Verify
+Bash("wc -l SeLe4n/Kernel/Capability/Invariant.lean")
+```
+
 ## Handling large search and command output
 
 Grep and other search tools can return oversized results in this codebase.


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: Documentation
- Recommendation IDs closed: N/A
- Scope notes: Adds detailed guidance to CLAUDE.md on safe practices for writing and editing large files, addressing common pitfalls with the Write tool and establishing best practices for Edit-based workflows.

## Changes

Added a new "Writing and editing large files" section to `CLAUDE.md` that documents:

1. **Core principle**: Prefer the Edit tool over Write for all changes to existing files, regardless of size, to avoid silent truncation and context-window pressure.

2. **Six actionable rules**:
   - Never rewrite large files with Write; use Edit with precise old_string/new_string pairs
   - One logical change per Edit call to maintain clarity and safety
   - Always read the target region first to ensure exact matching
   - Break large insertions (>80 lines) into multiple sequential Edit calls
   - Build new large files incrementally with an initial skeleton followed by Edit calls
   - Verify results by spot-checking modified regions and file line counts

3. **Concrete example**: Demonstrates the three-step workflow (Read → Edit → Verify) for appending a theorem block to a Lean file, showing the exact pattern to follow.

This guidance directly addresses failure modes observed in large-file operations and provides clear, repeatable procedures for contributors.

## Validation evidence

- [x] Documentation-only change; no code tests required
- [x] Content is self-contained within CLAUDE.md (no cross-file synchronization needed)
- [x] No generated navigation or GitBook mirrors affected

## Documentation synchronization checklist

- [x] Canonical source updated (`CLAUDE.md`)
- [x] No GitBook mirrors or generated files affected
- [x] No navigation generation required
- [x] No active workstream status changes

## Risks / follow-ups

- Residual risks: None; this is purely additive documentation
- Deferred items: None

https://claude.ai/code/session_01NCQtnphcod9tXeoGdn3Xpz