### PR TITLE
WS-E4: Dual-queue endpoint model with CDT-based revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Quick index. Full contracts and dependencies are in the v0.11.6 planning backbon
 - **WS-E1:** Test infrastructure and CI hardening -- **completed** (Medium; M-10, M-11, F-14, L-07, L-08)
 - **WS-E2:** Proof quality and invariant strengthening -- **completed** (High; C-01, H-01, H-03)
 - **WS-E3:** Kernel semantic hardening -- **completed** (High; H-06, H-07, H-08, H-09, M-09, L-06)
-- **WS-E4:** Capability and IPC model completion -- planned (Critical; C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4:** Capability and IPC model completion -- **in progress** (Critical; C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 - **WS-E5:** Information-flow maturity -- planned (High; H-04, H-05, M-07)
 - **WS-E6:** Model completeness and documentation -- planned (Low; M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 
@@ -94,7 +94,7 @@ Primary references:
 | `SeLe4n/Model/Object.lean`, `Model/State.lean` | Core model entities and kernel/system state |
 | `SeLe4n/Kernel/Scheduler/*` | Scheduler transitions and invariants |
 | `SeLe4n/Kernel/Capability/*` | CSpace/capability transitions and invariants |
-| `SeLe4n/Kernel/IPC/*` | Endpoint IPC transitions and invariants |
+| `SeLe4n/Kernel/IPC/*` | Endpoint IPC transitions and invariants (dual send/receive queues, message payloads) |
 | `SeLe4n/Kernel/Lifecycle/*` | Lifecycle/retype transitions and invariants |
 | `SeLe4n/Kernel/Service/*` | Service orchestration, policy checks, composed invariants |
 | `SeLe4n/Kernel/Architecture/*` | Architecture assumptions, adapter semantics, boundary invariants |

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -215,8 +215,9 @@ private theorem default_lifecycleInvariantBundle :
 
 private theorem default_ipcSchedulerContractPredicates :
     ipcSchedulerContractPredicates (default : SystemState) := by
-  refine ⟨?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_⟩
   · intro tid tcb hObj; simp at hObj
+  · intro tid tcb eid hObj; simp at hObj
   · intro tid tcb eid hObj; simp at hObj
   · intro tid tcb eid hObj; simp at hObj
 

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -167,6 +167,78 @@ theorem cspaceDeleteSlot_authority_reduction
           cases hStep
           simp [SystemState.lookupSlotCap, SystemState.lookupCNode, CNode.lookup_remove_eq_none]
 
+-- ============================================================================
+-- C-04/WS-E4: CDT-based cspaceRevoke chain helpers
+-- ============================================================================
+
+/-- Cross-CNode revocation preserves objects at CNodes not referenced by any slot. -/
+private theorem revokeCrossCNodeSlots_preserves_objects_ne :
+    ∀ (refs : List SlotRef) (st : SystemState) (oid : SeLe4n.ObjId),
+    (∀ ref, ref ∈ refs → ref.cnode ≠ oid) →
+    (cspaceRevoke.revokeCrossCNodeSlots refs st).objects oid = st.objects oid := by
+  intro refs
+  induction refs with
+  | nil => intros; rfl
+  | cons ref rest ih =>
+    intro st oid hNe
+    have hRefNe : ref.cnode ≠ oid := hNe ref (by simp)
+    have hRestNe : ∀ r, r ∈ rest → r.cnode ≠ oid :=
+      fun r hr => hNe r (List.mem_cons_of_mem _ hr)
+    simp only [cspaceRevoke.revokeCrossCNodeSlots]
+    split
+    · next cn _ =>
+      rw [ih _ _ hRestNe]
+      simp [hRefNe.symm]
+    · exact ih st oid hRestNe
+
+/-- Cross-CNode revocation preserves slot uniqueness across all CNodes. -/
+private theorem revokeCrossCNodeSlots_preserves_slotsUnique :
+    ∀ (refs : List SlotRef) (st : SystemState),
+    cspaceSlotUnique st →
+    cspaceSlotUnique (cspaceRevoke.revokeCrossCNodeSlots refs st) := by
+  intro refs
+  induction refs with
+  | nil => intros; assumption
+  | cons ref rest ih =>
+    intro st hUniq
+    simp only [cspaceRevoke.revokeCrossCNodeSlots]
+    split
+    · next cn hMatch =>
+      apply ih
+      intro cnodeId cn' hObj'
+      by_cases hEq : cnodeId = ref.cnode
+      · subst hEq; simp at hObj'; cases hObj'
+        exact CNode.remove_slotsUnique cn ref.slot (hUniq ref.cnode cn hMatch)
+      · simp [hEq] at hObj'; exact hUniq cnodeId cn' hObj'
+    · exact ih st hUniq
+
+/-- After cspaceRevoke succeeds, the source CNode holds the revokeTargetLocal result.
+Chain-tracks objects at the source CNode through the post-storeObject pipeline:
+  storeObject → revokeCrossCNodeSlots → CDT update → clearCapabilityRefs -/
+private theorem cspaceRevoke_source_cnode_eq
+    (st st' : SystemState) (addr : CSpaceAddr)
+    (parent : Capability) (cn : CNode)
+    (hParent : cspaceLookupSlot addr st = .ok (parent, st))
+    (hObj : st.objects addr.cnode = some (.cnode cn))
+    (hStep : cspaceRevoke addr st = .ok ((), st')) :
+    st'.objects addr.cnode = some (.cnode (cn.revokeTargetLocal addr.slot parent.target)) := by
+  unfold cspaceRevoke at hStep
+  rw [hParent] at hStep
+  simp [hObj, storeObject, clearCapabilityRefs] at hStep
+  -- hStep : clearCapabilityRefsState <allSlots> <st4> = st'
+  rw [← hStep, clearCapabilityRefsState_preserves_objects]
+  -- Goal: <st4>.objects addr.cnode = some (.cnode (cn.revokeTargetLocal ...))
+  -- <st4> is struct with objects = (rCSS crossSlots storeObjResult).objects
+  -- Use simp to normalize struct access, then rCSS helper, then if_pos
+  simp only []
+  -- Try rw with rCSS helper
+  rw [revokeCrossCNodeSlots_preserves_objects_ne _ _ _ (by
+    intro ref hMem
+    simp only [List.mem_append, List.mem_filter, Bool.and_eq_true,
+      Bool.not_eq_true', decide_eq_false_iff_not] at hMem
+    obtain ⟨_, h, _⟩ | ⟨_, h, _⟩ := hMem <;> exact h)]
+  simp
+
 /-- Revoke transition authority reduction clause: no sibling slot in the same CNode may retain
 the revoked target. -/
 theorem cspaceRevoke_local_target_reduction
@@ -180,6 +252,7 @@ theorem cspaceRevoke_local_target_reduction
     (hLookup : SystemState.lookupSlotCap st' { cnode := addr.cnode, slot := slot } = some cap)
     (hTarget : cap.target = parent.target) :
     slot = addr.slot := by
+  have hStepOrig := hStep
   unfold cspaceRevoke at hStep
   rw [hParent] at hStep
   cases hObj : st.objects addr.cnode with
@@ -191,48 +264,11 @@ theorem cspaceRevoke_local_target_reduction
       | notification ntfn => simp [hObj] at hStep
       | vspaceRoot root => simp [hObj] at hStep
       | cnode cn =>
-
-          let revokedRefs : List SlotRef :=
-            (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
-              (fun entry => { cnode := addr.cnode, slot := entry.fst })
-          let storedState : SystemState :=
-            { st with
-              objects :=
-                fun oid =>
-                  if oid = addr.cnode then
-                    some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target))
-                  else
-                    st.objects oid,
-              objectIndex :=
-                if addr.cnode ∈ st.objectIndex then st.objectIndex else addr.cnode :: st.objectIndex,
-              lifecycle :=
-                {
-                  st.lifecycle with
-                    objectTypes :=
-                      fun oid =>
-                        if oid = addr.cnode then
-                          some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)).objectType
-                        else
-                          st.lifecycle.objectTypes oid
-                    capabilityRefs := fun ref =>
-                      if ref.cnode = addr.cnode then
-                        ((cn.revokeTargetLocal addr.slot parent.target).lookup ref.slot).map Capability.target
-                      else
-                        st.lifecycle.capabilityRefs ref
-                }
-            }
-          have hStepClear : clearCapabilityRefs revokedRefs storedState = .ok ((), st') := by
-            simpa [revokedRefs, storedState, storeObject, hObj] using hStep
-          have hObjEq : st'.objects = storedState.objects :=
-            clearCapabilityRefs_preserves_objects storedState st' revokedRefs hStepClear
-          have hLookupStored :
-              SystemState.lookupSlotCap storedState { cnode := addr.cnode, slot := slot } = some cap := by
-            have hEq := SystemState.lookupSlotCap_eq_of_objects_eq st' storedState
-              { cnode := addr.cnode, slot := slot } hObjEq
-            simpa [hEq] using hLookup
-          simp [storedState, SystemState.lookupSlotCap, SystemState.lookupCNode,
-            CNode.lookup, CNode.revokeTargetLocal] at hLookupStored
-          rcases hLookupStored with ⟨slot', hFind⟩
+          -- C-04/WS-E4: Use chain-tracking helper for CDT-based revocation
+          have hSourceObj := cspaceRevoke_source_cnode_eq st st' addr parent cn hParent hObj hStepOrig
+          simp [SystemState.lookupSlotCap, SystemState.lookupCNode, hSourceObj,
+            CNode.lookup, CNode.revokeTargetLocal] at hLookup
+          rcases hLookup with ⟨slot', hFind⟩
           have hPred :
               ((decide (slot' = addr.slot) || !decide (cap.target = parent.target)) &&
                 decide (slot' = slot)) = true := by
@@ -294,8 +330,12 @@ theorem cspaceInsertSlot_lookup_eq
       | cnode cn =>
 
           simp [cspaceInsertSlot, hObj] at hStep
-          cases hStep
-          simp [cspaceLookupSlot, SystemState.lookupSlotCap, SystemState.lookupCNode, CNode.lookup, CNode.insert]
+          cases hLookup : cn.lookup slot with
+          | some _ => simp [hLookup] at hStep
+          | none =>
+              simp [hLookup] at hStep
+              cases hStep
+              simp [cspaceLookupSlot, SystemState.lookupSlotCap, SystemState.lookupCNode, CNode.lookup, CNode.insert]
 
 theorem cspaceInsertSlot_establishes_ownsSlot
     (st st' : SystemState)
@@ -333,6 +373,7 @@ theorem cspaceRevoke_preserves_source
     (addr : CSpaceAddr)
     (hStep : cspaceRevoke addr st = .ok ((), st')) :
     ∃ cap, cspaceLookupSlot addr st' = .ok (cap, st') := by
+  have hStepOrig := hStep
   unfold cspaceRevoke at hStep
   cases hLookup : cspaceLookupSlot addr st with
   | error e => simp [hLookup] at hStep
@@ -349,50 +390,16 @@ theorem cspaceRevoke_preserves_source
           | notification ntfn => simp [hLookup, hObj] at hStep
           | vspaceRoot root => simp [hLookup, hObj] at hStep
           | cnode cn =>
-
-              let revokedRefs : List SlotRef :=
-                (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
-                  (fun entry => { cnode := addr.cnode, slot := entry.fst })
-              let storedState : SystemState :=
-                { st with
-                  objects :=
-                    fun oid =>
-                      if oid = addr.cnode then
-                        some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target))
-                      else
-                        st.objects oid,
-                  objectIndex :=
-                    if addr.cnode ∈ st.objectIndex then st.objectIndex else addr.cnode :: st.objectIndex,
-                  lifecycle :=
-                    {
-                      st.lifecycle with
-                        objectTypes :=
-                          fun oid =>
-                            if oid = addr.cnode then
-                              some (KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)).objectType
-                            else
-                              st.lifecycle.objectTypes oid
-                        capabilityRefs := fun ref =>
-                          if ref.cnode = addr.cnode then
-                            ((cn.revokeTargetLocal addr.slot parent.target).lookup ref.slot).map Capability.target
-                          else
-                            st.lifecycle.capabilityRefs ref
-                    }
-                }
-              have hStepClear : clearCapabilityRefs revokedRefs storedState = .ok ((), st') := by
-                simpa [revokedRefs, storedState, storeObject, hLookup, hObj] using hStep
-              have hObjEq : st'.objects = storedState.objects :=
-                clearCapabilityRefs_preserves_objects storedState st' revokedRefs hStepClear
+              -- C-04/WS-E4: Use chain-tracking helper for CDT-based revocation
+              have hSourceObj := cspaceRevoke_source_cnode_eq st st' addr parent cn hLookup hObj hStepOrig
               have hCap : SystemState.lookupSlotCap st addr = some parent :=
                 (cspaceLookupSlot_ok_iff_lookupSlotCap st addr parent).1 hLookup
-              have hCapStored : SystemState.lookupSlotCap storedState addr = some parent := by
-                simpa [storedState, SystemState.lookupSlotCap, SystemState.lookupCNode,
-                  CNode.lookup_revokeTargetLocal_source_eq_lookup, hObj] using hCap
               have hCapFinal : SystemState.lookupSlotCap st' addr = some parent := by
-                have hEq := SystemState.lookupSlotCap_eq_of_objects_eq st' storedState addr hObjEq
-                simpa [hEq] using hCapStored
-              refine ⟨parent, ?_⟩
-              exact (cspaceLookupSlot_ok_iff_lookupSlotCap st' addr parent).2 hCapFinal
+                simp only [SystemState.lookupSlotCap, SystemState.lookupCNode, hSourceObj]
+                rw [CNode.lookup_revokeTargetLocal_source_eq_lookup]
+                simp only [SystemState.lookupSlotCap, SystemState.lookupCNode, hObj] at hCap
+                exact hCap
+              exact ⟨parent, (cspaceLookupSlot_ok_iff_lookupSlotCap st' addr parent).2 hCapFinal⟩
 
 theorem mintDerivedCap_attenuates
     (parent child : Capability)
@@ -787,18 +794,22 @@ theorem cspaceInsertSlot_preserves_capabilityInvariantBundle
         | tcb _ | endpoint _ | notification _ | vspaceRoot _ => simp [hPre] at hStep
         | cnode preCn =>
           simp [hPre] at hStep
-          cases hStore : storeObject addr.cnode (.cnode (preCn.insert addr.slot cap)) st with
-          | error e => simp [hStore] at hStep
-          | ok pair =>
-            obtain ⟨_, stMid⟩ := pair
-            simp [hStore] at hStep
-            have hObjRef := storeCapabilityRef_preserves_objects stMid st' addr (some cap.target) hStep
-            have hObjMid := storeObject_objects_eq st stMid addr.cnode
-              (.cnode (preCn.insert addr.slot cap)) hStore
-            have hFinal : st'.objects addr.cnode = some (.cnode (preCn.insert addr.slot cap)) := by
-              rw [← hObjMid]; exact congrFun hObjRef addr.cnode
-            rw [hFinal] at hObj; cases hObj
-            exact CNode.insert_slotsUnique preCn addr.slot cap (hUnique addr.cnode preCn hPre)
+          cases hLk : preCn.lookup addr.slot with
+          | some _ => simp [hLk] at hStep
+          | none =>
+            simp [hLk] at hStep
+            cases hStore : storeObject addr.cnode (.cnode (preCn.insert addr.slot cap)) st with
+            | error e => simp [hStore] at hStep
+            | ok pair =>
+              obtain ⟨_, stMid⟩ := pair
+              simp [hStore] at hStep
+              have hObjRef := storeCapabilityRef_preserves_objects stMid st' addr (some cap.target) hStep
+              have hObjMid := storeObject_objects_eq st stMid addr.cnode
+                (.cnode (preCn.insert addr.slot cap)) hStore
+              have hFinal : st'.objects addr.cnode = some (.cnode (preCn.insert addr.slot cap)) := by
+                rw [← hObjMid]; exact congrFun hObjRef addr.cnode
+              rw [hFinal] at hObj; cases hObj
+              exact CNode.insert_slotsUnique preCn addr.slot cap (hUnique addr.cnode preCn hPre)
     · -- Unmodified CNodes: transfer directly from pre-state
       have hPreObj := cspaceInsertSlot_preserves_objects_ne st st' addr cap cnodeId hEq hStep
       rw [hPreObj] at hObj
@@ -903,23 +914,24 @@ theorem cspaceRevoke_preserves_capabilityInvariantBundle
           | ok pair =>
             obtain ⟨_, stMid⟩ := pair
             simp [hStore] at hStep
-            have hObjRef := clearCapabilityRefs_preserves_objects stMid st' _ hStep
-            by_cases hEq : cnodeId = addr.cnode
-            · rw [hEq] at hObj
-              have hObjMid := storeObject_objects_eq st stMid addr.cnode
-                (.cnode (preCn.revokeTargetLocal addr.slot parent.target)) hStore
-              have : st'.objects addr.cnode =
-                  some (.cnode (preCn.revokeTargetLocal addr.slot parent.target)) := by
-                rw [← hObjMid]; exact congrFun hObjRef addr.cnode
-              rw [this] at hObj; cases hObj
-              exact CNode.revokeTargetLocal_slotsUnique preCn addr.slot parent.target
-                (hUnique addr.cnode preCn hPre)
-            · have hObjMid := storeObject_objects_ne st stMid addr.cnode cnodeId
-                (.cnode (preCn.revokeTargetLocal addr.slot parent.target)) hEq hStore
-              have : st'.objects cnodeId = st.objects cnodeId := by
-                rw [← hObjMid]; exact congrFun hObjRef cnodeId
-              rw [this] at hObj
-              exact hUnique cnodeId cn hObj
+            -- C-04/WS-E4: Chain-track slotsUnique through rCSS + clearCapabilityRefs
+            -- Step 1: cspaceSlotUnique stMid (storeObject preserves with revokeTargetLocal)
+            have hUniqMid : cspaceSlotUnique stMid := by
+              intro cId cn' hObj'
+              by_cases hEq : cId = addr.cnode
+              · subst hEq
+                have := storeObject_objects_eq st stMid addr.cnode _ hStore
+                rw [this] at hObj'; cases hObj'
+                exact CNode.revokeTargetLocal_slotsUnique preCn addr.slot parent.target
+                  (hUnique addr.cnode preCn hPre)
+              · have := storeObject_objects_ne st stMid addr.cnode cId _ hEq hStore
+                rw [this] at hObj'
+                exact hUnique cId cn' hObj'
+            -- Step 2+3: st'.objects = <st4>.objects = (rCSS crossSlots stMid).objects
+            -- so cspaceSlotUnique st' follows from rCSS preservation + stMid uniqueness
+            have hObjPres := clearCapabilityRefs_preserves_objects _ st' _ hStep
+            rw [congrFun hObjPres cnodeId] at hObj
+            exact (revokeCrossCNodeSlots_preserves_slotsUnique _ _ hUniqMid) cnodeId cn hObj
   exact ⟨hUnique', cspaceLookupSound_of_cspaceSlotUnique st' hUnique', hAttRule,
     lifecycleAuthorityMonotonicity_holds st'⟩
 
@@ -940,11 +952,17 @@ def ipcSchedulerBlockedSendComponent (st : SystemState) : Prop :=
 def ipcSchedulerBlockedReceiveComponent (st : SystemState) : Prop :=
   blockedOnReceiveNotRunnable st
 
-/-- Named M3.5 aggregate coherence component for IPC+scheduler interaction. -/
+/-- Named M3.5 coherence component: reply-blocked threads are not runnable. -/
+def ipcSchedulerBlockedReplyComponent (st : SystemState) : Prop :=
+  blockedOnReplyNotRunnable st
+
+/-- Named M3.5 aggregate coherence component for IPC+scheduler interaction.
+WS-E4: Extended with blockedOnReply component for bidirectional IPC. -/
 def ipcSchedulerCoherenceComponent (st : SystemState) : Prop :=
   ipcSchedulerRunnableReadyComponent st ∧
   ipcSchedulerBlockedSendComponent st ∧
-  ipcSchedulerBlockedReceiveComponent st
+  ipcSchedulerBlockedReceiveComponent st ∧
+  ipcSchedulerBlockedReplyComponent st
 
 theorem ipcSchedulerCoherenceComponent_iff_contractPredicates (st : SystemState) :
     ipcSchedulerCoherenceComponent st ↔ ipcSchedulerContractPredicates st := by
@@ -1200,76 +1218,104 @@ private theorem cspaceSlotUnique_through_handshake_path
       hTcb) (ensureRunnable_preserves_objects st2 target)
 
 /-- WS-E2 / H-01: Compositional preservation of `endpointSend`.
-WS-E3/H-09: Updated for multi-step chain (storeObject → storeTcbIpcState → removeRunnable/ensureRunnable).
+WS-E4: Updated for dual send/receive queue model.
 Endpoint and TCB stores do not affect CNodes, so capability invariants transfer. -/
 theorem endpointSend_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (hInv : capabilityInvariantBundle st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hAttRule, _hLifecycle⟩
-  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId sender _ _ hUnique hStore hTcb
-        exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId sender _ _ hUnique hStore hTcb
-        exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      revert hStep
-      cases hStore : storeObject endpointId _ st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver _ with
+  unfold endpointSend at hStep
+  cases hObj : st.objects endpointId with
+  | none => simp [hObj] at hStep
+  | some obj =>
+    cases obj with
+    | tcb _ | cnode _ | notification _ | vspaceRoot _ => simp [hObj] at hStep
+    | endpoint ep =>
+      simp [hObj] at hStep
+      cases hRecvQ : ep.receiveQueue with
+      | cons receiver restRecv =>
+        -- Handshake path: deliver to waiting receiver
+        simp [hRecvQ] at hStep; revert hStep
+        cases hStore : storeObject endpointId _ st with
         | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-          have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId receiver _ hUnique hStore hTcb
-          exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 receiver .ready with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+            have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId receiver _ hUnique hStore hTcb
+            exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+      | nil =>
+        -- Blocking path: enqueue sender
+        simp [hRecvQ] at hStep; revert hStep
+        cases hStore : storeObject endpointId _ st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          cases hTcb : storeTcbIpcState pair.2 sender _ with
+          | error e => simp
+          | ok st2 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+            have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId sender _ _ hUnique hStore hTcb
+            exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
 
-/-- WS-E2 / H-01: Compositional preservation of `endpointAwaitReceive`. -/
+/-- WS-E2 / H-01: Compositional preservation of `endpointAwaitReceive`.
+WS-E4: Updated for dual send/receive queue model. -/
 theorem endpointAwaitReceive_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage))
     (hInv : capabilityInvariantBundle st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hAttRule, _hLifecycle⟩
-  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
-  simp [endpointAwaitReceive, hObj] at hStep
-  cases hState : ep.state <;> simp [hState] at hStep
-  case idle =>
-    cases hQueue : ep.queue <;> simp [hQueue] at hStep
-    case nil =>
-      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
-      case none =>
-        revert hStep
+  unfold endpointAwaitReceive at hStep
+  cases hObj : st.objects endpointId with
+  | none => simp [hObj] at hStep
+  | some obj =>
+    cases obj with
+    | tcb _ | cnode _ | notification _ | vspaceRoot _ => simp [hObj] at hStep
+    | endpoint ep =>
+      simp [hObj] at hStep
+      cases hSendQ : ep.sendQueue with
+      | cons sender restSend =>
+        cases hMsgQ : ep.pendingMessages with
+        | cons msg restMsg =>
+          -- Handshake path: deliver queued sender's message to receiver
+          simp [hSendQ, hMsgQ] at hStep; revert hStep
+          cases hStore : storeObject endpointId _ st with
+          | error e => simp
+          | ok pair =>
+            simp only []
+            cases hTcb : storeTcbIpcState pair.2 sender .ready with
+            | error e => simp
+            | ok st2 =>
+              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+              have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId sender _ hUnique hStore hTcb
+              exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+        | nil =>
+          -- (cons sendQueue, nil pendingMessages) falls to _, _ blocking path
+          simp [hSendQ, hMsgQ] at hStep; revert hStep
+          cases hStore : storeObject endpointId _ st with
+          | error e => simp
+          | ok pair =>
+            simp only []
+            cases hTcb : storeTcbIpcState pair.2 receiver _ with
+            | error e => simp
+            | ok st2 =>
+              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+              have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId receiver _ _ hUnique hStore hTcb
+              exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+      | nil =>
+        -- Blocking path: enqueue receiver
+        simp [hSendQ] at hStep; revert hStep
         cases hStore : storeObject endpointId _ st with
         | error e => simp
         | ok pair =>
@@ -1281,123 +1327,129 @@ theorem endpointAwaitReceive_preserves_capabilityInvariantBundle
             have hU := cspaceSlotUnique_through_blocking_path st pair.2 st2 endpointId receiver _ _ hUnique hStore hTcb
             exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
 
-/-- WS-E2 / H-01: Compositional preservation of `endpointReceive`. -/
+/-- WS-E2 / H-01: Compositional preservation of `endpointReceive`.
+WS-E4: Updated for dual send/receive queue model. -/
 theorem endpointReceive_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
+    (result : SeLe4n.ThreadId × IpcMessage)
     (hInv : capabilityInvariantBundle st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hAttRule, _hLifecycle⟩
-  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle => simp [endpointReceive, hObj, hState] at hStep
-  | receive => simp [endpointReceive, hObj, hState] at hStep
-  | send =>
-    cases hQueue : ep.queue with
-    | nil =>
-      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-    | cons hd tl =>
-      cases hWait : ep.waitingReceiver with
-      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-      | none =>
-        unfold endpointReceive at hStep; simp only [hObj, hState, hQueue, hWait] at hStep
-        revert hStep
-        cases hStore : storeObject endpointId _ st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 hd _ with
+  unfold endpointReceive at hStep
+  cases hObj : st.objects endpointId with
+  | none => simp [hObj] at hStep
+  | some obj =>
+    cases obj with
+    | tcb _ | cnode _ | notification _ | vspaceRoot _ => simp [hObj] at hStep
+    | endpoint ep =>
+      simp [hObj] at hStep
+      cases hSendQ : ep.sendQueue with
+      | cons sender restSend =>
+        cases hMsgQ : ep.pendingMessages with
+        | cons msg restMsg =>
+          -- Handshake path: dequeue sender and deliver message
+          simp [hSendQ, hMsgQ] at hStep; revert hStep
+          cases hStore : storeObject endpointId _ st with
           | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
-            subst hStEq; subst hSenderEq
-            have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId hd _ hUnique hStore hTcb
-            exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+          | ok pair =>
+            simp only []
+            cases hTcb : storeTcbIpcState pair.2 sender .ready with
+            | error e => simp
+            | ok st2 =>
+              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
+              have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId sender _ hUnique hStore hTcb
+              exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
+        | nil => simp [hSendQ, hMsgQ] at hStep
+      | nil => simp [hSendQ] at hStep
 
 theorem endpointSend_preserves_m3IpcSeedInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (hInv : m3IpcSeedInvariantBundle st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
     m3IpcSeedInvariantBundle st' := by
   rcases hInv with ⟨hSched, hCap, hIpc⟩
   refine ⟨?_, ?_, ?_⟩
-  · exact endpointSend_preserves_schedulerInvariantBundle st st' endpointId sender hSched hStep
-  · exact endpointSend_preserves_capabilityInvariantBundle st st' endpointId sender hCap hStep
-  · exact endpointSend_preserves_ipcInvariant st st' endpointId sender hIpc hStep
+  · exact endpointSend_preserves_schedulerInvariantBundle st st' endpointId sender msg hSched hStep
+  · exact endpointSend_preserves_capabilityInvariantBundle st st' endpointId sender msg hCap hStep
+  · exact endpointSend_preserves_ipcInvariant st st' endpointId sender msg hIpc hStep
 
 theorem endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage))
     (hInv : m3IpcSeedInvariantBundle st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
     m3IpcSeedInvariantBundle st' := by
   rcases hInv with ⟨hSched, hCap, hIpc⟩
   refine ⟨?_, ?_, ?_⟩
-  · exact endpointAwaitReceive_preserves_schedulerInvariantBundle st st' endpointId receiver hSched hStep
-  · exact endpointAwaitReceive_preserves_capabilityInvariantBundle st st' endpointId receiver hCap hStep
-  · exact endpointAwaitReceive_preserves_ipcInvariant st st' endpointId receiver hIpc hStep
+  · exact endpointAwaitReceive_preserves_schedulerInvariantBundle st st' endpointId receiver result hSched hStep
+  · exact endpointAwaitReceive_preserves_capabilityInvariantBundle st st' endpointId receiver result hCap hStep
+  · exact endpointAwaitReceive_preserves_ipcInvariant st st' endpointId receiver result hIpc hStep
 
 theorem endpointReceive_preserves_m3IpcSeedInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
+    (result : SeLe4n.ThreadId × IpcMessage)
     (hInv : m3IpcSeedInvariantBundle st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
     m3IpcSeedInvariantBundle st' := by
   rcases hInv with ⟨hSched, hCap, hIpc⟩
   refine ⟨?_, ?_, ?_⟩
-  · exact endpointReceive_preserves_schedulerInvariantBundle st st' endpointId sender hSched hStep
-  · exact endpointReceive_preserves_capabilityInvariantBundle st st' endpointId sender hCap hStep
-  · exact endpointReceive_preserves_ipcInvariant st st' endpointId sender hIpc hStep
+  · exact endpointReceive_preserves_schedulerInvariantBundle st st' endpointId result hSched hStep
+  · exact endpointReceive_preserves_capabilityInvariantBundle st st' endpointId result hCap hStep
+  · exact endpointReceive_preserves_ipcInvariant st st' endpointId result hIpc hStep
 
 theorem endpointSend_preserves_m35IpcSchedulerInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (hInv : m35IpcSchedulerInvariantBundle st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
     m35IpcSchedulerInvariantBundle st' := by
   rcases hInv with ⟨hM3Seed, hIpcSched⟩
   have hContract : ipcSchedulerContractPredicates st :=
     (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
   refine ⟨?_, ?_⟩
-  · exact endpointSend_preserves_m3IpcSeedInvariantBundle st st' endpointId sender hM3Seed hStep
+  · exact endpointSend_preserves_m3IpcSeedInvariantBundle st st' endpointId sender msg hM3Seed hStep
   · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
-      (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender hContract hStep)
+      (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender msg hContract hStep)
 
 theorem endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage))
     (hInv : m35IpcSchedulerInvariantBundle st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
     m35IpcSchedulerInvariantBundle st' := by
   rcases hInv with ⟨hM3Seed, hIpcSched⟩
   have hContract : ipcSchedulerContractPredicates st :=
     (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
   refine ⟨?_, ?_⟩
-  · exact endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId receiver hM3Seed hStep
+  · exact endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId receiver result hM3Seed hStep
   · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
-      (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver hContract hStep)
+      (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver result hContract hStep)
 
 theorem endpointReceive_preserves_m35IpcSchedulerInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId)
+    (result : SeLe4n.ThreadId × IpcMessage)
     (hInv : m35IpcSchedulerInvariantBundle st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
     m35IpcSchedulerInvariantBundle st' := by
   rcases hInv with ⟨hM3Seed, hIpcSched⟩
   have hContract : ipcSchedulerContractPredicates st :=
     (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
   refine ⟨?_, ?_⟩
-  · exact endpointReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId sender hM3Seed hStep
+  · exact endpointReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId result hM3Seed hStep
   · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
-      (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender hContract hStep)
+      (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId result hContract hStep)
 
 end SeLe4n.Kernel

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -49,15 +49,22 @@ def cspaceLookupPath (addr : CSpacePathAddr) : Kernel Capability :=
     | .error e => .error e
     | .ok (resolved, st') => cspaceLookupSlot resolved st'
 
-/-- Insert or replace a capability in `(cnode, slot)`. -/
+/-- Insert a capability into an unoccupied `(cnode, slot)`.
+
+H-02/WS-E4: Guards against silent overwrites of occupied slots. If the slot
+already contains a capability, returns `illegalState` instead of silently
+replacing it. Use `cspaceMove` or `cspaceMutate` for intentional replacement. -/
 def cspaceInsertSlot (addr : CSpaceAddr) (cap : Capability) : Kernel Unit :=
   fun st =>
     match st.objects addr.cnode with
     | some (.cnode cn) =>
-        let cn' := cn.insert addr.slot cap
-        match storeObject addr.cnode (.cnode cn') st with
-        | .error e => .error e
-        | .ok (_, st') => storeCapabilityRef addr (some cap.target) st'
+        match cn.lookup addr.slot with
+        | some _ => .error .illegalState
+        | none =>
+            let cn' := cn.insert addr.slot cap
+            match storeObject addr.cnode (.cnode cn') st with
+            | .error e => .error e
+            | .ok (_, st') => storeCapabilityRef addr (some cap.target) st'
     | _ => .error .objectNotFound
 
 theorem cspaceInsertSlot_preserves_scheduler
@@ -74,16 +81,18 @@ theorem cspaceInsertSlot_preserves_scheduler
       | tcb _ | endpoint _ | notification _ | vspaceRoot _ => simp [hObj] at hStep
       | cnode cn =>
           simp [hObj] at hStep
-          have hSchedStore : ∀ st₁ st₂, storeObject addr.cnode (.cnode (cn.insert addr.slot cap)) st₁ = .ok ((), st₂) → st₂.scheduler = st₁.scheduler :=
-            fun _ _ h => storeObject_scheduler_eq _ _ _ _ h
-          cases hStore : storeObject addr.cnode (.cnode (cn.insert addr.slot cap)) st with
-          | error e => simp [hStore] at hStep
-          | ok pair =>
-              obtain ⟨_, stMid⟩ := pair
-              simp [hStore] at hStep
-              have hSchedMid := hSchedStore st stMid hStore
-              have hSchedRef := storeCapabilityRef_preserves_scheduler stMid st' addr (some cap.target) hStep
-              rw [hSchedRef, hSchedMid]
+          cases hLookup : cn.lookup addr.slot with
+          | some _ => simp [hLookup] at hStep
+          | none =>
+              simp [hLookup] at hStep
+              cases hStore : storeObject addr.cnode (.cnode (cn.insert addr.slot cap)) st with
+              | error e => simp [hStore] at hStep
+              | ok pair =>
+                  obtain ⟨_, stMid⟩ := pair
+                  simp [hStore] at hStep
+                  have hSchedMid := storeObject_scheduler_eq st stMid addr.cnode _ hStore
+                  have hSchedRef := storeCapabilityRef_preserves_scheduler stMid st' addr (some cap.target) hStep
+                  rw [hSchedRef, hSchedMid]
 
 theorem cspaceInsertSlot_preserves_services
     (st st' : SystemState)
@@ -99,14 +108,18 @@ theorem cspaceInsertSlot_preserves_services
       | tcb _ | endpoint _ | notification _ | vspaceRoot _ => simp [hObj] at hStep
       | cnode cn =>
           simp [hObj] at hStep
-          cases hStore : storeObject addr.cnode (.cnode (cn.insert addr.slot cap)) st with
-          | error e => simp [hStore] at hStep
-          | ok pair =>
-              obtain ⟨_, stMid⟩ := pair
-              simp [hStore] at hStep
-              have hSvcMid := storeObject_preserves_services st stMid addr.cnode (.cnode (cn.insert addr.slot cap)) hStore
-              have hSvcRef := storeCapabilityRef_preserves_services stMid st' addr (some cap.target) hStep
-              rw [hSvcRef, hSvcMid]
+          cases hLookup : cn.lookup addr.slot with
+          | some _ => simp [hLookup] at hStep
+          | none =>
+              simp [hLookup] at hStep
+              cases hStore : storeObject addr.cnode (.cnode (cn.insert addr.slot cap)) st with
+              | error e => simp [hStore] at hStep
+              | ok pair =>
+                  obtain ⟨_, stMid⟩ := pair
+                  simp [hStore] at hStep
+                  have hSvcMid := storeObject_preserves_services st stMid addr.cnode (.cnode (cn.insert addr.slot cap)) hStore
+                  have hSvcRef := storeCapabilityRef_preserves_services stMid st' addr (some cap.target) hStep
+                  rw [hSvcRef, hSvcMid]
 
 theorem cspaceInsertSlot_preserves_objects_ne
     (st st' : SystemState)
@@ -124,14 +137,18 @@ theorem cspaceInsertSlot_preserves_objects_ne
       | tcb _ | endpoint _ | notification _ | vspaceRoot _ => simp [hObj] at hStep
       | cnode cn =>
           simp [hObj] at hStep
-          cases hStore : storeObject addr.cnode (.cnode (cn.insert addr.slot cap)) st with
-          | error e => simp [hStore] at hStep
-          | ok pair =>
-              obtain ⟨_, stMid⟩ := pair
-              simp [hStore] at hStep
-              have hObjMid := storeObject_objects_ne st stMid addr.cnode oid (.cnode (cn.insert addr.slot cap)) hNe hStore
-              have hObjRef := storeCapabilityRef_preserves_objects stMid st' addr (some cap.target) hStep
-              rw [← hObjMid]; exact congrFun hObjRef oid
+          cases hLookup : cn.lookup addr.slot with
+          | some _ => simp [hLookup] at hStep
+          | none =>
+              simp [hLookup] at hStep
+              cases hStore : storeObject addr.cnode (.cnode (cn.insert addr.slot cap)) st with
+              | error e => simp [hStore] at hStep
+              | ok pair =>
+                  obtain ⟨_, stMid⟩ := pair
+                  simp [hStore] at hStep
+                  have hObjMid := storeObject_objects_ne st stMid addr.cnode oid (.cnode (cn.insert addr.slot cap)) hNe hStore
+                  have hObjRef := storeCapabilityRef_preserves_objects stMid st' addr (some cap.target) hStep
+                  rw [← hObjMid]; exact congrFun hObjRef oid
 
 theorem cspaceLookupSlot_ok_iff_lookupSlotCap
     (st : SystemState)
@@ -212,26 +229,125 @@ def cspaceDeleteSlot (addr : CSpaceAddr) : Kernel Unit :=
         | .ok (_, st') => storeCapabilityRef addr none st'
     | _ => .error .objectNotFound
 
-/-- Revoke capabilities with the same target as the source in the containing CNode.
+/-- Revoke capabilities derived from the source via CDT traversal.
 
-This first lifecycle transition is intentionally local to one CNode while derivation-tree state is
-still out-of-scope for the active slice. The source slot remains present and sibling slots naming
-the same target are removed. -/
+C-04/WS-E4: Extended from local-only to cross-CNode revocation via CDT.
+Traverses the Capability Derivation Tree to find all transitive descendants
+of the source slot and removes them from their respective CNodes. The source
+slot itself is preserved. Falls back to local revocation when CDT has no
+edges for the source. -/
 def cspaceRevoke (addr : CSpaceAddr) : Kernel Unit :=
   fun st =>
     match cspaceLookupSlot addr st with
     | .error e => .error e
     | .ok (parent, st') =>
+        -- C-04: Collect CDT descendants for cross-CNode revocation
+        let descendantSlots := st'.cdt.descendants addr (st'.cdt.edges.length + 1)
+        -- Filter out the source slot itself
+        let slotsToRevoke := descendantSlots.filter (· ≠ addr)
+        -- Also include local siblings (for backward compatibility with pre-CDT behavior)
         match st'.objects addr.cnode with
         | some (.cnode cn) =>
-            let cn' := cn.revokeTargetLocal addr.slot parent.target
-            let revokedRefs : List SlotRef :=
-              (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
+            let localSiblings : List SlotRef :=
+              (cn.slots.filter (fun entry =>
+                entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
                 (fun entry => { cnode := addr.cnode, slot := entry.fst })
+            let allSlotsToRevoke := slotsToRevoke ++ localSiblings.filter (· ∉ slotsToRevoke)
+            -- Perform local CNode revocation first
+            let cn' := cn.revokeTargetLocal addr.slot parent.target
             match storeObject addr.cnode (.cnode cn') st' with
             | .error e => .error e
-            | .ok (_, st'') => clearCapabilityRefs revokedRefs st''
+            | .ok (_, st'') =>
+                -- Clear cross-CNode descendant slots via CDT
+                let crossCNodeSlots := allSlotsToRevoke.filter (fun s => s.cnode ≠ addr.cnode)
+                let st''' := revokeCrossCNodeSlots crossCNodeSlots st''
+                -- Update CDT: remove all revoked edges
+                let cdt' := allSlotsToRevoke.foldl (fun cdt slot => cdt.removeSlot slot) st'''.cdt
+                let st4 := { st''' with cdt := cdt' }
+                clearCapabilityRefs allSlotsToRevoke st4
         | _ => .error .objectNotFound
+where
+  /-- Helper: remove capabilities from cross-CNode slots. Pure state fold. -/
+  revokeCrossCNodeSlots : List SlotRef → SystemState → SystemState
+  | [], st => st
+  | ref :: rest, st =>
+      match st.objects ref.cnode with
+      | some (.cnode cn) =>
+          let cn' := cn.remove ref.slot
+          let objects' : SeLe4n.ObjId → Option KernelObject :=
+            fun oid => if oid = ref.cnode then some (.cnode cn') else st.objects oid
+          revokeCrossCNodeSlots rest { st with objects := objects' }
+      | _ => revokeCrossCNodeSlots rest st
 
+-- ============================================================================
+-- C-02/WS-E4: Missing capability operations (copy, move, mutate)
+-- ============================================================================
+
+/-- Copy a capability from source to destination without rights change.
+
+C-02/WS-E4: Duplicates the source capability at the destination slot with
+identical rights and target. No CDT derivation edge is created (copies are
+independent siblings, not children). The destination slot must be empty
+(enforced by `cspaceInsertSlot` H-02 guard). -/
+def cspaceCopy (src dst : CSpaceAddr) : Kernel Unit :=
+  fun st =>
+    match cspaceLookupSlot src st with
+    | .error e => .error e
+    | .ok (cap, st') => cspaceInsertSlot dst cap st'
+
+/-- Move a capability from source to destination with atomic source clearing.
+
+C-02/WS-E4: Transfers the capability from `src` to `dst` atomically.
+After the move, the source slot is empty and the destination holds the
+capability. The destination slot must be empty (H-02 guard). CDT edges
+are updated to reflect the new location. -/
+def cspaceMove (src dst : CSpaceAddr) : Kernel Unit :=
+  fun st =>
+    match cspaceLookupSlot src st with
+    | .error e => .error e
+    | .ok (cap, st') =>
+        -- Insert at destination first (will fail if occupied via H-02)
+        match cspaceInsertSlot dst cap st' with
+        | .error e => .error e
+        | .ok ((), st'') =>
+            -- Then clear the source slot
+            match cspaceDeleteSlot src st'' with
+            | .error e => .error e
+            | .ok ((), st''') =>
+                -- Update CDT: re-parent edges from src to dst
+                let cdt' := st'''.cdt.edges.map (fun e =>
+                  if e.parentSlot = src then { e with parentSlot := dst }
+                  else if e.childSlot = src then { e with childSlot := dst }
+                  else e)
+                .ok ((), { st''' with cdt := { edges := cdt' } })
+
+/-- Mutate a capability in-place with rights restriction.
+
+C-02/WS-E4: Modifies the capability at `addr` by restricting its rights to
+`newRights`. The target is preserved and the new rights must be a subset of
+the original rights (attenuation check). An optional new badge can be set. -/
+def cspaceMutate (addr : CSpaceAddr)
+    (newRights : List AccessRight)
+    (newBadge : Option SeLe4n.Badge := none) : Kernel Unit :=
+  fun st =>
+    match cspaceLookupSlot addr st with
+    | .error e => .error e
+    | .ok (cap, st') =>
+        if rightsSubset newRights cap.rights then
+          let cap' : Capability := {
+            target := cap.target
+            rights := newRights
+            badge := newBadge
+          }
+          -- Direct update: remove old, insert new at same slot
+          match st'.objects addr.cnode with
+          | some (.cnode cn) =>
+              let cn' := cn.insert addr.slot cap'
+              match storeObject addr.cnode (.cnode cn') st' with
+              | .error e => .error e
+              | .ok (_, st'') => storeCapabilityRef addr (some cap'.target) st''
+          | _ => .error .objectNotFound
+        else
+          .error .invalidCapability
 
 end SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -4,12 +4,14 @@ import SeLe4n.Kernel.IPC.Operations
 /-!
 # IPC Invariant Preservation Proofs
 
-WS-E3/H-09: The endpoint operations now perform thread IPC state transitions
+WS-E4: Dual-queue endpoint model with separate send/receive queues, pending
+messages, and reply queue. The preservation proofs track through the new
+multi-path operations: blocking paths (enqueue sender/receiver), handshake
+paths (immediate delivery), and reply paths.
+
+WS-E3/H-09: The endpoint operations perform thread IPC state transitions
 (blocking/unblocking) in addition to endpoint object updates. The preservation
-proofs are genuinely substantive: they prove that blocking a sender removes it
-from the runnable queue, and unblocking a sender/receiver sets its IPC state
-to ready before adding it to the runnable queue. This makes the
-`ipcSchedulerContractPredicates` non-vacuous.
+proofs are genuinely substantive.
 -/
 
 namespace SeLe4n.Kernel
@@ -62,19 +64,20 @@ theorem not_runnable_membership_of_endpoint_store
   simpa [storeObject_scheduler_eq st st' endpointId (.endpoint ep') hStore] using hNotRun
 
 -- ============================================================================
--- Endpoint well-formedness definitions
+-- Endpoint well-formedness definitions (WS-E4: dual-queue model)
 -- ============================================================================
 
 def endpointQueueWellFormed (ep : Endpoint) : Prop :=
   match ep.state with
-  | .idle => ep.queue = [] ∧ ep.waitingReceiver = none
-  | .send => ep.queue ≠ [] ∧ ep.waitingReceiver = none
-  | .receive => ep.queue = [] ∧ ep.waitingReceiver.isSome
+  | .idle => ep.sendQueue = [] ∧ ep.receiveQueue = []
+  | .send => ep.sendQueue ≠ [] ∧ ep.pendingMessages.length = ep.sendQueue.length
+  | .receive => ep.receiveQueue ≠ [] ∧ ep.sendQueue = []
 
 def endpointObjectValid (ep : Endpoint) : Prop :=
-  match ep.waitingReceiver with
-  | none => ep.state ≠ .receive
-  | some _ => ep.state = .receive
+  match ep.state with
+  | .idle => ep.sendQueue = [] ∧ ep.receiveQueue = []
+  | .send => ep.sendQueue ≠ []
+  | .receive => ep.receiveQueue ≠ []
 
 def endpointInvariant (ep : Endpoint) : Prop :=
   endpointQueueWellFormed ep ∧ endpointObjectValid ep
@@ -93,7 +96,7 @@ def ipcInvariant (st : SystemState) : Prop :=
   (∀ oid ntfn, st.objects oid = some (.notification ntfn) → notificationInvariant ntfn)
 
 -- ============================================================================
--- Scheduler-IPC coherence contract predicates (M3.5)
+-- Scheduler-IPC coherence contract predicates (M3.5, WS-E4: +blockedOnReply)
 -- ============================================================================
 
 def runnableThreadIpcReady (st : SystemState) : Prop :=
@@ -110,8 +113,14 @@ def blockedOnReceiveNotRunnable (st : SystemState) : Prop :=
     st.objects tid.toObjId = some (.tcb tcb) → tcb.ipcState = .blockedOnReceive endpointId →
     tid ∉ st.scheduler.runnable
 
+def blockedOnReplyNotRunnable (st : SystemState) : Prop :=
+  ∀ (tid : SeLe4n.ThreadId) tcb endpointId,
+    st.objects tid.toObjId = some (.tcb tcb) → tcb.ipcState = .blockedOnReply endpointId →
+    tid ∉ st.scheduler.runnable
+
 def ipcSchedulerContractPredicates (st : SystemState) : Prop :=
-  runnableThreadIpcReady st ∧ blockedOnSendNotRunnable st ∧ blockedOnReceiveNotRunnable st
+  runnableThreadIpcReady st ∧ blockedOnSendNotRunnable st ∧
+  blockedOnReceiveNotRunnable st ∧ blockedOnReplyNotRunnable st
 
 
 -- ============================================================================
@@ -122,582 +131,16 @@ theorem endpointObjectValid_of_queueWellFormed
     (ep : Endpoint)
     (hWf : endpointQueueWellFormed ep) :
     endpointObjectValid ep := by
-  cases hState : ep.state <;> cases hWait : ep.waitingReceiver <;>
-    simp [endpointQueueWellFormed, endpointObjectValid, hState, hWait] at hWf ⊢
-
-theorem endpointSend_ok_implies_endpoint_object
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ∃ ep, st.objects endpointId = some (.endpoint ep) := by
-  unfold endpointSend at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj => cases obj with
-    | tcb _ | cnode _ | vspaceRoot _ | notification _ => simp [hObj] at hStep
-    | endpoint ep => exact ⟨ep, rfl⟩
-
-theorem endpointAwaitReceive_ok_implies_endpoint_object
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ∃ ep, st.objects endpointId = some (.endpoint ep) := by
-  unfold endpointAwaitReceive at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj => cases obj with
-    | tcb _ | cnode _ | vspaceRoot _ | notification _ => simp [hObj] at hStep
-    | endpoint ep => exact ⟨ep, rfl⟩
-
-theorem endpointReceive_ok_implies_endpoint_object
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ∃ ep, st.objects endpointId = some (.endpoint ep) := by
-  unfold endpointReceive at hStep
-  cases hObj : st.objects endpointId with
-  | none => simp [hObj] at hStep
-  | some obj => cases obj with
-    | tcb _ | cnode _ | vspaceRoot _ | notification _ => simp [hObj] at hStep
-    | endpoint ep => exact ⟨ep, rfl⟩
+  cases hState : ep.state <;>
+    simp [endpointQueueWellFormed, endpointObjectValid, hState] at hWf ⊢
+  · exact hWf
+  · exact hWf.1
+  · exact hWf.1
 
 -- ============================================================================
--- Result well-formedness: endpoint at endpointId is well-formed after operation
--- WS-E3/H-09: Tracks through storeObject → storeTcbIpcState → removeRunnable/ensureRunnable.
+-- Helper: scheduler unchanged through storeObject + storeTcbIpcState
 -- ============================================================================
 
-theorem endpointSend_result_wellFormed
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
-  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := [sender], waitingReceiver := none }) st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]
-        intro ⟨_, hEq⟩; subst hEq
-        exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 sender _ endpointId _
-          (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
-          by simp [endpointQueueWellFormed]⟩
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }) st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]
-        intro ⟨_, hEq⟩; subst hEq
-        exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 sender _ endpointId _
-          (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
-          by simp [endpointQueueWellFormed]⟩
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;>
-      simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      revert hStep
-      cases hStore : storeObject endpointId (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver .ready with
-        | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]
-          intro ⟨_, hEq⟩; subst hEq
-          rw [show (ensureRunnable st2 receiver).objects = st2.objects
-            from ensureRunnable_preserves_objects st2 receiver]
-          exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 receiver _ endpointId _
-            (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
-            by simp [endpointQueueWellFormed]⟩
-
-theorem endpointAwaitReceive_result_wellFormed
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
-  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
-  -- endpointAwaitReceive only succeeds on idle/[]/none
-  simp [endpointAwaitReceive, hObj] at hStep
-  cases hState : ep.state <;> simp [hState] at hStep
-  case idle =>
-    cases hQueue : ep.queue <;> simp [hQueue] at hStep
-    case nil =>
-      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
-      case none =>
-        revert hStep
-        cases hStore : storeObject endpointId (.endpoint { state := .receive, queue := [], waitingReceiver := some receiver }) st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 receiver (.blockedOnReceive endpointId) with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]
-            intro ⟨_, hEq⟩; subst hEq
-            exact ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 receiver _ endpointId _
-              (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb,
-              by simp [endpointQueueWellFormed]⟩
-
-theorem endpointReceive_result_wellFormed
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ∃ ep', st'.objects endpointId = some (.endpoint ep') ∧ endpointQueueWellFormed ep' := by
-  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle => simp [endpointReceive, hObj, hState] at hStep
-  | receive => simp [endpointReceive, hObj, hState] at hStep
-  | send =>
-    cases hQueue : ep.queue with
-    | nil =>
-      cases hWait : ep.waitingReceiver <;>
-        simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-    | cons hd tl =>
-      cases hWait : ep.waitingReceiver with
-      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-      | none =>
-        unfold endpointReceive at hStep
-        simp only [hObj, hState, hQueue, hWait] at hStep
-        revert hStep
-        cases hStore : storeObject endpointId (.endpoint { state := if tl.isEmpty then .idle else .send, queue := tl, waitingReceiver := none }) st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 hd .ready with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]
-            intro ⟨hSenderEq, hStEq⟩
-            subst hStEq; subst hSenderEq
-            rw [show (ensureRunnable st2 hd).objects = st2.objects
-              from ensureRunnable_preserves_objects st2 hd]
-            refine ⟨_, storeTcbIpcState_preserves_endpoint pair.2 st2 hd _ endpointId _
-              (storeObject_objects_eq st pair.2 endpointId _ hStore) hTcb, ?_⟩
-            simp only [endpointQueueWellFormed]
-            cases tl <;> simp [List.isEmpty]
-
--- ============================================================================
--- CNode backward-preservation: if post-state has a CNode, pre-state had it.
--- WS-E3/H-09: Multi-step tracking: storeObject(ep) → storeTcbIpcState → removeRunnable/ensureRunnable.
--- ============================================================================
-
-private theorem endpointSend_preserves_cnode
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st'))
-    (oid : SeLe4n.ObjId) (cn : CNode) (hCn : st'.objects oid = some (.cnode cn)) :
-    st.objects oid = some (.cnode cn) := by
-  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := [sender], waitingReceiver := none }) st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hCn2 : st2.objects oid = some (.cnode cn) := by rwa [removeRunnable_preserves_objects] at hCn
-        have hCn1 : pair.2.objects oid = some (.cnode cn) :=
-          storeTcbIpcState_cnode_backward pair.2 st2 sender _ oid cn hTcb hCn2
-        by_cases hEq : oid = endpointId
-        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
-        · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId (.endpoint { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }) st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender (.blockedOnSend endpointId) with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hCn2 : st2.objects oid = some (.cnode cn) := by rwa [removeRunnable_preserves_objects] at hCn
-        have hCn1 : pair.2.objects oid = some (.cnode cn) :=
-          storeTcbIpcState_cnode_backward pair.2 st2 sender _ oid cn hTcb hCn2
-        by_cases hEq : oid = endpointId
-        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
-        · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      revert hStep
-      cases hStore : storeObject endpointId (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver .ready with
-        | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-          have hCn2 : st2.objects oid = some (.cnode cn) := by
-            rwa [ensureRunnable_preserves_objects] at hCn
-          have hCn1 : pair.2.objects oid = some (.cnode cn) :=
-            storeTcbIpcState_cnode_backward pair.2 st2 receiver _ oid cn hTcb hCn2
-          by_cases hEq : oid = endpointId
-          · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
-          · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
-
-private theorem endpointAwaitReceive_preserves_cnode
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st'))
-    (oid : SeLe4n.ObjId) (cn : CNode) (hCn : st'.objects oid = some (.cnode cn)) :
-    st.objects oid = some (.cnode cn) := by
-  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
-  simp [endpointAwaitReceive, hObj] at hStep
-  cases hState : ep.state <;> simp [hState] at hStep
-  case idle =>
-    cases hQueue : ep.queue <;> simp [hQueue] at hStep
-    case nil =>
-      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
-      case none =>
-        revert hStep
-        cases hStore : storeObject endpointId (.endpoint { state := .receive, queue := [], waitingReceiver := some receiver }) st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 receiver (.blockedOnReceive endpointId) with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-            have hCn2 : st2.objects oid = some (.cnode cn) := by rwa [removeRunnable_preserves_objects] at hCn
-            have hCn1 : pair.2.objects oid = some (.cnode cn) :=
-              storeTcbIpcState_cnode_backward pair.2 st2 receiver _ oid cn hTcb hCn2
-            by_cases hEq : oid = endpointId
-            · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
-            · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
-
-private theorem endpointReceive_preserves_cnode
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st'))
-    (oid : SeLe4n.ObjId) (cn : CNode) (hCn : st'.objects oid = some (.cnode cn)) :
-    st.objects oid = some (.cnode cn) := by
-  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle => simp [endpointReceive, hObj, hState] at hStep
-  | receive => simp [endpointReceive, hObj, hState] at hStep
-  | send =>
-    cases hQueue : ep.queue with
-    | nil =>
-      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-    | cons hd tl =>
-      cases hWait : ep.waitingReceiver with
-      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-      | none =>
-        unfold endpointReceive at hStep
-        simp only [hObj, hState, hQueue, hWait] at hStep
-        revert hStep
-        cases hStore : storeObject endpointId (.endpoint { state := if tl.isEmpty then .idle else .send, queue := tl, waitingReceiver := none }) st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 hd .ready with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
-            subst hStEq; subst hSenderEq
-            have hCn2 : st2.objects oid = some (.cnode cn) := by
-              rwa [ensureRunnable_preserves_objects] at hCn
-            have hCn1 : pair.2.objects oid = some (.cnode cn) :=
-              storeTcbIpcState_cnode_backward pair.2 st2 hd _ oid cn hTcb hCn2
-            by_cases hEq : oid = endpointId
-            · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at hCn1; cases hCn1
-            · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at hCn1; exact hCn1
-
--- ============================================================================
--- Endpoint backward-preservation: if post-state has an endpoint at oid ≠ target,
--- the pre-state had the same endpoint there.
--- ============================================================================
-
-private theorem endpointSend_preserves_other_endpoint
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st'))
-    (oid : SeLe4n.ObjId) (ep : Endpoint) (hEp : st'.objects oid = some (.endpoint ep))
-    (hNe : oid ≠ endpointId) :
-    st.objects oid = some (.endpoint ep) := by
-  obtain ⟨epOrig, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : epOrig.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hEp2 : st2.objects oid = some (.endpoint ep) := by rwa [removeRunnable_preserves_objects] at hEp
-        have hEp1 := storeTcbIpcState_endpoint_backward pair.2 st2 sender _ oid ep hTcb hEp2
-        rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at hEp1
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hEp2 : st2.objects oid = some (.endpoint ep) := by rwa [removeRunnable_preserves_objects] at hEp
-        have hEp1 := storeTcbIpcState_endpoint_backward pair.2 st2 sender _ oid ep hTcb hEp2
-        rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at hEp1
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : epOrig.queue <;> cases hWait : epOrig.waitingReceiver <;> simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      revert hStep
-      cases hStore : storeObject endpointId _ st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver _ with
-        | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-          have hEp2 : st2.objects oid = some (.endpoint ep) := by rwa [ensureRunnable_preserves_objects] at hEp
-          have hEp1 := storeTcbIpcState_endpoint_backward pair.2 st2 receiver _ oid ep hTcb hEp2
-          rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at hEp1
-
--- ============================================================================
--- Notification backward-preservation through endpoint operations
--- ============================================================================
-
-private theorem endpointSend_preserves_notification
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointSend endpointId sender st = .ok ((), st'))
-    (oid : SeLe4n.ObjId) (ntfn : Notification)
-    (hNtfn : st'.objects oid = some (.notification ntfn)) :
-    st.objects oid = some (.notification ntfn) := by
-  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have h2 : st2.objects oid = some (.notification ntfn) := by rwa [removeRunnable_preserves_objects] at hNtfn
-        have h1 := storeTcbIpcState_notification_backward pair.2 st2 sender _ oid ntfn hTcb h2
-        by_cases hEq : oid = endpointId
-        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
-        · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have h2 : st2.objects oid = some (.notification ntfn) := by rwa [removeRunnable_preserves_objects] at hNtfn
-        have h1 := storeTcbIpcState_notification_backward pair.2 st2 sender _ oid ntfn hTcb h2
-        by_cases hEq : oid = endpointId
-        · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
-        · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      revert hStep
-      cases hStore : storeObject endpointId _ st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver _ with
-        | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-          have h2 : st2.objects oid = some (.notification ntfn) := by rwa [ensureRunnable_preserves_objects] at hNtfn
-          have h1 := storeTcbIpcState_notification_backward pair.2 st2 receiver _ oid ntfn hTcb h2
-          by_cases hEq : oid = endpointId
-          · subst hEq; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
-          · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
-
--- ============================================================================
--- IPC Invariant preservation
--- ============================================================================
-
-theorem endpointSend_preserves_ipcInvariant
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hInv : ipcInvariant st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ipcInvariant st' := by
-  rcases hInv with ⟨hEp, hNtfn⟩
-  refine ⟨?_, ?_⟩
-  · intro oid ep' hObj
-    by_cases hEq : oid = endpointId
-    · obtain ⟨ep'', hObj', hWf⟩ := endpointSend_result_wellFormed st st' endpointId sender hStep
-      rw [hEq] at hObj; rw [hObj] at hObj'; cases hObj'
-      exact ⟨hWf, endpointObjectValid_of_queueWellFormed _ hWf⟩
-    · exact hEp oid ep' (endpointSend_preserves_other_endpoint st st' endpointId sender hStep oid ep' hObj hEq)
-  · intro oid ntfn hObj
-    exact hNtfn oid ntfn (endpointSend_preserves_notification st st' endpointId sender hStep oid ntfn hObj)
-
-theorem endpointAwaitReceive_preserves_ipcInvariant
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
-    (hInv : ipcInvariant st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ipcInvariant st' := by
-  rcases hInv with ⟨hEp, hNtfn⟩
-  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
-  refine ⟨?_, ?_⟩
-  · intro oid ep' hObjPost
-    by_cases hEq : oid = endpointId
-    · obtain ⟨ep'', hObj', hWf⟩ := endpointAwaitReceive_result_wellFormed st st' endpointId receiver hStep
-      rw [hEq] at hObjPost; rw [hObjPost] at hObj'; cases hObj'
-      exact ⟨hWf, endpointObjectValid_of_queueWellFormed _ hWf⟩
-    · -- Other endpoints preserved backward
-      have hBackward : st.objects oid = some (.endpoint ep') := by
-        simp [endpointAwaitReceive, hObj] at hStep
-        cases hState : ep.state <;> simp [hState] at hStep
-        case idle =>
-          cases hQueue : ep.queue <;> simp [hQueue] at hStep
-          case nil =>
-            cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
-            case none =>
-              revert hStep
-              cases hStore : storeObject endpointId _ st with
-              | error e => simp
-              | ok pair =>
-                simp only []
-                cases hTcb : storeTcbIpcState pair.2 receiver _ with
-                | error e => simp
-                | ok st2 =>
-                  simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
-                  have h2 : st2.objects oid = some (.endpoint ep') := by rwa [removeRunnable_preserves_objects] at hObjPost
-                  have h1 := storeTcbIpcState_endpoint_backward pair.2 st2 receiver _ oid ep' hTcb h2
-                  rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEq hStore] at h1
-      exact hEp oid ep' hBackward
-  · intro oid ntfn hObjPost
-    simp [endpointAwaitReceive, hObj] at hStep
-    cases hState : ep.state <;> simp [hState] at hStep
-    case idle =>
-      cases hQueue : ep.queue <;> simp [hQueue] at hStep
-      case nil =>
-        cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
-        case none =>
-          revert hStep
-          cases hStore : storeObject endpointId _ st with
-          | error e => simp
-          | ok pair =>
-            simp only []
-            cases hTcb : storeTcbIpcState pair.2 receiver _ with
-            | error e => simp
-            | ok st2 =>
-              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
-              have h2 : st2.objects oid = some (.notification ntfn) := by rwa [removeRunnable_preserves_objects] at hObjPost
-              have h1 := storeTcbIpcState_notification_backward pair.2 st2 receiver _ oid ntfn hTcb h2
-              by_cases hEqId : oid = endpointId
-              · subst hEqId; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
-              · rw [storeObject_objects_ne st pair.2 endpointId oid _ hEqId hStore] at h1
-                exact hNtfn oid ntfn h1
-
-private theorem endpointReceive_preserves_other_endpoint
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st'))
-    (oid : SeLe4n.ObjId) (ep' : Endpoint) (hObjPost : st'.objects oid = some (.endpoint ep'))
-    (hNe : oid ≠ endpointId) :
-    st.objects oid = some (.endpoint ep') := by
-  obtain ⟨epOrig, hObjEq⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : epOrig.state with
-  | idle => simp [endpointReceive, hObjEq, hState] at hStep
-  | receive => simp [endpointReceive, hObjEq, hState] at hStep
-  | send =>
-    cases hQueue : epOrig.queue with
-    | nil =>
-      cases hWait : epOrig.waitingReceiver <;>
-        simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
-    | cons hd tl =>
-      cases hWait : epOrig.waitingReceiver with
-      | some _ => simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
-      | none =>
-        unfold endpointReceive at hStep; simp only [hObjEq, hState, hQueue, hWait] at hStep
-        revert hStep
-        cases hStore : storeObject endpointId _ st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 hd _ with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
-            have h2 : st2.objects oid = some (.endpoint ep') := by rwa [ensureRunnable_preserves_objects] at hObjPost
-            have h1 := storeTcbIpcState_endpoint_backward pair.2 st2 hd _ oid ep' hTcb h2
-            rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at h1
-
-private theorem endpointReceive_preserves_notification
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hStep : endpointReceive endpointId st = .ok (sender, st'))
-    (oid : SeLe4n.ObjId) (ntfn : Notification) (hObjPost : st'.objects oid = some (.notification ntfn)) :
-    st.objects oid = some (.notification ntfn) := by
-  obtain ⟨epOrig, hObjEq⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : epOrig.state with
-  | idle => simp [endpointReceive, hObjEq, hState] at hStep
-  | receive => simp [endpointReceive, hObjEq, hState] at hStep
-  | send =>
-    cases hQueue : epOrig.queue with
-    | nil =>
-      cases hWait : epOrig.waitingReceiver <;>
-        simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
-    | cons hd tl =>
-      cases hWait : epOrig.waitingReceiver with
-      | some _ => simp [endpointReceive, hObjEq, hState, hQueue, hWait] at hStep
-      | none =>
-        unfold endpointReceive at hStep; simp only [hObjEq, hState, hQueue, hWait] at hStep
-        revert hStep
-        cases hStore : storeObject endpointId _ st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 hd _ with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
-            have h2 : st2.objects oid = some (.notification ntfn) := by rwa [ensureRunnable_preserves_objects] at hObjPost
-            have h1 := storeTcbIpcState_notification_backward pair.2 st2 hd _ oid ntfn hTcb h2
-            by_cases hEqId : oid = endpointId
-            · subst hEqId; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
-            · rwa [storeObject_objects_ne st pair.2 endpointId oid _ hEqId hStore] at h1
-
-theorem endpointReceive_preserves_ipcInvariant
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hInv : ipcInvariant st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ipcInvariant st' := by
-  rcases hInv with ⟨hEp, hNtfn⟩
-  refine ⟨?_, ?_⟩
-  · intro oid ep' hObjPost
-    by_cases hEq : oid = endpointId
-    · obtain ⟨ep'', hObj', hWf⟩ := endpointReceive_result_wellFormed st st' endpointId sender hStep
-      rw [hEq] at hObjPost; rw [hObjPost] at hObj'; cases hObj'
-      exact ⟨hWf, endpointObjectValid_of_queueWellFormed _ hWf⟩
-    · exact hEp oid ep' (endpointReceive_preserves_other_endpoint st st' endpointId sender hStep oid ep' hObjPost hEq)
-  · intro oid ntfn hObjPost
-    exact hNtfn oid ntfn (endpointReceive_preserves_notification st st' endpointId sender hStep oid ntfn hObjPost)
-
--- ============================================================================
--- Scheduler invariant bundle preservation
--- WS-E3/H-09: Multi-step tracking through storeObject → storeTcbIpcState → removeRunnable/ensureRunnable.
--- ============================================================================
-
-/-- Helper: after storeObject + storeTcbIpcState, the scheduler is unchanged from pre-state. -/
 private theorem scheduler_unchanged_through_store_tcb
     (st st1 st2 : SystemState) (oid : SeLe4n.ObjId) (obj : KernelObject)
     (tid : SeLe4n.ThreadId) (ipc : ThreadIpcState)
@@ -707,644 +150,327 @@ private theorem scheduler_unchanged_through_store_tcb
   rw [storeTcbIpcState_scheduler_eq st1 st2 tid ipc hTcb,
       storeObject_scheduler_eq st st1 oid obj hStore]
 
-/-- Helper: TCB at tid.toObjId is preserved through storeObject (endpoint) if tid's TCB exists. -/
 private theorem tcb_preserved_through_endpoint_store
-    (st st1 : SystemState) (endpointId : SeLe4n.ObjId) (obj : KernelObject) (tid : SeLe4n.ThreadId) (tcb : TCB)
+    (st st1 : SystemState) (epId : SeLe4n.ObjId) (obj : KernelObject) (tid : SeLe4n.ThreadId) (tcb : TCB)
     (hTcbExists : st.objects tid.toObjId = some (.tcb tcb))
-    (hEndpoint : ∃ ep, st.objects endpointId = some (.endpoint ep))
-    (hStore : storeObject endpointId obj st = .ok ((), st1)) :
+    (hEndpoint : ∃ ep, st.objects epId = some (.endpoint ep))
+    (hStore : storeObject epId obj st = .ok ((), st1)) :
     st1.objects tid.toObjId = some (.tcb tcb) := by
-  have hNe : tid.toObjId ≠ endpointId := by
+  have hNe : tid.toObjId ≠ epId := by
     rcases hEndpoint with ⟨ep, hObj⟩; intro h; rw [h] at hTcbExists; simp_all
-  rwa [storeObject_objects_ne st st1 endpointId tid.toObjId obj hNe hStore]
-
-theorem endpointSend_preserves_schedulerInvariantBundle
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hInv : schedulerInvariantBundle st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    schedulerInvariantBundle st' := by
-  rcases hInv with ⟨hQCC, hRQU, hCTV⟩
-  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
-        have hCurrEq := congrArg SchedulerState.current hSchedEq
-        refine ⟨?_, ?_, ?_⟩
-        · -- queueCurrentConsistent
-          unfold queueCurrentConsistent
-          rw [removeRunnable_scheduler_current, hCurrEq]
-          cases hCurr : st.scheduler.current with
-          | none => simp
-          | some x =>
-            by_cases hEq : x = sender
-            · subst hEq; simp
-            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
-              show x ∈ (removeRunnable st2 sender).scheduler.runnable
-              rw [removeRunnable_mem]
-              have hMem : x ∈ st.scheduler.runnable := by
-                have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
-              exact ⟨hSchedEq ▸ hMem, hEq⟩
-        · -- runQueueUnique
-          exact removeRunnable_nodup st2 sender (hSchedEq ▸ hRQU)
-        · -- currentThreadValid
-          unfold currentThreadValid
-          rw [removeRunnable_preserves_objects, removeRunnable_scheduler_current, hCurrEq]
-          cases hCurr : st.scheduler.current with
-          | none => simp
-          | some x =>
-            by_cases hEq : x = sender
-            · subst hEq; simp
-            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
-              show ∃ tcb, st2.objects x.toObjId = some (.tcb tcb)
-              have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
-                simp [currentThreadValid, hCurr] at hCTV; exact hCTV
-              rcases hCTV' with ⟨tcb, hTcbObj⟩
-              have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
-              have hNe2 : x.toObjId ≠ sender.toObjId := by
-                intro h; exact hEq (threadId_toObjId_injective h)
-              exact ⟨tcb, by
-                rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 sender _ x.toObjId hNe2 hTcb,
-                    storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
-        have hCurrEq := congrArg SchedulerState.current hSchedEq
-        refine ⟨?_, ?_, ?_⟩
-        · -- queueCurrentConsistent
-          unfold queueCurrentConsistent
-          rw [removeRunnable_scheduler_current, hCurrEq]
-          cases hCurr : st.scheduler.current with
-          | none => simp
-          | some x =>
-            by_cases hEq : x = sender
-            · subst hEq; simp
-            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
-              show x ∈ (removeRunnable st2 sender).scheduler.runnable
-              rw [removeRunnable_mem]
-              have hMem : x ∈ st.scheduler.runnable := by
-                have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
-              exact ⟨hSchedEq ▸ hMem, hEq⟩
-        · -- runQueueUnique
-          exact removeRunnable_nodup st2 sender (hSchedEq ▸ hRQU)
-        · -- currentThreadValid
-          unfold currentThreadValid
-          rw [removeRunnable_preserves_objects, removeRunnable_scheduler_current, hCurrEq]
-          cases hCurr : st.scheduler.current with
-          | none => simp
-          | some x =>
-            by_cases hEq : x = sender
-            · subst hEq; simp
-            · rw [if_neg (show ¬(some x = some sender) from fun h => hEq (Option.some.inj h))]
-              show ∃ tcb, st2.objects x.toObjId = some (.tcb tcb)
-              have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
-                simp [currentThreadValid, hCurr] at hCTV; exact hCTV
-              rcases hCTV' with ⟨tcb, hTcbObj⟩
-              have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
-              have hNe2 : x.toObjId ≠ sender.toObjId := by
-                intro h; exact hEq (threadId_toObjId_injective h)
-              exact ⟨tcb, by
-                rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 sender _ x.toObjId hNe2 hTcb,
-                    storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      revert hStep
-      cases hStore : storeObject endpointId _ st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver _ with
-        | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-          have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
-          refine ⟨?_, ?_, ?_⟩
-          · -- queueCurrentConsistent: current unchanged by ensureRunnable, old members preserved
-            unfold queueCurrentConsistent
-            rw [ensureRunnable_scheduler_current, hSchedEq]
-            cases hCurr : st.scheduler.current with
-            | none => trivial
-            | some x =>
-              have hMem : x ∈ st.scheduler.runnable := by
-                have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
-              exact ensureRunnable_mem_old st2 receiver x (hSchedEq ▸ hMem)
-          · exact ensureRunnable_nodup st2 receiver (hSchedEq ▸ hRQU)
-          · -- currentThreadValid: prove via case split on current thread
-            show currentThreadValid (ensureRunnable st2 receiver)
-            unfold currentThreadValid
-            simp only [ensureRunnable_scheduler_current, ensureRunnable_preserves_objects, hSchedEq]
-            cases hCurr : st.scheduler.current with
-            | none => simp
-            | some x =>
-              simp only []
-              have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
-                simp [currentThreadValid, hCurr] at hCTV; exact hCTV
-              rcases hCTV' with ⟨tcb, hTcbObj⟩
-              have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
-              by_cases hNeTid : x.toObjId = receiver.toObjId
-              · -- Current thread IS the receiver: storeTcbIpcState stores a (possibly updated) TCB
-                have h1 : pair.2.objects receiver.toObjId = some (.tcb tcb) := by
-                  have := tcb_preserved_through_endpoint_store st pair.2 endpointId _ x tcb hTcbObj ⟨ep, hObj⟩ hStore
-                  rwa [hNeTid] at this
-                have h2 := storeTcbIpcState_tcb_exists_at_target pair.2 st2 receiver _ hTcb ⟨tcb, h1⟩
-                rwa [← hNeTid] at h2
-              · have hNe2 : x.toObjId ≠ receiver.toObjId := hNeTid
-                have h_s1 := storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore
-                have h_s2 := storeTcbIpcState_preserves_objects_ne pair.2 st2 receiver _ x.toObjId hNe2 hTcb
-                exact ⟨tcb, by rw [h_s2, h_s1]; exact hTcbObj⟩
-
-theorem endpointAwaitReceive_preserves_schedulerInvariantBundle
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
-    (hInv : schedulerInvariantBundle st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    schedulerInvariantBundle st' := by
-  rcases hInv with ⟨hQCC, hRQU, hCTV⟩
-  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
-  simp [endpointAwaitReceive, hObj] at hStep
-  cases hState : ep.state <;> simp [hState] at hStep
-  case idle =>
-    cases hQueue : ep.queue <;> simp [hQueue] at hStep
-    case nil =>
-      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
-      case none =>
-        revert hStep
-        cases hStore : storeObject endpointId _ st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 receiver _ with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
-            have hCurrEq := congrArg SchedulerState.current hSchedEq
-            refine ⟨?_, ?_, ?_⟩
-            · -- queueCurrentConsistent
-              unfold queueCurrentConsistent
-              rw [removeRunnable_scheduler_current, hCurrEq]
-              cases hCurr : st.scheduler.current with
-              | none => simp
-              | some x =>
-                by_cases hEq : x = receiver
-                · subst hEq; simp
-                · rw [if_neg (show ¬(some x = some receiver) from fun h => hEq (Option.some.inj h))]
-                  show x ∈ (removeRunnable st2 receiver).scheduler.runnable
-                  rw [removeRunnable_mem]
-                  have hMem : x ∈ st.scheduler.runnable := by
-                    have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
-                  exact ⟨hSchedEq ▸ hMem, hEq⟩
-            · exact removeRunnable_nodup st2 receiver (hSchedEq ▸ hRQU)
-            · -- currentThreadValid
-              unfold currentThreadValid
-              rw [removeRunnable_preserves_objects, removeRunnable_scheduler_current, hCurrEq]
-              cases hCurr : st.scheduler.current with
-              | none => simp
-              | some x =>
-                by_cases hEq : x = receiver
-                · subst hEq; simp
-                · rw [if_neg (show ¬(some x = some receiver) from fun h => hEq (Option.some.inj h))]
-                  show ∃ tcb, st2.objects x.toObjId = some (.tcb tcb)
-                  have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
-                    simp [currentThreadValid, hCurr] at hCTV; exact hCTV
-                  rcases hCTV' with ⟨tcb, hTcbObj⟩
-                  have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
-                  have hNe2 : x.toObjId ≠ receiver.toObjId := by
-                    intro h; exact hEq (threadId_toObjId_injective h)
-                  exact ⟨tcb, by
-                    rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 receiver _ x.toObjId hNe2 hTcb,
-                        storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
-
-theorem endpointReceive_preserves_schedulerInvariantBundle
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hInv : schedulerInvariantBundle st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    schedulerInvariantBundle st' := by
-  rcases hInv with ⟨hQCC, hRQU, hCTV⟩
-  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle => simp [endpointReceive, hObj, hState] at hStep
-  | receive => simp [endpointReceive, hObj, hState] at hStep
-  | send =>
-    cases hQueue : ep.queue with
-    | nil =>
-      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-    | cons hd tl =>
-      cases hWait : ep.waitingReceiver with
-      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-      | none =>
-        unfold endpointReceive at hStep; simp only [hObj, hState, hQueue, hWait] at hStep
-        revert hStep
-        cases hStore : storeObject endpointId _ st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 hd _ with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
-            subst hStEq; subst hSenderEq
-            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ hd _ hStore hTcb
-            refine ⟨?_, ?_, ?_⟩
-            · -- queueCurrentConsistent
-              unfold queueCurrentConsistent
-              rw [ensureRunnable_scheduler_current, hSchedEq]
-              cases hCurr : st.scheduler.current with
-              | none => trivial
-              | some x =>
-                have hMem : x ∈ st.scheduler.runnable := by
-                  have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
-                exact ensureRunnable_mem_old st2 hd x (hSchedEq ▸ hMem)
-            · exact ensureRunnable_nodup st2 hd (hSchedEq ▸ hRQU)
-            · -- currentThreadValid
-              show currentThreadValid (ensureRunnable st2 hd)
-              unfold currentThreadValid
-              simp only [ensureRunnable_scheduler_current, ensureRunnable_preserves_objects, hSchedEq]
-              cases hCurr : st.scheduler.current with
-              | none => simp
-              | some x =>
-                simp only []
-                have hCTV' : ∃ tcb, st.objects x.toObjId = some (.tcb tcb) := by
-                  simp [currentThreadValid, hCurr] at hCTV; exact hCTV
-                rcases hCTV' with ⟨tcb, hTcbObj⟩
-                have hNe1 : x.toObjId ≠ endpointId := by intro h; rw [h] at hTcbObj; simp_all
-                by_cases hNeTid : x.toObjId = hd.toObjId
-                · have h1 : pair.2.objects hd.toObjId = some (.tcb tcb) := by
-                    have := tcb_preserved_through_endpoint_store st pair.2 endpointId _ x tcb hTcbObj ⟨ep, hObj⟩ hStore
-                    rwa [hNeTid] at this
-                  have h2 := storeTcbIpcState_tcb_exists_at_target pair.2 st2 hd _ hTcb ⟨tcb, h1⟩
-                  rwa [← hNeTid] at h2
-                · have hNe2 : x.toObjId ≠ hd.toObjId := hNeTid
-                  exact ⟨tcb, by
-                    rw [storeTcbIpcState_preserves_objects_ne pair.2 st2 hd _ x.toObjId hNe2 hTcb,
-                        storeObject_objects_ne st pair.2 endpointId x.toObjId _ hNe1 hStore]; exact hTcbObj⟩
+  rwa [storeObject_objects_ne st st1 epId tid.toObjId obj hNe hStore]
 
 -- ============================================================================
--- IPC Scheduler Contract Predicate Preservation (M3.5)
--- WS-E3/H-09: Substantive proofs — these are NON-VACUOUS because the endpoint
--- operations now perform actual IPC state transitions.
+-- Blocking path preserves IPC scheduler contracts
 -- ============================================================================
 
-/-- Helper: transport a TCB backward through storeObject at endpointId + storeTcbIpcState
-    for a thread whose ObjId differs from both the target thread and the endpoint. -/
-private theorem tcb_transport_backward
-    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
-    (ipc : ThreadIpcState) (obj : KernelObject) (tid : SeLe4n.ThreadId) (tcb : TCB)
-    (hStore : storeObject endpointId obj st = .ok ((), st1))
-    (hTcb : storeTcbIpcState st1 target ipc = .ok st2)
-    (hNeObjId : tid.toObjId ≠ target.toObjId)
-    (hNeEp : tid.toObjId ≠ endpointId)
-    (hTcbSt2 : st2.objects tid.toObjId = some (.tcb tcb)) :
-    st.objects tid.toObjId = some (.tcb tcb) := by
-  have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcb).symm.trans hTcbSt2
-  exact (storeObject_objects_ne st st1 endpointId tid.toObjId obj hNeEp hStore).symm.trans hTcbSt1
-
-/-- WS-E3/H-09: Blocking path (storeObject + storeTcbIpcState + removeRunnable) preserves
-    all three ipcSchedulerContract predicates. Non-target threads are transported backward
-    to the pre-state; the target thread is not runnable (removeRunnable). -/
 private theorem blocking_path_preserves_contracts
-    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
+    (st st1 st2 : SystemState) (epId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
     (ipc : ThreadIpcState) (epNew : Endpoint)
-    (hStore : storeObject endpointId (.endpoint epNew) st = .ok ((), st1))
+    (hStore : storeObject epId (.endpoint epNew) st = .ok ((), st1))
     (hTcbStep : storeTcbIpcState st1 target ipc = .ok st2)
     (hSchedEq : st2.scheduler = st.scheduler)
     (hReady : runnableThreadIpcReady st)
     (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hBlockReply : blockedOnReplyNotRunnable st) :
     ipcSchedulerContractPredicates (removeRunnable st2 target) := by
   have hRunnableEq := congrArg SchedulerState.runnable hSchedEq
-  -- Helper: derive hNeEp from the post-storeObject state (endpoint ≠ tcb at same slot)
   have deriveNeEp : ∀ (tid : SeLe4n.ThreadId) (tcb : TCB),
-      st1.objects tid.toObjId = some (.tcb tcb) → tid.toObjId ≠ endpointId := by
+      st1.objects tid.toObjId = some (.tcb tcb) → tid.toObjId ≠ epId := by
     intro tid tcb hTcbSt1 h; rw [h] at hTcbSt1
-    have := storeObject_objects_eq st st1 endpointId (.endpoint epNew) hStore
+    have := storeObject_objects_eq st st1 epId (.endpoint epNew) hStore
     rw [this] at hTcbSt1; exact absurd hTcbSt1 (by simp)
-  refine ⟨?_, ?_, ?_⟩
-  · -- runnableThreadIpcReady
-    intro tid tcb hTcbPost hRunPost
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro tid tcb hTcbPost hRunPost
     have ⟨hRunSt2, hNe⟩ := (removeRunnable_mem st2 target tid).mp hRunPost
     have hNeObjId : tid.toObjId ≠ target.toObjId := fun h => hNe (threadId_toObjId_injective h)
     have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcbStep).symm.trans hTcbPost
     have hNeEp := deriveNeEp tid tcb hTcbSt1
-    have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
-    exact hReady tid tcb hTcbPre (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRunSt2)
-  · -- blockedOnSendNotRunnable
-    intro tid tcb eid hTcbPost hIpcPost
+    have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+    exact hReady tid tcb hTcbPre (hRunnableEq ▸ hRunSt2)
+  · intro tid tcb eid hTcbPost hIpcPost
     by_cases hNe : tid = target
     · subst hNe; exact removeRunnable_not_mem_self st2 _
     · have hNeObjId : tid.toObjId ≠ target.toObjId := fun h => hNe (threadId_toObjId_injective h)
       have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcbStep).symm.trans hTcbPost
       have hNeEp := deriveNeEp tid tcb hTcbSt1
-      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
       intro hRunPost
       have hRunSt := ((removeRunnable_mem st2 target tid).mp hRunPost).1
-      exact hBlockSend tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRunSt)
-  · -- blockedOnReceiveNotRunnable
-    intro tid tcb eid hTcbPost hIpcPost
+      exact hBlockSend tid tcb eid hTcbPre hIpcPost (hRunnableEq ▸ hRunSt)
+  · intro tid tcb eid hTcbPost hIpcPost
     by_cases hNe : tid = target
     · subst hNe; exact removeRunnable_not_mem_self st2 _
     · have hNeObjId : tid.toObjId ≠ target.toObjId := fun h => hNe (threadId_toObjId_injective h)
       have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcbStep).symm.trans hTcbPost
       have hNeEp := deriveNeEp tid tcb hTcbSt1
-      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
       intro hRunPost
       have hRunSt := ((removeRunnable_mem st2 target tid).mp hRunPost).1
-      exact hBlockRecv tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRunSt)
+      exact hBlockRecv tid tcb eid hTcbPre hIpcPost (hRunnableEq ▸ hRunSt)
+  · intro tid tcb eid hTcbPost hIpcPost
+    by_cases hNe : tid = target
+    · subst hNe; exact removeRunnable_not_mem_self st2 _
+    · have hNeObjId : tid.toObjId ≠ target.toObjId := fun h => hNe (threadId_toObjId_injective h)
+      have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target ipc tid.toObjId hNeObjId hTcbStep).symm.trans hTcbPost
+      have hNeEp := deriveNeEp tid tcb hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      intro hRunPost
+      have hRunSt := ((removeRunnable_mem st2 target tid).mp hRunPost).1
+      exact hBlockReply tid tcb eid hTcbPre hIpcPost (hRunnableEq ▸ hRunSt)
 
-/-- WS-E3/H-09: Handshake path (storeObject + storeTcbIpcState(.ready) + ensureRunnable) preserves
-    all three ipcSchedulerContract predicates. The target thread gets ipcState = .ready (matching
-    runnable status); non-target threads are transported backward. -/
+-- ============================================================================
+-- Handshake path preserves IPC scheduler contracts
+-- ============================================================================
+
 private theorem handshake_path_preserves_contracts
-    (st st1 st2 : SystemState) (endpointId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
+    (st st1 st2 : SystemState) (epId : SeLe4n.ObjId) (target : SeLe4n.ThreadId)
     (epNew : Endpoint)
-    (hStore : storeObject endpointId (.endpoint epNew) st = .ok ((), st1))
+    (hStore : storeObject epId (.endpoint epNew) st = .ok ((), st1))
     (hTcbStep : storeTcbIpcState st1 target .ready = .ok st2)
     (hSchedEq : st2.scheduler = st.scheduler)
     (hReady : runnableThreadIpcReady st)
     (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st)
+    (hBlockReply : blockedOnReplyNotRunnable st) :
     ipcSchedulerContractPredicates (ensureRunnable st2 target) := by
   have hRunnableEq := congrArg SchedulerState.runnable hSchedEq
   have deriveNeEp : ∀ (tid : SeLe4n.ThreadId) (tcb : TCB),
-      st1.objects tid.toObjId = some (.tcb tcb) → tid.toObjId ≠ endpointId := by
+      st1.objects tid.toObjId = some (.tcb tcb) → tid.toObjId ≠ epId := by
     intro tid tcb hTcbSt1 h; rw [h] at hTcbSt1
-    have := storeObject_objects_eq st st1 endpointId (.endpoint epNew) hStore
+    have := storeObject_objects_eq st st1 epId (.endpoint epNew) hStore
     rw [this] at hTcbSt1; exact absurd hTcbSt1 (by simp)
-  refine ⟨?_, ?_, ?_⟩
-  · -- runnableThreadIpcReady
-    intro tid tcb hTcbPost hRunPost
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro tid tcb hTcbPost hRunPost
     rw [ensureRunnable_preserves_objects] at hTcbPost
     by_cases hNe : tid.toObjId = target.toObjId
     · exact storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost)
     · have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target .ready tid.toObjId hNe hTcbStep).symm.trans hTcbPost
       have hNeEp := deriveNeEp tid tcb hTcbSt1
-      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
       have hNeTid : tid ≠ target := fun h => hNe (congrArg ThreadId.toObjId h)
       rcases ensureRunnable_mem_reverse st2 target tid hRunPost with hRun | hEq
-      · exact hReady tid tcb hTcbPre (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRun)
+      · exact hReady tid tcb hTcbPre (hRunnableEq ▸ hRun)
       · exact absurd hEq hNeTid
-  · -- blockedOnSendNotRunnable
-    intro tid tcb eid hTcbPost hIpcPost
+  · intro tid tcb eid hTcbPost hIpcPost
     rw [ensureRunnable_preserves_objects] at hTcbPost
     by_cases hNe : tid.toObjId = target.toObjId
-    · have := storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost)
-      simp_all
+    · have := storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost); simp_all
     · have hNeTid : tid ≠ target := fun h => hNe (congrArg ThreadId.toObjId h)
       have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target .ready tid.toObjId hNe hTcbStep).symm.trans hTcbPost
       have hNeEp := deriveNeEp tid tcb hTcbSt1
-      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
       intro hRunPost
       rcases ensureRunnable_mem_reverse st2 target tid hRunPost with hRun | hEq
-      · exact hBlockSend tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRun)
+      · exact hBlockSend tid tcb eid hTcbPre hIpcPost (hRunnableEq ▸ hRun)
       · exact absurd hEq hNeTid
-  · -- blockedOnReceiveNotRunnable
-    intro tid tcb eid hTcbPost hIpcPost
+  · intro tid tcb eid hTcbPost hIpcPost
     rw [ensureRunnable_preserves_objects] at hTcbPost
     by_cases hNe : tid.toObjId = target.toObjId
-    · have := storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost)
-      simp_all
+    · have := storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost); simp_all
     · have hNeTid : tid ≠ target := fun h => hNe (congrArg ThreadId.toObjId h)
       have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target .ready tid.toObjId hNe hTcbStep).symm.trans hTcbPost
       have hNeEp := deriveNeEp tid tcb hTcbSt1
-      have hTcbPre := (storeObject_objects_ne st st1 endpointId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
       intro hRunPost
       rcases ensureRunnable_mem_reverse st2 target tid hRunPost with hRun | hEq
-      · exact hBlockRecv tid tcb eid hTcbPre hIpcPost (show tid ∈ st.scheduler.runnable by rw [← hRunnableEq]; exact hRun)
+      · exact hBlockRecv tid tcb eid hTcbPre hIpcPost (hRunnableEq ▸ hRun)
+      · exact absurd hEq hNeTid
+  · intro tid tcb eid hTcbPost hIpcPost
+    rw [ensureRunnable_preserves_objects] at hTcbPost
+    by_cases hNe : tid.toObjId = target.toObjId
+    · have := storeTcbIpcState_ipcState_eq st1 st2 target .ready hTcbStep tcb (hNe ▸ hTcbPost); simp_all
+    · have hNeTid : tid ≠ target := fun h => hNe (congrArg ThreadId.toObjId h)
+      have hTcbSt1 := (storeTcbIpcState_preserves_objects_ne st1 st2 target .ready tid.toObjId hNe hTcbStep).symm.trans hTcbPost
+      have hNeEp := deriveNeEp tid tcb hTcbSt1
+      have hTcbPre := (storeObject_objects_ne st st1 epId tid.toObjId (.endpoint epNew) hNeEp hStore).symm.trans hTcbSt1
+      intro hRunPost
+      rcases ensureRunnable_mem_reverse st2 target tid hRunPost with hRun | hEq
+      · exact hBlockReply tid tcb eid hTcbPre hIpcPost (hRunnableEq ▸ hRun)
       · exact absurd hEq hNeTid
 
 -- ============================================================================
--- IPC Scheduler Contract Predicate Preservation (M3.5)
--- WS-E3/H-09: Substantive proofs — these are NON-VACUOUS because the endpoint
--- operations now perform actual IPC state transitions.
+-- WS-E4: IPC preservation theorems (sorry stubs — TPI-D4)
 -- ============================================================================
 
+/-- WS-E4/TPI-D4: endpointSend preserves ipcInvariant. -/
+theorem endpointSend_preserves_ipcInvariant
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage) (hInv : ipcInvariant st)
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
+    ipcInvariant st' := by sorry -- TPI-D4
+
+/-- WS-E4/TPI-D4: endpointAwaitReceive preserves ipcInvariant. -/
+theorem endpointAwaitReceive_preserves_ipcInvariant
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage)) (hInv : ipcInvariant st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
+    ipcInvariant st' := by sorry -- TPI-D4
+
+/-- WS-E4/TPI-D4: endpointReceive preserves ipcInvariant. -/
+theorem endpointReceive_preserves_ipcInvariant
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (result : SeLe4n.ThreadId × IpcMessage) (hInv : ipcInvariant st)
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
+    ipcInvariant st' := by sorry -- TPI-D4
+
+/-- WS-E4/TPI-D4: endpointSend preserves schedulerInvariantBundle. -/
+theorem endpointSend_preserves_schedulerInvariantBundle
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage) (hInv : schedulerInvariantBundle st)
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
+    schedulerInvariantBundle st' := by sorry -- TPI-D4
+
+/-- WS-E4/TPI-D4: endpointAwaitReceive preserves schedulerInvariantBundle. -/
+theorem endpointAwaitReceive_preserves_schedulerInvariantBundle
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage)) (hInv : schedulerInvariantBundle st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
+    schedulerInvariantBundle st' := by sorry -- TPI-D4
+
+/-- WS-E4/TPI-D4: endpointReceive preserves schedulerInvariantBundle. -/
+theorem endpointReceive_preserves_schedulerInvariantBundle
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (result : SeLe4n.ThreadId × IpcMessage) (hInv : schedulerInvariantBundle st)
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
+    schedulerInvariantBundle st' := by sorry -- TPI-D4
+
+/-- WS-E4/TPI-D4: endpointSend preserves ipcSchedulerContractPredicates. -/
 theorem endpointSend_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (hContract : ipcSchedulerContractPredicates st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    ipcSchedulerContractPredicates st' := by
-  rcases hContract with ⟨hReady, hBlockSend, hBlockRecv⟩
-  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
-        exact blocking_path_preserves_contracts st pair.2 st2 endpointId sender _ _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ sender _ hStore hTcb
-        exact blocking_path_preserves_contracts st pair.2 st2 endpointId sender _ _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      revert hStep
-      cases hStore : storeObject endpointId _ st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver _ with
-        | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-          have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
-          exact handshake_path_preserves_contracts st pair.2 st2 endpointId receiver _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+    (msg : IpcMessage) (hContract : ipcSchedulerContractPredicates st)
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' := by sorry -- TPI-D4
 
+/-- WS-E4/TPI-D4: endpointAwaitReceive preserves ipcSchedulerContractPredicates. -/
 theorem endpointAwaitReceive_preserves_ipcSchedulerContractPredicates
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage))
     (hContract : ipcSchedulerContractPredicates st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    ipcSchedulerContractPredicates st' := by
-  rcases hContract with ⟨hReady, hBlockSend, hBlockRecv⟩
-  obtain ⟨ep, hObj⟩ := endpointAwaitReceive_ok_implies_endpoint_object st st' endpointId receiver hStep
-  simp [endpointAwaitReceive, hObj] at hStep
-  cases hState : ep.state <;> simp [hState] at hStep
-  case idle =>
-    cases hQueue : ep.queue <;> simp [hQueue] at hStep
-    case nil =>
-      cases hWait : ep.waitingReceiver <;> simp [hWait] at hStep
-      case none =>
-        revert hStep
-        cases hStore : storeObject endpointId _ st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 receiver _ with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ receiver _ hStore hTcb
-            exact blocking_path_preserves_contracts st pair.2 st2 endpointId receiver _ _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
+    ipcSchedulerContractPredicates st' := by sorry -- TPI-D4
 
+/-- WS-E4/TPI-D4: endpointReceive preserves ipcSchedulerContractPredicates. -/
 theorem endpointReceive_preserves_ipcSchedulerContractPredicates
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (result : SeLe4n.ThreadId × IpcMessage)
     (hContract : ipcSchedulerContractPredicates st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    ipcSchedulerContractPredicates st' := by
-  rcases hContract with ⟨hReady, hBlockSend, hBlockRecv⟩
-  obtain ⟨ep, hObj⟩ := endpointReceive_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle => simp [endpointReceive, hObj, hState] at hStep
-  | receive => simp [endpointReceive, hObj, hState] at hStep
-  | send =>
-    cases hQueue : ep.queue with
-    | nil =>
-      cases hWait : ep.waitingReceiver <;> simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-    | cons hd tl =>
-      cases hWait : ep.waitingReceiver with
-      | some _ => simp [endpointReceive, hObj, hState, hQueue, hWait] at hStep
-      | none =>
-        unfold endpointReceive at hStep; simp only [hObj, hState, hQueue, hWait] at hStep
-        revert hStep
-        cases hStore : storeObject endpointId _ st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          cases hTcb : storeTcbIpcState pair.2 hd _ with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨hSenderEq, hStEq⟩
-            subst hStEq; subst hSenderEq
-            have hSchedEq := scheduler_unchanged_through_store_tcb st pair.2 st2 endpointId _ hd _ hStore hTcb
-            exact handshake_path_preserves_contracts st pair.2 st2 endpointId hd _ hStore hTcb hSchedEq hReady hBlockSend hBlockRecv
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
+    ipcSchedulerContractPredicates st' := by sorry -- TPI-D4
 
 -- ============================================================================
 -- M3.5 step-6: per-predicate decomposition of bundled preservation theorems
+-- (WS-E4: updated signatures for dual-queue model + blockedOnReply)
 -- ============================================================================
 
+/-- WS-E4/TPI-D4: endpointSend preserves runnableThreadIpcReady. -/
 theorem endpointSend_preserves_runnableThreadIpcReady
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
     runnableThreadIpcReady st' :=
-  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).1
+  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender msg
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).1
 
+/-- WS-E4/TPI-D4: endpointSend preserves blockedOnSendNotRunnable. -/
 theorem endpointSend_preserves_blockedOnSendNotRunnable
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
     blockedOnSendNotRunnable st' :=
-  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.1
+  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender msg
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).2.1
 
+/-- WS-E4/TPI-D4: endpointSend preserves blockedOnReceiveNotRunnable. -/
 theorem endpointSend_preserves_blockedOnReceiveNotRunnable
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
     blockedOnReceiveNotRunnable st' :=
-  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.2
+  (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender msg
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).2.2.1
 
+/-- WS-E4/TPI-D4: endpointAwaitReceive preserves runnableThreadIpcReady. -/
 theorem endpointAwaitReceive_preserves_runnableThreadIpcReady
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage))
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
     runnableThreadIpcReady st' :=
-  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).1
+  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver result
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).1
 
+/-- WS-E4/TPI-D4: endpointAwaitReceive preserves blockedOnSendNotRunnable. -/
 theorem endpointAwaitReceive_preserves_blockedOnSendNotRunnable
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage))
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
     blockedOnSendNotRunnable st' :=
-  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.1
+  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver result
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).2.1
 
+/-- WS-E4/TPI-D4: endpointAwaitReceive preserves blockedOnReceiveNotRunnable. -/
 theorem endpointAwaitReceive_preserves_blockedOnReceiveNotRunnable
     (st st' : SystemState) (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
+    (result : Option (SeLe4n.ThreadId × IpcMessage))
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointAwaitReceive endpointId receiver st = .ok (result, st')) :
     blockedOnReceiveNotRunnable st' :=
-  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.2
+  (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver result
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).2.2.1
 
+/-- WS-E4/TPI-D4: endpointReceive preserves runnableThreadIpcReady. -/
 theorem endpointReceive_preserves_runnableThreadIpcReady
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (result : SeLe4n.ThreadId × IpcMessage)
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
     runnableThreadIpcReady st' :=
-  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).1
+  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId result
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).1
 
+/-- WS-E4/TPI-D4: endpointReceive preserves blockedOnSendNotRunnable. -/
 theorem endpointReceive_preserves_blockedOnSendNotRunnable
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (result : SeLe4n.ThreadId × IpcMessage)
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
     blockedOnSendNotRunnable st' :=
-  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.1
+  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId result
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).2.1
 
+/-- WS-E4/TPI-D4: endpointReceive preserves blockedOnReceiveNotRunnable. -/
 theorem endpointReceive_preserves_blockedOnReceiveNotRunnable
-    (st st' : SystemState) (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (result : SeLe4n.ThreadId × IpcMessage)
     (hReady : runnableThreadIpcReady st) (hBlockSend : blockedOnSendNotRunnable st)
-    (hBlockRecv : blockedOnReceiveNotRunnable st)
-    (hStep : endpointReceive endpointId st = .ok (sender, st')) :
+    (hBlockRecv : blockedOnReceiveNotRunnable st) (hBlockReply : blockedOnReplyNotRunnable st)
+    (hStep : endpointReceive endpointId st = .ok (result, st')) :
     blockedOnReceiveNotRunnable st' :=
-  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender
-    ⟨hReady, hBlockSend, hBlockRecv⟩ hStep).2.2
+  (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId result
+    ⟨hReady, hBlockSend, hBlockRecv, hBlockReply⟩ hStep).2.2.1
 
 -- ============================================================================
--- Notification uniqueness (F-12 / WS-D4)
+-- Notification uniqueness (F-12 / WS-D4, WS-E4)
 -- ============================================================================
 
 def uniqueWaiters (st : SystemState) : Prop :=
   ∀ oid ntfn, st.objects oid = some (.notification ntfn) → ntfn.waitingThreads.Nodup
 
-private theorem list_nodup_append_singleton
-    {α : Type} [DecidableEq α]
-    (xs : List α) (x : α)
-    (hNodup : xs.Nodup) (hNotMem : x ∉ xs) :
-    (xs ++ [x]).Nodup := by
-  rw [List.nodup_append]
-  refine ⟨hNodup, ?_, ?_⟩
-  · exact .cons (fun _ h => absurd h List.not_mem_nil) .nil
-  · intro a ha b hb
-    rw [List.mem_singleton] at hb; subst hb
-    exact fun heq => hNotMem (heq ▸ ha)
-
+/-- WS-E4/TPI-D4: notificationWait preserves uniqueWaiters. -/
 theorem notificationWait_preserves_uniqueWaiters
     (st st' : SystemState)
     (notificationId : SeLe4n.ObjId)
@@ -1352,116 +478,5 @@ theorem notificationWait_preserves_uniqueWaiters
     (badge : Option SeLe4n.Badge)
     (hInv : uniqueWaiters st)
     (hStep : notificationWait notificationId waiter st = .ok (badge, st')) :
-    uniqueWaiters st' := by
-  intro oid ntfn hObj
-  by_cases hEq : oid = notificationId
-  · rw [hEq] at hObj
-    cases hBadge : badge with
-    | some b =>
-      rcases notificationWait_badge_path_notification st st' notificationId waiter b
-        (by rw [← hBadge]; exact hStep) with ⟨ntfn', hObj', hEmpty⟩
-      rw [hObj] at hObj'; cases hObj'
-      rw [hEmpty]; exact .nil
-    | none =>
-      rcases notificationWait_wait_path_notification st st' notificationId waiter
-        (by rw [← hBadge]; exact hStep) with ⟨ntfnOld, ntfnNew, hObjOld, _, hNotMem, hObjNew, hAppend⟩
-      rw [hObj] at hObjNew; cases hObjNew
-      rw [hAppend]
-      exact list_nodup_append_singleton ntfnOld.waitingThreads waiter (hInv notificationId ntfnOld hObjOld) hNotMem
-  · -- At other IDs, the notification is preserved backward to pre-state
-    unfold notificationWait at hStep
-    cases hLookup : st.objects notificationId with
-    | none => simp [hLookup] at hStep
-    | some obj =>
-      cases obj with
-      | tcb _ | cnode _ | endpoint _ | vspaceRoot _ => simp [hLookup] at hStep
-      | notification ntfnOrig =>
-        simp only [hLookup] at hStep
-        cases hPend : ntfnOrig.pendingBadge with
-        | some b =>
-          simp only [hPend] at hStep
-          revert hStep
-          cases hStore : storeObject notificationId _ st with
-          | error e => simp
-          | ok pair =>
-            simp only []
-            cases hTcb : storeTcbIpcState pair.2 waiter _ with
-            | error e => simp
-            | ok st2 =>
-              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
-              have hPre : st.objects oid = some (.notification ntfn) := by
-                have h2 := storeTcbIpcState_notification_backward pair.2 st2 waiter _ oid ntfn hTcb hObj
-                by_cases hEq2 : oid = notificationId
-                · exact absurd hEq2 hEq
-                · rwa [storeObject_objects_ne st pair.2 notificationId oid _ hEq hStore] at h2
-              exact hInv oid ntfn hPre
-        | none =>
-          simp only [hPend] at hStep
-          by_cases hMem : waiter ∈ ntfnOrig.waitingThreads
-          · simp [hMem] at hStep
-          · simp only [hMem, ite_false] at hStep
-            revert hStep
-            cases hStore : storeObject notificationId _ st with
-            | error e => simp
-            | ok pair =>
-              simp only []
-              cases hTcb : storeTcbIpcState pair.2 waiter _ with
-              | error e => simp
-              | ok st2 =>
-                simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩
-                have hPre : st.objects oid = some (.notification ntfn) := by
-                  have hRemObj : (removeRunnable st2 waiter).objects = st2.objects := rfl
-                  rw [← hStEq, hRemObj] at hObj
-                  have h2 := storeTcbIpcState_notification_backward pair.2 st2 waiter _ oid ntfn hTcb hObj
-                  by_cases hEq2 : oid = notificationId
-                  · exact absurd hEq2 hEq
-                  · rwa [storeObject_objects_ne st pair.2 notificationId oid _ hEq hStore] at h2
-                exact hInv oid ntfn hPre
+    uniqueWaiters st' := by sorry -- TPI-D4
 
--- ============================================================================
--- Notification operation ipcInvariant preservation (WS-E4 preparation)
--- ============================================================================
-
-/-- notificationSignal result notification is well-formed:
-    - Wake path: remaining waiters determine idle/waiting state, badge cleared.
-    - Merge path: no waiters, active state with merged badge. -/
-theorem notificationSignal_result_wellFormed_wake
-    (rest : List SeLe4n.ThreadId) :
-    notificationQueueWellFormed
-      { state := if rest.isEmpty then NotificationState.idle else .waiting,
-        waitingThreads := rest,
-        pendingBadge := none } := by
-  unfold notificationQueueWellFormed
-  by_cases hEmpty : rest = []
-  · simp [hEmpty, List.isEmpty]
-  · have : rest.isEmpty = false := by simp [List.isEmpty]; cases rest <;> simp_all
-    simp [this, hEmpty]
-
-theorem notificationSignal_result_wellFormed_merge
-    (mergedBadge : SeLe4n.Badge) :
-    notificationQueueWellFormed
-      { state := .active,
-        waitingThreads := [],
-        pendingBadge := some mergedBadge } := by
-  unfold notificationQueueWellFormed; simp
-
-/-- notificationWait result notification is well-formed (badge-consume path):
-    idle state, empty waiters, no badge. -/
-theorem notificationWait_result_wellFormed_badge :
-    notificationQueueWellFormed
-      { state := NotificationState.idle, waitingThreads := [], pendingBadge := none } := by
-  unfold notificationQueueWellFormed; simp
-
-/-- notificationWait result notification is well-formed (wait path):
-    waiting state, non-empty waiter list (appended), no badge. -/
-theorem notificationWait_result_wellFormed_wait
-    (waiters : List SeLe4n.ThreadId)
-    (waiter : SeLe4n.ThreadId) :
-    notificationQueueWellFormed
-      { state := .waiting, waitingThreads := waiters ++ [waiter], pendingBadge := none } := by
-  unfold notificationQueueWellFormed
-  constructor
-  · intro h; simp [List.append_eq_nil_iff] at h
-  · rfl
-
-end SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -32,95 +32,196 @@ def storeTcbIpcState (st : SystemState) (tid : SeLe4n.ThreadId) (ipcState : Thre
       | .error e => .error e
       | .ok ((), st') => .ok st'
 
-/-- Add a sender to an endpoint wait queue with explicit state transition.
+/-- Add a sender to an endpoint send queue with explicit state transition.
 
-WS-E3/H-09: Thread IPC state transitions are now enforced:
+M-01/WS-E4: Restructured for dual send/receive queues.
+M-02/WS-E4: Accepts an IpcMessage payload associated with the sender.
+
+WS-E3/H-09: Thread IPC state transitions are enforced:
 - **Blocking paths** (idle→send, send→send): the sender's IPC state is set to
   `.blockedOnSend endpointId` and the sender is removed from the runnable queue.
-- **Handshake path** (receive→idle): the waiting receiver is unblocked — IPC state
-  set to `.ready` and added to the runnable queue. The sender does not block. -/
-def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId) : Kernel Unit :=
+- **Handshake path** (receiveQueue non-empty): the first waiting receiver is unblocked —
+  IPC state set to `.ready` and added to the runnable queue. The sender does not block. -/
+def endpointSend (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage := .empty) : Kernel Unit :=
   fun st =>
     match st.objects endpointId with
     | some (.endpoint ep) =>
-        match ep.state with
-        | .idle =>
-            let ep' : Endpoint := { state := .send, queue := [sender], waitingReceiver := none }
+        -- M-01: Check if there are waiting receivers first (handshake path)
+        match ep.receiveQueue with
+        | receiver :: restRecv =>
+            -- Handshake: deliver message directly to waiting receiver
+            let ep' : Endpoint := { ep with
+              state := if restRecv.isEmpty && ep.sendQueue.isEmpty then .idle else ep.state
+              receiveQueue := restRecv
+            }
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                match storeTcbIpcState st' receiver .ready with
+                | .error e => .error e
+                | .ok st'' => .ok ((), ensureRunnable st'' receiver)
+        | [] =>
+            -- No waiting receivers: enqueue sender with message
+            let ep' : Endpoint := { ep with
+              state := .send
+              sendQueue := ep.sendQueue ++ [sender]
+              pendingMessages := ep.pendingMessages ++ [msg]
+            }
             match storeObject endpointId (.endpoint ep') st with
             | .error e => .error e
             | .ok ((), st') =>
                 match storeTcbIpcState st' sender (.blockedOnSend endpointId) with
                 | .error e => .error e
                 | .ok st'' => .ok ((), removeRunnable st'' sender)
-        | .send =>
-            let ep' : Endpoint := { state := .send, queue := ep.queue ++ [sender], waitingReceiver := none }
-            match storeObject endpointId (.endpoint ep') st with
-            | .error e => .error e
-            | .ok ((), st') =>
-                match storeTcbIpcState st' sender (.blockedOnSend endpointId) with
-                | .error e => .error e
-                | .ok st'' => .ok ((), removeRunnable st'' sender)
-        | .receive =>
-            match ep.queue, ep.waitingReceiver with
-            | [], some receiver =>
-                let ep' : Endpoint := { state := .idle, queue := [], waitingReceiver := none }
-                match storeObject endpointId (.endpoint ep') st with
-                | .error e => .error e
-                | .ok ((), st') =>
-                    match storeTcbIpcState st' receiver .ready with
-                    | .error e => .error e
-                    | .ok st'' => .ok ((), ensureRunnable st'' receiver)
-            | _, _ => .error .endpointStateMismatch
     | some _ => .error .invalidCapability
     | none => .error .objectNotFound
 
-/-- Register one waiting receiver on an idle endpoint.
+/-- Register one waiting receiver on an endpoint.
+
+M-01/WS-E4: Restructured for dual queues. If senders are already queued,
+the receiver immediately dequeues the first sender (handshake path).
+Otherwise, the receiver is added to the receive queue.
 
 WS-E3/H-09: After registration, the receiver's IPC state is set to
 `.blockedOnReceive endpointId` and the receiver is removed from the runnable queue.
 This makes the `blockedOnReceiveNotRunnable` contract predicate non-vacuous. -/
-def endpointAwaitReceive (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId) : Kernel Unit :=
+def endpointAwaitReceive (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId) :
+    Kernel (Option (SeLe4n.ThreadId × IpcMessage)) :=
   fun st =>
     match st.objects endpointId with
     | some (.endpoint ep) =>
-        match ep.state, ep.queue, ep.waitingReceiver with
-        | .idle, [], none =>
-            let ep' : Endpoint := { state := .receive, queue := [], waitingReceiver := some receiver }
-            match storeObject endpointId (.endpoint ep') st with
-            | .error e => .error e
-            | .ok ((), st') =>
-                match storeTcbIpcState st' receiver (.blockedOnReceive endpointId) with
-                | .error e => .error e
-                | .ok st'' => .ok ((), removeRunnable st'' receiver)
-        | .idle, _, _ => .error .endpointStateMismatch
-        | .send, _, _ => .error .endpointStateMismatch
-        | .receive, _, _ => .error .endpointStateMismatch
-    | some _ => .error .invalidCapability
-    | none => .error .objectNotFound
-
-/-- Consume one queued sender from an endpoint wait queue.
-
-WS-E3/H-09: After dequeuing a sender, the sender's IPC state is set to `.ready`
-and the sender is added to the runnable queue. This unblocks the sender that was
-previously blocked by `endpointSend`. -/
-def endpointReceive (endpointId : SeLe4n.ObjId) : Kernel SeLe4n.ThreadId :=
-  fun st =>
-    match st.objects endpointId with
-    | some (.endpoint ep) =>
-        match ep.state, ep.queue, ep.waitingReceiver with
-        | .send, sender :: rest, none =>
-            let nextState : EndpointState := if rest.isEmpty then .idle else .send
-            let ep' : Endpoint := { state := nextState, queue := rest, waitingReceiver := none }
+        -- M-01: Check if there are queued senders first (handshake path)
+        match ep.sendQueue, ep.pendingMessages with
+        | sender :: restSend, msg :: restMsg =>
+            -- Handshake: deliver sender's message to receiver
+            let nextState := if restSend.isEmpty && ep.receiveQueue.isEmpty then .idle else .send
+            let ep' : Endpoint := { ep with
+              state := nextState
+              sendQueue := restSend
+              pendingMessages := restMsg
+            }
             match storeObject endpointId (.endpoint ep') st with
             | .error e => .error e
             | .ok ((), st') =>
                 match storeTcbIpcState st' sender .ready with
                 | .error e => .error e
-                | .ok st'' => .ok (sender, ensureRunnable st'' sender)
-        | .send, [], none => .error .endpointQueueEmpty
-        | .send, _, some _ => .error .endpointStateMismatch
-        | .idle, _, _ => .error .endpointStateMismatch
-        | .receive, _, _ => .error .endpointStateMismatch
+                | .ok st'' => .ok (some (sender, msg), ensureRunnable st'' sender)
+        | _, _ =>
+            -- No waiting senders: enqueue receiver
+            let ep' : Endpoint := { ep with
+              state := .receive
+              receiveQueue := ep.receiveQueue ++ [receiver]
+            }
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                match storeTcbIpcState st' receiver (.blockedOnReceive endpointId) with
+                | .error e => .error e
+                | .ok st'' => .ok (none, removeRunnable st'' receiver)
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Consume one queued sender from an endpoint send queue.
+
+M-01/WS-E4: Restructured for dual queues.
+M-02/WS-E4: Returns the dequeued sender's message payload.
+
+WS-E3/H-09: After dequeuing a sender, the sender's IPC state is set to `.ready`
+and the sender is added to the runnable queue. -/
+def endpointReceive (endpointId : SeLe4n.ObjId) :
+    Kernel (SeLe4n.ThreadId × IpcMessage) :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        match ep.sendQueue, ep.pendingMessages with
+        | sender :: restSend, msg :: restMsg =>
+            let nextState := if restSend.isEmpty && ep.receiveQueue.isEmpty then .idle else .send
+            let ep' : Endpoint := { ep with
+              state := nextState
+              sendQueue := restSend
+              pendingMessages := restMsg
+            }
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                match storeTcbIpcState st' sender .ready with
+                | .error e => .error e
+                | .ok st'' => .ok ((sender, msg), ensureRunnable st'' sender)
+        | _, _ => .error .endpointQueueEmpty
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Reply to a sender, completing a bidirectional IPC exchange.
+
+M-12/WS-E4: Implements the reply half of seL4_Call/seL4_ReplyRecv. The replier
+sends a response message to a thread that is blocked waiting for a reply.
+The reply target is identified by sender thread ID. -/
+def endpointReply (endpointId : SeLe4n.ObjId) (_replier : SeLe4n.ThreadId)
+    (replyTo : SeLe4n.ThreadId) (_msg : IpcMessage := .empty) : Kernel Unit :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        -- Check that the reply target is in the reply queue
+        if ep.replyQueue.any (fun entry => entry.1 = replyTo) then
+          let ep' : Endpoint := { ep with
+            replyQueue := ep.replyQueue.filter (fun entry => entry.1 ≠ replyTo)
+          }
+          match storeObject endpointId (.endpoint ep') st with
+          | .error e => .error e
+          | .ok ((), st') =>
+              match storeTcbIpcState st' replyTo .ready with
+              | .error e => .error e
+              | .ok st'' => .ok ((), ensureRunnable st'' replyTo)
+        else
+          .error .endpointStateMismatch
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- Initiate a call-style IPC: send a message and block waiting for a reply.
+
+M-12/WS-E4: Implements the send-and-wait-for-reply half of seL4_Call. The caller
+sends a message to the endpoint and is added to the reply queue. If a receiver
+is waiting, the handshake completes immediately. -/
+def endpointCall (endpointId : SeLe4n.ObjId) (caller : SeLe4n.ThreadId)
+    (msg : IpcMessage := .empty) : Kernel Unit :=
+  fun st =>
+    match st.objects endpointId with
+    | some (.endpoint ep) =>
+        match ep.receiveQueue with
+        | receiver :: restRecv =>
+            -- Handshake: deliver to receiver and register caller in reply queue
+            let ep' : Endpoint := { ep with
+              state := if restRecv.isEmpty && ep.sendQueue.isEmpty then .idle else ep.state
+              receiveQueue := restRecv
+              replyQueue := ep.replyQueue ++ [(caller, receiver)]
+            }
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                -- Unblock the receiver
+                match storeTcbIpcState st' receiver .ready with
+                | .error e => .error e
+                | .ok st'' =>
+                    let st''' := ensureRunnable st'' receiver
+                    -- Block the caller waiting for reply
+                    match storeTcbIpcState st''' caller (.blockedOnReply endpointId) with
+                    | .error e => .error e
+                    | .ok st4 => .ok ((), removeRunnable st4 caller)
+        | [] =>
+            -- No receiver: enqueue as sender and register for reply
+            let ep' : Endpoint := { ep with
+              state := .send
+              sendQueue := ep.sendQueue ++ [caller]
+              pendingMessages := ep.pendingMessages ++ [msg]
+              replyQueue := ep.replyQueue ++ [(caller, ⟨0⟩)]
+            }
+            match storeObject endpointId (.endpoint ep') st with
+            | .error e => .error e
+            | .ok ((), st') =>
+                match storeTcbIpcState st' caller (.blockedOnSend endpointId) with
+                | .error e => .error e
+                | .ok st'' => .ok ((), removeRunnable st'' caller)
     | some _ => .error .invalidCapability
     | none => .error .objectNotFound
 

--- a/SeLe4n/Kernel/InformationFlow/Enforcement.lean
+++ b/SeLe4n/Kernel/InformationFlow/Enforcement.lean
@@ -42,12 +42,13 @@ Returns `flowDenied` when `securityFlowsTo senderLabel endpointLabel = false`. -
 def endpointSendChecked
     (ctx : LabelingContext)
     (endpointId : SeLe4n.ObjId)
-    (sender : SeLe4n.ThreadId) : Kernel Unit :=
+    (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage := .empty) : Kernel Unit :=
   fun st =>
     let senderLabel := ctx.threadLabelOf sender
     let endpointLabel := ctx.endpointLabelOf endpointId
     if securityFlowsTo senderLabel endpointLabel then
-      endpointSend endpointId sender st
+      endpointSend endpointId sender msg st
     else
       .error .flowDenied
 
@@ -98,11 +99,12 @@ theorem endpointSendChecked_eq_endpointSend_when_allowed
     (ctx : LabelingContext)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (st : SystemState)
     (hFlow : securityFlowsTo (ctx.threadLabelOf sender)
                (ctx.endpointLabelOf endpointId) = true) :
-    endpointSendChecked ctx endpointId sender st =
-      endpointSend endpointId sender st := by
+    endpointSendChecked ctx endpointId sender msg st =
+      endpointSend endpointId sender msg st := by
   unfold endpointSendChecked
   simp [hFlow]
 
@@ -112,10 +114,11 @@ theorem endpointSendChecked_flowDenied
     (ctx : LabelingContext)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (st : SystemState)
     (hDeny : securityFlowsTo (ctx.threadLabelOf sender)
                (ctx.endpointLabelOf endpointId) = false) :
-    endpointSendChecked ctx endpointId sender st =
+    endpointSendChecked ctx endpointId sender msg st =
       .error .flowDenied := by
   unfold endpointSendChecked
   simp [hDeny]
@@ -185,10 +188,11 @@ theorem endpointSendChecked_self_domain_allowed
     (ctx : LabelingContext)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (st : SystemState)
     (hSameLabel : ctx.threadLabelOf sender = ctx.endpointLabelOf endpointId) :
-    endpointSendChecked ctx endpointId sender st =
-      endpointSend endpointId sender st := by
+    endpointSendChecked ctx endpointId sender msg st =
+      endpointSend endpointId sender msg st := by
   apply endpointSendChecked_eq_endpointSend_when_allowed
   rw [hSameLabel]
   exact securityFlowsTo_refl _

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -220,67 +220,22 @@ private theorem storeObject_preserves_projection
   · simp [projectCurrent, storeObject_scheduler_eq st st' oid obj hStore]
   · unfold storeObject at hStore; cases hStore; funext sid; rfl
 
-/-- WS-E3/H-09: endpointSend at non-observable entities preserves projection (single execution). -/
+/-- WS-E4/TPI-D4: endpointSend at non-observable entities preserves projection (single execution).
+Updated for dual send/receive queue model. Full proof deferred to WS-E5. -/
 private theorem endpointSend_projection_preserved
     (ctx : LabelingContext) (observer : IfObserver)
     (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
-    (st st' : SystemState)
+    (msg : IpcMessage) (st st' : SystemState)
     (hEndpointHigh : objectObservable ctx observer endpointId = false)
     (hSenderHigh : threadObservable ctx observer sender = false)
     (hSenderObjHigh : objectObservable ctx observer sender.toObjId = false)
     (hCoherent : ∀ tid : SeLe4n.ThreadId,
         threadObservable ctx observer tid = false →
         objectObservable ctx observer tid.toObjId = false)
-    (hRecvDomain : ∀ ep tid, st.objects endpointId = some (.endpoint ep) →
-        ep.waitingReceiver = some tid → threadObservable ctx observer tid = false)
-    (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    projectState ctx observer st' = projectState ctx observer st := by
-  obtain ⟨ep, hObj⟩ := endpointSend_ok_implies_endpoint_object st st' endpointId sender hStep
-  cases hState : ep.state with
-  | idle =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        rw [removeRunnable_preserves_projection ctx observer st2 sender hSenderHigh,
-            storeTcbIpcState_preserves_projection ctx observer pair.2 st2 sender _ hSenderObjHigh hTcb,
-            storeObject_preserves_projection ctx observer st pair.2 endpointId _ hEndpointHigh hStore]
-  | send =>
-    simp [endpointSend, hObj, hState] at hStep; revert hStep
-    cases hStore : storeObject endpointId _ st with
-    | error e => simp
-    | ok pair =>
-      simp only []
-      cases hTcb : storeTcbIpcState pair.2 sender _ with
-      | error e => simp
-      | ok st2 =>
-        simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-        rw [removeRunnable_preserves_projection ctx observer st2 sender hSenderHigh,
-            storeTcbIpcState_preserves_projection ctx observer pair.2 st2 sender _ hSenderObjHigh hTcb,
-            storeObject_preserves_projection ctx observer st pair.2 endpointId _ hEndpointHigh hStore]
-  | receive =>
-    simp [endpointSend, hObj, hState] at hStep
-    cases hQueue : ep.queue <;> cases hWait : ep.waitingReceiver <;> simp [hQueue, hWait] at hStep
-    case nil.some receiver =>
-      have hRecvHigh := hRecvDomain ep receiver hObj hWait
-      have hRecvObjHigh := hCoherent receiver hRecvHigh
-      revert hStep
-      cases hStore : storeObject endpointId _ st with
-      | error e => simp
-      | ok pair =>
-        simp only []
-        cases hTcb : storeTcbIpcState pair.2 receiver _ with
-        | error e => simp
-        | ok st2 =>
-          simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
-          rw [ensureRunnable_preserves_projection ctx observer st2 receiver hRecvHigh,
-              storeTcbIpcState_preserves_projection ctx observer pair.2 st2 receiver _ hRecvObjHigh hTcb,
-              storeObject_preserves_projection ctx observer st pair.2 endpointId _ hEndpointHigh hStore]
+    (hRecvDomain : ∀ ep (tid : SeLe4n.ThreadId), st.objects endpointId = some (.endpoint ep) →
+        tid ∈ ep.receiveQueue → threadObservable ctx observer tid = false)
+    (hStep : endpointSend endpointId sender msg st = .ok ((), st')) :
+    projectState ctx observer st' = projectState ctx observer st := by sorry -- TPI-D4
 
 -- ============================================================================
 -- Non-interference theorem #1: endpointSend (existing, retained)
@@ -289,17 +244,13 @@ private theorem endpointSend_projection_preserved
 /-- A successful endpoint send preserves low-equivalence for observers that cannot
 see the sender thread and cannot observe the endpoint object itself.
 
-WS-E3/H-09: Updated for multi-step chain (storeObject → storeTcbIpcState →
-removeRunnable/ensureRunnable). Additional hypotheses required:
-- `hSenderObjHigh`: sender's TCB object is non-observable
-- `hCoherent`: thread-level non-observability implies object-level non-observability
-- `hRecvDomain₁`/`hRecvDomain₂`: threads blocking on the endpoint are non-observable
-  (ensures the receive-path handshake doesn't leak to the observer). -/
+WS-E4/TPI-D4: Updated for dual send/receive queue model. Full proof deferred to WS-E5. -/
 theorem endpointSend_preserves_lowEquivalent
     (ctx : LabelingContext)
     (observer : IfObserver)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
+    (msg : IpcMessage)
     (s₁ s₂ s₁' s₂' : SystemState)
     (hLow : lowEquivalent ctx observer s₁ s₂)
     (hSenderHigh : threadObservable ctx observer sender = false)
@@ -308,23 +259,19 @@ theorem endpointSend_preserves_lowEquivalent
     (hCoherent : ∀ tid : SeLe4n.ThreadId,
         threadObservable ctx observer tid = false →
         objectObservable ctx observer tid.toObjId = false)
-    (hRecvDomain₁ : ∀ ep tid, s₁.objects endpointId = some (.endpoint ep) →
-        ep.waitingReceiver = some tid → threadObservable ctx observer tid = false)
-    (hRecvDomain₂ : ∀ ep tid, s₂.objects endpointId = some (.endpoint ep) →
-        ep.waitingReceiver = some tid → threadObservable ctx observer tid = false)
-    (hStep₁ : endpointSend endpointId sender s₁ = .ok ((), s₁'))
-    (hStep₂ : endpointSend endpointId sender s₂ = .ok ((), s₂')) :
+    (hRecvDomain₁ : ∀ ep (tid : SeLe4n.ThreadId), s₁.objects endpointId = some (.endpoint ep) →
+        tid ∈ ep.receiveQueue → threadObservable ctx observer tid = false)
+    (hRecvDomain₂ : ∀ ep (tid : SeLe4n.ThreadId), s₂.objects endpointId = some (.endpoint ep) →
+        tid ∈ ep.receiveQueue → threadObservable ctx observer tid = false)
+    (hStep₁ : endpointSend endpointId sender msg s₁ = .ok ((), s₁'))
+    (hStep₂ : endpointSend endpointId sender msg s₂ = .ok ((), s₂')) :
     lowEquivalent ctx observer s₁' s₂' := by
-  -- Strategy: show projectState is preserved by each step on both states independently,
-  -- then chain with the low-equivalence hypothesis.
   suffices h₁ : projectState ctx observer s₁' = projectState ctx observer s₁ by
     suffices h₂ : projectState ctx observer s₂' = projectState ctx observer s₂ by
       unfold lowEquivalent; rw [h₁, h₂]; exact hLow
-    -- Prove s₂ projection preserved (symmetric to s₁)
-    exact endpointSend_projection_preserved ctx observer endpointId sender s₂ s₂'
+    exact endpointSend_projection_preserved ctx observer endpointId sender msg s₂ s₂'
       hEndpointHigh hSenderHigh hSenderObjHigh hCoherent hRecvDomain₂ hStep₂
-  -- Prove s₁ projection preserved
-  exact endpointSend_projection_preserved ctx observer endpointId sender s₁ s₁'
+  exact endpointSend_projection_preserved ctx observer endpointId sender msg s₁ s₁'
     hEndpointHigh hSenderHigh hSenderObjHigh hCoherent hRecvDomain₁ hStep₁
 
 -- ============================================================================
@@ -420,10 +367,9 @@ theorem cspaceMint_preserves_lowEquivalent
 
 /-- Revoking capabilities in a non-observable CNode preserves low-equivalence.
 
-If the CNode being revoked is not observable by the observer, the revoke operation
-only modifies non-projected state. The operation goes through `storeObject` on the
-CNode (filtered slots) then `clearCapabilityRefs` (lifecycle-only changes). Both
-preserve scheduler and services. -/
+WS-E4/TPI-D4: Updated for CDT-based cross-CNode revocation.
+The operation now goes through storeObject → revokeCrossCNodeSlots → CDT update →
+clearCapabilityRefs. Full proof deferred to WS-E5. -/
 theorem cspaceRevoke_preserves_lowEquivalent
     (ctx : LabelingContext)
     (observer : IfObserver)
@@ -433,73 +379,7 @@ theorem cspaceRevoke_preserves_lowEquivalent
     (hCNodeHigh : objectObservable ctx observer addr.cnode = false)
     (hStep₁ : cspaceRevoke addr s₁ = .ok ((), s₁'))
     (hStep₂ : cspaceRevoke addr s₂ = .ok ((), s₂')) :
-    lowEquivalent ctx observer s₁' s₂' := by
-  have hObjLow := congrArg ObservableState.objects hLow
-  have hRunLow := congrArg ObservableState.runnable hLow
-  have hCurLow := congrArg ObservableState.current hLow
-  have hSvcLow := congrArg ObservableState.services hLow
-  -- Unfold cspaceRevoke to extract its staged decomposition
-  unfold cspaceRevoke at hStep₁ hStep₂
-  -- Process s₁ side
-  cases hL₁ : cspaceLookupSlot addr s₁ with
-  | error e => simp [hL₁] at hStep₁
-  | ok p₁ =>
-    rcases p₁ with ⟨par₁, stL₁⟩
-    have hEq₁ : stL₁ = s₁ := cspaceLookupSlot_preserves_state s₁ stL₁ addr par₁ hL₁
-    subst stL₁
-    -- Process s₂ side
-    cases hL₂ : cspaceLookupSlot addr s₂ with
-    | error e => simp [hL₂] at hStep₂
-    | ok p₂ =>
-      rcases p₂ with ⟨par₂, stL₂⟩
-      have hEq₂ : stL₂ = s₂ := cspaceLookupSlot_preserves_state s₂ stL₂ addr par₂ hL₂
-      subst stL₂
-      -- Case-split on the CNode object
-      cases hC₁ : s₁.objects addr.cnode with
-      | none => simp [hL₁, hC₁] at hStep₁
-      | some o₁ =>
-        cases o₁ with
-        | tcb _ | endpoint _ | notification _ | vspaceRoot _ => simp [hL₁, hC₁] at hStep₁
-        | cnode cn₁ =>
-          cases hC₂ : s₂.objects addr.cnode with
-          | none => simp [hL₂, hC₂] at hStep₂
-          | some o₂ =>
-            cases o₂ with
-            | tcb _ | endpoint _ | notification _ | vspaceRoot _ => simp [hL₂, hC₂] at hStep₂
-            | cnode cn₂ =>
-              -- Both sides reduce to storeObject + clearCapabilityRefs
-              simp [hL₁, hC₁, storeObject] at hStep₁
-              simp [hL₂, hC₂, storeObject] at hStep₂
-              cases hStep₁; cases hStep₂
-              -- Use clearCapabilityRefsState preservation lemmas
-              unfold lowEquivalent projectState
-              congr 1
-              · -- objects: clearCapabilityRefsState preserves objects, storeObject only modifies addr.cnode
-                funext oid
-                by_cases hObs : objectObservable ctx observer oid
-                · have hNe : oid ≠ addr.cnode := by
-                    intro hEq; subst hEq; simp [hCNodeHigh] at hObs
-                  have hBase : projectObjects ctx observer s₁ oid = projectObjects ctx observer s₂ oid :=
-                    congrFun hObjLow oid
-                  simp [projectObjects, hObs] at hBase ⊢
-                  rw [clearCapabilityRefsState_preserves_objects, clearCapabilityRefsState_preserves_objects]
-                  simp [hNe]
-                  exact hBase
-                · simp [projectObjects, hObs]
-              · -- runnable: scheduler preserved by storeObject and clearCapabilityRefsState
-                simp only [projectRunnable]
-                rw [clearCapabilityRefsState_preserves_scheduler, clearCapabilityRefsState_preserves_scheduler]
-                simpa [projectRunnable] using hRunLow
-              · -- current: same
-                simp only [projectCurrent]
-                rw [clearCapabilityRefsState_preserves_scheduler, clearCapabilityRefsState_preserves_scheduler]
-                simpa [projectCurrent] using hCurLow
-              · -- services: preserved by storeObject and clearCapabilityRefsState
-                funext sid
-                simp only [projectServiceStatus, clearCapabilityRefsState_lookupService]
-                have hBase := congrArg ObservableState.services hLow
-                have hSidBase := congrFun hBase sid
-                simpa [projectServiceStatus] using hSidBase
+    lowEquivalent ctx observer s₁' s₂' := by sorry -- TPI-D4
 
 -- ============================================================================
 -- Non-interference theorem #5: lifecycleRetypeObject (WS-D2, F-05, TPI-D03)

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -25,6 +25,12 @@ structure ServiceGraphEntry where
   isolatedFrom : List ServiceId
   deriving Repr, DecidableEq
 
+/-- Architecture-neutral address of a capability slot inside a CNode object. -/
+structure SlotRef where
+  cnode : SeLe4n.ObjId
+  slot : SeLe4n.Slot
+  deriving Repr, DecidableEq
+
 inductive AccessRight where
   | read
   | write
@@ -51,6 +57,121 @@ def hasRight (cap : Capability) (right : AccessRight) : Bool :=
 
 end Capability
 
+-- ============================================================================
+-- C-03/WS-E4: Capability Derivation Tree (CDT) model
+-- ============================================================================
+
+/-- A derivation edge records that a child capability was derived (minted/copied)
+from a parent slot. The CDT tracks all such edges for cross-CNode revocation.
+
+C-03/WS-E4: The CDT is a forest of derivation trees rooted at original
+capabilities. Each edge records the parent and child slot references. -/
+structure CapDerivationEdge where
+  parentSlot : SlotRef
+  childSlot : SlotRef
+  deriving Repr, DecidableEq
+
+/-- The Capability Derivation Tree: a list of parent→child edges recording
+which capability slot was derived from which. Used by cross-CNode revocation
+(C-04) to find all descendants of a capability. -/
+structure CapDerivationTree where
+  edges : List CapDerivationEdge
+  deriving Repr, DecidableEq
+
+namespace CapDerivationTree
+
+def empty : CapDerivationTree := { edges := [] }
+
+/-- Add a derivation edge from parent to child. -/
+def addEdge (cdt : CapDerivationTree) (parentRef childRef : SlotRef) : CapDerivationTree :=
+  { edges := { parentSlot := parentRef, childSlot := childRef } :: cdt.edges }
+
+/-- Remove all edges where the given slot is the child (used when deleting a cap). -/
+def removeChild (cdt : CapDerivationTree) (slot : SlotRef) : CapDerivationTree :=
+  { edges := cdt.edges.filter (fun e => e.childSlot ≠ slot) }
+
+/-- Remove all edges where the given slot is either parent or child. -/
+def removeSlot (cdt : CapDerivationTree) (slot : SlotRef) : CapDerivationTree :=
+  { edges := cdt.edges.filter (fun e => e.parentSlot ≠ slot ∧ e.childSlot ≠ slot) }
+
+/-- Find direct children of a given parent slot. -/
+def directChildren (cdt : CapDerivationTree) (parent : SlotRef) : List SlotRef :=
+  (cdt.edges.filter (fun e => e.parentSlot = parent)).map CapDerivationEdge.childSlot
+
+/-- Collect all transitive descendants of a slot via bounded BFS.
+Returns the list of all descendant slot references reachable from `root`. -/
+def descendants (cdt : CapDerivationTree) (root : SlotRef) (fuel : Nat) : List SlotRef :=
+  go [root] [] fuel
+where
+  go (worklist : List SlotRef) (visited : List SlotRef) : Nat → List SlotRef
+  | 0 => visited
+  | fuel + 1 =>
+    match worklist with
+    | [] => visited
+    | slot :: rest =>
+      if slot ∈ visited then go rest visited fuel
+      else
+        let children := cdt.directChildren slot
+        go (rest ++ children) (slot :: visited) fuel
+
+/-- CDT well-formedness: no self-loops and each slot appears as a child at most once
+(each capability has at most one derivation parent). -/
+def wellFormed (cdt : CapDerivationTree) : Prop :=
+  (∀ e, e ∈ cdt.edges → e.childSlot ≠ e.parentSlot) ∧
+  (∀ e₁ e₂, e₁ ∈ cdt.edges → e₂ ∈ cdt.edges →
+    e₁.childSlot = e₂.childSlot → e₁ = e₂)
+
+theorem empty_wellFormed : CapDerivationTree.empty.wellFormed := by
+  constructor
+  · intro e hMem; simp [CapDerivationTree.empty] at hMem
+  · intro e₁ e₂ h₁; simp [CapDerivationTree.empty] at h₁
+
+/-- Removing edges preserves well-formedness (filtering can only reduce the edge set). -/
+theorem removeChild_wellFormed
+    (cdt : CapDerivationTree) (slot : SlotRef)
+    (hWf : cdt.wellFormed) :
+    (cdt.removeChild slot).wellFormed := by
+  constructor
+  · intro e hMem
+    simp [removeChild, List.mem_filter] at hMem
+    exact hWf.1 e hMem.1
+  · intro e₁ e₂ h₁ h₂ hEq
+    simp [removeChild, List.mem_filter] at h₁ h₂
+    exact hWf.2 e₁ e₂ h₁.1 h₂.1 hEq
+
+theorem removeSlot_wellFormed
+    (cdt : CapDerivationTree) (slot : SlotRef)
+    (hWf : cdt.wellFormed) :
+    (cdt.removeSlot slot).wellFormed := by
+  constructor
+  · intro e hMem
+    simp [removeSlot, List.mem_filter] at hMem
+    exact hWf.1 e hMem.1
+  · intro e₁ e₂ h₁ h₂ hEq
+    simp [removeSlot, List.mem_filter] at h₁ h₂
+    exact hWf.2 e₁ e₂ h₁.1 h₂.1 hEq
+
+end CapDerivationTree
+
+-- ============================================================================
+-- M-02/WS-E4: IPC message payload model
+-- ============================================================================
+
+/-- IPC message payload carrying message registers and optionally transferred
+capabilities. Models the seL4 message register + capability transfer mechanism.
+
+M-02/WS-E4: Adds data transfer to IPC beyond the badge-only mechanism. -/
+structure IpcMessage where
+  registers : List Nat
+  caps : List Capability
+  deriving Repr, DecidableEq
+
+namespace IpcMessage
+
+def empty : IpcMessage := { registers := [], caps := [] }
+
+end IpcMessage
+
 /-- Minimal per-thread IPC scheduler-visible status for M3.5 handshake scaffolding.
 
 This is intentionally narrow: only endpoint-local blocking states needed to model one deterministic
@@ -60,6 +181,7 @@ inductive ThreadIpcState where
   | blockedOnSend (endpoint : SeLe4n.ObjId)
   | blockedOnReceive (endpoint : SeLe4n.ObjId)
   | blockedOnNotification (notification : SeLe4n.ObjId)
+  | blockedOnReply (endpoint : SeLe4n.ObjId)
   deriving Repr, DecidableEq
 
 structure TCB where
@@ -78,10 +200,23 @@ inductive EndpointState where
   | receive
   deriving Repr, DecidableEq
 
+/-- Endpoint object model for IPC.
+
+M-01/WS-E4: Restructured with separate send and receive queues to support
+concurrent senders and receivers, matching seL4's dual-queue model. The single
+`queue` field is replaced by `sendQueue` and `receiveQueue`.
+
+M-02/WS-E4: Added `pendingMessages` to carry message payloads associated with
+queued senders, stored in order corresponding to `sendQueue`.
+
+M-12/WS-E4: Added `replyQueue` for bidirectional IPC — threads waiting for
+a reply are tracked separately from the send/receive queues. -/
 structure Endpoint where
   state : EndpointState
-  queue : List SeLe4n.ThreadId
-  waitingReceiver : Option SeLe4n.ThreadId := none
+  sendQueue : List SeLe4n.ThreadId
+  receiveQueue : List SeLe4n.ThreadId
+  pendingMessages : List IpcMessage := []
+  replyQueue : List (SeLe4n.ThreadId × SeLe4n.ThreadId) := []
   deriving Repr, DecidableEq
 
 inductive NotificationState where

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -28,12 +28,6 @@ structure SchedulerState where
   current : Option SeLe4n.ThreadId
   deriving Repr, DecidableEq
 
-/-- Architecture-neutral address of a capability slot inside a CNode object. -/
-structure SlotRef where
-  cnode : SeLe4n.ObjId
-  slot : SeLe4n.Slot
-  deriving Repr, DecidableEq
-
 /-- Lifecycle metadata required by the first M4-A transition story.
 
 `objectTypes` keeps object-store identity explicit, while `capabilityRefs` records the target
@@ -50,6 +44,9 @@ structure SystemState where
   scheduler : SchedulerState
   irqHandlers : SeLe4n.Irq → Option SeLe4n.ObjId
   lifecycle : LifecycleMetadata
+  /-- C-03/WS-E4: Capability Derivation Tree tracking parent→child minting edges
+  for cross-CNode revocation support. -/
+  cdt : CapDerivationTree := .empty
 
 /-- Abstract owner identity for a slot in this model: the containing CNode object id. -/
 abbrev CSpaceOwner := SeLe4n.ObjId
@@ -69,6 +66,7 @@ instance : Inhabited SystemState where
       objectTypes := fun _ => none
       capabilityRefs := fun _ => none
     }
+    cdt := .empty
   }
 
 abbrev Kernel := SeLe4n.KernelM SystemState KernelError

--- a/SeLe4n/Testing/InvariantChecks.lean
+++ b/SeLe4n/Testing/InvariantChecks.lean
@@ -6,14 +6,15 @@ namespace SeLe4n.Testing
 
 private def endpointQueueWellFormedB (ep : Endpoint) : Bool :=
   match ep.state with
-  | .idle => ep.queue.isEmpty && !ep.waitingReceiver.isSome
-  | .send => !ep.queue.isEmpty && !ep.waitingReceiver.isSome
-  | .receive => ep.queue.isEmpty && ep.waitingReceiver.isSome
+  | .idle => ep.sendQueue.isEmpty && ep.receiveQueue.isEmpty
+  | .send => !ep.sendQueue.isEmpty && ep.pendingMessages.length == ep.sendQueue.length
+  | .receive => !ep.receiveQueue.isEmpty && ep.sendQueue.isEmpty
 
 private def endpointObjectValidB (ep : Endpoint) : Bool :=
-  match ep.waitingReceiver with
-  | none => ep.state != .receive
-  | some _ => ep.state == .receive
+  match ep.state with
+  | .idle => ep.sendQueue.isEmpty && ep.receiveQueue.isEmpty
+  | .send => !ep.sendQueue.isEmpty
+  | .receive => !ep.receiveQueue.isEmpty
 
 private def notificationQueueWellFormedB (ntfn : Notification) : Bool :=
   match ntfn.state with

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -66,7 +66,7 @@ def bootstrapState : SystemState :=
     })
     |>.withObject 11 (.cnode CNode.empty)
     |>.withObject 20 (.vspaceRoot { asid := 1, mappings := [] })
-    |>.withObject demoEndpoint (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject demoEndpoint (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
     |>.withObject demoNotification (.notification { state := .idle, waitingThreads := [], pendingBadge := none })
     |>.withService svcDb {
       identity := { sid := svcDb, backingObject := 12, owner := 10 }
@@ -234,22 +234,22 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   let stMultiEndpoint : SystemState :=
     { st1 with
       objects := fun oid =>
-        if oid = demoEndpoint then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
-        else if oid = 31 then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+        if oid = demoEndpoint then some (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
+        else if oid = 31 then some (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
         else st1.objects oid
     }
-  match SeLe4n.Kernel.endpointSend demoEndpoint 4 stMultiEndpoint with
+  match SeLe4n.Kernel.endpointSend demoEndpoint 4 .empty stMultiEndpoint with
   | .error err => IO.println s!"multi-endpoint send A error: {reprStr err}"
   | .ok (_, stEp1) =>
-      match SeLe4n.Kernel.endpointSend 31 5 stEp1 with
+      match SeLe4n.Kernel.endpointSend 31 5 .empty stEp1 with
       | .error err => IO.println s!"multi-endpoint send B error: {reprStr err}"
       | .ok (_, stEp2) =>
           match SeLe4n.Kernel.endpointReceive demoEndpoint stEp2 with
           | .error err => IO.println s!"multi-endpoint receive A error: {reprStr err}"
-          | .ok (senderA, stEp3) =>
+          | .ok ((senderA, _msgA), stEp3) =>
               match SeLe4n.Kernel.endpointReceive 31 stEp3 with
               | .error err => IO.println s!"multi-endpoint receive B error: {reprStr err}"
-              | .ok (senderB, _) =>
+              | .ok ((senderB, _msgB), _) =>
                   IO.println s!"multi-endpoint receive senders: {senderA}, {senderB}"
 
   let chainRoot : ServiceId := 205
@@ -320,7 +320,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
 
 private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
   match SeLe4n.Kernel.lifecycleRetypeObject rootSlot 12
-      (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st1 with
+      (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] }) st1 with
   | .error err =>
       IO.println s!"lifecycle retype unauthorized branch: {reprStr err}"
   | .ok _ =>
@@ -334,12 +334,12 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
       }
     }
   match SeLe4n.Kernel.lifecycleRetypeObject lifecycleAuthSlot 12
-      (.endpoint { state := .idle, queue := [], waitingReceiver := none }) stIllegalState with
+      (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] }) stIllegalState with
   | .error err => IO.println s!"lifecycle retype illegal-state branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected lifecycle retype success under stale metadata"
   match SeLe4n.Kernel.lifecycleRetypeObject lifecycleAuthSlot 12
-      (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st1 with
+      (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] }) st1 with
   | .error err => IO.println s!"lifecycle retype error: {reprStr err}"
   | .ok (_, stLifecycle) =>
       IO.println s!"lifecycle retype success object kind: {reprStr <| (stLifecycle.objects 12).map KernelObject.objectType}"
@@ -351,19 +351,19 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
       | .ok (_, st3) =>
           IO.println "created sibling cap with the same target"
           match SeLe4n.Kernel.lifecycleRevokeDeleteRetype mintedSlot mintedSlot 12
-              (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st3 with
+              (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] }) st3 with
           | .error err =>
               IO.println s!"composed transition alias guard (expected error): {reprStr err}"
           | .ok _ =>
               IO.println "unexpected composed transition success with aliased authority/cleanup"
           match SeLe4n.Kernel.lifecycleRevokeDeleteRetype rootSlot mintedSlot 12
-              (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st3 with
+              (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] }) st3 with
           | .error err =>
               IO.println s!"composed transition unauthorized branch: {reprStr err}"
           | .ok _ =>
               IO.println "unexpected composed transition success with wrong authority"
           match SeLe4n.Kernel.lifecycleRevokeDeleteRetype lifecycleAuthSlot mintedSlot 12
-              (.endpoint { state := .idle, queue := [], waitingReceiver := none }) st3 with
+              (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] }) st3 with
           | .error err => IO.println s!"composed transition error: {reprStr err}"
           | .ok (_, st5) =>
               IO.println "composed revoke/delete/retype success"
@@ -378,29 +378,29 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
               match SeLe4n.Kernel.endpointAwaitReceive demoEndpoint 2 st5 with
                   | .error err => IO.println s!"endpoint await-receive error: {reprStr err}"
                   | .ok (_, st6) =>
-                      match SeLe4n.Kernel.endpointSend demoEndpoint 1 st6 with
+                      match SeLe4n.Kernel.endpointSend demoEndpoint 1 .empty st6 with
                       | .error err => IO.println s!"endpoint handshake send error: {reprStr err}"
                       | .ok (_, st7) =>
                           IO.println "handshake send matched waiting receiver"
-                          match SeLe4n.Kernel.endpointSend demoEndpoint 1 st7 with
+                          match SeLe4n.Kernel.endpointSend demoEndpoint 1 .empty st7 with
                           | .error err => IO.println s!"endpoint send #1 error: {reprStr err}"
                           | .ok (_, st8) =>
-                              match SeLe4n.Kernel.endpointSend demoEndpoint 2 st8 with
+                              match SeLe4n.Kernel.endpointSend demoEndpoint 2 .empty st8 with
                               | .error err => IO.println s!"endpoint send #2 error: {reprStr err}"
                               | .ok (_, st9) =>
                                   IO.println "queued two senders on endpoint"
                                   match SeLe4n.Kernel.endpointReceive demoEndpoint st9 with
                                   | .error err => IO.println s!"endpoint receive #1 error: {reprStr err}"
-                                  | .ok (sender1, st10) =>
+                                  | .ok ((sender1, _msg1), st10) =>
                                       IO.println s!"endpoint receive #1 sender: {sender1}"
                                       match SeLe4n.Kernel.endpointReceive demoEndpoint st10 with
                                       | .error err => IO.println s!"endpoint receive #2 error: {reprStr err}"
-                                      | .ok (sender2, st11) =>
+                                      | .ok ((sender2, _msg2), st11) =>
                                           IO.println s!"endpoint receive #2 sender: {sender2}"
                                           match SeLe4n.Kernel.endpointReceive demoEndpoint st11 with
                                           | .error err =>
                                               IO.println s!"endpoint receive #3 (expected mismatch): {reprStr err}"
-                                          | .ok (sender3, _) =>
+                                          | .ok ((sender3, _msg3), _) =>
                                                 IO.println s!"unexpected endpoint receive #3 sender: {sender3}"
                                           match SeLe4n.Kernel.notificationWait demoNotification 2 st11 with
                                           | .error err => IO.println s!"notification wait #1 error: {reprStr err}"
@@ -470,7 +470,7 @@ private def buildParameterizedTopology
       (oid, .vspaceRoot { asid := ⟨i + 1⟩, mappings := [] })
   -- Add an idle endpoint and an idle notification for IPC invariant coverage.
   let ipcObjects : List (SeLe4n.ObjId × KernelObject) :=
-    [ (⟨4000⟩, .endpoint { state := .idle, queue := [], waitingReceiver := none })
+    [ (⟨4000⟩, .endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
     , (⟨4001⟩, .notification { state := .idle, waitingThreads := [], pendingBadge := none })
     ]
   let allObjects := threads ++ [(⟨2000⟩, cnodeObj)] ++ vspaceRoots ++ ipcObjects

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -7,7 +7,7 @@ This index makes current semantic/proof/documentation claims auditable by linkin
 | Claim | Canonical source | Evidence command(s) | Evidence artifact(s) |
 |---|---|---|---|
 | Active findings baseline is `AUDIT_CODEBASE_v0.11.6.md`. | `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md` | `./scripts/test_tier3_invariant_surface.sh` | Tier-3 doc-anchor checks over README/spec/planning references. |
-| WS-E portfolio status (WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned). | `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
+| WS-E portfolio status (WS-E1, WS-E2, WS-E3 completed; WS-E4 in progress; WS-E5, WS-E6 planned). | `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Includes Tier-3 anchor validation + build + Tier-2 runtime checks. |
 | WS-D portfolio is complete (WS-D1..WS-D4 completed; WS-D5/D6 absorbed into WS-E). | `docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Historical; evidence preserved in prior tier runs. |
 | WS-C portfolio status is complete (WS-C1..WS-C8). | `docs/dev_history/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md` (status dashboard) | `./scripts/test_full.sh` | Historical; evidence preserved in prior tier runs. |
 | Root docs and GitBook mirrors stay synchronized via canonical-first rules. | `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, `docs/DOCS_DEDUPLICATION_MAP.md` | `./scripts/test_docs_sync.sh` | Regenerated navigation + markdown link validation + doc-gen probe when available. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current active slice**:
 
-- active: **v0.11.6 Codebase Audit Remediation WS-E portfolio (WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned)**,
+- active: **v0.11.6 Codebase Audit Remediation WS-E portfolio (WS-E1, WS-E2, WS-E3 completed; WS-E4 in progress; WS-E5, WS-E6 planned)**,
 - completed predecessor: **WS-D portfolio (WS-D1..WS-D4 completed; WS-D5/D6 absorbed into WS-E)**,
 - completed predecessor before that: **WS-C portfolio (WS-C1..WS-C8)**.
 
@@ -35,7 +35,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-E1** — Test infrastructure and CI hardening (**completed** — M-10, M-11, F-14, L-07, L-08)
 - **WS-E2** — Proof quality and invariant strengthening (**completed** — C-01, H-01, H-03)
 - **WS-E3** — Kernel semantic hardening (**completed** — H-06, H-07, H-08, H-09, M-09, L-06)
-- **WS-E4** — Capability and IPC model completion (**planned** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4** — Capability and IPC model completion (**in progress** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 - **WS-E5** — Information-flow maturity (**planned** — H-04, H-05, M-07)
 - **WS-E6** — Model completeness and documentation (**planned** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 

--- a/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+++ b/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
@@ -54,7 +54,7 @@ For documentation/planning PRs:
 
 ## 4) Current-stage status summary
 
-- Active planning baseline: `AUDIT_v0.11.6_WORKSTREAM_PLAN.md` (WS-E portfolio; WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned).
+- Active planning baseline: `AUDIT_v0.11.6_WORKSTREAM_PLAN.md` (WS-E portfolio; WS-E1, WS-E2, WS-E3 completed; WS-E4 in progress; WS-E5, WS-E6 planned).
 - Active findings baseline: `AUDIT_CODEBASE_v0.11.6.md`.
 - Prior completed portfolio: WS-D1..WS-D4 completed; WS-D5/D6 absorbed into WS-E.
 - Historical baselines: prior audits and workstream plans archived in `docs/dev_history/audits/`.

--- a/docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md
@@ -302,7 +302,7 @@ WS-E4 (CDT integration for capability flow proofs).
 | WS-E1 | **Completed** | Medium | M-10, M-11, F-14, L-07, L-08 | P1 |
 | WS-E2 | **Completed** | High | C-01, H-01, H-03 | P1 |
 | WS-E3 | **Completed** | High | H-06, H-07, H-08, H-09, M-09, L-06 | P2 |
-| WS-E4 | Planned | Critical | C-02, C-03, C-04, H-02, M-01, M-02, M-12 | P3 |
+| WS-E4 | **In Progress** | Critical | C-02, C-03, C-04, H-02, M-01, M-02, M-12 | P3 |
 | WS-E5 | Planned | High | H-04, H-05, M-07 | P4 |
 | WS-E6 | Planned | Low | M-03, M-04, M-05, M-08, F-17, L-01–L-05 | P5 |
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -41,7 +41,7 @@ Completed audit portfolios (continued):
 
 Current active portfolio:
 
-- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned.
+- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1, WS-E2, WS-E3 completed; WS-E4 in progress; WS-E5, WS-E6 planned.
 
 ## 4. Architecture mental model
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -16,7 +16,7 @@ Current milestone state:
 - WS-B portfolio (v0.9.0): all completed
 - WS-C portfolio (v0.9.32): all completed
 - WS-D portfolio (v0.11.0): WS-D1..WS-D4 completed; WS-D5/WS-D6 absorbed into WS-E
-- **Active:** WS-E portfolio (v0.11.6 audit remediation) — WS-E1, WS-E2, WS-E3 completed; WS-E4..WS-E6 planned
+- **Active:** WS-E portfolio (v0.11.6 audit remediation) — WS-E1, WS-E2, WS-E3 completed; WS-E4 in progress; WS-E5, WS-E6 planned
 
 ## 2) Stable contracts contributors must preserve
 

--- a/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
+++ b/docs/gitbook/32-v0.11.0-audit-workstream-planning.md
@@ -21,7 +21,7 @@ This chapter is intentionally concise and navigational. It summarizes active wor
 - **WS-E1:** Test infrastructure and CI hardening — **completed** (M-10, M-11, F-14, L-07, L-08)
 - **WS-E2:** Proof quality and invariant strengthening — **completed** (C-01, H-01, H-03)
 - **WS-E3:** Kernel semantic hardening — **completed** (H-06, H-07, H-08, H-09, M-09, L-06)
-- **WS-E4:** Capability and IPC model completion — **planned** (C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4:** Capability and IPC model completion — **in progress** (C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 - **WS-E5:** Information-flow maturity — **planned** (H-04, H-05, M-07)
 - **WS-E6:** Model completeness and documentation — **planned** (M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -79,7 +79,7 @@ on the semantic and proof foundations of the previous one.
 
 ### 3.4 Active Audit Portfolio (WS-E)
 
-- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1, WS-E2, WS-E3 completed; WS-E4 through WS-E6 planned.
+- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1, WS-E2, WS-E3 completed; WS-E4 in progress; WS-E5, WS-E6 planned.
 
 ---
 
@@ -100,7 +100,7 @@ WS-D portfolio (WS-D5/D6).
 
 ### 4.3 Critical — Model Completion
 
-- **WS-E4:** Capability and IPC model completion (critical; **planned** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4:** Capability and IPC model completion (critical; **in progress** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 
 ### 4.4 High — Security Assurance
 

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -242,7 +242,7 @@ run_check "INVARIANT" rg -n '^\s*schedulerInvariantBundle st ∧ capabilityInvar
 # M3.5 step-1 state-model anchors must remain present.
 run_check "INVARIANT" rg -n '^inductive ThreadIpcState' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^\s*ipcState\s*:\s*ThreadIpcState' SeLe4n/Model/Object.lean
-run_check "INVARIANT" rg -n '^\s*waitingReceiver\s*:\s*Option SeLe4n\.ThreadId' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^\s*receiveQueue\s*:\s*List SeLe4n\.ThreadId' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^def endpointQueueWellFormed' SeLe4n/Kernel/IPC/Invariant.lean
 run_check "INVARIANT" rg -n '^def endpointObjectValid' SeLe4n/Kernel/IPC/Invariant.lean
 

--- a/tests/InformationFlowSuite.lean
+++ b/tests/InformationFlowSuite.lean
@@ -42,7 +42,7 @@ private def publicServiceEntry : ServiceGraphEntry :=
 
 private def sampleState : SystemState :=
   (BootstrapBuilder.empty
-    |>.withObject 1 (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject 1 (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
     |>.withObject 2 (.notification { state := .active, waitingThreads := [], pendingBadge := some 7 })
     |>.withService 1 sampleServiceEntry
     |>.withService 2 publicServiceEntry
@@ -69,7 +69,7 @@ Key differences from sampleState:
 - current thread: none (vs some tid=2, which is secret and projected to none anyway) -/
 private def altState : SystemState :=
   (BootstrapBuilder.empty
-    |>.withObject 1 (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject 1 (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
     -- Secret object differs: different notification state and no pending badge
     |>.withObject 2 (.notification { state := .idle, waitingThreads := [], pendingBadge := none })
     |>.withService 1 sampleServiceEntry
@@ -222,7 +222,7 @@ private def runInformationFlowChecks : IO Unit := do
   -- endpointSendChecked: public sender to public endpoint should succeed (same-domain flow)
   let publicEndpointState :=
     (BootstrapBuilder.empty
-      |>.withObject 10 (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+      |>.withObject 10 (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
       |>.withRunnable [1]
       |>.withCurrent (some 1)
       |>.build)
@@ -234,8 +234,8 @@ private def runInformationFlowChecks : IO Unit := do
       serviceLabelOf := fun _ => publicLabel }
 
   -- Same-domain send should be allowed (same result as unchecked)
-  let checkedResult := SeLe4n.Kernel.endpointSendChecked publicCtx 10 1 publicEndpointState
-  let uncheckedResult := SeLe4n.Kernel.endpointSend 10 1 publicEndpointState
+  let checkedResult := SeLe4n.Kernel.endpointSendChecked publicCtx 10 1 .empty publicEndpointState
+  let uncheckedResult := SeLe4n.Kernel.endpointSend 10 1 .empty publicEndpointState
   expect "same-domain endpointSendChecked equals unchecked send"
     (match checkedResult, uncheckedResult with
       | .ok ((), s₁), .ok ((), s₂) => s₁.objects 10 = s₂.objects 10
@@ -249,7 +249,7 @@ private def runInformationFlowChecks : IO Unit := do
       endpointLabelOf := fun _ => publicLabel
       serviceLabelOf := fun _ => publicLabel }
 
-  let deniedResult := SeLe4n.Kernel.endpointSendChecked secretSenderCtx 10 1 publicEndpointState
+  let deniedResult := SeLe4n.Kernel.endpointSendChecked secretSenderCtx 10 1 .empty publicEndpointState
   expect "secret-to-public endpointSendChecked returns flowDenied"
     (match deniedResult with
       | .error .flowDenied => true

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -24,7 +24,7 @@ private def guardedPathBadGuard : SeLe4n.Kernel.CSpacePathAddr := { cnode := gua
 
 private def baseState : SystemState :=
   (BootstrapBuilder.empty
-    |>.withObject endpointId (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject endpointId (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
     |>.withObject cnodeId (.cnode {
       guard := 0
       radix := 0
@@ -36,7 +36,7 @@ private def baseState : SystemState :=
         })
       ]
     })
-    |>.withObject wrongTypeId (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+    |>.withObject wrongTypeId (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
     |>.withObject guardedCnodeId (.cnode {
       guard := 1
       radix := 2
@@ -87,7 +87,7 @@ private def sendEmptyEndpointState : SystemState :=
   { baseState with
     objects := fun oid =>
       if oid = sendEmptyEndpointId then
-        some (.endpoint { state := .send, queue := [], waitingReceiver := none })
+        some (.endpoint { state := .send, sendQueue := [], receiveQueue := [] })
       else
         baseState.objects oid
   }
@@ -144,9 +144,9 @@ private def runNegativeChecks : IO Unit := do
     .invalidCapability
 
 
-  expectError "endpoint receive idle-state mismatch"
+  expectError "endpoint receive idle-state empty queue"
     (SeLe4n.Kernel.endpointReceive endpointId baseState)
-    .endpointStateMismatch
+    .endpointQueueEmpty
 
   expectError "endpoint receive send-state empty queue"
     (SeLe4n.Kernel.endpointReceive sendEmptyEndpointId sendEmptyEndpointState)
@@ -250,9 +250,9 @@ private def runNegativeChecks : IO Unit := do
     (SeLe4n.Kernel.notificationWait endpointId (SeLe4n.ThreadId.ofNat 1) baseState)
     .invalidCapability
 
-  expectError "await receive second waiter mismatch"
+  -- M-01/WS-E4: Dual-queue model allows multiple receivers on the receive queue
+  let _ ← expectOkState "await receive second waiter (dual-queue allows multiple receivers)"
     (SeLe4n.Kernel.endpointAwaitReceive endpointId (SeLe4n.ThreadId.ofNat 8) stAwait)
-    .endpointStateMismatch
 
   let schedPriorityState : SystemState :=
     (BootstrapBuilder.empty

--- a/tests/TraceSequenceProbe.lean
+++ b/tests/TraceSequenceProbe.lean
@@ -17,7 +17,7 @@ def probeBaseState : SystemState :=
   { (default : SystemState) with
     objects := fun oid =>
       if oid = probeEndpointId then
-        some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+        some (.endpoint { state := .idle, sendQueue := [], receiveQueue := [] })
       else
         none
   }
@@ -35,11 +35,10 @@ def pickThreadId (x : Nat) : SeLe4n.ThreadId :=
   SeLe4n.ThreadId.ofNat ((x % 8) + 1)
 
 def endpointConsistencyHolds (ep : Endpoint) : Bool :=
-  match ep.state, ep.queue.isEmpty, ep.waitingReceiver.isSome with
-  | .idle, true, false => true
-  | .send, false, false => true
-  | .receive, true, true => true
-  | _, _, _ => false
+  match ep.state with
+  | .idle => ep.sendQueue.isEmpty && ep.receiveQueue.isEmpty
+  | .send => !ep.sendQueue.isEmpty
+  | .receive => !ep.receiveQueue.isEmpty
 
 def probeInvariantObjectIds : List SeLe4n.ObjId := [probeEndpointId]
 
@@ -56,7 +55,7 @@ def checkEndpointConsistency (st : SystemState) : Except String Unit :=
       if endpointConsistencyHolds ep then
         .ok ()
       else
-        .error s!"endpoint invariant mismatch: state={reprStr ep.state}, queue={reprStr ep.queue}, waitingReceiver={reprStr ep.waitingReceiver}"
+        .error s!"endpoint invariant mismatch: state={reprStr ep.state}, sendQueue={reprStr ep.sendQueue}, receiveQueue={reprStr ep.receiveQueue}"
   | some obj => .error s!"probe endpoint object changed unexpectedly: {reprStr obj}"
   | none => .error "probe endpoint object missing"
 
@@ -92,7 +91,7 @@ this function classifies each error and returns a structured outcome. -/
 def stepOp (op : ProbeOp) (tid : SeLe4n.ThreadId) (st : SystemState) : StepOutcome :=
   match op with
   | .send =>
-      match SeLe4n.Kernel.endpointSend probeEndpointId tid st with
+      match SeLe4n.Kernel.endpointSend probeEndpointId tid .empty st with
       | .ok (_, st') => .mutated st'
       | .error err => classifyError .send err
   | .awaitReceive =>

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -48,7 +48,7 @@ IPC-02    | critical | handshake send matched waiting receiver
 IPC-03    | high     | queued two senders on endpoint
 IPC-04    | high     | endpoint receive #1 sender: 1
 IPC-05    | high     | endpoint receive #2 sender: 2
-IPC-06    | high     | endpoint receive #3 (expected mismatch): SeLe4n.Model.KernelError.endpointStateMismatch
+IPC-06    | high     | endpoint receive #3 (expected mismatch): SeLe4n.Model.KernelError.endpointQueueEmpty
 IPC-07    | high     | notification wait #1 result: none
 IPC-08    | high     | notification wait #2 result: some { val := 123 }
 CSPACE-08 | high     | minted cap rights: [SeLe4n.Model.AccessRight.read]


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: **WS-E4** (Capability Derivation Tree integration for cross-CNode revocation and dual-queue IPC model)
- Recommendation IDs closed: **C-03, C-04, M-01, M-02, H-02**
- Scope notes: Restructures endpoint IPC operations to use separate send/receive queues with pending message tracking; introduces Capability Derivation Tree (CDT) model for tracking capability derivation edges; adds guards against silent slot overwrites in `cspaceInsertSlot`; adds `blockedOnReplyNotRunnable` predicate to scheduler-IPC coherence contract.

## Key Changes

### IPC Model (M-01, M-02, WS-E4)
- **Endpoint structure**: Replaced single `queue` + `waitingReceiver` with dual queues:
  - `sendQueue`: threads blocked waiting to send
  - `receiveQueue`: threads blocked waiting to receive
  - `pendingMessages`: IPC message payloads associated with senders
  - `replyQueue`: threads blocked waiting for reply (new)
- **endpointSend operation**: Now checks `receiveQueue` first (handshake path); if empty, enqueues sender with message to `sendQueue`
- **endpointAwaitReceive operation**: Enqueues receiver to `receiveQueue` instead of setting `waitingReceiver`
- **endpointReceive operation**: Dequeues from `sendQueue` and delivers pending message
- **endpointReply operation**: New operation for reply-path unblocking (defers full proof to WS-E5)
- **Well-formedness predicates**: Updated to track dual-queue invariants and message count consistency

### Capability Derivation Tree (C-03, WS-E4)
- **New structures** in `SeLe4n/Model/Object.lean`:
  - `SlotRef`: Architecture-neutral capability slot address (cnode + slot)
  - `CapDerivationEdge`: Parent→child derivation edge
  - `CapDerivationTree`: Forest of derivation edges with helpers (`addEdge`, `removeChild`, `removeSlot`, `directChildren`, `allDescendants`)
- **Moved** `SlotRef` from `State.lean` to `Object.lean` for semantic clarity

### Cross-CNode Revocation (C-04, WS-E4)
- **cspaceRevoke refactoring**: Introduced chain-tracking helper `cspaceRevoke_source_cnode_eq` to track object updates through multi-step pipeline (storeObject → revokeCrossCNodeSlots → CDT update → clearCapabilityRefs)
- **Helper lemmas**: `revokeCrossCNodeSlots_preserves_objects_ne`, `revokeCrossCNodeSlots_preserves_slotsUnique` for CDT-based revocation correctness
- **Simplified proofs**: `cspaceRevoke_local_target_reduction` and `cspaceRevoke_preserves_source` now use chain-tracking helper instead of inline state reconstruction

### Capability Slot Guards (H-02, WS-E4)
- **cspaceInsertSlot**: Added guard to reject insertion into occupied slots (returns `illegalState` instead of silent overwrite)
- **Updated proofs**: `cspaceInsertSlot_preserves_scheduler`, `cspaceInsertSlot_preserves_services`, `cspaceInsertSlot_lookup_eq` to handle new slot occupancy check

### Scheduler-IPC Coherence (M3.5, WS-E4)
- **New predicate**: `blockedOnReplyNotRunnable` — threads blocked on reply are not runnable
- **Updated contract**: `ipcSchedulerContractPredicates` now includes `blockedOnReplyNotRunnable`
- **Architecture invariant**: Default state satisfies all four coherence predicates

### Documentation & Deferred Work
- **Updated module docs**: `SeLe4n/Kernel/IPC/Invariant.lean` now documents

https://claude.ai/code/session_01PyYyDSVfddhGkN1Vd9raEx