### PR TITLE
Bump project patch version to 0.11.11 and sync documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 seLe4n is a Lean 4 formalization of core seL4 microkernel semantics. It produces
 machine-checked proofs of invariant preservation over executable transition
-semantics. Lean 4.28.0 toolchain, Lake build system, version 0.11.10.
+semantics. Lean 4.28.0 toolchain, Lake build system, version 0.11.11.
 
 ## Build and run
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.11.11] - 2026-02-25
+
+### Documentation and release metadata synchronization
+- Bumped patch version to **`0.11.11`** in `lakefile.toml`.
+- Updated version badges and current-version references in canonical docs (`README.md`, `docs/spec/SELE4N_SPEC.md`).
+- Updated contributor guidance mirrors (`AGENTS.md`, `CLAUDE.md`) so project metadata matches the codebase.
+
 ## [0.11.10] - 2026-02-25
 
 ### WS-E4 preparation — proof infrastructure and documentation accuracy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 seLe4n is a Lean 4 formalization of core seL4 microkernel semantics. It produces
 machine-checked proofs of invariant preservation over executable transition
-semantics. Lean 4.28.0 toolchain, Lake build system, version 0.11.10.
+semantics. Lean 4.28.0 toolchain, Lake build system, version 0.11.11.
 
 ## Build and run
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.11.10-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.11.11-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -22,7 +22,7 @@
 
 - **Active findings baseline:** `docs/audits/AUDIT_CODEBASE_v0.11.6.md`
 - **Active execution baseline:** `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`
-- **Current package version:** `0.11.10` (`lakefile.toml`)
+- **Current package version:** `0.11.11` (`lakefile.toml`)
 - **Current active portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)
 - **Prior completed portfolio:** WS-D1..WS-D4 (completed); WS-D5/D6 absorbed into WS-E
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -40,7 +40,7 @@ claims, and planning artifacts.
 
 ## 2. Current State Snapshot
 
-- **Current package version:** `0.11.10` (`lakefile.toml`)
+- **Current package version:** `0.11.11` (`lakefile.toml`)
 - **Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.11.6.md`](../audits/AUDIT_CODEBASE_v0.11.6.md)
 - **Active execution baseline:** [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md)
 - **Current active portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.11.10"
+version = "0.11.11"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Ensure the package metadata and all user-facing documentation consistently report the current patch version so repo metadata does not drift from code.
- Keep contributor guidance and spec snapshots aligned with the `lakefile.toml` package version to avoid confusion during builds and audits.

### Description
- Bumped the package version in `lakefile.toml` from `0.11.10` to `0.11.11`.
- Updated user-facing references to the package version in `README.md`, `docs/spec/SELE4N_SPEC.md`, `AGENTS.md`, and `CLAUDE.md` so badges and snapshot text match `lakefile.toml`.
- Prepended a `0.11.11` entry to `CHANGELOG.md` documenting the metadata and docs synchronization.

### Testing
- Ran `./scripts/test_smoke.sh`, which executed hygiene checks, `lake build`, scenario catalog validation, the trace harness, negative-state suite, and information-flow suite, and the script completed successfully.
- Build and unit/test suites exercised by the smoke script all passed (hygiene, build, trace fixture comparison, negative checks, and information-flow checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f85d94768832baf4ee23803663f5a)