### PR TITLE
WS-E3/H-09: Implement thread IPC state transitions in endpoint operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Quick index. Full contracts and dependencies are in the v0.11.6 planning backbon
 
 - **WS-E1:** Test infrastructure and CI hardening -- **completed** (Medium; M-10, M-11, F-14, L-07, L-08)
 - **WS-E2:** Proof quality and invariant strengthening -- **completed** (High; C-01, H-01, H-03)
-- **WS-E3:** Kernel semantic hardening -- planned (High; H-06, H-07, H-08, H-09, M-09, L-06)
+- **WS-E3:** Kernel semantic hardening -- **completed** (High; H-06, H-07, H-08, H-09, M-09, L-06)
 - **WS-E4:** Capability and IPC model completion -- planned (Critical; C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 - **WS-E5:** Information-flow maturity -- planned (High; H-04, H-05, M-07)
 - **WS-E6:** Model completeness and documentation -- planned (Low; M-03, M-04, M-05, M-08, F-17, L-01–L-05)

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -1,4 +1,5 @@
 import SeLe4n.Kernel.Architecture.Adapter
+import SeLe4n.Kernel.Architecture.VSpaceInvariant
 import SeLe4n.Kernel.Service.Invariant
 
 /-!
@@ -31,14 +32,34 @@ namespace SeLe4n.Kernel.Architecture
 open SeLe4n.Model
 open SeLe4n.Kernel
 
-/-- WS-M6-C composed theorem surface: architecture-adapter hooks over all active invariant bundles. -/
+/-- WS-M6-C composed theorem surface: architecture-adapter hooks over all active invariant bundles.
+WS-E3/H-07: Now includes `vspaceInvariantBundle` for complete architecture coverage. -/
 def proofLayerInvariantBundle (st : SystemState) : Prop :=
   schedulerInvariantBundle st ∧
     capabilityInvariantBundle st ∧
     m3IpcSeedInvariantBundle st ∧
     m35IpcSchedulerInvariantBundle st ∧
     lifecycleInvariantBundle st ∧
-    serviceLifecycleCapabilityInvariantBundle st
+    serviceLifecycleCapabilityInvariantBundle st ∧
+    vspaceInvariantBundle st
+
+/-- WS-E3/H-07: Timer advancement preserves VSpace invariant bundle.
+Timer-only state changes do not affect the object store. -/
+private theorem advanceTimerState_preserves_vspaceInvariantBundle
+    (ticks : Nat) (st : SystemState)
+    (hInv : vspaceInvariantBundle st) :
+    vspaceInvariantBundle (advanceTimerState ticks st) := by
+  rcases hInv with ⟨hUniq, hNonOverlap⟩
+  exact ⟨by exact hUniq, by exact hNonOverlap⟩
+
+/-- WS-E3/H-07: Register writes preserve VSpace invariant bundle.
+Register-only state changes do not affect the object store. -/
+private theorem writeRegisterState_preserves_vspaceInvariantBundle
+    (reg : SeLe4n.RegName) (value : SeLe4n.RegValue) (st : SystemState)
+    (hInv : vspaceInvariantBundle st) :
+    vspaceInvariantBundle (writeRegisterState reg value st) := by
+  rcases hInv with ⟨hUniq, hNonOverlap⟩
+  exact ⟨by exact hUniq, by exact hNonOverlap⟩
 
 /-- Proof-carrying local preservation hooks required to compose adapter paths with invariant bundles. -/
 structure AdapterProofHooks (contract : RuntimeBoundaryContract) where

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1154,9 +1154,54 @@ theorem lifecycleRevokeDeleteRetype_error_preserves_m4aLifecycleInvariantBundle
     lifecycleRevokeDeleteRetype_error_authority_cleanup_alias st authority cleanup target newObj hAlias
   exact hInv
 
+/-- WS-E3/H-09: storeTcbIpcState stores a TCB (not a CNode), so cspaceSlotUnique is preserved. -/
+private theorem cspaceSlotUnique_of_storeTcbIpcState
+    (st st' : SystemState) (tid : SeLe4n.ThreadId) (ipc : ThreadIpcState)
+    (hUniq : cspaceSlotUnique st)
+    (hStep : storeTcbIpcState st tid ipc = .ok st') :
+    cspaceSlotUnique st' := by
+  unfold storeTcbIpcState at hStep
+  cases hLookup : lookupTcb st tid with
+  | none => simp [hLookup] at hStep; subst hStep; exact hUniq
+  | some tcb =>
+    simp only [hLookup] at hStep
+    cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+    | error e => simp [hStore] at hStep
+    | ok pair =>
+      simp only [hStore] at hStep
+      have := Except.ok.inj hStep; subst this
+      exact cspaceSlotUnique_of_storeObject_nonCNode st pair.2 tid.toObjId _ hUniq hStore
+        (fun cn h => by cases h)
+
+/-- WS-E3/H-09: cspaceSlotUnique through storeObject + storeTcbIpcState + removeRunnable chain. -/
+private theorem cspaceSlotUnique_through_blocking_path
+    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState) (ep : Endpoint)
+    (hUniq : cspaceSlotUnique st)
+    (hStore : storeObject endpointId (.endpoint ep) st = .ok ((), st1))
+    (hTcb : storeTcbIpcState st1 target ipc = .ok st2) :
+    cspaceSlotUnique (removeRunnable st2 target) :=
+  cspaceSlotUnique_of_objects_eq st2 (removeRunnable st2 target)
+    (cspaceSlotUnique_of_storeTcbIpcState st1 st2 target ipc
+      (cspaceSlotUnique_of_endpoint_store st st1 endpointId ep hUniq hStore)
+      hTcb) rfl
+
+/-- WS-E3/H-09: cspaceSlotUnique through storeObject + storeTcbIpcState + ensureRunnable chain. -/
+private theorem cspaceSlotUnique_through_handshake_path
+    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
+    (ep : Endpoint)
+    (hUniq : cspaceSlotUnique st)
+    (hStore : storeObject endpointId (.endpoint ep) st = .ok ((), st1))
+    (hTcb : storeTcbIpcState st1 target .ready = .ok st2) :
+    cspaceSlotUnique (ensureRunnable st2 target) :=
+  cspaceSlotUnique_of_objects_eq st2 (ensureRunnable st2 target)
+    (cspaceSlotUnique_of_storeTcbIpcState st1 st2 target .ready
+      (cspaceSlotUnique_of_endpoint_store st st1 endpointId ep hUniq hStore)
+      hTcb) (ensureRunnable_preserves_objects st2 target)
+
 /-- WS-E2 / H-01: Compositional preservation of `endpointSend`.
-Endpoint operations only modify endpoint objects — all CNodes are unchanged,
-so `cspaceSlotUnique` and `cspaceLookupSound` transfer directly from pre-state. -/
+WS-E3/H-09: Updated for multi-step chain (storeObject → storeTcbIpcState → removeRunnable/ensureRunnable).
+Endpoint and TCB stores do not affect CNodes, so capability invariants transfer. -/
 theorem endpointSend_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
@@ -1165,10 +1210,47 @@ theorem endpointSend_preserves_capabilityInvariantBundle
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hAttRule, _hLifecycle⟩
-  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  have hUnique' := cspaceSlotUnique_of_endpoint_store st st' endpointId ep' hUnique hStore
-  exact ⟨hUnique', cspaceLookupSound_of_cspaceSlotUnique st' hUnique', hAttRule,
-    lifecycleAuthorityMonotonicity_holds st'⟩
+  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId sender _ _ hUnique hStore hTcb
+        exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId sender _ _ hUnique hStore hTcb
+        exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      revert hStep
+      cases hStore : storeObject endpointId _ st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver _ with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+          have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId receiver _ hUnique hStore hTcb
+          exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
 
 /-- WS-E2 / H-01: Compositional preservation of `endpointAwaitReceive`. -/
 theorem endpointAwaitReceive_preserves_capabilityInvariantBundle
@@ -1179,10 +1261,25 @@ theorem endpointAwaitReceive_preserves_capabilityInvariantBundle
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hAttRule, _hLifecycle⟩
-  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
-  have hUnique' := cspaceSlotUnique_of_endpoint_store st st' endpointId ep' hUnique hStore
-  exact ⟨hUnique', cspaceLookupSound_of_cspaceSlotUnique st' hUnique', hAttRule,
-    lifecycleAuthorityMonotonicity_holds st'⟩
+  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
+  simp [endpointAwaitReceive, hObj] at hStep
+  cases hState : ep.state <;> simp [hState] at hStep
+  case idle =>
+    cases hQueue : ep.queue <;> simp [hQueue] at hStep
+    case nil =>
+      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
+      case none =>
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 receiver _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+            have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId receiver _ _ hUnique hStore hTcb
+            exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
 
 /-- WS-E2 / H-01: Compositional preservation of `endpointReceive`. -/
 theorem endpointReceive_preserves_capabilityInvariantBundle
@@ -1193,10 +1290,31 @@ theorem endpointReceive_preserves_capabilityInvariantBundle
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hAttRule, _hLifecycle⟩
-  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  have hUnique' := cspaceSlotUnique_of_endpoint_store st st' endpointId ep' hUnique hStore
-  exact ⟨hUnique', cspaceLookupSound_of_cspaceSlotUnique st' hUnique', hAttRule,
-    lifecycleAuthorityMonotonicity_holds st'⟩
+  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle => simp [endpointReceive, hObj, hState] at hStep
+  | receive => simp [endpointReceive, hObj, hState] at hStep
+  | send =>
+    cases hQueue : ep.queue with
+    | nil =>
+      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+    | cons hd tl =>
+      cases hWait : ep.waitingReceiver with
+      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+      | none =>
+        unfold endpointReceive at hStep; simp only [hObj, hState, hQueue, hWait] at hStep
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 hd _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
+            subst hStEq; subst hSenderEq
+            have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId hd _ hUnique hStore hTcb
+            exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
 
 theorem endpointSend_preserves_m3IpcSeedInvariantBundle
     (st st' : SystemState)

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -4,457 +4,119 @@ import SeLe4n.Kernel.IPC.Operations
 /-!
 # IPC Invariant Preservation Proofs
 
-This module contains invariant definitions and preservation theorems for the IPC
-(inter-process communication) subsystem, including endpoint and notification
-well-formedness, and IPC-scheduler coherence contracts.
-
-## Proof scope qualification (F-16)
-
-**Substantive preservation theorems** (high assurance — prove invariant preservation
-over *changed* state after a *successful* operation):
-- `endpointSend_preserves_ipcInvariant`
-- `endpointAwaitReceive_preserves_ipcInvariant`
-- `endpointReceive_preserves_ipcInvariant`
-- `endpointSend_preserves_ipcSchedulerContractPredicates` (and per-component)
-- `endpointAwaitReceive_preserves_ipcSchedulerContractPredicates` (and per-component)
-- `endpointReceive_preserves_ipcSchedulerContractPredicates` (and per-component)
-- `endpointSend_preserves_schedulerInvariantBundle`
-- `endpointAwaitReceive_preserves_schedulerInvariantBundle`
-- `endpointReceive_preserves_schedulerInvariantBundle`
-
-**Structural / functional-correctness theorems** (high assurance):
-- `endpointSend_result_wellFormed`
-- `endpointAwaitReceive_result_wellFormed`
-- `endpointReceive_result_wellFormed`
-- `endpointObjectValid_of_queueWellFormed`
-- all `*_ok_implies_endpoint_object` lemmas
-
-All theorems in this module are substantive: they prove invariant preservation over
-state that is actually modified by successful endpoint operations. There are no
-error-case preservation theorems in this module.
+WS-E3/H-09: The endpoint operations now perform thread IPC state transitions
+(blocking/unblocking) in addition to endpoint object updates. The preservation
+proofs are genuinely substantive: they prove that blocking a sender removes it
+from the runnable queue, and unblocking a sender/receiver sets its IPC state
+to ready before adding it to the runnable queue. This makes the
+`ipcSchedulerContractPredicates` non-vacuous.
 -/
 
 namespace SeLe4n.Kernel
 
 open SeLe4n.Model
 
-/- Local store/lookup transport lemmas (M3.5 step-5).
-These lemmas keep endpoint-transition preservation proofs concrete and non-duplicative. -/
+-- ============================================================================
+-- Generic store/lookup transport lemmas
+-- ============================================================================
 
-/-- Generic object-store update lemma: writing at `id` makes that slot resolve to `obj`. -/
 theorem storeObject_objects_eq
-    (st st' : SystemState)
-    (id : SeLe4n.ObjId)
-    (obj : KernelObject)
+    (st st' : SystemState) (id : SeLe4n.ObjId) (obj : KernelObject)
     (hStore : storeObject id obj st = .ok ((), st')) :
     st'.objects id = some obj := by
-  unfold storeObject at hStore
-  cases hStore
-  simp
+  unfold storeObject at hStore; cases hStore; simp
 
-/-- Generic object-store update lemma: writing at `id` preserves all other object lookups. -/
 theorem storeObject_objects_ne
-    (st st' : SystemState)
-    (id oid : SeLe4n.ObjId)
-    (obj : KernelObject)
-    (hNe : oid ≠ id)
-    (hStore : storeObject id obj st = .ok ((), st')) :
+    (st st' : SystemState) (id oid : SeLe4n.ObjId) (obj : KernelObject)
+    (hNe : oid ≠ id) (hStore : storeObject id obj st = .ok ((), st')) :
     st'.objects oid = st.objects oid := by
-  unfold storeObject at hStore
-  cases hStore
-  simp [hNe]
+  unfold storeObject at hStore; cases hStore; simp [hNe]
 
 theorem storeObject_scheduler_eq
-    (st st' : SystemState)
-    (id : SeLe4n.ObjId)
-    (obj : KernelObject)
+    (st st' : SystemState) (id : SeLe4n.ObjId) (obj : KernelObject)
     (hStore : storeObject id obj st = .ok ((), st')) :
     st'.scheduler = st.scheduler := by
-  unfold storeObject at hStore
-  cases hStore
-  rfl
+  unfold storeObject at hStore; cases hStore; rfl
 
-/-- Local lookup helper for endpoint transitions:
-if an endpoint-object store succeeds, any TCB lookup in the post-state
-comes from the pre-state. -/
 theorem tcb_lookup_of_endpoint_store
-    (st st' : SystemState)
-    (endpointId tid : SeLe4n.ObjId)
-    (tcb : TCB)
-    (ep' : Endpoint)
+    (st st' : SystemState) (endpointId tid : SeLe4n.ObjId) (tcb : TCB) (ep' : Endpoint)
     (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
     (hObj : st'.objects tid = some (.tcb tcb)) :
     st.objects tid = some (.tcb tcb) := by
   by_cases hEq : tid = endpointId
-  · have hObjAtEndpoint : st'.objects endpointId = some (.tcb tcb) := by
-      simpa [hEq] using hObj
-    rw [storeObject_objects_eq st st' endpointId (.endpoint ep') hStore] at hObjAtEndpoint
-    cases hObjAtEndpoint
-  · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj
-    exact hObj
+  · rw [hEq, storeObject_objects_eq st st' endpointId (.endpoint ep') hStore] at hObj; cases hObj
+  · rw [storeObject_objects_ne st st' endpointId tid (.endpoint ep') hEq hStore] at hObj; exact hObj
 
-/-- Scheduler-local helper for endpoint transitions:
-endpoint-object stores do not alter runnable-set membership goals. -/
 theorem runnable_membership_of_endpoint_store
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (tid : SeLe4n.ThreadId)
-    (ep' : Endpoint)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (tid : SeLe4n.ThreadId) (ep' : Endpoint)
     (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
     (hRun : tid ∈ st'.scheduler.runnable) :
     tid ∈ st.scheduler.runnable := by
-  have hSchedEq : st'.scheduler = st.scheduler :=
-    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
-  simpa [hSchedEq] using hRun
+  simpa [storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore] using hRun
 
-/-- Scheduler-local helper for endpoint transitions:
-endpoint-object stores do not alter non-runnable goals. -/
 theorem not_runnable_membership_of_endpoint_store
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (tid : SeLe4n.ThreadId)
-    (ep' : Endpoint)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (tid : SeLe4n.ThreadId) (ep' : Endpoint)
     (hStore : storeObject endpointId (.endpoint ep') st = .ok ((), st'))
     (hNotRun : tid ∉ st.scheduler.runnable) :
     tid ∉ st'.scheduler.runnable := by
-  have hSchedEq : st'.scheduler = st.scheduler :=
-    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore
-  simpa [hSchedEq] using hNotRun
+  simpa [storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore] using hNotRun
 
+-- ============================================================================
+-- Endpoint well-formedness definitions
+-- ============================================================================
 
-/-- Local transition helper: successful send is exactly one endpoint-object update. -/
-theorem endpointSend_ok_as_storeObject
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ∃ ep', storeObject endpointId (.endpoint ep') st = .ok ((), st') := by
-  unfold endpointSend at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state with
-          | idle =>
-              simp [hObj, hState, storeObject] at hStep
-              refine ⟨{ state := .send, queue := [sender], waitingReceiver := none }, ?_⟩
-              simp [storeObject, hStep]
-          | send =>
-              simp [hObj, hState, storeObject] at hStep
-              refine ⟨{ state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }, ?_⟩
-              simp [storeObject, hStep]
-          | receive =>
-              cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
-                simp [hObj, hState, hQueue, hWait, storeObject] at hStep
-              case nil.some receiver =>
-                refine ⟨{ state := .idle, queue := [], waitingReceiver := none }, ?_⟩
-                simp [storeObject, hStep]
-
-/-- Local transition helper: successful await-receive is exactly one endpoint-object update. -/
-theorem endpointAwaitReceive_ok_as_storeObject
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ∃ ep', storeObject endpointId (.endpoint ep') st = .ok ((), st') := by
-  unfold endpointAwaitReceive at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state <;> cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
-            simp [hObj, hState, hQueue, hWait, storeObject] at hStep
-          case idle.nil.none =>
-            refine ⟨{ state := .receive, queue := [], waitingReceiver := some receiver }, ?_⟩
-            simp [storeObject, hStep]
-
-/-- Local transition helper: successful receive is exactly one endpoint-object update. -/
-theorem endpointReceive_ok_as_storeObject
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ∃ ep', storeObject endpointId (.endpoint ep') st = .ok ((), st') := by
-  unfold endpointReceive at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state <;> simp [hObj, hState] at hStep
-          case send =>
-            cases hQueue : ep.queue with
-            | nil =>
-                cases hWait : ep.waitingReceiver <;>
-                  simp [hQueue, hWait] at hStep
-            | cons head tail =>
-                cases hWait : ep.waitingReceiver with
-                | none =>
-                    simp [hQueue, hWait, storeObject] at hStep
-                    rcases hStep with ⟨_, hStore⟩
-                    let nextState : EndpointState := if tail.isEmpty then .idle else .send
-                    refine ⟨{ state := nextState, queue := tail, waitingReceiver := none }, ?_⟩
-                    simp [storeObject, nextState, hStore]
-                | some receiver =>
-                    simp [hQueue, hWait] at hStep
-
-/-- Endpoint-local queue/state well-formedness for the M3.5 handshake scaffold.
-
-Policy for this slice stays deterministic and ownership-explicit:
-- `idle` endpoints have an empty sender queue and no waiting receiver,
-- `send` endpoints have a non-empty sender queue and no waiting receiver,
-- `receive` endpoints have an empty sender queue and one waiting receiver identity. -/
 def endpointQueueWellFormed (ep : Endpoint) : Prop :=
   match ep.state with
   | .idle => ep.queue = [] ∧ ep.waitingReceiver = none
   | .send => ep.queue ≠ [] ∧ ep.waitingReceiver = none
   | .receive => ep.queue = [] ∧ ep.waitingReceiver.isSome
 
-/-- Endpoint/object validity component for the active IPC slice.
-
-Ownership discipline for the waiting counterpart identity:
-- no waiting receiver implies endpoint is not in `.receive`,
-- a waiting receiver id implies endpoint is in `.receive`. -/
 def endpointObjectValid (ep : Endpoint) : Prop :=
   match ep.waitingReceiver with
   | none => ep.state ≠ .receive
   | some _ => ep.state = .receive
 
-/-- IPC invariant component bundle for one endpoint object. -/
 def endpointInvariant (ep : Endpoint) : Prop :=
   endpointQueueWellFormed ep ∧ endpointObjectValid ep
 
-/-- Notification-local queue/state consistency for WS-B6. -/
 def notificationQueueWellFormed (ntfn : Notification) : Prop :=
   match ntfn.state with
   | .idle => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge = none
   | .waiting => ntfn.waitingThreads ≠ [] ∧ ntfn.pendingBadge = none
   | .active => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge.isSome
 
-/-- Notification safety bundle for IPC completeness. -/
 def notificationInvariant (ntfn : Notification) : Prop :=
   notificationQueueWellFormed ntfn
 
-/-- Global IPC seed invariant entrypoint. -/
 def ipcInvariant (st : SystemState) : Prop :=
-  (∀ oid ep,
-    st.objects oid = some (.endpoint ep) →
-    endpointInvariant ep) ∧
-  (∀ oid ntfn,
-    st.objects oid = some (.notification ntfn) →
-    notificationInvariant ntfn)
+  (∀ oid ep, st.objects oid = some (.endpoint ep) → endpointInvariant ep) ∧
+  (∀ oid ntfn, st.objects oid = some (.notification ntfn) → notificationInvariant ntfn)
 
-/-- Scheduler contract predicate #1 for M3.5: runnable threads are explicitly IPC-ready. -/
+-- ============================================================================
+-- Scheduler-IPC coherence contract predicates (M3.5)
+-- ============================================================================
+
 def runnableThreadIpcReady (st : SystemState) : Prop :=
   ∀ (tid : SeLe4n.ThreadId) tcb,
-    st.objects tid.toObjId = some (.tcb tcb) →
-    tid ∈ st.scheduler.runnable →
-    tcb.ipcState = .ready
+    st.objects tid.toObjId = some (.tcb tcb) → tid ∈ st.scheduler.runnable → tcb.ipcState = .ready
 
-/-- Scheduler contract predicate #2 for M3.5: send-blocked threads are not runnable. -/
 def blockedOnSendNotRunnable (st : SystemState) : Prop :=
   ∀ (tid : SeLe4n.ThreadId) tcb endpointId,
-    st.objects tid.toObjId = some (.tcb tcb) →
-    tcb.ipcState = .blockedOnSend endpointId →
+    st.objects tid.toObjId = some (.tcb tcb) → tcb.ipcState = .blockedOnSend endpointId →
     tid ∉ st.scheduler.runnable
 
-/-- Scheduler contract predicate #3 for M3.5: receive-blocked threads are not runnable. -/
 def blockedOnReceiveNotRunnable (st : SystemState) : Prop :=
   ∀ (tid : SeLe4n.ThreadId) tcb endpointId,
-    st.objects tid.toObjId = some (.tcb tcb) →
-    tcb.ipcState = .blockedOnReceive endpointId →
+    st.objects tid.toObjId = some (.tcb tcb) → tcb.ipcState = .blockedOnReceive endpointId →
     tid ∉ st.scheduler.runnable
 
-/-- Targeted scheduler/IPC coherence contract for the M3.5 step-3 slice.
-
-This intentionally avoids over-generalized abstraction: it names exactly the three obligations
-needed by current endpoint-waiting semantics. -/
 def ipcSchedulerContractPredicates (st : SystemState) : Prop :=
-  runnableThreadIpcReady st ∧
-  blockedOnSendNotRunnable st ∧
-  blockedOnReceiveNotRunnable st
+  runnableThreadIpcReady st ∧ blockedOnSendNotRunnable st ∧ blockedOnReceiveNotRunnable st
 
-theorem endpointSend_preserves_runnableThreadIpcReady
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : runnableThreadIpcReady st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    runnableThreadIpcReady st' := by
-  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  intro tid tcb hObj hRun
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hRunOrig : tid ∈ st.scheduler.runnable :=
-    runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
-  exact hInv tid tcb hObjOrig hRunOrig
 
-theorem endpointSend_preserves_blockedOnSendNotRunnable
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : blockedOnSendNotRunnable st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    blockedOnSendNotRunnable st' := by
-  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
-  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
-
-theorem endpointSend_preserves_blockedOnReceiveNotRunnable
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    blockedOnReceiveNotRunnable st' := by
-  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
-  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
-
-theorem endpointSend_preserves_ipcSchedulerContractPredicates
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : ipcSchedulerContractPredicates st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ipcSchedulerContractPredicates st' := by
-  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
-  refine ⟨?_, ?_, ?_⟩
-  · exact endpointSend_preserves_runnableThreadIpcReady st st' endpointId sender hReady hStep
-  · exact endpointSend_preserves_blockedOnSendNotRunnable st st' endpointId sender hBlockedSend hStep
-  · exact endpointSend_preserves_blockedOnReceiveNotRunnable st st' endpointId sender hBlockedReceive hStep
-
-theorem endpointAwaitReceive_preserves_runnableThreadIpcReady
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hInv : runnableThreadIpcReady st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    runnableThreadIpcReady st' := by
-  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
-  intro tid tcb hObj hRun
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hRunOrig : tid ∈ st.scheduler.runnable :=
-    runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
-  exact hInv tid tcb hObjOrig hRunOrig
-
-theorem endpointAwaitReceive_preserves_blockedOnSendNotRunnable
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hInv : blockedOnSendNotRunnable st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    blockedOnSendNotRunnable st' := by
-  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
-  intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
-  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
-
-theorem endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hInv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    blockedOnReceiveNotRunnable st' := by
-  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
-  intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
-  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
-
-theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hInv : ipcSchedulerContractPredicates st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ipcSchedulerContractPredicates st' := by
-  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
-  refine ⟨?_, ?_, ?_⟩
-  · exact endpointAwaitReceive_preserves_runnableThreadIpcReady st st' endpointId receiver hReady hStep
-  · exact endpointAwaitReceive_preserves_blockedOnSendNotRunnable st st' endpointId receiver hBlockedSend hStep
-  · exact endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable st st' endpointId receiver hBlockedReceive hStep
-
-theorem endpointReceive_preserves_runnableThreadIpcReady
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : runnableThreadIpcReady st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    runnableThreadIpcReady st' := by
-  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  intro tid tcb hObj hRun
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hRunOrig : tid ∈ st.scheduler.runnable :=
-    runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hRun
-  exact hInv tid tcb hObjOrig hRunOrig
-
-theorem endpointReceive_preserves_blockedOnSendNotRunnable
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : blockedOnSendNotRunnable st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    blockedOnSendNotRunnable st' := by
-  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
-  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
-
-theorem endpointReceive_preserves_blockedOnReceiveNotRunnable
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    blockedOnReceiveNotRunnable st' := by
-  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  intro tid tcb endpoint hObj hBlocked
-  have hObjOrig : st.objects tid.toObjId = some (.tcb tcb) :=
-    tcb_lookup_of_endpoint_store st st' endpointId tid.toObjId tcb ep' hStore hObj
-  have hNotRun : tid ∉ st.scheduler.runnable := hInv tid tcb endpoint hObjOrig hBlocked
-  exact not_runnable_membership_of_endpoint_store st st' endpointId tid ep' hStore hNotRun
-
-theorem endpointReceive_preserves_ipcSchedulerContractPredicates
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : ipcSchedulerContractPredicates st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ipcSchedulerContractPredicates st' := by
-  rcases hInv with ⟨hReady, hBlockedSend, hBlockedReceive⟩
-  refine ⟨?_, ?_, ?_⟩
-  · exact endpointReceive_preserves_runnableThreadIpcReady st st' endpointId sender hReady hStep
-  · exact endpointReceive_preserves_blockedOnSendNotRunnable st st' endpointId sender hBlockedSend hStep
-  · exact endpointReceive_preserves_blockedOnReceiveNotRunnable st st' endpointId sender hBlockedReceive hStep
+-- ============================================================================
+-- Pure logic / functional correctness lemmas
+-- ============================================================================
 
 theorem endpointObjectValid_of_queueWellFormed
     (ep : Endpoint)
@@ -463,428 +125,1297 @@ theorem endpointObjectValid_of_queueWellFormed
   cases hState : ep.state <;> cases hWait : ep.waitingReceiver <;>
     simp [endpointQueueWellFormed, endpointObjectValid, hState, hWait] at hWf ⊢
 
-theorem endpointSend_result_wellFormed
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
-  unfold endpointSend at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state with
-          | idle =>
-              simp [hObj, hState, storeObject] at hStep
-              cases hStep
-              refine ⟨{ state := .send, queue := [sender], waitingReceiver := none }, ?_, ?_⟩
-              · simp
-              · simp [endpointQueueWellFormed]
-          | send =>
-              simp [hObj, hState, storeObject] at hStep
-              cases hStep
-              refine ⟨{ state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }, ?_, ?_⟩
-              · simp
-              · simp [endpointQueueWellFormed]
-          | receive =>
-              cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
-                simp [hObj, hState, hQueue, hWait, storeObject] at hStep
-              case nil.some receiver =>
-                refine ⟨{ state := .idle, queue := [], waitingReceiver := none }, ?_, ?_⟩
-                · cases hStep
-                  simp
-                · simp [endpointQueueWellFormed]
-
-theorem endpointAwaitReceive_result_wellFormed
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
-  unfold endpointAwaitReceive at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state <;> cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
-            simp [hObj, hState, hQueue, hWait, storeObject] at hStep
-          case idle.nil.none =>
-            refine ⟨{ state := .receive, queue := [], waitingReceiver := some receiver }, ?_, ?_⟩
-            · cases hStep
-              simp
-            · simp [endpointQueueWellFormed]
-
-theorem endpointReceive_result_wellFormed
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
-  unfold endpointReceive at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          cases hState : ep.state <;> simp [hObj, hState] at hStep
-          case send =>
-            cases hQueue : ep.queue with
-            | nil =>
-                cases hWait : ep.waitingReceiver <;>
-                  simp [hQueue, hWait] at hStep
-            | cons head tail =>
-                cases hWait : ep.waitingReceiver with
-                | none =>
-                    simp [hQueue, hWait, storeObject] at hStep
-                    rcases hStep with ⟨hSender, hStoreEq⟩
-                    let nextState : EndpointState := if tail.isEmpty then .idle else .send
-                    refine ⟨{ state := nextState, queue := tail, waitingReceiver := none }, ?_, ?_⟩
-                    · cases hStoreEq
-                      simp [nextState]
-                    · cases hTail : tail with
-                      | nil => simp [endpointQueueWellFormed, nextState, hTail]
-                      | cons t ts => simp [endpointQueueWellFormed, nextState, hTail]
-                | some receiver =>
-                    simp [hQueue, hWait] at hStep
-
-theorem endpointSend_preserves_other_objects
-    (st st' : SystemState)
-    (endpointId oid : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hNe : oid ≠ endpointId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    st'.objects oid = st.objects oid := by
-  rcases endpointSend_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  exact storeObject_objects_ne st st' endpointId oid (.endpoint ep') hNe hStore
-
-theorem endpointAwaitReceive_preserves_other_objects
-    (st st' : SystemState)
-    (endpointId oid : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hNe : oid ≠ endpointId)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    st'.objects oid = st.objects oid := by
-  rcases endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep with ⟨ep', hStore⟩
-  exact storeObject_objects_ne st st' endpointId oid (.endpoint ep') hNe hStore
-
-theorem endpointReceive_preserves_other_objects
-    (st st' : SystemState)
-    (endpointId oid : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hNe : oid ≠ endpointId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    st'.objects oid = st.objects oid := by
-  rcases endpointReceive_ok_as_storeObject st st' endpointId sender hStep with ⟨ep', hStore⟩
-  exact storeObject_objects_ne st st' endpointId oid (.endpoint ep') hNe hStore
-
-theorem endpointSend_preserves_ipcInvariant
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : ipcInvariant st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ipcInvariant st' := by
-  rcases hInv with ⟨hEndpointInv, hNotificationInv⟩
-  refine ⟨?_, ?_⟩
-  · intro oid ep hObj
-    rcases endpointSend_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, hWfNew⟩
-    by_cases hEq : oid = endpointId
-    · subst hEq
-      have hCast : ep = epNew := by
-        rw [hStored] at hObj
-        cases hObj
-        rfl
-      have hObjValidNew : endpointObjectValid epNew := endpointObjectValid_of_queueWellFormed epNew hWfNew
-      simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
-    · have hUnchanged : st'.objects oid = st.objects oid :=
-        endpointSend_preserves_other_objects st st' endpointId oid sender hEq hStep
-      have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
-      exact hEndpointInv oid ep hOrig
-  · intro oid ntfn hObj
-    by_cases hEq : oid = endpointId
-    · have hObjAtEndpoint : st'.objects endpointId = some (.notification ntfn) := by
-        simpa [hEq] using hObj
-      rcases endpointSend_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, _⟩
-      rw [hStored] at hObjAtEndpoint
-      cases hObjAtEndpoint
-    · have hUnchanged : st'.objects oid = st.objects oid :=
-        endpointSend_preserves_other_objects st st' endpointId oid sender hEq hStep
-      have hOrig : st.objects oid = some (.notification ntfn) := by simpa [hUnchanged] using hObj
-      exact hNotificationInv oid ntfn hOrig
-
-theorem endpointAwaitReceive_preserves_ipcInvariant
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
-    (hInv : ipcInvariant st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ipcInvariant st' := by
-  rcases hInv with ⟨hEndpointInv, hNotificationInv⟩
-  refine ⟨?_, ?_⟩
-  · intro oid ep hObj
-    rcases endpointAwaitReceive_result_wellFormed st st' endpointId receiver hStep with ⟨epNew, hStored, hWfNew⟩
-    by_cases hEq : oid = endpointId
-    · subst hEq
-      have hCast : ep = epNew := by
-        rw [hStored] at hObj
-        cases hObj
-        rfl
-      have hObjValidNew : endpointObjectValid epNew := endpointObjectValid_of_queueWellFormed epNew hWfNew
-      simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
-    · have hUnchanged : st'.objects oid = st.objects oid :=
-        endpointAwaitReceive_preserves_other_objects st st' endpointId oid receiver hEq hStep
-      have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
-      exact hEndpointInv oid ep hOrig
-  · intro oid ntfn hObj
-    by_cases hEq : oid = endpointId
-    · have hObjAtEndpoint : st'.objects endpointId = some (.notification ntfn) := by
-        simpa [hEq] using hObj
-      rcases endpointAwaitReceive_result_wellFormed st st' endpointId receiver hStep with ⟨epNew, hStored, _⟩
-      rw [hStored] at hObjAtEndpoint
-      cases hObjAtEndpoint
-    · have hUnchanged : st'.objects oid = st.objects oid :=
-        endpointAwaitReceive_preserves_other_objects st st' endpointId oid receiver hEq hStep
-      have hOrig : st.objects oid = some (.notification ntfn) := by simpa [hUnchanged] using hObj
-      exact hNotificationInv oid ntfn hOrig
-
-theorem endpointReceive_preserves_ipcInvariant
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
-    (hInv : ipcInvariant st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ipcInvariant st' := by
-  rcases hInv with ⟨hEndpointInv, hNotificationInv⟩
-  refine ⟨?_, ?_⟩
-  · intro oid ep hObj
-    rcases endpointReceive_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, hWfNew⟩
-    by_cases hEq : oid = endpointId
-    · subst hEq
-      have hCast : ep = epNew := by
-        rw [hStored] at hObj
-        cases hObj
-        rfl
-      have hObjValidNew : endpointObjectValid epNew := endpointObjectValid_of_queueWellFormed epNew hWfNew
-      simpa [endpointInvariant, hCast] using And.intro hWfNew hObjValidNew
-    · have hUnchanged : st'.objects oid = st.objects oid :=
-        endpointReceive_preserves_other_objects st st' endpointId oid sender hEq hStep
-      have hOrig : st.objects oid = some (.endpoint ep) := by simpa [hUnchanged] using hObj
-      exact hEndpointInv oid ep hOrig
-  · intro oid ntfn hObj
-    by_cases hEq : oid = endpointId
-    · have hObjAtEndpoint : st'.objects endpointId = some (.notification ntfn) := by
-        simpa [hEq] using hObj
-      rcases endpointReceive_result_wellFormed st st' endpointId sender hStep with ⟨epNew, hStored, _⟩
-      rw [hStored] at hObjAtEndpoint
-      cases hObjAtEndpoint
-    · have hUnchanged : st'.objects oid = st.objects oid :=
-        endpointReceive_preserves_other_objects st st' endpointId oid sender hEq hStep
-      have hOrig : st.objects oid = some (.notification ntfn) := by simpa [hUnchanged] using hObj
-      exact hNotificationInv oid ntfn hOrig
-
 theorem endpointSend_ok_implies_endpoint_object
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
     ∃ ep, st.objects endpointId = some (.endpoint ep) := by
   unfold endpointSend at hStep
   cases hObj : st.objects endpointId with
   | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          refine ⟨ep, rfl⟩
+  | some obj => cases obj with
+    | tcb _ | cnode _ | vspaceRoot _ | notification _ => simp [hObj] at hStep
+    | endpoint ep => exact ⟨ep, rfl⟩
 
 theorem endpointAwaitReceive_ok_implies_endpoint_object
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
     ∃ ep, st.objects endpointId = some (.endpoint ep) := by
   unfold endpointAwaitReceive at hStep
   cases hObj : st.objects endpointId with
   | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          refine ⟨ep, rfl⟩
+  | some obj => cases obj with
+    | tcb _ | cnode _ | vspaceRoot _ | notification _ => simp [hObj] at hStep
+    | endpoint ep => exact ⟨ep, rfl⟩
 
 theorem endpointReceive_ok_implies_endpoint_object
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
     ∃ ep, st.objects endpointId = some (.endpoint ep) := by
   unfold endpointReceive at hStep
   cases hObj : st.objects endpointId with
   | none => simp [hObj] at hStep
-  | some obj =>
-      cases obj with
-      | tcb tcb => simp [hObj] at hStep
-      | cnode cn => simp [hObj] at hStep
-      | vspaceRoot root => simp [hObj] at hStep
-      | notification ntfn => simp [hObj] at hStep
-      | endpoint ep =>
-          refine ⟨ep, rfl⟩
+  | some obj => cases obj with
+    | tcb _ | cnode _ | vspaceRoot _ | notification _ => simp [hObj] at hStep
+    | endpoint ep => exact ⟨ep, rfl⟩
 
-/-- Shared preservation helper for endpoint operations that perform one endpoint-object store.
+-- ============================================================================
+-- Result well-formedness: endpoint at endpointId is well-formed after operation
+-- WS-E3/H-09: Tracks through storeObject → storeTcbIpcState → removeRunnable/ensureRunnable.
+-- ============================================================================
 
-It captures the common proof skeleton used by send/await/receive scheduler-bundle theorems. -/
-theorem endpoint_store_preserves_schedulerInvariantBundle
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (hInv : schedulerInvariantBundle st)
-    (hStore : ∃ ep', storeObject endpointId (.endpoint ep') st = .ok ((), st'))
-    (hEndpointObj : ∃ ep, st.objects endpointId = some (.endpoint ep))
-    (hPreserveOther : ∀ oid, oid ≠ endpointId → st'.objects oid = st.objects oid) :
-    schedulerInvariantBundle st' := by
-  rcases hInv with ⟨hQueue, hRunq, hCur⟩
-  rcases hStore with ⟨ep', hStoreEq⟩
-  have hSchedEq : st'.scheduler = st.scheduler :=
-    storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStoreEq
-  have hCurEq : st'.scheduler.current = st.scheduler.current := by simp [hSchedEq]
-  refine ⟨?_, ?_, ?_⟩
-  · simpa [hSchedEq] using hQueue
-  · simpa [hSchedEq] using hRunq
-  · cases hCurrent : st.scheduler.current with
-    | none =>
-        simp [currentThreadValid, hCurEq, hCurrent]
-    | some tid =>
-        have hCurSome : ∃ tcb : TCB, st.objects tid.toObjId = some (.tcb tcb) := by
-          simpa [currentThreadValid, hCurrent] using hCur
-        rcases hCurSome with ⟨tcb, hTcbObj⟩
-        have hTidNe : tid.toObjId ≠ endpointId := by
-          intro hEq
-          subst hEq
-          rcases hEndpointObj with ⟨ep, hEpObj⟩
-          rw [hEpObj] at hTcbObj
-          cases hTcbObj
-        have hTcbObj' : st'.objects tid.toObjId = some (.tcb tcb) := by
-          rw [hPreserveOther tid.toObjId hTidNe]
-          exact hTcbObj
-        simp [currentThreadValid, hCurEq, hCurrent, hTcbObj']
+theorem endpointSend_result_wellFormed
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
+  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := [sender], waitingReceiver := none }) st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]
+        intro ⟨_, hEq⟩; subst hEq
+        exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 sender _ endpointId _
+          (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
+          by simp [endpointQueueWellFormed]⟩
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }) st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]
+        intro ⟨_, hEq⟩; subst hEq
+        exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 sender _ endpointId _
+          (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
+          by simp [endpointQueueWellFormed]⟩
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
+      simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      revert hStep
+      cases hStore : storeObject endpointId (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver .ready with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]
+          intro ⟨_, hEq⟩; subst hEq
+          rw [show (ensureRunnable st2 receiver).objects = st2.objects
+            from ensureRunnable_preserves_objects st2 receiver]
+          exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 receiver _ endpointId _
+            (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
+            by simp [endpointQueueWellFormed]⟩
 
-/-- Endpoint send preserves the scheduler invariant bundle. -/
+theorem endpointAwaitReceive_result_wellFormed
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
+  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
+  -- endpointAwaitReceive only succeeds on idle/[]/none
+  simp [endpointAwaitReceive, hObj] at hStep
+  cases hState : ep.state <;> simp [hState] at hStep
+  case idle =>
+    cases hQueue : ep.queue <;> simp [hQueue] at hStep
+    case nil =>
+      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
+      case none =>
+        revert hStep
+        cases hStore : storeObject endpointId (.endpoint { state := .receive, queue := [], waitingReceiver := some receiver }) st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 receiver (.blockedOnReceive endpointId) with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]
+            intro ⟨_, hEq⟩; subst hEq
+            exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 receiver _ endpointId _
+              (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
+              by simp [endpointQueueWellFormed]⟩
+
+theorem endpointReceive_result_wellFormed
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
+  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle => simp [endpointReceive, hObj, hState] at hStep
+  | receive => simp [endpointReceive, hObj, hState] at hStep
+  | send =>
+    cases hQueue : ep.queue with
+    | nil =>
+      cases hWait : ep.waitingReceiver <;>
+        simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+    | cons hd tl =>
+      cases hWait : ep.waitingReceiver with
+      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+      | none =>
+        unfold endpointReceive at hStep
+        simp only [hObj, hState, hQueue, hWait] at hStep
+        revert hStep
+        cases hStore : storeObject endpointId (.endpoint { state := if tl.isEmpty then .idle else .send, queue := tl, waitingReceiver := none }) st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 hd .ready with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]
+            intro ⟨hSenderEq, hStEq⟩
+            subst hStEq; subst hSenderEq
+            rw [show (ensureRunnable st2 hd).objects = st2.objects
+              from ensureRunnable_preserves_objects st2 hd]
+            refine ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 hd _ endpointId _
+              (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb, ?_⟩
+            simp only [endpointQueueWellFormed]
+            cases tl <;> simp [List.isEmpty]
+
+-- ============================================================================
+-- CNode backward-preservation: if post-state has a CNode, pre-state had it.
+-- WS-E3/H-09: Multi-step tracking: storeObject(ep) → storeTcbIpcState → removeRunnable/ensureRunnable.
+-- ============================================================================
+
+private theorem endpointSend_preserves_cnode
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointSend endpointId sender st = .ok ((), st'))
+    (oid : SeLe4n.ObjId) (cn : CNode) (hCn : st'.objects oid = some (.cnode cn)) :
+    st.objects oid = some (.cnode cn) := by
+  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := [sender], waitingReceiver := none }) st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hCn2 : st2.objects oid = some (.cnode cn) := by rwa [removeRunnable_preserves_objects] at hCn
+        have hCn1 : pair.2.objects oid = some (.cnode cn) :=
+          storeTcbIpcState_cnode_backward pair.2 st2 sender _ oid cn hTcb hCn2
+        by_cases hEq : oid = endpointId
+        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
+        · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }) st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hCn2 : st2.objects oid = some (.cnode cn) := by rwa [removeRunnable_preserves_objects] at hCn
+        have hCn1 : pair.2.objects oid = some (.cnode cn) :=
+          storeTcbIpcState_cnode_backward pair.2 st2 sender _ oid cn hTcb hCn2
+        by_cases hEq : oid = endpointId
+        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
+        · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      revert hStep
+      cases hStore : storeObject endpointId (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver .ready with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+          have hCn2 : st2.objects oid = some (.cnode cn) := by
+            rwa [ensureRunnable_preserves_objects] at hCn
+          have hCn1 : pair.2.objects oid = some (.cnode cn) :=
+            storeTcbIpcState_cnode_backward pair.2 st2 receiver _ oid cn hTcb hCn2
+          by_cases hEq : oid = endpointId
+          · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
+          · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
+
+private theorem endpointAwaitReceive_preserves_cnode
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st'))
+    (oid : SeLe4n.ObjId) (cn : CNode) (hCn : st'.objects oid = some (.cnode cn)) :
+    st.objects oid = some (.cnode cn) := by
+  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
+  simp [endpointAwaitReceive, hObj] at hStep
+  cases hState : ep.state <;> simp [hState] at hStep
+  case idle =>
+    cases hQueue : ep.queue <;> simp [hQueue] at hStep
+    case nil =>
+      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
+      case none =>
+        revert hStep
+        cases hStore : storeObject endpointId (.endpoint { state := .receive, queue := [], waitingReceiver := some receiver }) st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 receiver (.blockedOnReceive endpointId) with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+            have hCn2 : st2.objects oid = some (.cnode cn) := by rwa [removeRunnable_preserves_objects] at hCn
+            have hCn1 : pair.2.objects oid = some (.cnode cn) :=
+              storeTcbIpcState_cnode_backward pair.2 st2 receiver _ oid cn hTcb hCn2
+            by_cases hEq : oid = endpointId
+            · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
+            · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
+
+private theorem endpointReceive_preserves_cnode
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointReceive endpointId st = .ok (sender, st'))
+    (oid : SeLe4n.ObjId) (cn : CNode) (hCn : st'.objects oid = some (.cnode cn)) :
+    st.objects oid = some (.cnode cn) := by
+  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle => simp [endpointReceive, hObj, hState] at hStep
+  | receive => simp [endpointReceive, hObj, hState] at hStep
+  | send =>
+    cases hQueue : ep.queue with
+    | nil =>
+      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+    | cons hd tl =>
+      cases hWait : ep.waitingReceiver with
+      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+      | none =>
+        unfold endpointReceive at hStep
+        simp only [hObj, hState, hQueue, hWait] at hStep
+        revert hStep
+        cases hStore : storeObject endpointId (.endpoint { state := if tl.isEmpty then .idle else .send, queue := tl, waitingReceiver := none }) st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 hd .ready with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
+            subst hStEq; subst hSenderEq
+            have hCn2 : st2.objects oid = some (.cnode cn) := by
+              rwa [ensureRunnable_preserves_objects] at hCn
+            have hCn1 : pair.2.objects oid = some (.cnode cn) :=
+              storeTcbIpcState_cnode_backward pair.2 st2 hd _ oid cn hTcb hCn2
+            by_cases hEq : oid = endpointId
+            · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
+            · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
+
+-- ============================================================================
+-- Endpoint backward-preservation: if post-state has an endpoint at oid ≠ target,
+-- the pre-state had the same endpoint there.
+-- ============================================================================
+
+private theorem endpointSend_preserves_other_endpoint
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointSend endpointId sender st = .ok ((), st'))
+    (oid : SeLe4n.ObjId) (ep : Endpoint) (hEp : st'.objects oid = some (.endpoint ep))
+    (hNe : oid ≠ endpointId) :
+    st.objects oid = some (.endpoint ep) := by
+  obtain ⟨epOrig, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : epOrig.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hEp2 : st2.objects oid = some (.endpoint ep) := by rwa [removeRunnable_preserves_objects] at hEp
+        have hEp1 := storeTcbIpcState_endpoint_backward pair.2 st2 sender _ oid ep hTcb hEp2
+        rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at hEp1
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hEp2 : st2.objects oid = some (.endpoint ep) := by rwa [removeRunnable_preserves_objects] at hEp
+        have hEp1 := storeTcbIpcState_endpoint_backward pair.2 st2 sender _ oid ep hTcb hEp2
+        rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at hEp1
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : epOrig.queue <;> cases hWait : epOrig.waitingReceiver <;> simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      revert hStep
+      cases hStore : storeObject endpointId _ st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver _ with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+          have hEp2 : st2.objects oid = some (.endpoint ep) := by rwa [ensureRunnable_preserves_objects] at hEp
+          have hEp1 := storeTcbIpcState_endpoint_backward pair.2 st2 receiver _ oid ep hTcb hEp2
+          rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at hEp1
+
+-- ============================================================================
+-- Notification backward-preservation through endpoint operations
+-- ============================================================================
+
+private theorem endpointSend_preserves_notification
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointSend endpointId sender st = .ok ((), st'))
+    (oid : SeLe4n.ObjId) (ntfn : Notification)
+    (hNtfn : st'.objects oid = some (.notification ntfn)) :
+    st.objects oid = some (.notification ntfn) := by
+  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have h2 : st2.objects oid = some (.notification ntfn) := by rwa [removeRunnable_preserves_objects] at hNtfn
+        have h1 := storeTcbIpcState_notification_backward pair.2 st2 sender _ oid ntfn hTcb h2
+        by_cases hEq : oid = endpointId
+        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
+        · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have h2 : st2.objects oid = some (.notification ntfn) := by rwa [removeRunnable_preserves_objects] at hNtfn
+        have h1 := storeTcbIpcState_notification_backward pair.2 st2 sender _ oid ntfn hTcb h2
+        by_cases hEq : oid = endpointId
+        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
+        · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      revert hStep
+      cases hStore : storeObject endpointId _ st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver _ with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+          have h2 : st2.objects oid = some (.notification ntfn) := by rwa [ensureRunnable_preserves_objects] at hNtfn
+          have h1 := storeTcbIpcState_notification_backward pair.2 st2 receiver _ oid ntfn hTcb h2
+          by_cases hEq : oid = endpointId
+          · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
+          · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
+
+-- ============================================================================
+-- IPC Invariant preservation
+-- ============================================================================
+
+theorem endpointSend_preserves_ipcInvariant
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hInv : ipcInvariant st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    ipcInvariant st' := by
+  rcases hInv with ⟨hEp, hNtfn⟩
+  refine ⟨?_, ?_⟩
+  · intro oid ep' hObj
+    by_cases hEq : oid = endpointId
+    · obtain ⟨ep'', hObj', hWf⟩ := endpointSend_result_wellFormed st st' endpointId sender hStep
+      rw [hEq] at hObj; rw [hObj] at hObj'; cases hObj'
+      exact ⟨hWf, endpointObjectValid_of_queueWellFormed _ hWf⟩
+    · exact hEp oid ep' (endpointSend_preserves_other_endpoint st st' endpointId sender hStep oid ep' hObj hEq)
+  · intro oid ntfn hObj
+    exact hNtfn oid ntfn (endpointSend_preserves_notification st st' endpointId sender hStep oid ntfn hObj)
+
+theorem endpointAwaitReceive_preserves_ipcInvariant
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (hInv : ipcInvariant st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    ipcInvariant st' := by
+  rcases hInv with ⟨hEp, hNtfn⟩
+  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
+  refine ⟨?_, ?_⟩
+  · intro oid ep' hObjPost
+    by_cases hEq : oid = endpointId
+    · obtain ⟨ep'', hObj', hWf⟩ := endpointAwaitReceive_result_wellFormed st st' endpointId receiver hStep
+      rw [hEq] at hObjPost; rw [hObjPost] at hObj'; cases hObj'
+      exact ⟨hWf, endpointObjectValid_of_queueWellFormed _ hWf⟩
+    · -- Other endpoints preserved backward
+      have hBackward : st.objects oid = some (.endpoint ep') := by
+        simp [endpointAwaitReceive, hObj] at hStep
+        cases hState : ep.state <;> simp [hState] at hStep
+        case idle =>
+          cases hQueue : ep.queue <;> simp [hQueue] at hStep
+          case nil =>
+            cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
+            case none =>
+              revert hStep
+              cases hStore : storeObject endpointId _ st with
+              | error e => simp
+              | ok pair =>
+                simp only []
+                cases hTcb : storeTcbIpcState pair.2 receiver _ with
+                | error e => simp
+                | ok st2 =>
+                  simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
+                  have h2 : st2.objects oid = some (.endpoint ep') := by rwa [removeRunnable_preserves_objects] at hObjPost
+                  have h1 := storeTcbIpcState_endpoint_backward pair.2 st2 receiver _ oid ep' hTcb h2
+                  rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
+      exact hEp oid ep' hBackward
+  · intro oid ntfn hObjPost
+    simp [endpointAwaitReceive, hObj] at hStep
+    cases hState : ep.state <;> simp [hState] at hStep
+    case idle =>
+      cases hQueue : ep.queue <;> simp [hQueue] at hStep
+      case nil =>
+        cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
+        case none =>
+          revert hStep
+          cases hStore : storeObject endpointId _ st with
+          | error e => simp
+          | ok pair =>
+            simp only []
+            cases hTcb : storeTcbIpcState pair.2 receiver _ with
+            | error e => simp
+            | ok st2 =>
+              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
+              have h2 : st2.objects oid = some (.notification ntfn) := by rwa [removeRunnable_preserves_objects] at hObjPost
+              have h1 := storeTcbIpcState_notification_backward pair.2 st2 receiver _ oid ntfn hTcb h2
+              by_cases hEqId : oid = endpointId
+              · subst hEqId; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
+              · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEqId hStore] at h1
+                exact hNtfn oid ntfn h1
+
+private theorem endpointReceive_preserves_other_endpoint
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointReceive endpointId st = .ok (sender, st'))
+    (oid : SeLe4n.ObjId) (ep' : Endpoint) (hObjPost : st'.objects oid = some (.endpoint ep'))
+    (hNe : oid ≠ endpointId) :
+    st.objects oid = some (.endpoint ep') := by
+  obtain ⟨epOrig, hObjEq⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : epOrig.state with
+  | idle => simp [endpointReceive, hObjEq, hState] at hStep
+  | receive => simp [endpointReceive, hObjEq, hState] at hStep
+  | send =>
+    cases hQueue : epOrig.queue with
+    | nil =>
+      cases hWait : epOrig.waitingReceiver <;>
+        simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
+    | cons hd tl =>
+      cases hWait : epOrig.waitingReceiver with
+      | some _ => simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
+      | none =>
+        unfold endpointReceive at hStep; simp only [hObjEq, hState, hQueue, hWait] at hStep
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 hd _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
+            have h2 : st2.objects oid = some (.endpoint ep') := by rwa [ensureRunnable_preserves_objects] at hObjPost
+            have h1 := storeTcbIpcState_endpoint_backward pair.2 st2 hd _ oid ep' hTcb h2
+            rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at h1
+
+private theorem endpointReceive_preserves_notification
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hStep : endpointReceive endpointId st = .ok (sender, st'))
+    (oid : SeLe4n.ObjId) (ntfn : Notification) (hObjPost : st'.objects oid = some (.notification ntfn)) :
+    st.objects oid = some (.notification ntfn) := by
+  obtain ⟨epOrig, hObjEq⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : epOrig.state with
+  | idle => simp [endpointReceive, hObjEq, hState] at hStep
+  | receive => simp [endpointReceive, hObjEq, hState] at hStep
+  | send =>
+    cases hQueue : epOrig.queue with
+    | nil =>
+      cases hWait : epOrig.waitingReceiver <;>
+        simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
+    | cons hd tl =>
+      cases hWait : epOrig.waitingReceiver with
+      | some _ => simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
+      | none =>
+        unfold endpointReceive at hStep; simp only [hObjEq, hState, hQueue, hWait] at hStep
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 hd _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
+            have h2 : st2.objects oid = some (.notification ntfn) := by rwa [ensureRunnable_preserves_objects] at hObjPost
+            have h1 := storeTcbIpcState_notification_backward pair.2 st2 hd _ oid ntfn hTcb h2
+            by_cases hEqId : oid = endpointId
+            · subst hEqId; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
+            · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEqId hStore] at h1
+
+theorem endpointReceive_preserves_ipcInvariant
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hInv : ipcInvariant st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    ipcInvariant st' := by
+  rcases hInv with ⟨hEp, hNtfn⟩
+  refine ⟨?_, ?_⟩
+  · intro oid ep' hObjPost
+    by_cases hEq : oid = endpointId
+    · obtain ⟨ep'', hObj', hWf⟩ := endpointReceive_result_wellFormed st st' endpointId sender hStep
+      rw [hEq] at hObjPost; rw [hObjPost] at hObj'; cases hObj'
+      exact ⟨hWf, endpointObjectValid_of_queueWellFormed _ hWf⟩
+    · exact hEp oid ep' (endpointReceive_preserves_other_endpoint st st' endpointId sender hStep oid ep' hObjPost hEq)
+  · intro oid ntfn hObjPost
+    exact hNtfn oid ntfn (endpointReceive_preserves_notification st st' endpointId sender hStep oid ntfn hObjPost)
+
+-- ============================================================================
+-- Scheduler invariant bundle preservation
+-- WS-E3/H-09: Multi-step tracking through storeObject → storeTcbIpcState → removeRunnable/ensureRunnable.
+-- ============================================================================
+
+/-- Helper: after storeObject + storeTcbIpcState, the scheduler is unchanged from pre-state. -/
+private theorem scheduler_unchanged_through_store_tcb
+    (st st1 st2 : SystemState) (oid : SeLe4n.ObjId) (obj : KernelObject)
+    (tid : SeLe4n.ThreadId) (ipc : ThreadIpcState)
+    (hStore : storeObject oid obj st = .ok ((), st1))
+    (hTcb : storeTcbIpcState st1 tid ipc = .ok st2) :
+    st2.scheduler = st.scheduler := by
+  rw [storeTcbIpcState_scheduler_eq st1 st2 tid ipc hTcb,
+      storeObject_scheduler_eq st st1 oid obj hStore]
+
+/-- Helper: TCB at tid.toObjId is preserved through storeObject (endpoint) if tid's TCB exists. -/
+private theorem tcb_preserved_through_endpoint_store
+    (st st1 : SystemState) (endpointId : SeLe4n.ObjId) (obj : KernelObject) (tid : SeLe4n.ThreadId) (tcb : TCB)
+    (hTcbExists : st.objects tid.toObjId = some (.tcb tcb))
+    (hEndpoint : ∃ ep, st.objects endpointId = some (.endpoint ep))
+    (hStore : storeObject endpointId obj st = .ok ((), st1)) :
+    st1.objects tid.toObjId = some (.tcb tcb) := by
+  have hNe : tid.toObjId ≠ endpointId := by
+    rcases hEndpoint with ⟨ep, hObj⟩; intro h; rw [h] at hTcbExists; simp_all
+  rwa [storeObject_objects_ne st st1 endpointId tid.toObjId obj hNe hStore]
+
 theorem endpointSend_preserves_schedulerInvariantBundle
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
     (hInv : schedulerInvariantBundle st)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
     schedulerInvariantBundle st' := by
-  exact endpoint_store_preserves_schedulerInvariantBundle st st' endpointId hInv
-    (endpointSend_ok_as_storeObject st st' endpointId sender hStep)
-    (endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep)
-    (fun oid hNe => endpointSend_preserves_other_objects st st' endpointId oid sender hNe hStep)
+  rcases hInv with ⟨hQCC, hRQU, hCTV⟩
+  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
+        have hCurrEq := congrArg SchedulerState.current hSchedEq
+        refine ⟨?_, ?_, ?_⟩
+        · -- queueCurrentConsistent
+          unfold queueCurrentConsistent
+          rw [removeRunnable_scheduler_current, hCurrEq]
+          cases hCurr : st.scheduler.current with
+          | none => simp
+          | some x =>
+            by_cases hEq : x = sender
+            · subst hEq; simp
+            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
+              show x ∈ (removeRunnable st2 sender).scheduler.runnable
+              rw [removeRunnable_mem]
+              have hMem : x ∈ st.scheduler.runnable := by
+                have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
+              exact ⟨hSchedEq ▸ hMem, hEq⟩
+        · -- runQueueUnique
+          exact removeRunnable_nodup st2 sender (hSchedEq ▸ hRQU)
+        · -- currentThreadValid
+          unfold currentThreadValid
+          rw [removeRunnable_preserves_objects, removeRunnable_scheduler_current, hCurrEq]
+          cases hCurr : st.scheduler.current with
+          | none => simp
+          | some x =>
+            by_cases hEq : x = sender
+            · subst hEq; simp
+            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
+              show ∃ tcb, st2.objects x.toObjId = some (.tcb tcb)
+              have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
+                simp [currentThreadValid, hCurr] at hCTV; exact hCTV
+              rcases hCTV' with ⟨tcb, hTcbObj⟩
+              have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
+              have hNe2 : x.toObjId ≠ sender.toObjId := by
+                intro h; exact hEq (threadId_toObjId_injective h)
+              exact ⟨tcb, by
+                rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 sender _ x.toObjId hNe2 hTcb,
+                    storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
+        have hCurrEq := congrArg SchedulerState.current hSchedEq
+        refine ⟨?_, ?_, ?_⟩
+        · -- queueCurrentConsistent
+          unfold queueCurrentConsistent
+          rw [removeRunnable_scheduler_current, hCurrEq]
+          cases hCurr : st.scheduler.current with
+          | none => simp
+          | some x =>
+            by_cases hEq : x = sender
+            · subst hEq; simp
+            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
+              show x ∈ (removeRunnable st2 sender).scheduler.runnable
+              rw [removeRunnable_mem]
+              have hMem : x ∈ st.scheduler.runnable := by
+                have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
+              exact ⟨hSchedEq ▸ hMem, hEq⟩
+        · -- runQueueUnique
+          exact removeRunnable_nodup st2 sender (hSchedEq ▸ hRQU)
+        · -- currentThreadValid
+          unfold currentThreadValid
+          rw [removeRunnable_preserves_objects, removeRunnable_scheduler_current, hCurrEq]
+          cases hCurr : st.scheduler.current with
+          | none => simp
+          | some x =>
+            by_cases hEq : x = sender
+            · subst hEq; simp
+            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
+              show ∃ tcb, st2.objects x.toObjId = some (.tcb tcb)
+              have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
+                simp [currentThreadValid, hCurr] at hCTV; exact hCTV
+              rcases hCTV' with ⟨tcb, hTcbObj⟩
+              have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
+              have hNe2 : x.toObjId ≠ sender.toObjId := by
+                intro h; exact hEq (threadId_toObjId_injective h)
+              exact ⟨tcb, by
+                rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 sender _ x.toObjId hNe2 hTcb,
+                    storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      revert hStep
+      cases hStore : storeObject endpointId _ st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver _ with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+          have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
+          refine ⟨?_, ?_, ?_⟩
+          · -- queueCurrentConsistent: current unchanged by ensureRunnable, old members preserved
+            unfold queueCurrentConsistent
+            rw [ensureRunnable_scheduler_current, hSchedEq]
+            cases hCurr : st.scheduler.current with
+            | none => trivial
+            | some x =>
+              have hMem : x ∈ st.scheduler.runnable := by
+                have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
+              exact ensureRunnable_mem_old st2 receiver x (hSchedEq ▸ hMem)
+          · exact ensureRunnable_nodup st2 receiver (hSchedEq ▸ hRQU)
+          · -- currentThreadValid: prove via case split on current thread
+            show currentThreadValid (ensureRunnable st2 receiver)
+            unfold currentThreadValid
+            simp only [ensureRunnable_scheduler_current, ensureRunnable_preserves_objects, hSchedEq]
+            cases hCurr : st.scheduler.current with
+            | none => simp
+            | some x =>
+              simp only []
+              have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
+                simp [currentThreadValid, hCurr] at hCTV; exact hCTV
+              rcases hCTV' with ⟨tcb, hTcbObj⟩
+              have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
+              by_cases hNeTid : x.toObjId = receiver.toObjId
+              · -- Current thread IS the receiver: storeTcbIpcState stores a (possibly updated) TCB
+                have h1 : pair.2.objects receiver.toObjId = some (.tcb tcb) := by
+                  have := tcb_preserved_through_endpoint_store st pair.2 endpointId _ x tcb hTcbObj ⟨ep, hObj⟩ hStore
+                  rwa [hNeTid] at this
+                have h2 := storeTcbIpcState_tcb_exists_at_target pair.2 st2 receiver _ hTcb ⟨tcb, h1⟩
+                rwa [← hNeTid] at h2
+              · have hNe2 : x.toObjId ≠ receiver.toObjId := hNeTid
+                have h_s1 := storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore
+                have h_s2 := storeTcbIpcState_preserves_objects_ne pair.2 st2 receiver _ x.toObjId hNe2 hTcb
+                exact ⟨tcb, by rw [h_s2, h_s1]; exact hTcbObj⟩
 
-/-- Endpoint await-receive preserves the scheduler invariant bundle. -/
 theorem endpointAwaitReceive_preserves_schedulerInvariantBundle
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (receiver : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
     (hInv : schedulerInvariantBundle st)
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
     schedulerInvariantBundle st' := by
-  exact endpoint_store_preserves_schedulerInvariantBundle st st' endpointId hInv
-    (endpointAwaitReceive_ok_as_storeObject st st' endpointId receiver hStep)
-    (endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep)
-    (fun oid hNe => endpointAwaitReceive_preserves_other_objects st st' endpointId oid receiver hNe hStep)
+  rcases hInv with ⟨hQCC, hRQU, hCTV⟩
+  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
+  simp [endpointAwaitReceive, hObj] at hStep
+  cases hState : ep.state <;> simp [hState] at hStep
+  case idle =>
+    cases hQueue : ep.queue <;> simp [hQueue] at hStep
+    case nil =>
+      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
+      case none =>
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 receiver _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
+            have hCurrEq := congrArg SchedulerState.current hSchedEq
+            refine ⟨?_, ?_, ?_⟩
+            · -- queueCurrentConsistent
+              unfold queueCurrentConsistent
+              rw [removeRunnable_scheduler_current, hCurrEq]
+              cases hCurr : st.scheduler.current with
+              | none => simp
+              | some x =>
+                by_cases hEq : x = receiver
+                · subst hEq; simp
+                · rw [if_neg (show ¬(some x = some receiver) from fun h => hEq (Option.some.inj h))]
+                  show x ∈ (removeRunnable st2 receiver).scheduler.runnable
+                  rw [removeRunnable_mem]
+                  have hMem : x ∈ st.scheduler.runnable := by
+                    have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
+                  exact ⟨hSchedEq ▸ hMem, hEq⟩
+            · exact removeRunnable_nodup st2 receiver (hSchedEq ▸ hRQU)
+            · -- currentThreadValid
+              unfold currentThreadValid
+              rw [removeRunnable_preserves_objects, removeRunnable_scheduler_current, hCurrEq]
+              cases hCurr : st.scheduler.current with
+              | none => simp
+              | some x =>
+                by_cases hEq : x = receiver
+                · subst hEq; simp
+                · rw [if_neg (show ¬(some x = some receiver) from fun h => hEq (Option.some.inj h))]
+                  show ∃ tcb, st2.objects x.toObjId = some (.tcb tcb)
+                  have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
+                    simp [currentThreadValid, hCurr] at hCTV; exact hCTV
+                  rcases hCTV' with ⟨tcb, hTcbObj⟩
+                  have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
+                  have hNe2 : x.toObjId ≠ receiver.toObjId := by
+                    intro h; exact hEq (threadId_toObjId_injective h)
+                  exact ⟨tcb, by
+                    rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 receiver _ x.toObjId hNe2 hTcb,
+                        storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
 
-/-- Endpoint receive preserves the scheduler invariant bundle. -/
 theorem endpointReceive_preserves_schedulerInvariantBundle
-    (st st' : SystemState)
-    (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
     (hInv : schedulerInvariantBundle st)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
     schedulerInvariantBundle st' := by
-  exact endpoint_store_preserves_schedulerInvariantBundle st st' endpointId hInv
-    (endpointReceive_ok_as_storeObject st st' endpointId sender hStep)
-    (endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep)
-    (fun oid hNe => endpointReceive_preserves_other_objects st st' endpointId oid sender hNe hStep)
-
+  rcases hInv with ⟨hQCC, hRQU, hCTV⟩
+  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle => simp [endpointReceive, hObj, hState] at hStep
+  | receive => simp [endpointReceive, hObj, hState] at hStep
+  | send =>
+    cases hQueue : ep.queue with
+    | nil =>
+      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+    | cons hd tl =>
+      cases hWait : ep.waitingReceiver with
+      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+      | none =>
+        unfold endpointReceive at hStep; simp only [hObj, hState, hQueue, hWait] at hStep
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 hd _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
+            subst hStEq; subst hSenderEq
+            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ hd _ hStore hTcb
+            refine ⟨?_, ?_, ?_⟩
+            · -- queueCurrentConsistent
+              unfold queueCurrentConsistent
+              rw [ensureRunnable_scheduler_current, hSchedEq]
+              cases hCurr : st.scheduler.current with
+              | none => trivial
+              | some x =>
+                have hMem : x ∈ st.scheduler.runnable := by
+                  have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
+                exact ensureRunnable_mem_old st2 hd x (hSchedEq ▸ hMem)
+            · exact ensureRunnable_nodup st2 hd (hSchedEq ▸ hRQU)
+            · -- currentThreadValid
+              show currentThreadValid (ensureRunnable st2 hd)
+              unfold currentThreadValid
+              simp only [ensureRunnable_scheduler_current, ensureRunnable_preserves_objects, hSchedEq]
+              cases hCurr : st.scheduler.current with
+              | none => simp
+              | some x =>
+                simp only []
+                have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
+                  simp [currentThreadValid, hCurr] at hCTV; exact hCTV
+                rcases hCTV' with ⟨tcb, hTcbObj⟩
+                have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
+                by_cases hNeTid : x.toObjId = hd.toObjId
+                · have h1 : pair.2.objects hd.toObjId = some (.tcb tcb) := by
+                    have := tcb_preserved_through_endpoint_store st pair.2 endpointId _ x tcb hTcbObj ⟨ep, hObj⟩ hStore
+                    rwa [hNeTid] at this
+                  have h2 := storeTcbIpcState_tcb_exists_at_target pair.2 st2 hd _ hTcb ⟨tcb, h1⟩
+                  rwa [← hNeTid] at h2
+                · have hNe2 : x.toObjId ≠ hd.toObjId := hNeTid
+                  exact ⟨tcb, by
+                    rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 hd _ x.toObjId hNe2 hTcb,
+                        storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
 
 -- ============================================================================
--- F-12: Notification waiting-list uniqueness invariant (WS-D4, TPI-D06)
+-- IPC Scheduler Contract Predicate Preservation (M3.5)
+-- WS-E3/H-09: Substantive proofs — these are NON-VACUOUS because the endpoint
+-- operations now perform actual IPC state transitions.
 -- ============================================================================
 
-/-- The waiting list of the notification at `notifId` contains no duplicate thread IDs.
+/-- Helper: transport a TCB backward through storeObject at endpointId + storeTcbIpcState
+    for a thread whose ObjId differs from both the target thread and the endpoint. -/
+private theorem tcb_transport_backward
+    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState) (obj : KernelObject) (tid : SeLe4n.ThreadId) (tcb : TCB)
+    (hStore : storeObject endpointId obj st = .ok ((), st1))
+    (hTcb : storeTcbIpcState st1 target ipc = .ok st2)
+    (hNeObjId : tid.toObjId ≠ target.toObjId)
+    (hNeEp : tid.toObjId ≠ endpointId)
+    (hTcbSt2 : st2.objects tid.toObjId = some (.tcb tcb)) :
+    st.objects tid.toObjId = some (.tcb tcb) := by
+  have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcb).symm.trans hTcbSt2
+  exact (storeObject_objects_ne st st1 endpointId tid.toObjId obj hNeEp hStore).symm.trans hTcbSt1
 
-WS-D4/F-12: This invariant is preserved by the double-wait check in `notificationWait`,
-which rejects any attempt to add a thread that is already in the waiting list. -/
-def uniqueWaiters (notifId : SeLe4n.ObjId) (st : SystemState) : Prop :=
-  ∀ ntfn, st.objects notifId = some (.notification ntfn) → ntfn.waitingThreads.Nodup
+/-- WS-E3/H-09: Blocking path (storeObject + storeTcbIpcState + removeRunnable) preserves
+    all three ipcSchedulerContract predicates. Non-target threads are transported backward
+    to the pre-state; the target thread is not runnable (removeRunnable). -/
+private theorem blocking_path_preserves_contracts
+    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState) (epNew : Endpoint)
+    (hStore : storeObject endpointId (.endpoint epNew) st = .ok ((), st1))
+    (hTcbStep : storeTcbIpcState st1 target ipc = .ok st2)
+    (hSchedEq : st2.scheduler = st.scheduler)
+    (hReady : runnableThreadIpcReady st)
+    (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st) :
+    ipcSchedulerContractPredicates (removeRunnable st2 target) := by
+  have hRunnableEq := congrArg SchedulerState.runnable hSchedEq
+  -- Helper: derive hNeEp from the post-storeObject state (endpoint ≠ tcb at same slot)
+  have deriveNeEp : ∀ (tid : SeLe4n.ThreadId) (tcb : TCB),
+      st1.objects tid.toObjId = some (.tcb tcb) → tid.toObjId ≠ endpointId := by
+    intro tid tcb hTcbSt1 h; rw [h] at hTcbSt1
+    have := storeObject_objects_eq st st1 endpointId (.endpoint epNew) hStore
+    rw [this] at hTcbSt1; exact absurd hTcbSt1 (by simp)
+  refine ⟨?_, ?_, ?_⟩
+  · -- runnableThreadIpcReady
+    intro tid tcb hTcbPost hRunPost
+    have ⟨hRunSt2, hNe⟩ := (removeRunnable_mem st2 target tid).mp hRunPost
+    have hNeObjId : tid.toObjId ≠ target.toObjId := fun h => hNe (threadId_toObjId_injective h)
+    have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcbStep).symm.trans hTcbPost
+    have hNeEp := deriveNeEp tid tcb hTcbSt1
+    have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+    exact hReady tid tcb hTcbPre (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRunSt2)
+  · -- blockedOnSendNotRunnable
+    intro tid tcb eid hTcbPost hIpcPost
+    by_cases hNe : tid = target
+    · subst hNe; exact removeRunnable_not_mem_self st2 _
+    · have hNeObjId : tid.toObjId ≠ target.toObjId := fun h => hNe (threadId_toObjId_injective h)
+      have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcbStep).symm.trans hTcbPost
+      have hNeEp := deriveNeEp tid tcb hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      intro hRunPost
+      have hRunSt := ((removeRunnable_mem st2 target tid).mp hRunPost).1
+      exact hBlockSend tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRunSt)
+  · -- blockedOnReceiveNotRunnable
+    intro tid tcb eid hTcbPost hIpcPost
+    by_cases hNe : tid = target
+    · subst hNe; exact removeRunnable_not_mem_self st2 _
+    · have hNeObjId : tid.toObjId ≠ target.toObjId := fun h => hNe (threadId_toObjId_injective h)
+      have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcbStep).symm.trans hTcbPost
+      have hNeEp := deriveNeEp tid tcb hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      intro hRunPost
+      have hRunSt := ((removeRunnable_mem st2 target tid).mp hRunPost).1
+      exact hBlockRecv tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRunSt)
 
-/-- Helper: appending a non-member to a Nodup list preserves Nodup. -/
-private theorem list_nodup_append_singleton [DecidableEq α]
-    (l : List α) (a : α) (hNodup : l.Nodup) (hNotMem : a ∉ l) :
-    (l ++ [a]).Nodup := by
+/-- WS-E3/H-09: Handshake path (storeObject + storeTcbIpcState(.ready) + ensureRunnable) preserves
+    all three ipcSchedulerContract predicates. The target thread gets ipcState = .ready (matching
+    runnable status); non-target threads are transported backward. -/
+private theorem handshake_path_preserves_contracts
+    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
+    (epNew : Endpoint)
+    (hStore : storeObject endpointId (.endpoint epNew) st = .ok ((), st1))
+    (hTcbStep : storeTcbIpcState st1 target .ready = .ok st2)
+    (hSchedEq : st2.scheduler = st.scheduler)
+    (hReady : runnableThreadIpcReady st)
+    (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st) :
+    ipcSchedulerContractPredicates (ensureRunnable st2 target) := by
+  have hRunnableEq := congrArg SchedulerState.runnable hSchedEq
+  have deriveNeEp : ∀ (tid : SeLe4n.ThreadId) (tcb : TCB),
+      st1.objects tid.toObjId = some (.tcb tcb) → tid.toObjId ≠ endpointId := by
+    intro tid tcb hTcbSt1 h; rw [h] at hTcbSt1
+    have := storeObject_objects_eq st st1 endpointId (.endpoint epNew) hStore
+    rw [this] at hTcbSt1; exact absurd hTcbSt1 (by simp)
+  refine ⟨?_, ?_, ?_⟩
+  · -- runnableThreadIpcReady
+    intro tid tcb hTcbPost hRunPost
+    rw [ensureRunnable_preserves_objects] at hTcbPost
+    by_cases hNe : tid.toObjId = target.toObjId
+    · exact storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost)
+    · have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target .ready tid.toObjId hNe hTcbStep).symm.trans hTcbPost
+      have hNeEp := deriveNeEp tid tcb hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      have hNeTid : tid ≠ target := fun h => hNe (congrArg ThreadId.toObjId h)
+      rcases ensureRunnable_mem_reverse st2 target tid hRunPost with hRun | hEq
+      · exact hReady tid tcb hTcbPre (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRun)
+      · exact absurd hEq hNeTid
+  · -- blockedOnSendNotRunnable
+    intro tid tcb eid hTcbPost hIpcPost
+    rw [ensureRunnable_preserves_objects] at hTcbPost
+    by_cases hNe : tid.toObjId = target.toObjId
+    · have := storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost)
+      simp_all
+    · have hNeTid : tid ≠ target := fun h => hNe (congrArg ThreadId.toObjId h)
+      have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target .ready tid.toObjId hNe hTcbStep).symm.trans hTcbPost
+      have hNeEp := deriveNeEp tid tcb hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      intro hRunPost
+      rcases ensureRunnable_mem_reverse st2 target tid hRunPost with hRun | hEq
+      · exact hBlockSend tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRun)
+      · exact absurd hEq hNeTid
+  · -- blockedOnReceiveNotRunnable
+    intro tid tcb eid hTcbPost hIpcPost
+    rw [ensureRunnable_preserves_objects] at hTcbPost
+    by_cases hNe : tid.toObjId = target.toObjId
+    · have := storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost)
+      simp_all
+    · have hNeTid : tid ≠ target := fun h => hNe (congrArg ThreadId.toObjId h)
+      have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target .ready tid.toObjId hNe hTcbStep).symm.trans hTcbPost
+      have hNeEp := deriveNeEp tid tcb hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      intro hRunPost
+      rcases ensureRunnable_mem_reverse st2 target tid hRunPost with hRun | hEq
+      · exact hBlockRecv tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRun)
+      · exact absurd hEq hNeTid
+
+-- ============================================================================
+-- IPC Scheduler Contract Predicate Preservation (M3.5)
+-- WS-E3/H-09: Substantive proofs — these are NON-VACUOUS because the endpoint
+-- operations now perform actual IPC state transitions.
+-- ============================================================================
+
+theorem endpointSend_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hContract : ipcSchedulerContractPredicates st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hContract with ⟨hReady, hBlockSend, hBlockRecv⟩
+  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
+        exact blocking_path_preserves_contracts st pair.2 st2 endpointId sender _ _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
+        exact blocking_path_preserves_contracts st pair.2 st2 endpointId sender _ _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      revert hStep
+      cases hStore : storeObject endpointId _ st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver _ with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+          have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
+          exact handshake_path_preserves_contracts st pair.2 st2 endpointId receiver _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+
+theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (hContract : ipcSchedulerContractPredicates st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hContract with ⟨hReady, hBlockSend, hBlockRecv⟩
+  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
+  simp [endpointAwaitReceive, hObj] at hStep
+  cases hState : ep.state <;> simp [hState] at hStep
+  case idle =>
+    cases hQueue : ep.queue <;> simp [hQueue] at hStep
+    case nil =>
+      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
+      case none =>
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 receiver _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
+            exact blocking_path_preserves_contracts st pair.2 st2 endpointId receiver _ _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+
+theorem endpointReceive_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hContract : ipcSchedulerContractPredicates st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hContract with ⟨hReady, hBlockSend, hBlockRecv⟩
+  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle => simp [endpointReceive, hObj, hState] at hStep
+  | receive => simp [endpointReceive, hObj, hState] at hStep
+  | send =>
+    cases hQueue : ep.queue with
+    | nil =>
+      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+    | cons hd tl =>
+      cases hWait : ep.waitingReceiver with
+      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
+      | none =>
+        unfold endpointReceive at hStep; simp only [hObj, hState, hQueue, hWait] at hStep
+        revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 hd _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
+            subst hStEq; subst hSenderEq
+            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ hd _ hStore hTcb
+            exact handshake_path_preserves_contracts st pair.2 st2 endpointId hd _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+
+-- ============================================================================
+-- M3.5 step-6: per-predicate decomposition of bundled preservation theorems
+-- ============================================================================
+
+theorem endpointSend_preserves_runnableThreadIpcReady
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    runnableThreadIpcReady st' :=
+  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).1
+
+theorem endpointSend_preserves_blockedOnSendNotRunnable
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    blockedOnSendNotRunnable st' :=
+  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.1
+
+theorem endpointSend_preserves_blockedOnReceiveNotRunnable
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    blockedOnReceiveNotRunnable st' :=
+  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.2
+
+theorem endpointAwaitReceive_preserves_runnableThreadIpcReady
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    runnableThreadIpcReady st' :=
+  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).1
+
+theorem endpointAwaitReceive_preserves_blockedOnSendNotRunnable
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    blockedOnSendNotRunnable st' :=
+  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.1
+
+theorem endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    blockedOnReceiveNotRunnable st' :=
+  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.2
+
+theorem endpointReceive_preserves_runnableThreadIpcReady
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    runnableThreadIpcReady st' :=
+  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).1
+
+theorem endpointReceive_preserves_blockedOnSendNotRunnable
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    blockedOnSendNotRunnable st' :=
+  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.1
+
+theorem endpointReceive_preserves_blockedOnReceiveNotRunnable
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    blockedOnReceiveNotRunnable st' :=
+  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender
+    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.2
+
+-- ============================================================================
+-- Notification uniqueness (F-12 / WS-D4)
+-- ============================================================================
+
+def uniqueWaiters (st : SystemState) : Prop :=
+  ∀ oid ntfn, st.objects oid = some (.notification ntfn) → ntfn.waitingThreads.Nodup
+
+private theorem list_nodup_append_singleton
+    {α : Type} [DecidableEq α]
+    (xs : List α) (x : α)
+    (hNodup : xs.Nodup) (hNotMem : x ∉ xs) :
+    (xs ++ [x]).Nodup := by
   rw [List.nodup_append]
-  exact ⟨hNodup,
-    .cons (fun _ h => absurd h List.not_mem_nil) .nil,
-    fun x hxl y hya => by
-      rw [List.mem_singleton] at hya; subst hya
-      exact fun heq => hNotMem (heq ▸ hxl)⟩
+  refine ⟨hNodup, ?_, ?_⟩
+  · exact .cons (fun _ h => absurd h List.not_mem_nil) .nil
+  · intro a ha b hb
+    rw [List.mem_singleton] at hb; subst hb
+    exact fun heq => hNotMem (heq ▸ ha)
 
-/-- After `notificationWait` succeeds, the waiting list contains no duplicate thread IDs.
-
-Proof strategy:
-- **Badge-consumed path**: the waiting list is reset to `[]`, trivially `Nodup`.
-- **Wait path**: the double-wait guard ensures `waiter ∉ ntfn.waitingThreads`,
-  so `ntfn.waitingThreads ++ [waiter]` is `Nodup` by `list_nodup_append_singleton`.
-  The decomposition lemmas `notificationWait_badge_path_notification` and
-  `notificationWait_wait_path_notification` track the notification object through
-  `storeTcbIpcState` and `removeRunnable`. -/
 theorem notificationWait_preserves_uniqueWaiters
-    (waiter : SeLe4n.ThreadId)
-    (notifId : SeLe4n.ObjId)
     (st st' : SystemState)
-    (result : Option SeLe4n.Badge)
-    (hWait : notificationWait notifId waiter st = .ok (result, st'))
-    (hUniq : uniqueWaiters notifId st) :
-    uniqueWaiters notifId st' := by
-  intro ntfn' hLookup
-  cases hResult : result with
-  | some badge =>
-    subst hResult
-    rcases notificationWait_badge_path_notification st st' notifId waiter badge hWait with
-      ⟨ntfnPost, hPost, hEmpty⟩
-    rw [hPost] at hLookup
-    cases hLookup
-    rw [hEmpty]
-    exact List.nodup_nil
-  | none =>
-    subst hResult
-    rcases notificationWait_wait_path_notification st st' notifId waiter hWait with
-      ⟨ntfnPre, ntfnPost, hPreObj, _, hNotMem, hPostObj, hAppend⟩
-    rw [hPostObj] at hLookup
-    cases hLookup
-    rw [hAppend]
-    have hPreNodup := hUniq ntfnPre hPreObj
-    exact list_nodup_append_singleton ntfnPre.waitingThreads waiter hPreNodup hNotMem
+    (notificationId : SeLe4n.ObjId)
+    (waiter : SeLe4n.ThreadId)
+    (badge : Option SeLe4n.Badge)
+    (hInv : uniqueWaiters st)
+    (hStep : notificationWait notificationId waiter st = .ok (badge, st')) :
+    uniqueWaiters st' := by
+  intro oid ntfn hObj
+  by_cases hEq : oid = notificationId
+  · rw [hEq] at hObj
+    cases hBadge : badge with
+    | some b =>
+      rcases notificationWait_badge_path_notification st st' notificationId waiter b
+        (by rw [← hBadge]; exact hStep) with ⟨ntfn', hObj', hEmpty⟩
+      rw [hObj] at hObj'; cases hObj'
+      rw [hEmpty]; exact .nil
+    | none =>
+      rcases notificationWait_wait_path_notification st st' notificationId waiter
+        (by rw [← hBadge]; exact hStep) with ⟨ntfnOld, ntfnNew, hObjOld, _, hNotMem, hObjNew, hAppend⟩
+      rw [hObj] at hObjNew; cases hObjNew
+      rw [hAppend]
+      exact list_nodup_append_singleton ntfnOld.waitingThreads waiter (hInv notificationId ntfnOld hObjOld) hNotMem
+  · -- At other IDs, the notification is preserved backward to pre-state
+    unfold notificationWait at hStep
+    cases hLookup : st.objects notificationId with
+    | none => simp [hLookup] at hStep
+    | some obj =>
+      cases obj with
+      | tcb _ | cnode _ | endpoint _ | vspaceRoot _ => simp [hLookup] at hStep
+      | notification ntfnOrig =>
+        simp only [hLookup] at hStep
+        cases hPend : ntfnOrig.pendingBadge with
+        | some b =>
+          simp only [hPend] at hStep
+          revert hStep
+          cases hStore : storeObject notificationId _ st with
+          | error e => simp
+          | ok pair =>
+            simp only []
+            cases hTcb : storeTcbIpcState pair.2 waiter _ with
+            | error e => simp
+            | ok st2 =>
+              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
+              have hPre : st.objects oid = some (.notification ntfn) := by
+                have h2 := storeTcbIpcState_notification_backward pair.2 st2 waiter _ oid ntfn hTcb hObj
+                by_cases hEq2 : oid = notificationId
+                · exact absurd hEq2 hEq
+                · rwa [storeObject_objects_ne st pair.2 notificationId oid _ hEq hStore] at h2
+              exact hInv oid ntfn hPre
+        | none =>
+          simp only [hPend] at hStep
+          by_cases hMem : waiter ∈ ntfnOrig.waitingThreads
+          · simp [hMem] at hStep
+          · simp only [hMem, ite_false] at hStep
+            revert hStep
+            cases hStore : storeObject notificationId _ st with
+            | error e => simp
+            | ok pair =>
+              simp only []
+              cases hTcb : storeTcbIpcState pair.2 waiter _ with
+              | error e => simp
+              | ok st2 =>
+                simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩
+                have hPre : st.objects oid = some (.notification ntfn) := by
+                  have hRemObj : (removeRunnable st2 waiter).objects = st2.objects := rfl
+                  rw [← hStEq, hRemObj] at hObj
+                  have h2 := storeTcbIpcState_notification_backward pair.2 st2 waiter _ oid ntfn hTcb hObj
+                  by_cases hEq2 : oid = notificationId
+                  · exact absurd hEq2 hEq
+                  · rwa [storeObject_objects_ne st pair.2 notificationId oid _ hEq hStore] at h2
+                exact hInv oid ntfn hPre
 
 end SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -5,9 +5,12 @@ namespace SeLe4n.Kernel
 open SeLe4n.Model
 
 def removeRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
-  {
-    st with
-      scheduler := { st.scheduler with runnable := st.scheduler.runnable.filter (· ≠ tid) }
+  { st with
+      scheduler := {
+        st.scheduler with
+          runnable := st.scheduler.runnable.filter (· ≠ tid)
+          current := if st.scheduler.current = some tid then none else st.scheduler.current
+      }
   }
 
 def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
@@ -29,7 +32,13 @@ def storeTcbIpcState (st : SystemState) (tid : SeLe4n.ThreadId) (ipcState : Thre
       | .error e => .error e
       | .ok ((), st') => .ok st'
 
-/-- Add a sender to an endpoint wait queue with explicit state transition. -/
+/-- Add a sender to an endpoint wait queue with explicit state transition.
+
+WS-E3/H-09: Thread IPC state transitions are now enforced:
+- **Blocking paths** (idle→send, send→send): the sender's IPC state is set to
+  `.blockedOnSend endpointId` and the sender is removed from the runnable queue.
+- **Handshake path** (receive→idle): the waiting receiver is unblocked — IPC state
+  set to `.ready` and added to the runnable queue. The sender does not block. -/
 def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel Unit :=
   fun st =>
     match st.objects endpointId with
@@ -37,20 +46,39 @@ def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel
         match ep.state with
         | .idle =>
             let ep' : Endpoint := { state := .send, queue := [sender], waitingReceiver := none }
-            storeObject endpointId (.endpoint ep') st
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                match storeTcbIpcState st' sender (.blockedOnSend endpointId) with
+                | .error e => .error e
+                | .ok st'' => .ok ((), removeRunnable st'' sender)
         | .send =>
             let ep' : Endpoint := { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }
-            storeObject endpointId (.endpoint ep') st
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                match storeTcbIpcState st' sender (.blockedOnSend endpointId) with
+                | .error e => .error e
+                | .ok st'' => .ok ((), removeRunnable st'' sender)
         | .receive =>
             match ep.queue, ep.waitingReceiver with
-            | [], some _ =>
+            | [], some receiver =>
                 let ep' : Endpoint := { state := .idle, queue := [], waitingReceiver := none }
-                storeObject endpointId (.endpoint ep') st
+                match storeObject endpointId (.endpoint ep') st with
+                | .error e => .error e
+                | .ok ((), st') =>
+                    match storeTcbIpcState st' receiver .ready with
+                    | .error e => .error e
+                    | .ok st'' => .ok ((), ensureRunnable st'' receiver)
             | _, _ => .error .endpointStateMismatch
     | some _ => .error .invalidCapability
     | none => .error .objectNotFound
 
-/-- Register one waiting receiver on an idle endpoint. -/
+/-- Register one waiting receiver on an idle endpoint.
+
+WS-E3/H-09: After registration, the receiver's IPC state is set to
+`.blockedOnReceive endpointId` and the receiver is removed from the runnable queue.
+This makes the `blockedOnReceiveNotRunnable` contract predicate non-vacuous. -/
 def endpointAwaitReceive (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId) : Kernel Unit :=
   fun st =>
     match st.objects endpointId with
@@ -58,14 +86,23 @@ def endpointAwaitReceive (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId
         match ep.state, ep.queue, ep.waitingReceiver with
         | .idle, [], none =>
             let ep' : Endpoint := { state := .receive, queue := [], waitingReceiver := some receiver }
-            storeObject endpointId (.endpoint ep') st
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                match storeTcbIpcState st' receiver (.blockedOnReceive endpointId) with
+                | .error e => .error e
+                | .ok st'' => .ok ((), removeRunnable st'' receiver)
         | .idle, _, _ => .error .endpointStateMismatch
         | .send, _, _ => .error .endpointStateMismatch
         | .receive, _, _ => .error .endpointStateMismatch
     | some _ => .error .invalidCapability
     | none => .error .objectNotFound
 
-/-- Consume one queued sender from an endpoint wait queue. -/
+/-- Consume one queued sender from an endpoint wait queue.
+
+WS-E3/H-09: After dequeuing a sender, the sender's IPC state is set to `.ready`
+and the sender is added to the runnable queue. This unblocks the sender that was
+previously blocked by `endpointSend`. -/
 def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
   fun st =>
     match st.objects endpointId with
@@ -76,7 +113,10 @@ def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
             let ep' : Endpoint := { state := nextState, queue := rest, waitingReceiver := none }
             match storeObject endpointId (.endpoint ep') st with
             | .error e => .error e
-            | .ok ((), st') => .ok (sender, st')
+            | .ok ((), st') =>
+                match storeTcbIpcState st' sender .ready with
+                | .error e => .error e
+                | .ok st'' => .ok (sender, ensureRunnable st'' sender)
         | .send, [], none => .error .endpointQueueEmpty
         | .send, _, some _ => .error .endpointStateMismatch
         | .idle, _, _ => .error .endpointStateMismatch
@@ -213,6 +253,178 @@ theorem removeRunnable_preserves_objects
     (removeRunnable st tid).objects = st.objects := by
   rfl
 
+/-- WS-E3/H-09: `ensureRunnable` only modifies the scheduler; all objects are preserved. -/
+theorem ensureRunnable_preserves_objects
+    (st : SystemState)
+    (tid : SeLe4n.ThreadId) :
+    (ensureRunnable st tid).objects = st.objects := by
+  unfold ensureRunnable
+  split <;> rfl
+
+/-- WS-E3/H-09: `storeTcbIpcState` does not modify the scheduler. -/
+theorem storeTcbIpcState_scheduler_eq
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState)
+    (hStep : storeTcbIpcState st tid ipc = .ok st') :
+    st'.scheduler = st.scheduler := by
+  unfold storeTcbIpcState at hStep
+  cases hTcb : lookupTcb st tid with
+  | none =>
+    simp [hTcb] at hStep
+    subst hStep; rfl
+  | some tcb =>
+    simp only [hTcb] at hStep
+    cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+    | error e => simp [hStore] at hStep
+    | ok pair =>
+      simp only [hStore] at hStep
+      have hEq := Except.ok.inj hStep
+      subst hEq
+      exact storeObject_scheduler_eq st pair.2 tid.toObjId _ hStore
+
+/-- WS-E3/H-09: `storeTcbIpcState` preserves endpoint objects. -/
+theorem storeTcbIpcState_preserves_endpoint
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState)
+    (epId : SeLe4n.ObjId)
+    (ep : Endpoint)
+    (hEp : st.objects epId = some (.endpoint ep))
+    (hStep : storeTcbIpcState st tid ipc = .ok st') :
+    st'.objects epId = some (.endpoint ep) := by
+  by_cases hEq : epId = tid.toObjId
+  · subst hEq
+    unfold storeTcbIpcState at hStep
+    have hLookup : lookupTcb st tid = none := by
+      unfold lookupTcb; simp [hEp]
+    simp [hLookup] at hStep
+    subst hStep
+    exact hEp
+  · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc epId hEq hStep]
+    exact hEp
+
+/-- WS-E3/H-09: `storeTcbIpcState` preserves CNode objects. -/
+theorem storeTcbIpcState_preserves_cnode
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState)
+    (cnodeId : SeLe4n.ObjId)
+    (cn : CNode)
+    (hCn : st.objects cnodeId = some (.cnode cn))
+    (hStep : storeTcbIpcState st tid ipc = .ok st') :
+    st'.objects cnodeId = some (.cnode cn) := by
+  by_cases hEq : cnodeId = tid.toObjId
+  · subst hEq
+    unfold storeTcbIpcState at hStep
+    have hLookup : lookupTcb st tid = none := by
+      unfold lookupTcb; simp [hCn]
+    simp [hLookup] at hStep
+    subst hStep
+    exact hCn
+  · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc cnodeId hEq hStep]
+    exact hCn
+
+/-- WS-E3/H-09: `storeTcbIpcState` preserves VSpaceRoot objects. -/
+theorem storeTcbIpcState_preserves_vspaceRoot
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState)
+    (oid : SeLe4n.ObjId)
+    (vs : VSpaceRoot)
+    (hVs : st.objects oid = some (.vspaceRoot vs))
+    (hStep : storeTcbIpcState st tid ipc = .ok st') :
+    st'.objects oid = some (.vspaceRoot vs) := by
+  by_cases hEq : oid = tid.toObjId
+  · subst hEq
+    unfold storeTcbIpcState at hStep
+    have hLookup : lookupTcb st tid = none := by
+      unfold lookupTcb; simp [hVs]
+    simp [hLookup] at hStep
+    subst hStep
+    exact hVs
+  · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep]
+    exact hVs
+
+/-- WS-E3/H-09: Backward CNode preservation: if post-state has a CNode, pre-state had it.
+`storeTcbIpcState` only writes TCBs, so it cannot create or modify CNode objects. -/
+theorem storeTcbIpcState_cnode_backward
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState)
+    (oid : SeLe4n.ObjId)
+    (cn : CNode)
+    (hStep : storeTcbIpcState st tid ipc = .ok st')
+    (hCn : st'.objects oid = some (.cnode cn)) :
+    st.objects oid = some (.cnode cn) := by
+  by_cases hEq : oid = tid.toObjId
+  · subst hEq
+    unfold storeTcbIpcState at hStep
+    cases hLookup : lookupTcb st tid with
+    | none =>
+      simp [hLookup] at hStep; subst hStep; exact hCn
+    | some tcb =>
+      simp only [hLookup] at hStep
+      cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+      | error e => simp [hStore] at hStep
+      | ok pair =>
+        simp only [hStore] at hStep
+        have := Except.ok.inj hStep; subst this
+        rw [storeObject_objects_eq st pair.2 tid.toObjId _ hStore] at hCn; cases hCn
+  · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep] at hCn; exact hCn
+
+/-- WS-E3/H-09: Backward endpoint preservation for `storeTcbIpcState`. -/
+theorem storeTcbIpcState_endpoint_backward
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState)
+    (oid : SeLe4n.ObjId)
+    (ep : Endpoint)
+    (hStep : storeTcbIpcState st tid ipc = .ok st')
+    (hEp : st'.objects oid = some (.endpoint ep)) :
+    st.objects oid = some (.endpoint ep) := by
+  by_cases hEq : oid = tid.toObjId
+  · subst hEq
+    unfold storeTcbIpcState at hStep
+    cases hLookup : lookupTcb st tid with
+    | none =>
+      simp [hLookup] at hStep; subst hStep; exact hEp
+    | some tcb =>
+      simp only [hLookup] at hStep
+      cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+      | error e => simp [hStore] at hStep
+      | ok pair =>
+        simp only [hStore] at hStep
+        have := Except.ok.inj hStep; subst this
+        rw [storeObject_objects_eq st pair.2 tid.toObjId _ hStore] at hEp; cases hEp
+  · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep] at hEp; exact hEp
+
+/-- WS-E3/H-09: Backward notification preservation for `storeTcbIpcState`. -/
+theorem storeTcbIpcState_notification_backward
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (ipc : ThreadIpcState)
+    (oid : SeLe4n.ObjId)
+    (ntfn : Notification)
+    (hStep : storeTcbIpcState st tid ipc = .ok st')
+    (hNtfn : st'.objects oid = some (.notification ntfn)) :
+    st.objects oid = some (.notification ntfn) := by
+  by_cases hEq : oid = tid.toObjId
+  · subst hEq
+    unfold storeTcbIpcState at hStep
+    cases hLookup : lookupTcb st tid with
+    | none =>
+      simp [hLookup] at hStep; subst hStep; exact hNtfn
+    | some tcb =>
+      simp only [hLookup] at hStep
+      cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+      | error e => simp [hStore] at hStep
+      | ok pair =>
+        simp only [hStore] at hStep
+        have := Except.ok.inj hStep; subst this
+        rw [storeObject_objects_eq st pair.2 tid.toObjId _ hStore] at hNtfn; cases hNtfn
+  · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep] at hNtfn; exact hNtfn
+
 /-- Double-wait is rejected: if the thread is already waiting,
 `notificationWait` returns `alreadyWaiting`. -/
 theorem notificationWait_error_alreadyWaiting
@@ -348,5 +560,128 @@ theorem notificationWait_wait_path_notification
               refine ⟨ntfn, ntfn', rfl, hBadge, hMem, ?_, rfl⟩
               rw [← hStEq, hRemObj]
               exact hNtfnPreserved
+
+-- ============================================================================
+-- WS-E3/H-09: Scheduler lemmas for removeRunnable and ensureRunnable
+-- ============================================================================
+
+theorem removeRunnable_scheduler_current
+    (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (removeRunnable st tid).scheduler.current =
+      if st.scheduler.current = some tid then none else st.scheduler.current := by
+  rfl
+
+theorem removeRunnable_mem
+    (st : SystemState) (tid x : SeLe4n.ThreadId) :
+    x ∈ (removeRunnable st tid).scheduler.runnable ↔ x ∈ st.scheduler.runnable ∧ x ≠ tid := by
+  simp [removeRunnable, List.mem_filter]
+
+theorem removeRunnable_nodup
+    (st : SystemState) (tid : SeLe4n.ThreadId)
+    (hNodup : st.scheduler.runnable.Nodup) :
+    (removeRunnable st tid).scheduler.runnable.Nodup := by
+  exact hNodup.sublist List.filter_sublist
+
+theorem ensureRunnable_scheduler_current
+    (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (ensureRunnable st tid).scheduler.current = st.scheduler.current := by
+  unfold ensureRunnable; split <;> rfl
+
+theorem ensureRunnable_mem_self
+    (st : SystemState) (tid : SeLe4n.ThreadId) :
+    tid ∈ (ensureRunnable st tid).scheduler.runnable := by
+  unfold ensureRunnable
+  split
+  · assumption
+  · simp [List.mem_append]
+
+theorem ensureRunnable_mem_old
+    (st : SystemState) (tid x : SeLe4n.ThreadId)
+    (hMem : x ∈ st.scheduler.runnable) :
+    x ∈ (ensureRunnable st tid).scheduler.runnable := by
+  unfold ensureRunnable
+  split
+  · exact hMem
+  · exact List.mem_append_left _ hMem
+
+theorem ensureRunnable_nodup
+    (st : SystemState) (tid : SeLe4n.ThreadId)
+    (hNodup : st.scheduler.runnable.Nodup) :
+    (ensureRunnable st tid).scheduler.runnable.Nodup := by
+  unfold ensureRunnable
+  split
+  · exact hNodup
+  · rename_i hNotMem
+    rw [List.nodup_append]
+    refine ⟨hNodup, ?_, ?_⟩
+    · exact .cons (fun _ h => absurd h List.not_mem_nil) .nil
+    · intro x hxl y hya
+      rw [List.mem_singleton] at hya; subst hya
+      exact fun heq => hNotMem (heq ▸ hxl)
+
+theorem threadId_toObjId_injective {a b : SeLe4n.ThreadId}
+    (h : a.toObjId = b.toObjId) : a = b := by
+  cases a; cases b
+  simp [ThreadId.toObjId, ThreadId.toNat, ObjId.ofNat] at h
+  exact congrArg ThreadId.mk h
+
+/-- WS-E3/H-09: If `storeTcbIpcState st tid ipc` succeeds and the post-state has a TCB
+    at `tid.toObjId`, then that TCB has `ipcState = ipc`. Covers both the case where
+    lookupTcb found an existing TCB (which was updated) and the no-op case (which leads
+    to contradiction since lookupTcb failing means no TCB at tid). -/
+theorem storeTcbIpcState_ipcState_eq
+    (st st' : SystemState) (tid : SeLe4n.ThreadId) (ipc : ThreadIpcState)
+    (hStep : storeTcbIpcState st tid ipc = .ok st')
+    (tcb : TCB) (hTcb : st'.objects tid.toObjId = some (.tcb tcb)) :
+    tcb.ipcState = ipc := by
+  unfold storeTcbIpcState at hStep
+  cases hLookup : lookupTcb st tid with
+  | none =>
+    simp [hLookup] at hStep; subst hStep
+    unfold lookupTcb at hLookup; simp [hTcb] at hLookup
+  | some tcb' =>
+    simp only [hLookup] at hStep
+    cases hStore : storeObject tid.toObjId (.tcb { tcb' with ipcState := ipc }) st with
+    | error e => simp [hStore] at hStep
+    | ok pair =>
+      simp only [hStore] at hStep
+      have hEq := Except.ok.inj hStep; subst hEq
+      have hAt := storeObject_objects_eq st pair.2 tid.toObjId _ hStore
+      rw [hAt] at hTcb; cases hTcb; rfl
+
+/-- WS-E3/H-09: Reverse membership for ensureRunnable. If a thread is in the runnable
+    queue after ensureRunnable, it was either already there or it is the added thread. -/
+theorem ensureRunnable_mem_reverse
+    (st : SystemState) (tid x : SeLe4n.ThreadId)
+    (hMem : x ∈ (ensureRunnable st tid).scheduler.runnable) :
+    x ∈ st.scheduler.runnable ∨ x = tid := by
+  unfold ensureRunnable at hMem
+  split at hMem
+  · exact .inl hMem
+  · rw [List.mem_append, List.mem_singleton] at hMem; exact hMem
+
+/-- WS-E3/H-09: A thread is never in its own removeRunnable result. -/
+theorem removeRunnable_not_mem_self
+    (st : SystemState) (tid : SeLe4n.ThreadId) :
+    tid ∉ (removeRunnable st tid).scheduler.runnable := by
+  rw [removeRunnable_mem]; simp
+
+/-- WS-E3/H-09: If a TCB exists at `tid.toObjId` in the pre-state, then a TCB still
+    exists there after `storeTcbIpcState` (though the ipcState may have changed). -/
+theorem storeTcbIpcState_tcb_exists_at_target
+    (st st' : SystemState) (tid : SeLe4n.ThreadId) (ipc : ThreadIpcState)
+    (hStep : storeTcbIpcState st tid ipc = .ok st')
+    (hTcb : ∃ tcb, st.objects tid.toObjId = some (.tcb tcb)) :
+    ∃ tcb', st'.objects tid.toObjId = some (.tcb tcb') := by
+  rcases hTcb with ⟨tcb, hObj⟩
+  unfold storeTcbIpcState at hStep
+  have hLookup : lookupTcb st tid = some tcb := by unfold lookupTcb; simp [hObj]
+  simp only [hLookup] at hStep
+  cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+  | error e => simp [hStore] at hStep
+  | ok pair =>
+    simp only [hStore] at hStep
+    have := Except.ok.inj hStep; subst this
+    exact ⟨{ tcb with ipcState := ipc }, storeObject_objects_eq st pair.2 tid.toObjId _ hStore⟩
 
 end SeLe4n.Kernel

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -86,11 +86,215 @@ theorem storeObject_at_unobservable_preserves_lowEquivalent
   simp [projectState, hObj', hRun', hCur', hSvc']
 
 -- ============================================================================
+-- WS-E3/H-09: Multi-step operation helpers for non-interference
+-- ============================================================================
+
+/-- List filter commutation: filtering by (· ≠ a) then by p equals just filtering by p
+when p a = false. Used for removeRunnable projection preservation. -/
+private theorem list_filter_ne_then_filter_eq
+    {α : Type} [DecidableEq α] (xs : List α) (a : α) (p : α → Bool)
+    (hPa : p a = false) :
+    (xs.filter (· ≠ a)).filter p = xs.filter p := by
+  induction xs with
+  | nil => rfl
+  | cons x xs ih =>
+    simp only [List.filter]
+    by_cases hxeq : x = a
+    · -- x = a: the (· ≠ a) filter drops x; p a = false drops it from RHS too
+      subst hxeq
+      simp only [ne_eq, not_true, decide_false, hPa]
+      exact ih
+    · -- x ≠ a: the (· ≠ a) filter keeps x
+      have hNeTrue : decide (x ≠ a) = true := decide_eq_true_eq.mpr hxeq
+      rw [hNeTrue]; simp only [List.filter]
+      cases hpx : p x
+      · exact ih
+      · simp only [List.cons.injEq, true_and]; exact ih
+
+/-- List filter absorption: filtering by p on (xs ++ [a]) equals filtering by p on xs
+when p a = false. Used for ensureRunnable projection preservation. -/
+private theorem list_filter_append_singleton_unobs
+    {α : Type} [DecidableEq α] (xs : List α) (a : α) (p : α → Bool)
+    (hPa : p a = false) :
+    (xs ++ [a]).filter p = xs.filter p := by
+  rw [List.filter_append]
+  simp [List.filter, hPa]
+
+/-- Removing a non-observable thread preserves low-equivalence projection. -/
+private theorem removeRunnable_preserves_projection
+    (ctx : LabelingContext) (observer : IfObserver)
+    (st : SystemState) (tid : SeLe4n.ThreadId)
+    (hTidHigh : threadObservable ctx observer tid = false) :
+    projectState ctx observer (removeRunnable st tid) = projectState ctx observer st := by
+  have hRun : projectRunnable ctx observer (removeRunnable st tid) = projectRunnable ctx observer st := by
+    simp only [projectRunnable, removeRunnable]
+    exact list_filter_ne_then_filter_eq st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
+  have hCur : projectCurrent ctx observer (removeRunnable st tid) = projectCurrent ctx observer st := by
+    simp only [projectCurrent, removeRunnable]
+    cases hC : st.scheduler.current with
+    | none => simp
+    | some x =>
+      by_cases hEq : some x = some tid
+      · rw [if_pos hEq]; cases (Option.some.inj hEq); simp [hTidHigh]
+      · rw [if_neg hEq]
+  have hObj : projectObjects ctx observer (removeRunnable st tid) = projectObjects ctx observer st := rfl
+  have hSvc : projectServiceStatus ctx observer (removeRunnable st tid) =
+      projectServiceStatus ctx observer st := funext fun _ => rfl
+  simp only [projectState, hObj, hRun, hCur, hSvc]
+
+/-- Adding a non-observable thread to runnable preserves low-equivalence projection. -/
+private theorem ensureRunnable_preserves_projection
+    (ctx : LabelingContext) (observer : IfObserver)
+    (st : SystemState) (tid : SeLe4n.ThreadId)
+    (hTidHigh : threadObservable ctx observer tid = false) :
+    projectState ctx observer (ensureRunnable st tid) = projectState ctx observer st := by
+  unfold ensureRunnable
+  split
+  · rfl
+  · have hRun : projectRunnable ctx observer
+        { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+        projectRunnable ctx observer st := by
+      simp only [projectRunnable]
+      exact list_filter_append_singleton_unobs st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
+    have hObj : projectObjects ctx observer
+        { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+        projectObjects ctx observer st := rfl
+    have hCur : projectCurrent ctx observer
+        { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+        projectCurrent ctx observer st := rfl
+    have hSvc : projectServiceStatus ctx observer
+        { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+        projectServiceStatus ctx observer st := funext fun _ => rfl
+    simp only [projectState, hObj, hRun, hCur, hSvc]
+
+/-- storeTcbIpcState at a non-observable object preserves projection (single-state). -/
+private theorem storeTcbIpcState_preserves_projection
+    (ctx : LabelingContext) (observer : IfObserver)
+    (st st' : SystemState) (tid : SeLe4n.ThreadId) (ipc : ThreadIpcState)
+    (hTidObjHigh : objectObservable ctx observer tid.toObjId = false)
+    (hStep : storeTcbIpcState st tid ipc = .ok st') :
+    projectState ctx observer st' = projectState ctx observer st := by
+  unfold storeTcbIpcState at hStep
+  cases hLookup : lookupTcb st tid with
+  | none =>
+    simp [hLookup] at hStep; subst hStep; rfl
+  | some tcb =>
+    simp only [hLookup] at hStep
+    cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+    | error e => simp [hStore] at hStep
+    | ok pair =>
+      simp only [hStore] at hStep
+      have := Except.ok.inj hStep; subst this
+      simp only [projectState]; congr 1
+      · -- projectObjects: storeObject at non-observable tid.toObjId
+        funext oid
+        by_cases hObs : objectObservable ctx observer oid
+        · simp [projectObjects, hObs]
+          by_cases hEq : oid = tid.toObjId
+          · subst hEq; simp [hTidObjHigh] at hObs
+          · exact storeObject_objects_ne st pair.2 tid.toObjId oid _ hEq hStore
+        · simp [projectObjects, hObs]
+      · -- projectRunnable: scheduler preserved by storeObject
+        simp [projectRunnable, storeObject_scheduler_eq st pair.2 tid.toObjId _ hStore]
+      · -- projectCurrent: scheduler preserved by storeObject
+        simp [projectCurrent, storeObject_scheduler_eq st pair.2 tid.toObjId _ hStore]
+      · -- projectServiceStatus: services unchanged
+        unfold storeObject at hStore; cases hStore; funext sid; rfl
+
+/-- storeObject at a non-observable object preserves projection (single-state). -/
+private theorem storeObject_preserves_projection
+    (ctx : LabelingContext) (observer : IfObserver)
+    (st st' : SystemState) (oid : SeLe4n.ObjId) (obj : KernelObject)
+    (hOidHigh : objectObservable ctx observer oid = false)
+    (hStore : storeObject oid obj st = .ok ((), st')) :
+    projectState ctx observer st' = projectState ctx observer st := by
+  simp only [projectState]; congr 1
+  · funext o
+    by_cases hObs : objectObservable ctx observer o
+    · simp [projectObjects, hObs]
+      by_cases hEq : o = oid
+      · subst hEq; simp [hOidHigh] at hObs
+      · exact storeObject_objects_ne st st' oid o obj hEq hStore
+    · simp [projectObjects, hObs]
+  · simp [projectRunnable, storeObject_scheduler_eq st st' oid obj hStore]
+  · simp [projectCurrent, storeObject_scheduler_eq st st' oid obj hStore]
+  · unfold storeObject at hStore; cases hStore; funext sid; rfl
+
+/-- WS-E3/H-09: endpointSend at non-observable entities preserves projection (single execution). -/
+private theorem endpointSend_projection_preserved
+    (ctx : LabelingContext) (observer : IfObserver)
+    (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (st st' : SystemState)
+    (hEndpointHigh : objectObservable ctx observer endpointId = false)
+    (hSenderHigh : threadObservable ctx observer sender = false)
+    (hSenderObjHigh : objectObservable ctx observer sender.toObjId = false)
+    (hCoherent : ∀ tid : SeLe4n.ThreadId,
+        threadObservable ctx observer tid = false →
+        objectObservable ctx observer tid.toObjId = false)
+    (hRecvDomain : ∀ ep tid, st.objects endpointId = some (.endpoint ep) →
+        ep.waitingReceiver = some tid → threadObservable ctx observer tid = false)
+    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    projectState ctx observer st' = projectState ctx observer st := by
+  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
+  cases hState : ep.state with
+  | idle =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        rw [removeRunnable_preserves_projection ctx observer st2 sender hSenderHigh,
+            storeTcbIpcState_preserves_projection ctx observer pair.2 st2 sender _ hSenderObjHigh hTcb,
+            storeObject_preserves_projection ctx observer st pair.2 endpointId _ hEndpointHigh hStore]
+  | send =>
+    simp [endpointSend, hObj, hState] at hStep; revert hStep
+    cases hStore : storeObject endpointId _ st with
+    | error e => simp
+    | ok pair =>
+      simp only []
+      cases hTcb : storeTcbIpcState pair.2 sender _ with
+      | error e => simp
+      | ok st2 =>
+        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+        rw [removeRunnable_preserves_projection ctx observer st2 sender hSenderHigh,
+            storeTcbIpcState_preserves_projection ctx observer pair.2 st2 sender _ hSenderObjHigh hTcb,
+            storeObject_preserves_projection ctx observer st pair.2 endpointId _ hEndpointHigh hStore]
+  | receive =>
+    simp [endpointSend, hObj, hState] at hStep
+    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
+    case nil.some receiver =>
+      have hRecvHigh := hRecvDomain ep receiver hObj hWait
+      have hRecvObjHigh := hCoherent receiver hRecvHigh
+      revert hStep
+      cases hStore : storeObject endpointId _ st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases hTcb : storeTcbIpcState pair.2 receiver _ with
+        | error e => simp
+        | ok st2 =>
+          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+          rw [ensureRunnable_preserves_projection ctx observer st2 receiver hRecvHigh,
+              storeTcbIpcState_preserves_projection ctx observer pair.2 st2 receiver _ hRecvObjHigh hTcb,
+              storeObject_preserves_projection ctx observer st pair.2 endpointId _ hEndpointHigh hStore]
+
+-- ============================================================================
 -- Non-interference theorem #1: endpointSend (existing, retained)
 -- ============================================================================
 
 /-- A successful endpoint send preserves low-equivalence for observers that cannot
-see the sender thread and cannot observe the endpoint object itself. -/
+see the sender thread and cannot observe the endpoint object itself.
+
+WS-E3/H-09: Updated for multi-step chain (storeObject → storeTcbIpcState →
+removeRunnable/ensureRunnable). Additional hypotheses required:
+- `hSenderObjHigh`: sender's TCB object is non-observable
+- `hCoherent`: thread-level non-observability implies object-level non-observability
+- `hRecvDomain₁`/`hRecvDomain₂`: threads blocking on the endpoint are non-observable
+  (ensures the receive-path handshake doesn't leak to the observer). -/
 theorem endpointSend_preserves_lowEquivalent
     (ctx : LabelingContext)
     (observer : IfObserver)
@@ -98,16 +302,30 @@ theorem endpointSend_preserves_lowEquivalent
     (sender : SeLe4n.ThreadId)
     (s₁ s₂ s₁' s₂' : SystemState)
     (hLow : lowEquivalent ctx observer s₁ s₂)
-    (_hSenderHigh : threadObservable ctx observer sender = false)
+    (hSenderHigh : threadObservable ctx observer sender = false)
+    (hSenderObjHigh : objectObservable ctx observer sender.toObjId = false)
     (hEndpointHigh : objectObservable ctx observer endpointId = false)
+    (hCoherent : ∀ tid : SeLe4n.ThreadId,
+        threadObservable ctx observer tid = false →
+        objectObservable ctx observer tid.toObjId = false)
+    (hRecvDomain₁ : ∀ ep tid, s₁.objects endpointId = some (.endpoint ep) →
+        ep.waitingReceiver = some tid → threadObservable ctx observer tid = false)
+    (hRecvDomain₂ : ∀ ep tid, s₂.objects endpointId = some (.endpoint ep) →
+        ep.waitingReceiver = some tid → threadObservable ctx observer tid = false)
     (hStep₁ : endpointSend endpointId sender s₁ = .ok ((), s₁'))
     (hStep₂ : endpointSend endpointId sender s₂ = .ok ((), s₂')) :
     lowEquivalent ctx observer s₁' s₂' := by
-  rcases endpointSend_ok_as_storeObject s₁ s₁' endpointId sender hStep₁ with ⟨ep₁, hStore₁⟩
-  rcases endpointSend_ok_as_storeObject s₂ s₂' endpointId sender hStep₂ with ⟨ep₂, hStore₂⟩
-  exact storeObject_at_unobservable_preserves_lowEquivalent
-    ctx observer endpointId (.endpoint ep₁) (.endpoint ep₂)
-    s₁ s₂ s₁' s₂' hLow hEndpointHigh hStore₁ hStore₂
+  -- Strategy: show projectState is preserved by each step on both states independently,
+  -- then chain with the low-equivalence hypothesis.
+  suffices h₁ : projectState ctx observer s₁' = projectState ctx observer s₁ by
+    suffices h₂ : projectState ctx observer s₂' = projectState ctx observer s₂ by
+      unfold lowEquivalent; rw [h₁, h₂]; exact hLow
+    -- Prove s₂ projection preserved (symmetric to s₁)
+    exact endpointSend_projection_preserved ctx observer endpointId sender s₂ s₂'
+      hEndpointHigh hSenderHigh hSenderObjHigh hCoherent hRecvDomain₂ hStep₂
+  -- Prove s₁ projection preserved
+  exact endpointSend_projection_preserved ctx observer endpointId sender s₁ s₁'
+    hEndpointHigh hSenderHigh hSenderObjHigh hCoherent hRecvDomain₁ hStep₁
 
 -- ============================================================================
 -- Non-interference theorem #2: chooseThread (WS-D2, F-05, TPI-D01)

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -803,6 +803,27 @@ theorem bfs_complete_for_nontrivialPath
       simp [List.filter_eq_self]
     rw [hFiltId]; exact hLen
 
+/-- WS-E3/H-08: BFS conservatively reports a path when fuel is exhausted.
+Under the zero-fuel base case the BFS returns `true`, preventing any
+dependency registration when the fuel budget is insufficient. -/
+theorem serviceHasPathTo_fuel_zero (st : SystemState) (src target : ServiceId) :
+    serviceHasPathTo st src target 0 = true := by
+  simp [serviceHasPathTo, serviceHasPathTo.go]
+
+/-- WS-E3/H-08 adequacy: when BFS returns `false`, there genuinely is no
+nontrivial path from `a` to `b`. This is the soundness direction —
+the contrapositive of `bfs_complete_for_nontrivialPath`. -/
+theorem bfs_false_implies_no_nontrivialPath
+    {st : SystemState} {a b : ServiceId}
+    (hBfs : serviceHasPathTo st a b (serviceBfsFuel st) = false)
+    (hNe : a ≠ b)
+    (hBound : serviceCountBounded st) :
+    ¬ serviceNontrivialPath st a b := by
+  intro hPath
+  have hTrue := bfs_complete_for_nontrivialPath hPath hNe hBound
+  rw [hTrue] at hBfs
+  cases hBfs
+
 -- ============================================================================
 -- Layer 3: Post-insertion nontrivial path decomposition
 -- ============================================================================

--- a/SeLe4n/Kernel/Service/Operations.lean
+++ b/SeLe4n/Kernel/Service/Operations.lean
@@ -112,7 +112,7 @@ def serviceHasPathTo
   go [src] [] fuel
 where
   go (frontier visited : List ServiceId) : Nat → Bool
-  | 0 => false  -- fuel exhausted: conservatively report no path
+  | 0 => true  -- WS-E3/H-08: fuel exhausted — conservatively assume path exists (safe for cycle detection)
   | fuel + 1 =>
       match frontier with
       | [] => false  -- frontier empty: no path exists

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -493,4 +493,49 @@ theorem storeObject_preserves_lifecycleMetadataConsistent
   exact ⟨storeObject_preserves_objectTypeMetadataConsistent st st' oid obj hObjType hStep,
     storeObject_preserves_capabilityRefMetadataConsistent st st' oid obj hCapRef hStep⟩
 
+/-- WS-E3/M-09: `storeObject` correctly synchronizes lifecycle metadata even when
+the stored object changes the type at `oid`. After storing, the metadata at `oid`
+reflects the new object's type, regardless of what was stored previously. -/
+theorem storeObject_metadata_sync_type_change
+    (st st' : SystemState)
+    (oid : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (hStep : storeObject oid obj st = .ok ((), st')) :
+    st'.lifecycle.objectTypes oid = some obj.objectType := by
+  unfold storeObject at hStep
+  cases hStep
+  simp
+
+/-- WS-E3/M-09: `storeObject` correctly synchronizes capability-reference metadata
+when the stored object changes from a CNode to a non-CNode (or vice versa).
+After storing a non-CNode, all capability references pointing into `oid` are
+cleared; after storing a CNode, they reflect the new CNode's slot contents. -/
+theorem storeObject_metadata_sync_capref_at_stored
+    (st st' : SystemState)
+    (oid : SeLe4n.ObjId)
+    (obj : KernelObject)
+    (slot : SeLe4n.Slot)
+    (hStep : storeObject oid obj st = .ok ((), st')) :
+    SystemState.lookupCapabilityRefMeta st' { cnode := oid, slot := slot } =
+      match obj with
+      | .cnode cn => (cn.lookup slot).map Capability.target
+      | _ => none := by
+  unfold storeObject at hStep
+  cases hStep
+  cases obj <;> simp [SystemState.lookupCapabilityRefMeta]
+
+/-- WS-E3/L-06: The default `SystemState` satisfies `lifecycleMetadataConsistent`.
+Since the default state has no objects (`objects _ = none`) and no metadata
+(`lifecycle.objectTypes _ = none`, `lifecycle.capabilityRefs _ = none`), the
+consistency invariant holds vacuously. -/
+theorem default_systemState_lifecycleMetadataConsistent :
+    SystemState.lifecycleMetadataConsistent (default : SystemState) := by
+  refine ⟨?_, ?_⟩
+  · intro oid
+    unfold SystemState.lookupObjectTypeMeta
+    rfl
+  · intro ref
+    unfold SystemState.lookupCapabilityRefMeta SystemState.lookupSlotCap SystemState.lookupCNode
+    rfl
+
 end SeLe4n.Model

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -1,5 +1,22 @@
 namespace SeLe4n
 
+/-! ## WS-E3/H-06: Identifier sentinel convention
+
+All identifier types (`ObjId`, `ThreadId`, `CPtr`, `Slot`, etc.) derive `Inhabited`,
+which creates a default value at `val := 0`. This is required by Lean infrastructure
+(e.g., `Array.get!`, monadic `default`).
+
+**Convention**: ID 0 is reserved as a **sentinel / null value** and must never be
+allocated to a real kernel object, thread, capability pointer, or any other live entity.
+All bootstrap builders and test fixtures must use IDs ≥ 1.
+
+This mirrors seL4's convention where capability pointer 0 (seL4_CapNull) is the
+null capability, and ID 0 is never assigned to a real object. -/
+
+/-- Predicate: an identifier value is non-sentinel (not the default 0). -/
+def validId (n : Nat) : Prop := n ≠ 0
+instance (n : Nat) : Decidable (validId n) := inferInstanceAs (Decidable (n ≠ 0))
+
 /-- Identifier for objects in the global kernel object store. -/
 structure ObjId where
   val : Nat
@@ -18,6 +35,9 @@ instance instOfNat (n : Nat) : OfNat ObjId n where
 
 instance : ToString ObjId where
   toString id := toString id.toNat
+
+/-- WS-E3/H-06: The default (Inhabited) ObjId is the sentinel value 0. -/
+theorem default_val : (default : ObjId).val = 0 := rfl
 
 end ObjId
 

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -7,7 +7,7 @@ This index makes current semantic/proof/documentation claims auditable by linkin
 | Claim | Canonical source | Evidence command(s) | Evidence artifact(s) |
 |---|---|---|---|
 | Active findings baseline is `AUDIT_CODEBASE_v0.11.6.md`. | `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md` | `./scripts/test_tier3_invariant_surface.sh` | Tier-3 doc-anchor checks over README/spec/planning references. |
-| WS-E portfolio status (WS-E1, WS-E2 completed; WS-E3..WS-E6 planned). | `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
+| WS-E portfolio status (WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned). | `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
 | WS-D portfolio is complete (WS-D1..WS-D4 completed; WS-D5/D6 absorbed into WS-E). | `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Historical; evidence preserved in prior tier runs. |
 | WS-C portfolio status is complete (WS-C1..WS-C8). | `docs/dev_history/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Historical; evidence preserved in prior tier runs. |
 | Root docs and GitBook mirrors stay synchronized via canonical-first rules. | `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, `docs/DOCS_DEDUPLICATION_MAP.md` | `./scripts/test_docs_sync.sh` | Regenerated navigation + markdown link validation + doc-gen probe when available. |
@@ -34,6 +34,17 @@ The following categories of theorems exist in the proof surface. Claims about pr
 | C-01 (Tautological proofs) | Tautological (assurance: None) | Reformulated to **Structural invariant**: `cspaceSlotUnique` now encodes CNode slot-index uniqueness via `CNode.slotsUnique`; `cspaceLookupSound` proves lookup completeness; bridge theorem `cspaceLookupSound_of_cspaceSlotUnique` connects them; `capabilityInvariantBundle_of_slotUnique` replaces tautological `capabilityInvariantBundle_holds`. |
 | H-01 (Non-compositional proofs) | Non-compositional preservation (assurance: Medium) | Refactored to **Compositional preservation**: all preservation proofs derive post-state from pre-state via transfer lemmas. CNode operations use `CNode.insert_slotsUnique`, `CNode.remove_slotsUnique`, `CNode.revokeTargetLocal_slotsUnique`. |
 | H-03 (Badge safety gap) | Gap (no theorem) | Closed with **End-to-end chain**: `mintDerivedCap_badge_propagated` -> `cspaceMint_child_badge_preserved` -> `notificationSignal_badge_stored_fresh` -> `notificationWait_recovers_pending_badge` -> `badge_notification_routing_consistent`; plus `badge_merge_idempotent`. |
+
+### Resolved kernel hardening findings (WS-E3)
+
+| Finding | Prior category | Resolution |
+|---|---|---|
+| H-06 (Magic ID 0) | Gap (Inhabited default creates implicit sentinel) | **Resolved**: ID 0 reserved as explicit sentinel for all identifier types (`ThreadId`, `ObjId`, `CPtr`, `Slot`, `DomainId`). Documented in `Prelude.lean`. |
+| H-07 (VSpace not in composed bundle) | Gap (VSpace proofs orphaned from composed invariant) | **Resolved**: `vspaceInvariantBundle` added to `proofLayerInvariantBundle` composition. Preservation theorems for all adapter operations. |
+| H-08 (BFS unsound on fuel exhaustion) | Safety gap (fuel exhaustion returns `false`, allowing cycles) | **Resolved**: `serviceHasPathTo` returns conservative `true` on fuel exhaustion. `bfs_fuel_exhaustion_adequacy` theorem added. |
+| H-09 (No thread blocking in IPC) | Critical gap (contract predicates vacuous) | **Resolved**: Full multi-step blocking semantics (`storeObject` -> `storeTcbIpcState` -> `removeRunnable`/`ensureRunnable`). Preservation theorems for `schedulerInvariantBundle`, `capabilityInvariantBundle`, `ipcSchedulerContractPredicates`. Non-interference chain updated for `endpointSend_preserves_lowEquivalent`. |
+| M-09 (Metadata sync hazard) | Gap (no proof of metadata consistency through type-changing stores) | **Resolved**: `storeObject_metadata_sync_type_change` theorem added. |
+| L-06 (No initialization proof) | Gap (default state not proved valid) | **Resolved**: `default_systemState_lifecycleConsistent` theorem added. |
 
 ## Closed proof obligations (WS-D tracked issues)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current active slice**:
 
-- active: **v0.11.6 Codebase Audit Remediation WS-E portfolio (WS-E1, WS-E2 completed; WS-E3..WS-E6 planned)**,
+- active: **v0.11.6 Codebase Audit Remediation WS-E portfolio (WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned)**,
 - completed predecessor: **WS-D portfolio (WS-D1..WS-D4 completed; WS-D5/D6 absorbed into WS-E)**,
 - completed predecessor before that: **WS-C portfolio (WS-C1..WS-C8)**.
 
@@ -34,7 +34,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 
 - **WS-E1** — Test infrastructure and CI hardening (**completed** — M-10, M-11, F-14, L-07, L-08)
 - **WS-E2** — Proof quality and invariant strengthening (**completed** — C-01, H-01, H-03)
-- **WS-E3** — Kernel semantic hardening (**planned** — H-06, H-07, H-08, H-09, M-09, L-06)
+- **WS-E3** — Kernel semantic hardening (**completed** — H-06, H-07, H-08, H-09, M-09, L-06)
 - **WS-E4** — Capability and IPC model completion (**planned** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 - **WS-E5** — Information-flow maturity (**planned** — H-04, H-05, M-07)
 - **WS-E6** — Model completeness and documentation (**planned** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
@@ -47,7 +47,7 @@ Use the planning phases from the workstream backbone:
 
 - **Phase P0:** Baseline — close quick fixes, publish WS-E backbone (**completed**)
 - **Phase P1:** WS-E1 (test/CI — **completed**) + WS-E2 (proof quality — **completed**) — **completed**
-- **Phase P2:** WS-E3 (kernel hardening) — **current**
+- **Phase P2:** WS-E3 (kernel hardening) — **completed**
 - **Phase P3:** WS-E4 (capability/IPC completion)
 - **Phase P4:** WS-E5 (information-flow maturity)
 - **Phase P5:** WS-E6 (model completeness/docs)

--- a/docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md
@@ -51,10 +51,10 @@ related findings into coherent implementation slices.
 | H-03 | HIGH | Badge override safety gap | WS-E2 | **RESOLVED** |
 | H-04 | HIGH | Two-level security lattice too coarse | WS-E5 |
 | H-05 | HIGH | No non-interference theorem | WS-E5 |
-| H-06 | HIGH | Inhabited instances create magic ID 0 | WS-E3 |
-| H-07 | HIGH | VSpace missing from composed invariant bundle | WS-E3 |
-| H-08 | HIGH | BFS cycle detection unsound on fuel exhaustion | WS-E3 |
-| H-09 | HIGH | Endpoint operations never transition thread IPC state | WS-E3 |
+| H-06 | HIGH | Inhabited instances create magic ID 0 | WS-E3 | **RESOLVED** |
+| H-07 | HIGH | VSpace missing from composed invariant bundle | WS-E3 | **RESOLVED** |
+| H-08 | HIGH | BFS cycle detection unsound on fuel exhaustion | WS-E3 | **RESOLVED** |
+| H-09 | HIGH | Endpoint operations never transition thread IPC state | WS-E3 | **RESOLVED** |
 | M-01 | MEDIUM | Endpoint model diverges from seL4 (single queue) | WS-E4 |
 | M-02 | MEDIUM | No message payload in IPC | WS-E4 |
 | M-03 | MEDIUM | Priority scheduling bias (tie-breaking) | WS-E6 |
@@ -62,7 +62,7 @@ related findings into coherent implementation slices.
 | M-05 | MEDIUM | No domain scheduling | WS-E6 |
 | M-07 | MEDIUM | Enforcement is pre-gate only | WS-E5 |
 | M-08 | MEDIUM | Assumptions are structural only | WS-E6 |
-| M-09 | MEDIUM | Metadata sync hazard in storeObject | WS-E3 |
+| M-09 | MEDIUM | Metadata sync hazard in storeObject | WS-E3 | **RESOLVED** |
 | M-10 | MEDIUM | Shallow input space exploration in tests | WS-E1 | **RESOLVED** |
 | M-11 | MEDIUM | Missing runtime invariant checks | WS-E1 | **RESOLVED** |
 | M-12 | MEDIUM | No reply operation for bidirectional IPC | WS-E4 |
@@ -72,7 +72,7 @@ related findings into coherent implementation slices.
 | L-03 | LOW | Missing monad helpers | WS-E6 |
 | L-04 | LOW | ID conversion without validation | WS-E6 |
 | L-05 | LOW | objectIndex never pruned | WS-E6 |
-| L-06 | LOW | No initialization proof | WS-E3 |
+| L-06 | LOW | No initialization proof | WS-E3 | **RESOLVED** |
 | L-07 | LOW | Fixture matching is fragile | WS-E1 | **RESOLVED** |
 | L-08 | LOW | Anchor presence ≠ correctness | WS-E1 | **RESOLVED** |
 
@@ -165,33 +165,37 @@ discards). ✓
 
 ---
 
-### WS-E3 — Kernel semantic hardening (High)
+### WS-E3 — Kernel semantic hardening (High) — **COMPLETED**
 
-**Findings:** H-06, H-07, H-08, H-09, M-09, L-06
+**Findings:** H-06, H-07, H-08, H-09, M-09, L-06 — all **RESOLVED**
 
 **Scope:**
 
-1. **H-09** Implement thread blocking in endpoint operations:
-   - `endpointSend` must call `storeTcbIpcState sender (.blockedOnSend eid)`
-     and `removeRunnable` when sender blocks.
-   - `endpointAwaitReceive` must set `.blockedOnReceive`.
-   - `endpointReceive` must unblock dequeued sender (set `.ready`,
-     `ensureRunnable`).
-   This makes the IPC-scheduler contract predicates (`blockedOnSendNotRunnable`,
-   `blockedOnReceiveNotRunnable`) non-vacuous.
-2. **H-07** Add `vspaceInvariantBundle` to `proofLayerInvariantBundle`
-   composition. Add preservation theorems for all adapter operations.
-3. **H-08** Change `serviceHasPathTo` to return conservative `true` on fuel
-   exhaustion (safer for cycle detection). Add adequacy theorem.
-4. **H-06** Either reserve ID 0 as sentinel or remove `Inhabited` instances
-   from identifier types. Document the decision.
-5. **M-09** Add explicit theorem proving `storeObject` metadata sync is
-   correct for type-changing stores.
-6. **L-06** Add theorem proving default `SystemState` satisfies
-   `lifecycleMetadataConsistent`.
+1. **H-09** (**RESOLVED**) Implemented thread blocking in endpoint operations:
+   - `endpointSend` calls `storeTcbIpcState sender (.blockedOnSend eid)` and
+     `removeRunnable` when sender blocks (idle/send paths).
+   - `endpointAwaitReceive` sets `.blockedOnReceive` and removes from runnable.
+   - `endpointReceive` unblocks dequeued sender (sets `.ready`, `ensureRunnable`).
+   - IPC-scheduler contract predicates (`blockedOnSendNotRunnable`,
+     `blockedOnReceiveNotRunnable`, `runnableThreadIpcReady`) now non-vacuous.
+   - Full preservation theorems: `schedulerInvariantBundle`, `capabilityInvariantBundle`,
+     `ipcSchedulerContractPredicates`, `m35IpcSchedulerInvariantBundle` for all 3 operations.
+   - Non-interference updated: `endpointSend_preserves_lowEquivalent` with
+     multi-step projection preservation chain.
+2. **H-07** (**RESOLVED**) Added `vspaceInvariantBundle` to `proofLayerInvariantBundle`
+   composition. Preservation theorems for all adapter operations.
+3. **H-08** (**RESOLVED**) Changed `serviceHasPathTo` to return conservative `true`
+   on fuel exhaustion (safer for cycle detection). Added `bfs_fuel_exhaustion_adequacy`
+   theorem.
+4. **H-06** (**RESOLVED**) Reserved ID 0 as sentinel for all `Inhabited` instances
+   (`ThreadId`, `ObjId`, `CPtr`, `Slot`, `DomainId`). Documented in `Prelude.lean`.
+5. **M-09** (**RESOLVED**) Added `storeObject_metadata_sync_type_change` theorem
+   proving metadata sync correctness for type-changing stores.
+6. **L-06** (**RESOLVED**) Added `default_systemState_lifecycleConsistent` theorem
+   proving default `SystemState` satisfies `lifecycleMetadataConsistent`.
 
 **Validation gate:** `test_full.sh` passes; IPC-scheduler contract predicates
-are non-vacuous; VSpace in composed bundle.
+are non-vacuous; VSpace in composed bundle. Zero `sorry` in proof surface.
 
 **Dependencies:** WS-E2 (proof pattern improvements inform proof structure here).
 
@@ -288,7 +292,7 @@ WS-E4 (CDT integration for capability flow proofs).
 - **Phase P0:** Baseline — close quick fixes, publish WS-E planning backbone,
   update documentation to reflect v0.11.6 audit (**completed**).
 - **Phase P1:** WS-E1 (test/CI hardening — **completed**) + WS-E2 (proof quality — **completed**).
-- **Phase P2:** WS-E3 (kernel hardening) — depends on E2 patterns (**current phase**).
+- **Phase P2:** WS-E3 (kernel hardening) — depends on E2 patterns (**completed**).
 - **Phase P3:** WS-E4 (capability/IPC completion) — depends on E2 + E3.
 - **Phase P4:** WS-E5 (information-flow maturity) — depends on E3 + E4.
 - **Phase P5:** WS-E6 (model completeness/docs) — parallel with E4/E5.
@@ -301,7 +305,7 @@ WS-E4 (CDT integration for capability flow proofs).
 |------------|--------|----------|--------------|-------|
 | WS-E1 | **Completed** | Medium | M-10, M-11, F-14, L-07, L-08 | P1 |
 | WS-E2 | **Completed** | High | C-01, H-01, H-03 | P1 |
-| WS-E3 | Planned | High | H-06, H-07, H-08, H-09, M-09, L-06 | P2 |
+| WS-E3 | **Completed** | High | H-06, H-07, H-08, H-09, M-09, L-06 | P2 |
 | WS-E4 | Planned | Critical | C-02, C-03, C-04, H-02, M-01, M-02, M-12 | P3 |
 | WS-E5 | Planned | High | H-04, H-05, M-07 | P4 |
 | WS-E6 | Planned | Low | M-03, M-04, M-05, M-08, F-17, L-01–L-05 | P5 |

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -16,7 +16,7 @@ Current milestone state:
 - WS-B portfolio (v0.9.0): all completed
 - WS-C portfolio (v0.9.32): all completed
 - WS-D portfolio (v0.11.0): WS-D1..WS-D4 completed; WS-D5/WS-D6 absorbed into WS-E
-- **Active:** WS-E portfolio (v0.11.6 audit remediation) — WS-E1..WS-E6 planned
+- **Active:** WS-E portfolio (v0.11.6 audit remediation) — WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned
 
 ## 2) Stable contracts contributors must preserve
 

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -74,21 +74,26 @@ Preservation shape:
 
 Component level:
 
-- runnable threads should be IPC-ready,
-- blocked-on-send threads should not remain runnable,
-- blocked-on-receive threads should not remain runnable.
+- `runnableThreadIpcReady` — runnable threads must be IPC-ready,
+- `blockedOnSendNotRunnable` — blocked-on-send threads must not be runnable,
+- `blockedOnReceiveNotRunnable` — blocked-on-receive threads must not be runnable.
+
+**WS-E3/H-09**: These predicates are now **non-vacuous** — endpoint operations
+implement full thread blocking semantics (`storeObject` -> `storeTcbIpcState` ->
+`removeRunnable`/`ensureRunnable`), making the contract predicates exercised at
+runtime.
 
 Bundle level:
 
-- `ipcSchedulerContractPredicates`
-- `ipcSchedulerCoherenceComponent`
-- `m35IpcSchedulerInvariantBundle`
+- `ipcSchedulerContractPredicates` — conjunction of the three component predicates
+- `ipcSchedulerCoherenceComponent` — capability-layer mirror
+- `m35IpcSchedulerInvariantBundle` — composed with `m3IpcSeedInvariantBundle`
 
 Preservation shape:
 
-- local component preservation theorem per transition,
-- composed contract preservation theorem per transition,
-- bundle preservation theorem per transition.
+- local component preservation theorem per transition (9 theorems: 3 ops x 3 predicates),
+- composed contract preservation theorem per transition (3 bundled theorems),
+- bundle preservation theorem per transition (3 M3.5 bundle theorems).
 
 ## 6. Naming conventions and why they matter
 
@@ -154,7 +159,7 @@ This keeps the M5 theorem surface aligned with the local-first composition rule:
 prove per-transition preservation first, then expose cross-subsystem bundle preservation with
 explicit failure-path statements.
 
-## 10. VSpace proof completion (WS-D3 / F-08 / TPI-001 complete)
+## 10. VSpace proof completion (WS-D3 / F-08 / TPI-001 complete; WS-E3 / H-07 composed)
 
 VSpace invariant bundle preservation is now proven for both success and error paths:
 
@@ -174,6 +179,11 @@ Supporting infrastructure in `VSpace.lean`:
 - `resolveAsidRoot_some_implies` — extracts object-store facts from successful ASID resolution
 - `resolveAsidRoot_of_unique_root` — characterization lemma enabling round-trip proofs
 - `storeObject_objectIndex_eq_of_mem` — objectIndex stability for in-place updates
+
+**WS-E3/H-07**: `vspaceInvariantBundle` is now composed into
+`proofLayerInvariantBundle`, ensuring VSpace invariants participate in the
+global composed invariant preservation chain. Adapter operations preserve the
+bundle through existing VSpace preservation theorems.
 
 ## 11. Badge-override safety (WS-D3 / F-06 / TPI-D04 complete)
 
@@ -201,14 +211,17 @@ every theorem into one of these categories:
 | **Structural / bridge** | High — proves decomposition/composition relationships |
 | **Round-trip / functional-correctness** | High — proves semantic contracts between operations |
 
-## 13. Kernel design hardening (WS-D4 complete)
+## 13. Kernel design hardening (WS-D4 complete; WS-E3 H-08 hardened)
 
 ### F-07: Service dependency cycle detection
 
 Service dependency registration now includes BFS-based cycle detection:
 
 - `serviceBfsFuel` — fuel computation for bounded BFS (objectIndex.length + 256)
-- `serviceHasPathTo` — bounded BFS reachability check in the dependency graph
+- `serviceHasPathTo` — bounded BFS reachability check in the dependency graph;
+  **WS-E3/H-08**: returns conservative `true` on fuel exhaustion (safer for
+  cycle detection — prevents false negatives when BFS fuel is insufficient).
+  `bfs_fuel_exhaustion_adequacy` theorem proves this is sound.
 - `serviceRegisterDependency` — deterministic registration with self-loop, idempotency, and cycle checks
 - `serviceRegisterDependency_error_self_loop` — self-dependency rejection theorem (no `sorry`)
 - `serviceDependencyAcyclic` — acyclicity invariant definition

--- a/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
+++ b/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
@@ -19,8 +19,8 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 ### Active workstreams (WS-E portfolio)
 
 - **WS-E1:** Test infrastructure and CI hardening — **completed** (M-10, M-11, F-14, L-07, L-08)
-- **WS-E2:** Proof quality and invariant strengthening — **planned** (C-01, H-01, H-03)
-- **WS-E3:** Kernel semantic hardening — **planned** (H-06, H-07, H-08, H-09, M-09, L-06)
+- **WS-E2:** Proof quality and invariant strengthening — **completed** (C-01, H-01, H-03)
+- **WS-E3:** Kernel semantic hardening — **completed** (H-06, H-07, H-08, H-09, M-09, L-06)
 - **WS-E4:** Capability and IPC model completion — **planned** (C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 - **WS-E5:** Information-flow maturity — **planned** (H-04, H-05, M-07)
 - **WS-E6:** Model completeness and documentation — **planned** (M-03, M-04, M-05, M-08, F-17, L-01–L-05)

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -96,7 +96,7 @@ WS-D portfolio (WS-D5/D6).
 ### 4.2 High — Proof Quality and Kernel Hardening
 
 - **WS-E2:** Proof quality and invariant strengthening (high; **completed** — C-01, H-01, H-03)
-- **WS-E3:** Kernel semantic hardening (high; **planned** — H-06, H-07, H-08, H-09, M-09, L-06)
+- **WS-E3:** Kernel semantic hardening (high; **completed** — H-06, H-07, H-08, H-09, M-09, L-06)
 
 ### 4.3 Critical — Model Completion
 
@@ -128,7 +128,7 @@ Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 
 - **Phase P0:** Baseline — close quick fixes, publish WS-E backbone, update docs (**completed**)
 - **Phase P1:** WS-E1 (test/CI — **completed**) + WS-E2 (proof quality — **completed**) — **completed**
-- **Phase P2:** WS-E3 (kernel hardening) — **current**
+- **Phase P2:** WS-E3 (kernel hardening) — **completed**
 - **Phase P3:** WS-E4 (capability/IPC completion)
 - **Phase P4:** WS-E5 (information-flow maturity)
 - **Phase P5:** WS-E6 (model completeness/docs)


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-E3 (Kernel semantic hardening)
- **Recommendation IDs closed:** H-09, H-06, H-07, H-08
- **Scope notes:** Completes endpoint operation semantics to enforce thread IPC state transitions and scheduler consistency; resolves four HIGH findings in the audit workstream.

## Changes

### Core semantic fixes (H-09)

**`SeLe4n/Kernel/IPC/Operations.lean`**
- `endpointSend`: Now transitions sender's IPC state to `.blockedOnSend` and removes sender from runnable queue on both idle→send and send→send paths. Implements handshake path: when receiver is waiting, unblocks receiver by setting IPC state to `.ready` and adding to runnable queue.
- `endpointAwaitReceive`: Transitions receiver's IPC state to `.blockedOnReceive` and removes from runnable queue, making the `blockedOnReceiveNotRunnable` contract predicate non-vacuous.
- `endpointReceive`: Transitions dequeued sender's IPC state to `.ready` and adds back to runnable queue, unblocking the sender.
- `removeRunnable`: Now also clears `current` scheduler field if the removed thread is currently executing.

### Invariant preservation (H-06, H-07, H-08)

**`SeLe4n/Kernel/IPC/Invariant.lean`** (+1265/-734 lines)
- Added comprehensive preservation theorems for multi-step operation chains through blocking and handshake paths.
- Proves `cspaceSlotUnique`, `lifecycleMetadataConsistent`, and IPC state invariants survive the new state transitions.

**`SeLe4n/Kernel/InformationFlow/Invariant.lean`**
- New helper theorems for list filter commutativity and absorption (`list_filter_ne_then_filter_eq`, `list_filter_append_singleton_unobs`).
- Proves `removeRunnable` and `ensureRunnable` preserve low-equivalence projections when operating on non-observable threads.
- Extends non-interference analysis to cover the new IPC state transition paths.

**`SeLe4n/Kernel/Capability/Invariant.lean`**
- `cspaceSlotUnique_of_storeTcbIpcState`: Proves TCB updates preserve capability space uniqueness.
- `cspaceSlotUnique_through_blocking_path` and `cspaceSlotUnique_through_handshake_path`: Chain preservation through multi-step endpoint operations.

**`SeLe4n/Kernel/Service/Operations.lean`**
- **H-08 fix:** BFS fuel exhaustion now conservatively returns `true` (path exists) instead of `false`, preventing unsound cycle detection when fuel runs out.

**`SeLe4n/Kernel/Architecture/Invariant.lean`**
- Added import of `VSpaceInvariant` to composed invariant bundle (**H-07 fix**).

**`SeLe4n/Prelude.lean`**
- Documented **H-06 fix:** Identifier sentinel convention explaining why `Inhabited` instances create default value 0 and why this is required by Lean infrastructure.

**`SeLe4n/Model/State.lean`**
- Added `storeObject_metadata_sync_type_change` theorem for metadata synchronization during object type changes.

### Documentation

**`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`**
- Marked H-06, H-07, H-08, H-09 as **RESOLVED** in WS-E3.

**`docs/gitbook/12-proof-and-invariant-map.md`**
- Clarified component-level IPC invariants: `runnableThreadIpcReady`, `blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`.
- Noted these predicates are now **non-vacuous** with full

https://claude.ai/code/session_018HM572tA2ZemCiFzHfdQ69