### PR TITLE
Complete BFS soundness bridge (TPI-D07-BRIDGE): prove bfs_complete_for_nontrivialPath

### DIFF
--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -780,34 +780,27 @@ private theorem go_complete
                 rcases List.mem_cons.mp hBFron with rfl | hBRest
                 · exact Or.inl List.mem_cons_self  -- b = node ∈ new visited
                 · exact Or.inr (List.mem_append_left _ hBRest)  -- b ∈ rest ⊆ newFrontier
-          -- Find witness in new frontier
-          -- We need ∃ w' ∈ newFrontier, w' ∉ (node :: visited) ∧ serviceReachable st w' target
-          -- Use frontier_witness_of_reachable
-          -- We know w reaches target. Where is w in the new state?
-          rcases List.mem_cons.mp hMemW with rfl | hMemRest
-          · -- w = node: node reaches target, node is now in new visited.
-            -- Use frontier_witness_of_reachable: node ∈ new visited, node reaches target.
+          -- Find witness in new frontier.
+          -- w reaches target — determine if w entered newVisited or stayed in frontier.
+          by_cases hWNode : w = node
+          · -- w = node: now in newVisited. Extract a new frontier witness.
+            subst hWNode
             have hWit := frontier_witness_of_reachable st target
               newFrontier newVisited hNewClosure _ hReachW
               hNewTargetNotVis (Or.inl List.mem_cons_self)
             exact ih_fuel newFrontier newVisited hWit
               hNewFReach hNewVisReach hNewNodup hNewTargetNotVis hNewBudget hNewClosure
-          · -- w ∈ rest: is w in new visited?
-            by_cases hWNode : w = node
-            · -- w = node: same as above
-              subst hWNode
-              have hWit := frontier_witness_of_reachable st target
-                newFrontier newVisited hNewClosure _ hReachW
-                hNewTargetNotVis (Or.inl List.mem_cons_self)
-              exact ih_fuel newFrontier newVisited hWit
-                hNewFReach hNewVisReach hNewNodup hNewTargetNotVis hNewBudget hNewClosure
-            · -- w ≠ node, w ∉ visited → w ∉ node :: visited
-              have hWNotNewVis : w ∉ newVisited := by
-                simp [newVisited, List.mem_cons]; exact ⟨hWNode, hNotVisW⟩
-              have hWInNew : w ∈ newFrontier := List.mem_append_left _ hMemRest
-              exact ih_fuel newFrontier newVisited
-                ⟨w, hWInNew, hWNotNewVis, hReachW⟩
-                hNewFReach hNewVisReach hNewNodup hNewTargetNotVis hNewBudget hNewClosure
+          · -- w ≠ node, w ∉ visited → w ∉ newVisited, w ∈ rest ⊆ newFrontier
+            have hWNotNewVis : w ∉ newVisited := by
+              simp [newVisited, List.mem_cons]; exact ⟨hWNode, hNotVisW⟩
+            have hMemRest : w ∈ rest := by
+              rcases List.mem_cons.mp hMemW with rfl | h
+              · exact absurd rfl hWNode
+              · exact h
+            have hWInNew : w ∈ newFrontier := List.mem_append_left _ hMemRest
+            exact ih_fuel newFrontier newVisited
+              ⟨w, hWInNew, hWNotNewVis, hReachW⟩
+              hNewFReach hNewVisReach hNewNodup hNewTargetNotVis hNewBudget hNewClosure
 
 -- --------------------------------------------------------------------------
 -- B5: serviceHasPathTo complete
@@ -855,7 +848,7 @@ theorem bfs_complete_for_nontrivialPath
   serviceHasPathTo_complete st a b (serviceReachable_of_nontrivialPath hPath) hBound
 
 -- --------------------------------------------------------------------------
--- B7: soundness of false (corollary)
+-- B7: completeness contrapositive (BFS false → not reachable)
 -- --------------------------------------------------------------------------
 
 /-- BFS false implies no declarative path (contrapositive of B5). -/

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -343,41 +343,41 @@ theorem serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvaria
 -- ============================================================================
 
 /-!
-## TPI-D07 proof infrastructure plan
+## TPI-D07 proof infrastructure (COMPLETED)
 
 ### Definitions (Layer 0)
 - `serviceEdge` — direct dependency edge relation
 - `serviceReachable` — reflexive-transitive closure of serviceEdge
-- `serviceHasNontrivialPath` — path of length ≥ 1
-- `serviceDependencyAcyclicDecl` — declarative acyclicity (no non-trivial self-loops)
+- `serviceNontrivialPath` — path of length ≥ 1
+- `serviceDependencyAcyclic` — declarative acyclicity (no non-trivial self-loops)
 
 ### Structural lemmas (Layer 1)
-- `serviceEdge_iff_mem` — definitional unfolding
 - `serviceReachable_trans` — path concatenation
 - `serviceReachable_of_edge` — single-edge path
-- `serviceReachable_step_right` — right-append edge
-- `serviceHasNontrivialPath_of_edge` — edge implies nontrivial path
-- `storeServiceState_objectIndex_eq` — objectIndex frame condition
-- `serviceBfsFuel_storeServiceState_eq` — fuel frame condition
-- `serviceEdge_storeServiceState_eq` — edge at updated service
+- `serviceReachable_of_nontrivialPath` — nontrivial path → reachable
+- `serviceNontrivialPath_of_edge_reachable` — edge + reachable → nontrivial
+- `serviceNontrivialPath_of_reachable_ne` — reachable + distinct → nontrivial
 - `serviceEdge_storeServiceState_ne` — edge at non-updated service
+- `serviceEdge_storeServiceState_updated` — edge at updated service
 - `serviceEdge_post_insert` — edge characterization after insertion
 
-### BFS soundness (Layer 2)
-- `serviceHasPathTo_true_implies_reachable` — BFS true → declarative path
-- `serviceHasPathTo_go_invariant` — BFS loop invariant
-- `serviceBfsFuel_sufficient` — fuel adequacy
-- `serviceHasPathTo_false_implies_not_reachable` — BFS false → no path
+### BFS soundness bridge (Layer 2) — B1-B7
+- `go_true_implies_exists_reachable` (B1) — go true → ∃ reachable frontier node
+- `serviceHasPathTo_true_implies_reachable` (B2) — BFS true → declarative path
+- `serviceHasPathTo_true_implies_nontrivial` (B3) — BFS true + distinct → nontrivial
+- `serviceCountBounded` — fuel adequacy precondition
+- `frontier_witness_of_reachable` — closure invariant witness extraction
+- `go_complete` (B4) — BFS go loop completeness under invariants
+- `serviceHasPathTo_complete` (B5) — BFS completeness wrapper
+- `bfs_complete_for_nontrivialPath` (B6) — TPI-D07-BRIDGE closure theorem
+- `serviceHasPathTo_false_implies_not_reachable` (B7) — BFS false → no path
 
-### Edge insertion (Layer 3)
-- `serviceEdge_post_cases` — post-state edge decomposition
-- `serviceReachable_post_insert_cases` — post-state path decomposition
-- `nontrivial_cycle_post_insert_implies_pre_reach` — cycle → pre-state reachability
-- `serviceDependencyAcyclicDecl_preserved` — declarative acyclicity preserved
+### Post-insertion path decomposition (Layer 3)
+- `nontrivialPath_post_insert_cases` — post-state path decomposition
 
-### Final closure (Layer 4)
-- `serviceDependencyAcyclic_implies_acyclicDecl` — BFS → declarative equivalence
-- `serviceDependencyAcyclicDecl_implies_acyclic` — declarative → BFS equivalence
+### Acyclicity preservation (Layer 4)
+- `serviceRegisterDependency_preserves_acyclicity` — acyclicity preserved
+  (under `serviceCountBounded` precondition)
 -/
 
 -- ============================================================================
@@ -507,28 +507,367 @@ theorem serviceEdge_post_insert {st : SystemState} {svcId depId : ServiceId}
       · exact absurd hEq ha
       · exact h
 
+
 -- ============================================================================
--- Layer 2: BFS completeness bridge (TPI-D07-BRIDGE)
+-- Layer 2: BFS soundness bridge (M2 — BFS Soundness Bridge, TPI-D07 closure)
 -- ============================================================================
 
-/-- BFS completeness bridge: a nontrivial path between distinct services is
-detected by `serviceHasPathTo` with `serviceBfsFuel` fuel.
+/-! ### B1–B7: BFS ↔ declarative path equivalence
 
-This connects the declarative path relation to the executable BFS check
-used in `serviceRegisterDependency`. The property is operationally
-validated by the negative state suite (cycle detection tests) and the
-depth-5 dependency chain smoke test.
+This section proves the soundness and completeness of the bounded BFS
+reachability check `serviceHasPathTo` with respect to the declarative
+path relation `serviceReachable` / `serviceNontrivialPath`.
 
-TPI-D07-BRIDGE: Formal proof of BFS loop-invariant completeness is
-deferred as future infrastructure (see Risk 1, Risk 3 in the risk
-register). The assumption is that `serviceBfsFuel` provides sufficient
-fuel and the BFS correctly explores all reachable nodes. -/
+#### Easy direction (B1–B3): BFS `true` → declarative path
+- B1: `go_true_implies_exists_reachable`
+- B2: `serviceHasPathTo_true_implies_reachable`
+- B3: `serviceHasPathTo_true_implies_nontrivial`
+
+#### Hard direction (B4–B7): declarative path → BFS `true`
+- B4: `go_complete` — the core BFS loop completeness lemma
+- B5: `serviceHasPathTo_complete` — outer completeness wrapper
+- B6: `bfs_complete_for_nontrivialPath` — closes TPI-D07-BRIDGE
+- B7: `serviceHasPathTo_false_implies_not_reachable` — soundness of `false`
+
+#### Fuel adequacy
+- `serviceCountBounded` — reachable set size < `serviceBfsFuel st`.
+-/
+
+-- --------------------------------------------------------------------------
+-- B1: go true → ∃ reachable frontier node
+-- --------------------------------------------------------------------------
+
+/-- If the BFS inner loop returns `true`, some frontier node reaches target. -/
+private theorem go_true_implies_exists_reachable
+    (st : SystemState) (target : ServiceId)
+    (frontier visited : List ServiceId) (fuel : Nat)
+    (hTrue : serviceHasPathTo.go st target frontier visited fuel = true) :
+    ∃ node ∈ frontier, serviceReachable st node target := by
+  induction fuel generalizing frontier visited with
+  | zero => simp [serviceHasPathTo.go] at hTrue
+  | succ n ih =>
+    revert hTrue
+    induction frontier generalizing visited with
+    | nil => intro hTrue; simp [serviceHasPathTo.go] at hTrue
+    | cons node rest ih_frontier =>
+      intro hTrue
+      unfold serviceHasPathTo.go at hTrue
+      by_cases hEq : node = target
+      · exact ⟨node, List.mem_cons_self, hEq ▸ .refl⟩
+      · simp only [hEq, ite_false] at hTrue
+        by_cases hVis : node ∈ visited
+        · simp only [hVis, ite_true] at hTrue
+          rcases ih_frontier visited hTrue with ⟨w, hMem, hReach⟩
+          exact ⟨w, List.mem_cons_of_mem _ hMem, hReach⟩
+        · simp only [hVis, ite_false] at hTrue
+          rcases ih _ _ hTrue with ⟨w, hMem, hReach⟩
+          rw [List.mem_append] at hMem
+          rcases hMem with hRest | hDep
+          · exact ⟨w, List.mem_cons_of_mem _ hRest, hReach⟩
+          · rw [List.mem_filter] at hDep
+            have hMemDeps := hDep.1
+            have hEdge : serviceEdge st node w := by
+              cases hLookup : lookupService st node with
+              | none => simp only [hLookup] at hMemDeps; exact absurd hMemDeps (List.not_mem_nil)
+              | some svc => simp only [hLookup] at hMemDeps; exact ⟨svc, hLookup, hMemDeps⟩
+            exact ⟨node, List.mem_cons_self, .step hEdge hReach⟩
+
+-- --------------------------------------------------------------------------
+-- B2: serviceHasPathTo true → serviceReachable
+-- --------------------------------------------------------------------------
+
+/-- If `serviceHasPathTo` returns `true`, then a declarative path exists. -/
+theorem serviceHasPathTo_true_implies_reachable
+    (st : SystemState) (src target : ServiceId) (fuel : Nat)
+    (hTrue : serviceHasPathTo st src target fuel = true) :
+    serviceReachable st src target := by
+  unfold serviceHasPathTo at hTrue
+  rcases go_true_implies_exists_reachable st target [src] [] fuel hTrue
+    with ⟨node, hMem, hReach⟩
+  simp at hMem
+  subst hMem; exact hReach
+
+-- --------------------------------------------------------------------------
+-- B3: serviceHasPathTo true + src ≠ target → serviceNontrivialPath
+-- --------------------------------------------------------------------------
+
+/-- If src ≠ target and BFS returns true, the path is non-trivial. -/
+theorem serviceHasPathTo_true_implies_nontrivial
+    (st : SystemState) (src target : ServiceId) (fuel : Nat)
+    (hNeq : src ≠ target)
+    (hTrue : serviceHasPathTo st src target fuel = true) :
+    serviceNontrivialPath st src target := by
+  have hReach := serviceHasPathTo_true_implies_reachable st src target fuel hTrue
+  cases hReach with
+  | refl => exact absurd rfl hNeq
+  | step hedge hreach => exact serviceNontrivialPath_of_edge_reachable hedge hreach
+
+-- --------------------------------------------------------------------------
+-- Fuel adequacy definition
+-- --------------------------------------------------------------------------
+
+/-- Fuel adequacy: for any source, all Nodup lists of nodes reachable from
+    it have length strictly less than `serviceBfsFuel st`.  This ensures
+    the BFS has positive fuel whenever a target node is dequeued. -/
+def serviceCountBounded (st : SystemState) : Prop :=
+  ∀ (src : ServiceId) (sids : List ServiceId),
+    sids.Nodup →
+    (∀ sid ∈ sids, serviceReachable st src sid) →
+    sids.length < serviceBfsFuel st
+
+-- --------------------------------------------------------------------------
+-- Helper: witness extraction from closure invariant
+-- --------------------------------------------------------------------------
+
+/-- Given a node reachable from `v` to `target`, if `v ∈ visited ∪ frontier`,
+    `target ∉ visited`, and every visited node's deps are in `visited ∪ frontier`,
+    then some frontier node (not in visited) reaches `target`.
+
+    This is the key link between the BFS closure invariant and the
+    existence of a valid frontier witness. -/
+private theorem frontier_witness_of_reachable
+    (st : SystemState) (target : ServiceId)
+    (frontier visited : List ServiceId)
+    (hClosure : ∀ v ∈ visited, ∀ b, serviceEdge st v b → b ∈ visited ∨ b ∈ frontier)
+    (v : ServiceId)
+    (hReach : serviceReachable st v target)
+    (hTargetNotVis : target ∉ visited)
+    (hInSet : v ∈ visited ∨ v ∈ frontier) :
+    ∃ w ∈ frontier, w ∉ visited ∧ serviceReachable st w target := by
+  revert hTargetNotVis hInSet
+  induction hReach with
+  | refl =>
+    intro hTargetNotVis hInSet
+    rcases hInSet with hVis | hFron
+    · exact absurd hVis hTargetNotVis
+    · exact ⟨_, hFron, hTargetNotVis, .refl⟩
+  | @step src mid _ hedge hreach ih =>
+    intro hTargetNotVis hInSet
+    rcases hInSet with hVis | hFron
+    · -- src ∈ visited: by closure, mid ∈ visited ∨ mid ∈ frontier
+      rcases hClosure src hVis _ hedge with hMidVis | hMidFron
+      · exact ih hTargetNotVis (Or.inl hMidVis)
+      · exact ih hTargetNotVis (Or.inr hMidFron)
+    · -- src ∈ frontier: check if also in visited
+      by_cases hSrcVis : src ∈ visited
+      · rcases hClosure src hSrcVis _ hedge with hMidVis | hMidFron
+        · exact ih hTargetNotVis (Or.inl hMidVis)
+        · exact ih hTargetNotVis (Or.inr hMidFron)
+      · exact ⟨src, hFron, hSrcVis, .step hedge hreach⟩
+
+-- --------------------------------------------------------------------------
+-- B4: go completeness (core inner lemma)
+-- --------------------------------------------------------------------------
+
+/-- BFS `go` completeness with invariants:
+    1. All frontier nodes reachable from `src`
+    2. All visited nodes reachable from `src`
+    3. `visited.Nodup`
+    4. `target ∉ visited`
+    5. `fuel + visited.length = serviceBfsFuel st`
+    6. Closure: deps of visited nodes are in visited ∪ frontier
+    7. `serviceCountBounded st`
+    8. ∃ witness in frontier reaching target and not in visited -/
+private theorem go_complete
+    (st : SystemState) (target : ServiceId) (src : ServiceId)
+    (hBound : serviceCountBounded st) (fuel : Nat) :
+    ∀ (frontier visited : List ServiceId),
+    (∃ w ∈ frontier, w ∉ visited ∧ serviceReachable st w target) →
+    (∀ w ∈ frontier, serviceReachable st src w) →
+    (∀ v ∈ visited, serviceReachable st src v) →
+    visited.Nodup →
+    target ∉ visited →
+    fuel + visited.length = serviceBfsFuel st →
+    (∀ v ∈ visited, ∀ b, serviceEdge st v b → b ∈ visited ∨ b ∈ frontier) →
+    serviceHasPathTo.go st target frontier visited fuel = true := by
+  induction fuel with
+  | zero =>
+    -- fuel = 0 → visited.length = serviceBfsFuel st.
+    -- But serviceCountBounded implies visited.length < serviceBfsFuel st.
+    -- Contradiction.
+    intro frontier visited _ _ hVisReach hNodup _ hBudget _
+    exfalso
+    have := hBound src visited hNodup hVisReach
+    omega
+  | succ n ih_fuel =>
+    intro frontier
+    induction frontier with
+    | nil => intro _ ⟨w, hMemW, _, _⟩; exact absurd hMemW (List.not_mem_nil)
+    | cons node rest ih_frontier =>
+      intro visited ⟨w, hMemW, hNotVisW, hReachW⟩
+        hFReach hVisReach hNodup hTargetNotVis hBudget hClosure
+      -- Is node the target?
+      by_cases hEq : node = target
+      · subst hEq; simp [serviceHasPathTo.go]
+      · simp only [serviceHasPathTo.go, hEq, ite_false]
+        by_cases hVis : node ∈ visited
+        · -- Visited: skip, fuel recycled
+          simp only [hVis, ite_true]
+          -- Witness: w ≠ node (since w ∉ visited, node ∈ visited) → w ∈ rest
+          have hWRest : w ∈ rest := by
+            rcases List.mem_cons.mp hMemW with rfl | h
+            · exact absurd hVis hNotVisW
+            · exact h
+          -- Closure still holds for rest: deps of visited nodes are in visited ∨ rest
+          have hClosureRest : ∀ v ∈ visited, ∀ b, serviceEdge st v b →
+              b ∈ visited ∨ b ∈ rest := by
+            intro v hv b hEdge
+            rcases hClosure v hv b hEdge with hBVis | hBFron
+            · exact Or.inl hBVis
+            · rcases List.mem_cons.mp hBFron with rfl | hBRest
+              · exact Or.inl hVis  -- b = node ∈ visited
+              · exact Or.inr hBRest
+          exact ih_frontier visited
+            ⟨w, hWRest, hNotVisW, hReachW⟩
+            (fun x hx => hFReach x (List.mem_cons_of_mem _ hx))
+            hVisReach hNodup hTargetNotVis hBudget hClosureRest
+        · -- New node: expand, fuel decrements
+          simp only [hVis, ite_false]
+          -- New state
+          let newVisited := node :: visited
+          -- The let-binding in go unfolds to:
+          -- let deps := match lookupService st node with | some svc => svc.dependencies | none => []
+          -- let newFrontier := rest ++ deps.filter (· ∉ visited)
+          -- go newFrontier newVisited n
+          have hNewNodup : (node :: visited).Nodup := List.nodup_cons.mpr ⟨hVis, hNodup⟩
+          have hNewTargetNotVis : target ∉ node :: visited := by
+            simp [List.mem_cons]; exact ⟨Ne.symm hEq, hTargetNotVis⟩
+          have hNewBudget : n + (node :: visited).length = serviceBfsFuel st := by
+            simp [List.length_cons]; omega
+          have hNodeReach : serviceReachable st src node :=
+            hFReach node List.mem_cons_self
+          -- Compute deps
+          let deps := match lookupService st node with
+            | some svc => svc.dependencies
+            | none => []
+          let newFrontier := rest ++ (deps.filter (· ∉ visited))
+          -- New frontier reachability
+          have hNewFReach : ∀ x ∈ newFrontier, serviceReachable st src x := by
+            intro x hx; rw [List.mem_append] at hx
+            rcases hx with hRest | hDep
+            · exact hFReach x (List.mem_cons_of_mem _ hRest)
+            · rw [List.mem_filter] at hDep
+              have hEdge : serviceEdge st node x := by
+                simp only [deps] at hDep
+                cases hL : lookupService st node with
+                | none => simp [hL] at hDep
+                | some svc => simp [hL] at hDep; exact ⟨svc, hL, hDep.1⟩
+              exact serviceReachable_trans hNodeReach (serviceReachable_of_edge hEdge)
+          have hNewVisReach : ∀ v ∈ node :: visited, serviceReachable st src v := by
+            intro v hv; rcases List.mem_cons.mp hv with rfl | h
+            · exact hNodeReach
+            · exact hVisReach v h
+          -- New closure: deps of (node :: visited) nodes are in (node :: visited) ∨ newFrontier
+          have hNewClosure : ∀ v ∈ node :: visited, ∀ b, serviceEdge st v b →
+              b ∈ node :: visited ∨ b ∈ newFrontier := by
+            intro v hv b hEdge
+            rcases List.mem_cons.mp hv with rfl | hOld
+            · -- v = node: b is in node's deps
+              rcases hEdge with ⟨svc, hLookup, hMemDep⟩
+              by_cases hBVis : b ∈ visited
+              · exact Or.inl (List.mem_cons_of_mem _ hBVis)
+              · -- b ∉ visited: b is in deps.filter (· ∉ visited) ⊆ newFrontier
+                right
+                apply List.mem_append_right
+                rw [List.mem_filter]
+                constructor
+                · simp only [deps, hLookup]; exact hMemDep
+                · simp [hBVis]
+            · -- v ∈ visited (old): by old closure, b ∈ visited ∨ b ∈ (node :: rest)
+              rcases hClosure v hOld b hEdge with hBVis | hBFron
+              · exact Or.inl (List.mem_cons_of_mem _ hBVis)
+              · -- b ∈ node :: rest
+                rcases List.mem_cons.mp hBFron with rfl | hBRest
+                · exact Or.inl List.mem_cons_self  -- b = node ∈ new visited
+                · exact Or.inr (List.mem_append_left _ hBRest)  -- b ∈ rest ⊆ newFrontier
+          -- Find witness in new frontier
+          -- We need ∃ w' ∈ newFrontier, w' ∉ (node :: visited) ∧ serviceReachable st w' target
+          -- Use frontier_witness_of_reachable
+          -- We know w reaches target. Where is w in the new state?
+          rcases List.mem_cons.mp hMemW with rfl | hMemRest
+          · -- w = node: node reaches target, node is now in new visited.
+            -- Use frontier_witness_of_reachable: node ∈ new visited, node reaches target.
+            have hWit := frontier_witness_of_reachable st target
+              newFrontier newVisited hNewClosure _ hReachW
+              hNewTargetNotVis (Or.inl List.mem_cons_self)
+            exact ih_fuel newFrontier newVisited hWit
+              hNewFReach hNewVisReach hNewNodup hNewTargetNotVis hNewBudget hNewClosure
+          · -- w ∈ rest: is w in new visited?
+            by_cases hWNode : w = node
+            · -- w = node: same as above
+              subst hWNode
+              have hWit := frontier_witness_of_reachable st target
+                newFrontier newVisited hNewClosure _ hReachW
+                hNewTargetNotVis (Or.inl List.mem_cons_self)
+              exact ih_fuel newFrontier newVisited hWit
+                hNewFReach hNewVisReach hNewNodup hNewTargetNotVis hNewBudget hNewClosure
+            · -- w ≠ node, w ∉ visited → w ∉ node :: visited
+              have hWNotNewVis : w ∉ newVisited := by
+                simp [newVisited, List.mem_cons]; exact ⟨hWNode, hNotVisW⟩
+              have hWInNew : w ∈ newFrontier := List.mem_append_left _ hMemRest
+              exact ih_fuel newFrontier newVisited
+                ⟨w, hWInNew, hWNotNewVis, hReachW⟩
+                hNewFReach hNewVisReach hNewNodup hNewTargetNotVis hNewBudget hNewClosure
+
+-- --------------------------------------------------------------------------
+-- B5: serviceHasPathTo complete
+-- --------------------------------------------------------------------------
+
+/-- BFS completeness: `serviceReachable st src target` with bounded services
+    implies `serviceHasPathTo` returns `true`. -/
+theorem serviceHasPathTo_complete
+    (st : SystemState) (src target : ServiceId)
+    (hReach : serviceReachable st src target)
+    (hBound : serviceCountBounded st) :
+    serviceHasPathTo st src target (serviceBfsFuel st) = true := by
+  unfold serviceHasPathTo
+  have hSrcReach : serviceReachable st src src := .refl
+  -- Initial frontier = [src], visited = []
+  -- Witness: src ∈ [src], src ∉ [], serviceReachable st src target
+  -- Closure: ∀ v ∈ [], ... vacuously true
+  -- target ∉ []: true
+  -- Budget: serviceBfsFuel st + 0 = serviceBfsFuel st
+  exact go_complete st target src hBound (serviceBfsFuel st) [src] []
+    ⟨src, List.mem_cons_self, List.not_mem_nil, hReach⟩
+    (fun w hw => by simp at hw; subst hw; exact hSrcReach)
+    (fun _ hv => absurd hv List.not_mem_nil)
+    List.nodup_nil
+    List.not_mem_nil
+    (by simp)
+    (fun _ hv => absurd hv List.not_mem_nil)
+
+-- --------------------------------------------------------------------------
+-- B6: bfs_complete_for_nontrivialPath — main bridge theorem
+-- --------------------------------------------------------------------------
+
+/-- BFS completeness bridge: a nontrivial path between distinct services
+    is detected by `serviceHasPathTo` with `serviceBfsFuel` fuel.
+
+    This closes TPI-D07-BRIDGE. The `serviceCountBounded` precondition is
+    operationally guaranteed by the service creation protocol and propagated
+    to the downstream acyclicity preservation theorem. -/
 theorem bfs_complete_for_nontrivialPath
     {st : SystemState} {a b : ServiceId}
-    (_hPath : serviceNontrivialPath st a b)
-    (_hNe : a ≠ b) :
-    serviceHasPathTo st a b (serviceBfsFuel st) = true := by
-  sorry -- TPI-D07-BRIDGE: BFS completeness proof deferred (validated by executable tests)
+    (hPath : serviceNontrivialPath st a b)
+    (_hNe : a ≠ b)
+    (hBound : serviceCountBounded st) :
+    serviceHasPathTo st a b (serviceBfsFuel st) = true :=
+  serviceHasPathTo_complete st a b (serviceReachable_of_nontrivialPath hPath) hBound
+
+-- --------------------------------------------------------------------------
+-- B7: soundness of false (corollary)
+-- --------------------------------------------------------------------------
+
+/-- BFS false implies no declarative path (contrapositive of B5). -/
+theorem serviceHasPathTo_false_implies_not_reachable
+    (st : SystemState) (src target : ServiceId)
+    (hBound : serviceCountBounded st)
+    (hBfs : serviceHasPathTo st src target (serviceBfsFuel st) = false) :
+    ¬ serviceReachable st src target := by
+  intro hReach
+  have hTrue := serviceHasPathTo_complete st src target hReach hBound
+  simp [hTrue] at hBfs
+
 
 -- ============================================================================
 -- Layer 3: Post-insertion nontrivial path decomposition
@@ -575,7 +914,8 @@ theorem nontrivialPath_post_insert_cases
 -- Layer 4: Acyclicity preservation (TPI-D07 closure)
 -- ============================================================================
 
-/-- After a successful dependency registration, the dependency graph remains acyclic.
+/-- After a successful dependency registration, the dependency graph remains acyclic,
+provided the service graph has bounded count (`serviceCountBounded`).
 
 The `serviceRegisterDependency` function checks whether `depId` can reach
 `svcId` through existing edges before adding `svcId → depId`. If the check
@@ -585,13 +925,14 @@ so adding the edge preserves acyclicity.
 Risk 0 resolution (WS-D4/TPI-D07): The vacuous BFS-based invariant has been
 replaced with a declarative acyclicity definition. The preservation proof is
 genuine — it proceeds by post-insertion path decomposition and derives a
-contradiction from the BFS cycle-detection check. The sole deferred obligation
-is BFS completeness (`bfs_complete_for_nontrivialPath`, TPI-D07-BRIDGE),
-which connects the declarative path relation to the executable BFS check. -/
+contradiction from the BFS cycle-detection check. BFS completeness
+(`bfs_complete_for_nontrivialPath`) is now proved under the fuel adequacy
+precondition `serviceCountBounded`, closing TPI-D07-BRIDGE. -/
 theorem serviceRegisterDependency_preserves_acyclicity
     (svcId depId : ServiceId) (st st' : SystemState)
     (hReg : serviceRegisterDependency svcId depId st = .ok ((), st'))
-    (hAcyc : serviceDependencyAcyclic st) :
+    (hAcyc : serviceDependencyAcyclic st)
+    (hBound : serviceCountBounded st) :
     serviceDependencyAcyclic st' := by
   unfold serviceRegisterDependency at hReg
   cases hSvc : lookupService st svcId with
@@ -632,7 +973,7 @@ theorem serviceRegisterDependency_preserves_acyclicity
                 serviceNontrivialPath_of_reachable_ne hDepSvc (Ne.symm hSelf)
               -- BFS completeness: nontrivial path → BFS returns true
               have hBfsTrue : serviceHasPathTo st depId svcId (serviceBfsFuel st) = true :=
-                bfs_complete_for_nontrivialPath hNontrivial (Ne.symm hSelf)
+                bfs_complete_for_nontrivialPath hNontrivial (Ne.symm hSelf) hBound
               -- Contradiction with the BFS check that returned false
               exact absurd hBfsTrue hCycle
 

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -34,7 +34,7 @@ The following categories of theorems exist in the proof surface. Claims about pr
 | TPI-D04 | Badge-override safety in cspaceMint | WS-D3 | CLOSED |
 | TPI-D05 | VSpace successful-operation preservation + round-trip theorems | WS-D3 | CLOSED |
 | TPI-D06 | Waiting-list uniqueness invariant | WS-D4 | CLOSED |
-| TPI-D07 | Service dependency acyclicity invariant (Risk 0 resolved: vacuous definition fixed, declarative proof complete; BFS completeness bridge `sorry` tracked as TPI-D07-BRIDGE) | WS-D4 | CLOSED |
+| TPI-D07 | Service dependency acyclicity invariant (Risk 0 resolved: vacuous definition fixed, declarative proof complete; BFS completeness bridge fully proved under `serviceCountBounded`) | WS-D4 | CLOSED |
 
 ## Update policy
 

--- a/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
+++ b/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
@@ -232,22 +232,21 @@ theorem notificationWait_preserves_uniqueWaiters
     `serviceNontrivialPath_step_right`. Frame lemmas: `serviceEdge_storeServiceState_ne`,
     `serviceEdge_storeServiceState_updated`, `serviceEdge_post_insert`.
   - **Layer 2 (BFS bridge):** `bfs_complete_for_nontrivialPath` — BFS completeness
-    bridge connecting declarative paths to the executable BFS check. Uses `sorry`
-    (annotated TPI-D07-BRIDGE); operationally validated by executable tests.
+    bridge connecting declarative paths to the executable BFS check. Fully proved
+    via `serviceHasPathTo_complete` under `serviceCountBounded` precondition.
   - **Layer 3 (Path decomposition):** `nontrivialPath_post_insert_cases` — decomposes
     any post-insertion nontrivial path into either a pre-state path or a composition
     using the new edge with pre-state reachability.
   - **Layer 4 (Closure):** `serviceRegisterDependency_preserves_acyclicity` — genuine
     preservation proof via post-insertion path decomposition and contradiction with the
-    BFS cycle-detection check. The main theorem is sorry-free; only the focused BFS
-    bridge lemma carries a deferred `sorry`.
+    BFS cycle-detection check. Takes `serviceCountBounded` precondition for fuel adequacy.
 
-  **Remaining sub-obligation (TPI-D07-BRIDGE):** The focused `sorry` on
-  `bfs_complete_for_nontrivialPath` defers a formal proof that the BFS with
-  `serviceBfsFuel` fuel is complete enough to detect all nontrivial paths between
-  distinct services. This is a well-scoped, non-vacuous assumption validated by
-  executable tests (negative state suite cycle detection + depth-5 dependency chain
-  smoke test). See Risk 1 and Risk 3 in the risk register for future closure path.
+  **Closure (TPI-D07-BRIDGE resolved):** The BFS completeness bridge
+  `bfs_complete_for_nontrivialPath` is now fully proved. The proof establishes that
+  any nontrivial path between distinct services is detected by the bounded BFS when
+  `serviceCountBounded st` holds (reachable service count < BFS fuel). The full B1-B7
+  suite proves BFS-declarative path equivalence. Fuel adequacy is propagated as
+  a precondition to `serviceRegisterDependency_preserves_acyclicity`.
 
 Closed theorem obligation:
 

--- a/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
+++ b/docs/audits/AUDIT_v0.11.0_TRACKED_PROOF_ISSUES.md
@@ -258,10 +258,11 @@ def serviceDependencyAcyclic (st : SystemState) : Prop :=
 theorem serviceRegisterDependency_preserves_acyclicity
     (svcId depId : ServiceId) (st st' : SystemState)
     (hReg : serviceRegisterDependency svcId depId st = .ok ((), st'))
-    (hAcyc : serviceDependencyAcyclic st) :
+    (hAcyc : serviceDependencyAcyclic st)
+    (hBound : serviceCountBounded st) :
     serviceDependencyAcyclic st' := by
   ...  -- genuine proof: post-insertion path decomposition + BFS contradiction
-  -- sole deferred obligation: bfs_complete_for_nontrivialPath (TPI-D07-BRIDGE)
+  -- TPI-D07-BRIDGE closed: bfs_complete_for_nontrivialPath fully proved
 ```
 
 ---

--- a/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
@@ -68,7 +68,7 @@ Close all 17 findings (F-01 through F-17) identified in the v0.11.0 end-to-end r
 - **WS-D3:** Close remaining proof gaps (badge safety, VSpace success preservation). **Completed.**
 - All three findings (F-06, F-08, F-16) resolved. TPI-D04 and TPI-D05 closed. TPI-001 obligations from WS-C fully discharged. Four round-trip theorems proved. Seven Invariant.lean files annotated with proof-scope docstrings. Tier 0-3 gates pass.
 - **WS-D4:** Harden kernel design (cycle detection, failure semantics, double-wait). **Completed.**
-- All three findings (F-07, F-11, F-12) resolved. TPI-D06 closed. TPI-D07 closed (Risk 0 resolved: declarative acyclicity with Layers 0-4; sole deferred `sorry` on BFS bridge TPI-D07-BRIDGE). Tier 0-3 gates pass.
+- All three findings (F-07, F-11, F-12) resolved. TPI-D06 closed. TPI-D07 closed (Risk 0 resolved: declarative acyclicity with full Layers 0-4 proofs; BFS soundness bridge TPI-D07-BRIDGE now proved under `serviceCountBounded`). Tier 0-3 gates pass.
 
 ### Phase P4 — infrastructure expansion (Medium/Low)
 
@@ -475,7 +475,7 @@ Each workstream PR must include:
 | WS-D1 | **Completed** | Critical/High | F-01, F-03, F-04 | Test error handling and validity restoration. Gate G1 passed: Tier 0-3 clean. |
 | WS-D2 | **Completed** | High | F-02, F-05 | Information-flow enforcement and non-interference proof expansion. Gate G2 passed: enforcement in 3 operations, 4 additional non-interference theorems. |
 | WS-D3 | **Completed** | Medium | F-06, F-08, F-16 | Proof gap closure (badge safety, VSpace preservation, proof documentation). TPI-001 closed. Gate G3 (proof) passed. |
-| WS-D4 | **Completed** | Medium | F-07, F-11, F-12 | Kernel design hardening (cycles, failure semantics, double-wait). TPI-D06 closed. TPI-D07 closed (Risk 0 resolved: declarative acyclicity with Layers 0-4; sole deferred `sorry` on BFS bridge TPI-D07-BRIDGE). |
+| WS-D4 | **Completed** | Medium | F-07, F-11, F-12 | Kernel design hardening (cycles, failure semantics, double-wait). TPI-D06 closed. TPI-D07 closed (Risk 0 resolved: declarative acyclicity with full Layers 0-4 proofs; BFS completeness bridge now proved under `serviceCountBounded`). |
 | WS-D5 | Planned | Medium | F-09, F-10 | Test infrastructure expansion (fixtures, ID bounds). |
 | WS-D6 | Planned | Low | F-13, F-14, F-15, F-17 | CI/CD polish and documentation governance. F-13 likely already resolved. |
 

--- a/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md
@@ -336,9 +336,9 @@ All acceptance criteria met. Summary of changes:
    proved without `sorry`. **Risk 0 resolved (TPI-D07 closed):** The vacuous BFS-based
    acyclicity invariant was replaced with a declarative definition using `serviceNontrivialPath`.
    The preservation theorem (`serviceRegisterDependency_preserves_acyclicity`) is proved via
-   post-insertion path decomposition and BFS contradiction — the main theorem is sorry-free.
-   The sole deferred obligation is `bfs_complete_for_nontrivialPath` (TPI-D07-BRIDGE), a
-   focused BFS completeness bridge validated by executable tests. NegativeStateSuite validates
+   post-insertion path decomposition and BFS contradiction. BFS completeness
+   (`bfs_complete_for_nontrivialPath`) is fully proved under the `serviceCountBounded`
+   precondition, closing TPI-D07-BRIDGE. NegativeStateSuite validates
    self-loop, missing-target, cycle, and idempotent re-registration paths.
    Full execution plan in `docs/audits/execution_plans/`; M0 baseline lock completed.
 

--- a/docs/audits/execution_plans/04_THEOREM_DEPENDENCY_GRAPH.md
+++ b/docs/audits/execution_plans/04_THEOREM_DEPENDENCY_GRAPH.md
@@ -2,7 +2,7 @@
 
 This document is the complete inventory of definitions and theorems required for TPI-D07 closure, ordered by dependency. Each theorem depends only on those above it in the same layer or prior layers.
 
-> **Implementation status:** Layers 0, 1, 3, and 4 are fully implemented in `SeLe4n/Kernel/Service/Invariant.lean` (lines 381-637). Layer 2 (BFS soundness) was reduced to a single focused `sorry` on `bfs_complete_for_nontrivialPath` (TPI-D07-BRIDGE, line 531) rather than the full B1-B7 theorem suite originally planned here. Naming evolved during implementation: planned `serviceHasNontrivialPath` (D3) became `serviceNontrivialPath` (inductive type rather than existential def); planned `serviceDependencyAcyclicDecl` (D4) was eliminated — `serviceDependencyAcyclic` itself was redefined declaratively.
+> **Implementation status:** All layers (0-4) are fully implemented and proved without `sorry` in `SeLe4n/Kernel/Service/Invariant.lean`. Layer 2 (BFS soundness) includes the complete B1-B7 suite; `bfs_complete_for_nontrivialPath` (TPI-D07-BRIDGE) is proved under the `serviceCountBounded` precondition. Naming evolved during implementation: planned `serviceHasNontrivialPath` (D3) became `serviceNontrivialPath` (inductive type rather than existential def); planned `serviceDependencyAcyclicDecl` (D4) was eliminated — `serviceDependencyAcyclic` itself was redefined declaratively.
 
 ---
 
@@ -14,8 +14,8 @@ These introduce the declarative graph semantics. No proofs required — only wel
 |---|---|---|---|---|
 | D1 | `serviceEdge` | `SystemState → ServiceId → ServiceId → Prop` | `Service/Invariant.lean` | M1 |
 | D2 | `serviceReachable` | `SystemState → ServiceId → ServiceId → Prop` (inductive) | `Service/Invariant.lean` | M1 |
-| D3 | `serviceHasNontrivialPath` | `SystemState → ServiceId → ServiceId → Prop` (at least one edge) | `Service/Invariant.lean` | M1 |
-| D4 | `serviceDependencyAcyclicDecl` | `SystemState → Prop` (declarative version, optional if Option 2) | `Service/Invariant.lean` | M1 |
+| D3 | `serviceNontrivialPath` | `SystemState → ServiceId → ServiceId → Prop` (inductive, at least one edge) | `Service/Invariant.lean` | M1 |
+| D4 | `serviceDependencyAcyclic` | `SystemState → Prop` (declarative: `∀ sid, ¬ serviceNontrivialPath st sid sid`) | `Service/Invariant.lean` | M1 |
 
 ### Definition details
 
@@ -29,13 +29,14 @@ inductive serviceReachable (st : SystemState) : ServiceId → ServiceId → Prop
   | refl  : serviceReachable st a a
   | step  : serviceEdge st a b → serviceReachable st b c → serviceReachable st a c
 
--- D3: Non-trivial path (at least one step)
-def serviceHasNontrivialPath (st : SystemState) (a b : ServiceId) : Prop :=
-  ∃ mid, serviceEdge st a mid ∧ serviceReachable st mid b
+-- D3: Non-trivial path (at least one step, inductive)
+inductive serviceNontrivialPath (st : SystemState) : ServiceId → ServiceId → Prop where
+  | single : serviceEdge st a b → serviceNontrivialPath st a b
+  | cons   : serviceEdge st a b → serviceNontrivialPath st b c → serviceNontrivialPath st a c
 
 -- D4: Declarative acyclicity (no non-trivial self-loops)
-def serviceDependencyAcyclicDecl (st : SystemState) : Prop :=
-  ∀ sid, ¬ serviceHasNontrivialPath st sid sid
+def serviceDependencyAcyclic (st : SystemState) : Prop :=
+  ∀ sid, ¬ serviceNontrivialPath st sid sid
 ```
 
 **Design rationale for D3:** `serviceReachable` includes `refl` (every node trivially reaches itself), so `¬ serviceReachable st sid sid` is always false. The acyclicity invariant must exclude trivial paths. `serviceHasNontrivialPath` captures "reachable via at least one edge."
@@ -48,23 +49,21 @@ These establish basic properties of the declarative path relation and its intera
 
 | ID | Name | Statement sketch | Depends on | Tactic hint |
 |---|---|---|---|---|
-| L1 | `serviceEdge_iff_mem` | `serviceEdge st a b ↔ ∃ svc, lookupService st a = some svc ∧ b ∈ svc.dependencies` | D1 | `simp [serviceEdge]` |
-| L2 | `serviceReachable_trans` | `serviceReachable st a b → serviceReachable st b c → serviceReachable st a c` | D2 | Induction on first `serviceReachable` |
-| L3 | `serviceReachable_of_edge` | `serviceEdge st a b → serviceReachable st a b` | D1, D2 | `exact .step h .refl` |
-| L4 | `serviceReachable_step_right` | `serviceReachable st a b → serviceEdge st b c → serviceReachable st a c` | L2, L3 | `exact L2 h (L3 hedge)` |
-| L5 | `serviceHasNontrivialPath_of_edge` | `serviceEdge st a b → serviceHasNontrivialPath st a b` | D1, D3 | `exact ⟨b, h, .refl⟩` |
-| L6 | `serviceHasNontrivialPath_trans_edge` | `serviceHasNontrivialPath st a b → serviceEdge st b c → serviceHasNontrivialPath st a c` | D3, L4 | Unfold, compose with L4 |
-| L7 | `serviceHasNontrivialPath_of_edge_reachable` | `serviceEdge st a b → serviceReachable st b c → serviceHasNontrivialPath st a c` | D1, D2, D3 | `exact ⟨b, h, hreach⟩` |
+| L1 | `serviceReachable_trans` | `serviceReachable st a b → serviceReachable st b c → serviceReachable st a c` | D2 | Induction on first `serviceReachable` |
+| L2 | `serviceReachable_of_edge` | `serviceEdge st a b → serviceReachable st a b` | D1, D2 | `exact .step h .refl` |
+| L3 | `serviceReachable_of_nontrivialPath` | `serviceNontrivialPath st a b → serviceReachable st a b` | D3, L2 | Induction on nontrivial path |
+| L4 | `serviceNontrivialPath_of_edge_reachable` | `serviceEdge st a b → serviceReachable st b c → serviceNontrivialPath st a c` | D1, D2, D3 | Match on reachable, construct nontrivial |
+| L5 | `serviceNontrivialPath_of_reachable_ne` | `serviceReachable st a b → a ≠ b → serviceNontrivialPath st a b` | L4 | Cases on reachable, absurd on refl |
+| L6 | `serviceNontrivialPath_trans` | `serviceNontrivialPath st a b → serviceNontrivialPath st b c → serviceNontrivialPath st a c` | D3 | Induction on first path |
+| L7 | `serviceNontrivialPath_step_right` | `serviceNontrivialPath st a b → serviceEdge st b c → serviceNontrivialPath st a c` | D3 | Induction on path |
 
 ### Store-interaction lemmas
 
 | ID | Name | Statement sketch | Depends on | Tactic hint |
 |---|---|---|---|---|
-| S1 | `storeServiceState_objectIndex_eq` | `(storeServiceState sid entry st).objectIndex = st.objectIndex` | — | `simp [storeServiceState]` |
-| S2 | `serviceBfsFuel_storeServiceState_eq` | `serviceBfsFuel (storeServiceState sid entry st) = serviceBfsFuel st` | S1 | `simp [serviceBfsFuel, S1]` |
-| S3 | `serviceEdge_storeServiceState_eq` | `serviceEdge (storeServiceState svcId svc' st) svcId b ↔ b ∈ svc'.dependencies` | D1, `storeServiceState_lookup_eq` | Unfold, apply lookup_eq |
-| S4 | `serviceEdge_storeServiceState_ne` | `sid ≠ svcId → (serviceEdge (storeServiceState svcId svc' st) sid b ↔ serviceEdge st sid b)` | D1, `storeServiceState_lookup_ne` | Unfold, apply lookup_ne |
-| S5 | `serviceEdge_post_insert` | For the specific `svc' = { svc with dependencies := svc.dependencies ++ [depId] }`: `serviceEdge st' svcId b ↔ b ∈ svc.dependencies ∨ b = depId` | S3 | `simp [S3, List.mem_append, List.mem_singleton]` |
+| S1 | `serviceEdge_storeServiceState_ne` | `a ≠ svcId → (serviceEdge (storeServiceState svcId entry st) a b ↔ serviceEdge st a b)` | D1, `storeServiceState_lookup_ne` | Unfold, apply lookup_ne |
+| S2 | `serviceEdge_storeServiceState_updated` | `serviceEdge (storeServiceState svcId entry st) svcId b ↔ b ∈ entry.dependencies` | D1, `storeServiceState_lookup_eq` | Unfold, apply lookup_eq |
+| S3 | `serviceEdge_post_insert` | Edge characterization after appending `depId` to `svc.dependencies` | S1, S2 | by_cases on `a = svcId`, apply S1 or S2 |
 
 ---
 
@@ -72,13 +71,13 @@ These establish basic properties of the declarative path relation and its intera
 
 | ID | Name | Statement sketch | Depends on | Tactic hint |
 |---|---|---|---|---|
-| B1 | `serviceHasPathTo_go_true_implies_reachable` | If `go frontier visited fuel = true` and every frontier node is reachable from `src`, then `src` reaches `target` | D2, L1 | Induction on `fuel` with frontier/visited generalization |
+| B1 | `go_true_implies_exists_reachable` | If `go frontier visited fuel = true`, some frontier node reaches target | D2, L1 | Induction on `fuel` with inner induction on `frontier` |
 | B2 | `serviceHasPathTo_true_implies_reachable` | `serviceHasPathTo st src target fuel = true → serviceReachable st src target` | B1, D2 | Apply B1 with initial frontier `[src]`, visited `[]` |
-| B3 | `serviceHasPathTo_true_implies_nontrivial` | `src ≠ target → serviceHasPathTo st src target fuel = true → serviceHasNontrivialPath st src target` | B2, D3 | If src ≠ target, the BFS must take at least one edge step |
-| B4 | `serviceHasPathTo_go_invariant` | Loop invariant: if a declarative path from `src` to `target` exists, then either `target ∈ visited`, or some `mid ∈ frontier` with `serviceReachable st mid target`, or `go` returns `true` | D2, L1 | Strong induction on `fuel`, with generalized frontier/visited |
-| B5 | `serviceBfsFuel_sufficient` | Fuel adequacy: `serviceBfsFuel st` exceeds the number of distinct services in the graph (or: stated as a precondition) | — | See [Risk R1](./05_RISK_REGISTER.md#risk-1) |
-| B6 | `serviceHasPathTo_false_implies_not_reachable` | `serviceHasPathTo st src target (serviceBfsFuel st) = false → ¬ serviceReachable st src target` | B4, B5 | Contrapositive: assume reachable, apply B4 to show BFS must return true |
-| B7 | `serviceHasPathTo_false_implies_not_nontrivial` | `serviceHasPathTo st src target (serviceBfsFuel st) = false → ¬ serviceHasNontrivialPath st src target` | B6, D3 | Since nontrivial path implies reachability, apply B6 |
+| B3 | `serviceHasPathTo_true_implies_nontrivial` | `src ≠ target → serviceHasPathTo st src target fuel = true → serviceNontrivialPath st src target` | B2, D3 | If src ≠ target, the BFS must take at least one edge step |
+| B4 | `go_complete` | BFS go loop completeness: given witness in frontier, closure invariant, Nodup visited, and fuel budget, go returns true | D2, L1, `frontier_witness_of_reachable` | Induction on `fuel`, inner induction on `frontier` |
+| B5 | `serviceHasPathTo_complete` | `serviceReachable st src target → serviceCountBounded st → serviceHasPathTo st src target (serviceBfsFuel st) = true` | B4, `serviceCountBounded` | Apply B4 with initial state: frontier `[src]`, visited `[]` |
+| B6 | `bfs_complete_for_nontrivialPath` | `serviceNontrivialPath st a b → a ≠ b → serviceCountBounded st → serviceHasPathTo st a b (serviceBfsFuel st) = true` | B5, L2 | Extract reachability from nontrivial path, apply B5 |
+| B7 | `serviceHasPathTo_false_implies_not_reachable` | `serviceCountBounded st → serviceHasPathTo ... = false → ¬ serviceReachable st src target` | B5 | Contrapositive of B5 |
 
 **Note on B1 vs B4:** B1 proves the "easy direction" (BFS returns `true` → real path exists). B4 proves the "hard direction" setup (real path exists → BFS returns `true`). Both are needed: B1 for Option 1 completeness and for the edge-insertion proof, B4/B6 for soundness.
 
@@ -113,29 +112,17 @@ The key insight is that condition (3c) is the conclusion we want. The proof proc
 
 | ID | Name | Statement sketch | Depends on | Tactic hint |
 |---|---|---|---|---|
-| E1 | `serviceEdge_post_cases` | `serviceEdge st' x y → (x = svcId ∧ (y ∈ svc.dependencies ∨ y = depId)) ∨ (x ≠ svcId ∧ serviceEdge st x y)` | S3, S4, S5 | Case split on `x = svcId` |
-| E2 | `serviceReachable_post_insert_of_pre` | `serviceReachable st a b → serviceReachable st' a b` | S4, S5, D2 | Induction on `serviceReachable st a b`; each edge either preserved or strengthened |
-| E3 | `serviceReachable_post_insert_cases` | Post-state path decomposes: `serviceReachable st' a b → serviceReachable st a b ∨ (serviceReachable st a svcId ∧ serviceReachable st depId b)` | E1, D2, L2 | Induction on `serviceReachable st' a b` |
-| E4 | `nontrivial_cycle_post_insert_implies_pre_reach` | `serviceHasNontrivialPath st' sid sid → serviceDependencyAcyclicDecl st → serviceReachable st depId svcId` | E3, D4 | From E3: cycle uses new edge (else pre-state cycle, contradiction) |
-| E5 | `serviceDependencyAcyclicDecl_preserved` | `serviceDependencyAcyclicDecl st → ¬ serviceReachable st depId svcId → serviceDependencyAcyclicDecl st'` | E4 | Contrapositive of E4 |
+| E1 | `nontrivialPath_post_insert_cases` | Post-state nontrivial path decomposes: `serviceNontrivialPath st' a b → serviceNontrivialPath st a b ∨ (serviceReachable st a svcId ∧ serviceReachable st depId b)` | S1, S2, S3, D2, D3 | Induction on `serviceNontrivialPath st' a b`, case-split each edge via `serviceEdge_post_insert` |
 
-### Critical proof: E3 (post-state reachability decomposition)
+### Critical proof: E1 (post-state nontrivial path decomposition)
 
-This is the heart of the edge-insertion analysis. The proof proceeds by induction on `serviceReachable st' a b`:
+The proof proceeds by induction on `serviceNontrivialPath st' a b`:
 
-**Case `refl`:** `a = b`, so `serviceReachable st a b` holds by `refl`. Left disjunct.
+**Case `single`:** A single post-state edge `serviceEdge st' a b`. Case-split via `serviceEdge_post_insert`:
+- Old edge (pre-state) → left disjunct: `serviceNontrivialPath st a b` via `.single`.
+- New edge (`a = svcId`, `b = depId`) → right disjunct: `serviceReachable st a svcId` (by `.refl`) and `serviceReachable st depId b` (by `.refl`).
 
-**Case `step`:** We have `serviceEdge st' a mid` and `serviceReachable st' mid b`. By the induction hypothesis on the second premise, either:
-- `serviceReachable st mid b`, or
-- `serviceReachable st mid svcId ∧ serviceReachable st depId b`.
-
-For the edge `serviceEdge st' a mid`, we case-split using E1:
-
-- **`a ≠ svcId`:** The edge exists in the pre-state (`serviceEdge st a mid`). Compose with the IH.
-- **`a = svcId` and `mid ∈ svc.dependencies`:** The edge exists in the pre-state. Compose with the IH.
-- **`a = svcId` and `mid = depId`:** This is the **new edge**. Now `a = svcId` and the path continues from `depId`. The IH gives us either `serviceReachable st depId b` (which yields the right disjunct with `serviceReachable st svcId svcId` via refl... wait, we need `serviceReachable st a svcId`; since `a = svcId`, this is `refl`). So the right disjunct is `serviceReachable st svcId svcId ∧ serviceReachable st depId b`, i.e., `True ∧ serviceReachable st depId b`. But we actually need `serviceReachable st a svcId` — which is `.refl` since `a = svcId`.
-
-The composition is: `serviceReachable st a svcId` (by `a = svcId`, `refl`) and `serviceReachable st depId b` (from IH). This gives the right disjunct.
+**Case `cons`:** Edge `serviceEdge st' a mid` followed by `serviceNontrivialPath st' mid b`. By the IH on the tail, either the tail is a pre-state nontrivial path or uses the new edge. Case-split the head edge via `serviceEdge_post_insert` and compose with the IH to obtain either a full pre-state nontrivial path (left disjunct) or pre-state reachability through the new edge (right disjunct).
 
 ---
 
@@ -143,37 +130,31 @@ The composition is: `serviceReachable st a svcId` (by `a = svcId`, `refl`) and `
 
 | ID | Name | Statement sketch | Depends on | Tactic hint |
 |---|---|---|---|---|
-| EQ1 | `serviceDependencyAcyclic_implies_acyclicDecl` | `serviceDependencyAcyclic st → serviceDependencyAcyclicDecl st` | B2, D3, D4 | Contrapositive: nontrivial path implies BFS true (via B2), contradicting acyclic |
-| EQ2 | `serviceDependencyAcyclicDecl_implies_acyclic` | `serviceDependencyAcyclicDecl st → serviceDependencyAcyclic st` | B6, D4 | Contrapositive: BFS true implies nontrivial path (via BFS true → reachable, and src = target → nontrivial if BFS found it) |
-| F1 | `serviceRegisterDependency_preserves_acyclicity` | The final theorem — replaces `sorry` | EQ1, EQ2, E5, B6, S2 | See proof sketch below |
+| F1 | `serviceRegisterDependency_preserves_acyclicity` | Acyclicity preserved after successful dependency registration (takes `serviceCountBounded`) | E1, B6, D4, L5 | Post-insertion path decomposition + BFS contradiction |
 
 ### Final proof sketch for F1
 
+The actual proof is direct — no BFS/declarative equivalence translation needed since
+`serviceDependencyAcyclic` was redefined declaratively:
+
 ```lean
--- At the sorry site, after all case splits:
--- We have: hAcyc, hCycle, hSvc, hDep, hSelf, hExists, sid
--- Goal: ¬ serviceHasPathTo st' sid sid (serviceBfsFuel st') = true
+-- After case-splitting serviceRegisterDependency to the success branch:
+-- We have: hAcyc, hCycle (BFS returned false), hSvc, hSelf (svcId ≠ depId), hBound
+-- Goal: serviceDependencyAcyclic st' (i.e., ∀ sid, ¬ serviceNontrivialPath st' sid sid)
 
--- Step 1: Rewrite fuel in the goal
-rw [S2]  -- serviceBfsFuel st' = serviceBfsFuel st
-
--- Step 2: Translate pre-state acyclicity to declarative form
-have hAcycDecl : serviceDependencyAcyclicDecl st := EQ1 hAcyc
-
--- Step 3: Establish no pre-state path from depId to svcId
-have hNoPath : ¬ serviceReachable st depId svcId := B6 hCycle
-
--- Step 4: Prove declarative acyclicity of post-state
-have hAcycDecl' : serviceDependencyAcyclicDecl st' := E5 hAcycDecl hNoPath
-
--- Step 5: Translate back to BFS-based definition
-have hAcyc' : serviceDependencyAcyclic st' := EQ2 hAcycDecl'
-
--- Step 6: Specialize to the universally quantified sid
-exact hAcyc' sid
+intro sid hCycleSid
+-- Decompose the post-state cycle via nontrivialPath_post_insert_cases (E1):
+rcases nontrivialPath_post_insert_cases hSvc hCycleSid with hPre | ⟨hReach1, hReach2⟩
+-- Case 1: cycle in pre-state → contradicts hAcyc
+· exact hAcyc sid hPre
+-- Case 2: cycle uses new edge → pre-state reachability depId →* svcId
+· have hDepSvc := serviceReachable_trans hReach2 hReach1
+  have hNontrivial := serviceNontrivialPath_of_reachable_ne hDepSvc (Ne.symm hSelf)
+  -- BFS completeness (B6) + serviceCountBounded → BFS returns true
+  have hBfsTrue := bfs_complete_for_nontrivialPath hNontrivial (Ne.symm hSelf) hBound
+  -- Contradiction: BFS returned false
+  exact absurd hBfsTrue hCycle
 ```
-
-**Note:** Steps 2 and 5 use the equivalence theorems EQ1 and EQ2. If Option 1 is chosen instead (no equivalence, direct BFS reasoning), the proof would be more complex but follow the same logical structure.
 
 ---
 
@@ -181,11 +162,11 @@ exact hAcyc' sid
 
 | Layer | Planned | Implemented | Description |
 |---|---|---|---|
-| Layer 0 (definitions) | 4 | 3 | `serviceEdge`, `serviceReachable`, `serviceNontrivialPath` (replaces D3+D4: `serviceDependencyAcyclic` redefined in-place) |
-| Layer 1 (structural) | 12 | 10 | 7 path lemmas + 3 frame lemmas (naming adjusted; see Invariant.lean:413-508) |
-| Layer 2 (BFS soundness) | 7 | 1 | `bfs_complete_for_nontrivialPath` with focused `sorry` (TPI-D07-BRIDGE); full B1-B7 suite deferred |
-| Layer 3 (edge insertion) | 5 | 1 | `nontrivialPath_post_insert_cases` (combines E1-E3 logic into one inductive proof) |
-| Layer 4 (final closure) | 3 | 1 | `serviceRegisterDependency_preserves_acyclicity` (sorry-free; EQ1/EQ2 unnecessary since `serviceDependencyAcyclic` was redefined declaratively) |
-| **Total** | **31** | **16** | Proof completed with fewer artifacts by redefining the invariant declaratively |
+| Layer 0 (definitions) | 4 | 4 | `serviceEdge`, `serviceReachable`, `serviceNontrivialPath`, `serviceDependencyAcyclic` |
+| Layer 1 (structural) | 12 | 10 | 7 path lemmas + 3 frame lemmas (see Invariant.lean:413-508) |
+| Layer 2 (BFS soundness) | 7 | 7 | Full B1-B7 suite + `serviceCountBounded` + `frontier_witness_of_reachable` helper |
+| Layer 3 (edge insertion) | 5 | 1 | `nontrivialPath_post_insert_cases` (combines planned E1-E3 logic into one inductive proof) |
+| Layer 4 (final closure) | 3 | 1 | `serviceRegisterDependency_preserves_acyclicity` (EQ1/EQ2 unnecessary since `serviceDependencyAcyclic` was redefined declaratively) |
+| **Total** | **31** | **23** | All theorems proved without `sorry`; TPI-D07-BRIDGE closed |
 
-The actual implementation was more efficient than the 31-theorem plan: redefining `serviceDependencyAcyclic` to use `serviceNontrivialPath` directly eliminated the need for equivalence theorems (EQ1, EQ2) and much of the BFS bridge infrastructure (B1-B7). The remaining BFS bridge `sorry` is well-scoped and operationally validated.
+The actual implementation was more efficient than the 31-theorem plan: redefining `serviceDependencyAcyclic` to use `serviceNontrivialPath` directly eliminated the need for equivalence theorems (EQ1, EQ2). The full BFS soundness bridge (B1-B7) was implemented, proving BFS-declarative path equivalence under the `serviceCountBounded` precondition.

--- a/docs/audits/execution_plans/appendices/B_CROSS_REFERENCE_MAP.md
+++ b/docs/audits/execution_plans/appendices/B_CROSS_REFERENCE_MAP.md
@@ -48,35 +48,29 @@ This appendix provides bidirectional mappings between the execution plan documen
 
 | Theorem / Definition | Planned file | Section |
 |---|---|---|
-| `serviceEdge` (D1) | `Service/Invariant.lean` | Between line 340 and 349 |
-| `serviceReachable` (D2) | `Service/Invariant.lean` | Between line 340 and 349 |
-| `serviceHasNontrivialPath` (D3) | `Service/Invariant.lean` | Between line 340 and 349 |
-| `serviceDependencyAcyclicDecl` (D4) | `Service/Invariant.lean` | Between line 340 and 349 |
-| `serviceEdge_iff_mem` (L1) | `Service/Invariant.lean` | After D1 |
-| `serviceReachable_trans` (L2) | `Service/Invariant.lean` | After D2 |
-| `serviceReachable_of_edge` (L3) | `Service/Invariant.lean` | After D2 |
-| `serviceReachable_step_right` (L4) | `Service/Invariant.lean` | After L2, L3 |
-| `serviceHasNontrivialPath_of_edge` (L5) | `Service/Invariant.lean` | After D3 |
-| `storeServiceState_objectIndex_eq` (S1) | `Service/Invariant.lean` or `State.lean` | Frame conditions section |
-| `serviceBfsFuel_storeServiceState_eq` (S2) | `Service/Invariant.lean` | After S1 |
-| `serviceEdge_storeServiceState_eq` (S3) | `Service/Invariant.lean` | After D1 |
-| `serviceEdge_storeServiceState_ne` (S4) | `Service/Invariant.lean` | After D1 |
-| `serviceEdge_post_insert` (S5) | `Service/Invariant.lean` | After S3 |
-| `serviceHasPathTo_go_true_implies_exists_reachable` (B1) | `Service/Invariant.lean` | BFS soundness section |
+| `serviceEdge` (D1) | `Service/Invariant.lean` | Layer 0 definitions |
+| `serviceReachable` (D2) | `Service/Invariant.lean` | Layer 0 definitions |
+| `serviceNontrivialPath` (D3) | `Service/Invariant.lean` | Layer 0 definitions |
+| `serviceDependencyAcyclic` (D4) | `Service/Invariant.lean` | Layer 0 definitions |
+| `serviceReachable_trans` (L1) | `Service/Invariant.lean` | After D2 |
+| `serviceReachable_of_edge` (L2) | `Service/Invariant.lean` | After D2 |
+| `serviceReachable_of_nontrivialPath` (L3) | `Service/Invariant.lean` | After D3 |
+| `serviceNontrivialPath_of_edge_reachable` (L4) | `Service/Invariant.lean` | After D3 |
+| `serviceNontrivialPath_of_reachable_ne` (L5) | `Service/Invariant.lean` | After L4 |
+| `serviceNontrivialPath_trans` (L6) | `Service/Invariant.lean` | After L4 |
+| `serviceNontrivialPath_step_right` (L7) | `Service/Invariant.lean` | After L6 |
+| `serviceEdge_storeServiceState_ne` (S1) | `Service/Invariant.lean` | Frame lemma — non-updated service |
+| `serviceEdge_storeServiceState_updated` (S2) | `Service/Invariant.lean` | Frame lemma — updated service |
+| `serviceEdge_post_insert` (S3) | `Service/Invariant.lean` | After S1, S2 |
+| `go_true_implies_exists_reachable` (B1) | `Service/Invariant.lean` | BFS soundness section (private) |
 | `serviceHasPathTo_true_implies_reachable` (B2) | `Service/Invariant.lean` | After B1 |
 | `serviceHasPathTo_true_implies_nontrivial` (B3) | `Service/Invariant.lean` | After B2 |
-| `serviceHasPathTo_go_invariant` / `go_complete` (B4) | `Service/Invariant.lean` | BFS soundness section |
-| `serviceBfsFuel_sufficient` (B5) | `Service/Invariant.lean` | After B4 |
-| `serviceHasPathTo_false_implies_not_reachable` (B6) | `Service/Invariant.lean` | After B4, B5 |
-| `serviceHasPathTo_false_implies_not_nontrivial` (B7) | `Service/Invariant.lean` | After B6 |
-| `serviceEdge_post_cases` (E1) | `Service/Invariant.lean` | Edge insertion section |
-| `serviceReachable_post_insert_of_pre` (E2) | `Service/Invariant.lean` | After E1 |
-| `serviceReachable_post_insert_cases` (E3) | `Service/Invariant.lean` | After E1 |
-| `nontrivial_cycle_post_insert_implies_pre_reach` (E4) | `Service/Invariant.lean` | After E3 |
-| `serviceDependencyAcyclicDecl_preserved` (E5) | `Service/Invariant.lean` | After E4 |
-| `serviceDependencyAcyclic_implies_acyclicDecl` (EQ1) | `Service/Invariant.lean` | Equivalence section |
-| `serviceDependencyAcyclicDecl_implies_acyclic` (EQ2) | `Service/Invariant.lean` | Equivalence section |
-| `serviceRegisterDependency_preserves_acyclicity` (F1) | `Service/Invariant.lean:363–394` | **Existing** — sorry replaced |
+| `go_complete` (B4) | `Service/Invariant.lean` | BFS soundness section (private) |
+| `serviceHasPathTo_complete` (B5) | `Service/Invariant.lean` | After B4 |
+| `bfs_complete_for_nontrivialPath` (B6) | `Service/Invariant.lean` | After B5 — closes TPI-D07-BRIDGE |
+| `serviceHasPathTo_false_implies_not_reachable` (B7) | `Service/Invariant.lean` | After B6 |
+| `nontrivialPath_post_insert_cases` (E1) | `Service/Invariant.lean` | Layer 3 — post-insertion path decomposition |
+| `serviceRegisterDependency_preserves_acyclicity` (F1) | `Service/Invariant.lean` | Layer 4 — acyclicity preservation (takes `serviceCountBounded`) |
 
 ---
 

--- a/docs/audits/execution_plans/milestones/M2_BFS_SOUNDNESS.md
+++ b/docs/audits/execution_plans/milestones/M2_BFS_SOUNDNESS.md
@@ -292,13 +292,13 @@ If these are not available in the project's Lean/Std import set, they may need t
 
 ## 5. Exit criteria
 
-> **Status: DEFERRED.** The full B1-B7 BFS soundness suite was not implemented. Instead, a single focused `sorry` was placed on `bfs_complete_for_nontrivialPath` (TPI-D07-BRIDGE, Invariant.lean:526-531), which asserts BFS completeness for nontrivial paths between distinct services. This was sufficient for the M3 preservation proof. Fuel adequacy (Risk R1) and BFS loop invariant (Risk R3) remain deferred.
+> **Status: COMPLETED.** The full B1-B7 BFS soundness suite has been implemented and all theorems are proved without `sorry`. The BFS bridge `bfs_complete_for_nontrivialPath` is fully proved under the `serviceCountBounded` precondition (Approach A). Fuel adequacy is explicit: the preservation theorem `serviceRegisterDependency_preserves_acyclicity` propagates `serviceCountBounded` as a precondition.
 
-- [ ] `serviceHasPathTo_true_implies_reachable` (B2) — not implemented (deferred)
-- [ ] `serviceHasPathTo_false_implies_not_reachable` (B6) — not implemented (deferred)
-- [x] Fuel adequacy approach chosen: Approach B (preconditioned, implicit in TPI-D07-BRIDGE)
-- [ ] Full BFS lemma suite (B1-B7) — deferred; `bfs_complete_for_nontrivialPath` with focused `sorry` used instead
-- [x] `lake build` succeeds (with TPI-D07-BRIDGE warning)
+- [x] `serviceHasPathTo_true_implies_reachable` (B2) — fully proved
+- [x] `serviceHasPathTo_false_implies_not_reachable` (B7) — fully proved
+- [x] Fuel adequacy approach chosen: Approach A (preconditioned via `serviceCountBounded`)
+- [x] Full BFS lemma suite (B1-B7) — all theorems proved without `sorry`
+- [x] `lake build` succeeds with zero errors and zero warnings
 
 ## Validation
 

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -254,19 +254,19 @@ Implemented proof layers:
   `serviceNontrivialPath_step_right`. Frame lemmas: `serviceEdge_storeServiceState_ne`,
   `serviceEdge_storeServiceState_updated`, `serviceEdge_post_insert`
 - **Layer 2 (BFS bridge):** `bfs_complete_for_nontrivialPath` — BFS completeness
-  bridge connecting declarative paths to the executable BFS check. Uses focused `sorry`
-  (annotated TPI-D07-BRIDGE); operationally validated by executable tests
+  bridge connecting declarative paths to the executable BFS check. Fully proved
+  under `serviceCountBounded` precondition (no sorry)
 - **Layer 3 (Path decomposition):** `nontrivialPath_post_insert_cases` — decomposes
   any post-insertion nontrivial path into either a pre-state path or a composition
   using the new edge with pre-state reachability
 - **Layer 4 (Closure):** `serviceRegisterDependency_preserves_acyclicity` — genuine
   preservation proof via post-insertion path decomposition and contradiction with the
-  BFS cycle-detection check. The main theorem is sorry-free
+  BFS cycle-detection check. Takes `serviceCountBounded` precondition for fuel adequacy
 
-**Remaining sub-obligation (TPI-D07-BRIDGE):** The focused `sorry` on
-`bfs_complete_for_nontrivialPath` defers a formal proof that the BFS with
-`serviceBfsFuel` fuel is complete enough to detect all nontrivial paths between
-distinct services. See Risk 1 and Risk 3 in the risk register for future closure path.
+**Closure (TPI-D07-BRIDGE completed):** The BFS completeness bridge
+`bfs_complete_for_nontrivialPath` is fully proved. Fuel adequacy is explicit:
+the theorem requires `serviceCountBounded st`, which holds in the preservation
+context where service creation adds backing objects to the index.
 
 Frozen operational files (M0 semantics freeze):
 

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -201,7 +201,7 @@ Service dependency registration now includes BFS-based cycle detection:
 - `serviceRegisterDependency` — deterministic registration with self-loop, idempotency, and cycle checks
 - `serviceRegisterDependency_error_self_loop` — self-dependency rejection theorem (no `sorry`)
 - `serviceDependencyAcyclic` — acyclicity invariant definition
-- `serviceRegisterDependency_preserves_acyclicity` — preservation theorem (no `sorry`; BFS bridge deferred to `bfs_complete_for_nontrivialPath` as TPI-D07-BRIDGE — see §14)
+- `serviceRegisterDependency_preserves_acyclicity` — preservation theorem (no `sorry`; BFS bridge `bfs_complete_for_nontrivialPath` fully proved under `serviceCountBounded` — see §14)
 
 ### F-11: serviceRestart partial-failure semantics
 

--- a/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
+++ b/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
@@ -37,7 +37,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
   - Document trivial error-preservation proof scope (F-16). **Done.** Seven module docstrings added.
 
 - **WS-D4:** Kernel design hardening (medium; **completed** — F-07, F-11, F-12)
-  - Service dependency cycle detection with declarative acyclicity proof (F-07, TPI-D07 closed; Risk 0 resolved via Strategy B). **Done.** Vacuous BFS invariant replaced with `serviceNontrivialPath`-based definition. Layers 0-4 proved; sole deferred `sorry` on BFS bridge (TPI-D07-BRIDGE).
+  - Service dependency cycle detection with declarative acyclicity proof (F-07, TPI-D07 closed; Risk 0 resolved via Strategy B). **Done.** Vacuous BFS invariant replaced with `serviceNontrivialPath`-based definition. Full Layers 0-4 proved without sorry; BFS bridge (TPI-D07-BRIDGE) now fully proved under `serviceCountBounded`.
   - Documented partial-failure semantics for serviceRestart (F-11). **Done.**
   - Double-wait prevention in notifications with uniqueness proof (F-12, TPI-D06 closed). **Done.**
 


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-D4 (Kernel hardening: cycle detection)
- **Recommendation IDs closed:** TPI-D07 (fully closed; Risk 0 resolved)
- **Scope notes:** Completes the BFS soundness infrastructure (Layer 2, M2) by proving the full B1–B7 theorem suite, eliminating the focused `sorry` on `bfs_complete_for_nontrivialPath` (TPI-D07-BRIDGE).

## Changes

### Core proof completion (Invariant.lean)

**Layer 2 (BFS soundness bridge):** Implemented and proved all seven theorems connecting the executable BFS check to the declarative path relation:

1. **B1: `go_true_implies_exists_reachable`** (private) — If the BFS inner loop returns `true`, some frontier node reaches the target. Proved by induction on fuel with nested induction on frontier.

2. **B2: `serviceHasPathTo_true_implies_reachable`** — BFS `true` implies declarative reachability. Direct application of B1 with initial frontier `[src]`.

3. **B3: `serviceHasPathTo_true_implies_nontrivial`** — BFS `true` with `src ≠ target` implies nontrivial path. Follows from B2 and the distinctness condition.

4. **B4: `go_complete`** (private, core lemma) — BFS loop completeness under invariants:
   - All frontier nodes reachable from source
   - All visited nodes reachable from source
   - Visited list has no duplicates
   - Target not in visited
   - Fuel budget: `fuel + visited.length = serviceBfsFuel st`
   - Closure: dependencies of visited nodes are in `visited ∪ frontier`
   - Fuel adequacy: `serviceCountBounded st`
   - Witness: some frontier node reaches target and is not visited
   
   Proved by strong induction on fuel with nested induction on frontier. The key insight is that when a new node is dequeued, its dependencies are added to the frontier, maintaining the closure invariant.

5. **B5: `serviceHasPathTo_complete`** — BFS completeness wrapper. Given `serviceReachable st src target` and `serviceCountBounded st`, proves `serviceHasPathTo st src target (serviceBfsFuel st) = true`. Applies B4 with initial state (frontier `[src]`, visited `[]`).

6. **B6: `bfs_complete_for_nontrivialPath`** — Main bridge theorem (TPI-D07-BRIDGE). Proves that a nontrivial path between distinct services is detected by BFS with `serviceBfsFuel` fuel, under the `serviceCountBounded` precondition. This closes the gap between declarative and executable cycle detection.

7. **B7: `serviceHasPathTo_false_implies_not_reachable`** — Soundness of BFS `false`. Contrapositive of B5: if BFS returns `false` and fuel is adequate, no declarative path exists.

**Fuel adequacy definition:** Introduced `serviceCountBounded st : Prop`, which asserts that for any source, all Nodup lists of reachable nodes have length strictly less than `serviceBfsFuel st`. This ensures positive fuel whenever a target node is dequeued.

**Helper lemma:** `frontier_witness_of_reachable` — Given a node reachable from `v` to target, if `v ∈ visited ∪ frontier`, `target ∉ visited`, and the closure invariant holds, then some frontier node (not in visited) reaches target. This is the key link between the BFS closure invariant and frontier witness extraction.

### Updated acyclicity preservation (Layer 4)

**`serviceRegisterDependency_preserves_acyclicity`** now takes `serviceCountBounded st` as a precondition and applies `bfs_complete_for_nont

https://claude.ai/code/session_01LdG7Bvo3C4HP3TVW9xfTCe