### PR TITLE
Introduce SecureAPI hardened kernel entrypoint wrappers and negative-state tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Primary references:
 | `SeLe4n/Kernel/Architecture/*` | Architecture assumptions, adapter semantics, boundary invariants |
 | `SeLe4n/Kernel/InformationFlow/*` | Information-flow policy, projection, and low-equivalence |
 | `SeLe4n/Kernel/API.lean` | Unified public API surface, invariant bundle alias, stability table |
+| `SeLe4n/Kernel/SecureAPI.lean` | Hardened wrappers: sentinel-ID rejection, strict IPC TCB presence checks, info-flow-gated entrypoints, ASID-uniqueness guard for VSpace |
 | `Main.lean` | Executable trace/demo harness |
 | `tests/fixtures/main_trace_smoke.expected` | Stable trace expectation anchors |
 | `scripts/test_tier*.sh` | Tiered quality gates used by CI and local workflows |

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -12,3 +12,4 @@ import SeLe4n.Kernel.Architecture.VSpace
 import SeLe4n.Kernel.Architecture.VSpaceInvariant
 
 import SeLe4n.Kernel.InformationFlow.Enforcement
+import SeLe4n.Kernel.SecureAPI

--- a/SeLe4n/Kernel/SecureAPI.lean
+++ b/SeLe4n/Kernel/SecureAPI.lean
@@ -1,0 +1,117 @@
+import SeLe4n.Kernel.InformationFlow.Enforcement
+import SeLe4n.Kernel.Architecture.VSpace
+
+namespace SeLe4n.Kernel
+
+open SeLe4n.Model
+
+private def tcbExists (st : SystemState) (tid : SeLe4n.ThreadId) : Bool :=
+  match st.objects tid.toObjId with
+  | some (.tcb _) => true
+  | _ => false
+
+/-- Detect duplicate ASID roots in the discovered object index window. -/
+def asidRootUnique (st : SystemState) (asid : SeLe4n.ASID) : Bool :=
+  decide (((st.objectIndex.filter (fun oid =>
+    match st.objects oid with
+    | some (.vspaceRoot root) => root.asid = asid
+    | _ => false)).length) ≤ 1)
+
+/-- L-09/WS-E6: Secure API wrapper for endpoint send.
+Rejects reserved IDs, missing sender TCBs, and applies information-flow checks. -/
+def endpointSendSecure
+    (ctx : LabelingContext)
+    (endpointId : SeLe4n.ObjId)
+    (sender : SeLe4n.ThreadId) : Kernel Unit :=
+  fun st =>
+    if endpointId.isReserved || sender.isReserved then
+      .error .invalidCapability
+    else if ¬ tcbExists st sender then
+      .error .objectNotFound
+    else
+      endpointSendChecked ctx endpointId sender st
+
+/-- L-09/WS-E6: Secure API wrapper for endpoint receive registration.
+Rejects reserved IDs and missing receiver TCBs. -/
+def endpointAwaitReceiveSecure
+    (endpointId : SeLe4n.ObjId)
+    (receiver : SeLe4n.ThreadId) : Kernel Unit :=
+  fun st =>
+    if endpointId.isReserved || receiver.isReserved then
+      .error .invalidCapability
+    else if ¬ tcbExists st receiver then
+      .error .objectNotFound
+    else
+      endpointAwaitReceive endpointId receiver st
+
+/-- L-09/WS-E6: Secure API wrapper for notification wait.
+Rejects reserved IDs and missing waiter TCBs. -/
+def notificationWaitSecure
+    (notificationId : SeLe4n.ObjId)
+    (waiter : SeLe4n.ThreadId) : Kernel (Option SeLe4n.Badge) :=
+  fun st =>
+    if notificationId.isReserved || waiter.isReserved then
+      .error .invalidCapability
+    else if ¬ tcbExists st waiter then
+      .error .objectNotFound
+    else
+      notificationWait notificationId waiter st
+
+/-- L-09/WS-E6: Secure API wrapper for capability mint.
+Rejects sentinel CNode identifiers and applies information-flow checks. -/
+def cspaceMintSecure
+    (ctx : LabelingContext)
+    (src dst : CSpaceAddr)
+    (rights : List AccessRight)
+    (badge : Option SeLe4n.Badge := none) : Kernel Unit :=
+  fun st =>
+    if src.cnode.isReserved || dst.cnode.isReserved then
+      .error .invalidCapability
+    else
+      cspaceMintChecked ctx src dst rights badge st
+
+/-- L-09/WS-E6: Secure API wrapper for service restart.
+Rejects sentinel service identifiers and applies information-flow checks. -/
+def serviceRestartSecure
+    (ctx : LabelingContext)
+    (orchestrator sid : ServiceId)
+    (policyAllowsStop : ServicePolicy)
+    (policyAllowsStart : ServicePolicy) : Kernel Unit :=
+  fun st =>
+    if orchestrator.isReserved || sid.isReserved then
+      .error .invalidCapability
+    else
+      serviceRestartChecked ctx orchestrator sid policyAllowsStop policyAllowsStart st
+
+/-- L-09/WS-E6: Strict VSpace map wrapper that rejects ambiguous ASID bindings. -/
+def vspaceMapPageSecure
+    (asid : SeLe4n.ASID)
+    (vaddr : SeLe4n.VAddr)
+    (paddr : SeLe4n.PAddr) : Kernel Unit :=
+  fun st =>
+    if asidRootUnique st asid then
+      SeLe4n.Kernel.Architecture.vspaceMapPage asid vaddr paddr st
+    else
+      .error .illegalState
+
+/-- L-09/WS-E6: Strict VSpace unmap wrapper that rejects ambiguous ASID bindings. -/
+def vspaceUnmapPageSecure
+    (asid : SeLe4n.ASID)
+    (vaddr : SeLe4n.VAddr) : Kernel Unit :=
+  fun st =>
+    if asidRootUnique st asid then
+      SeLe4n.Kernel.Architecture.vspaceUnmapPage asid vaddr st
+    else
+      .error .illegalState
+
+/-- L-09/WS-E6: Strict VSpace lookup wrapper that rejects ambiguous ASID bindings. -/
+def vspaceLookupSecure
+    (asid : SeLe4n.ASID)
+    (vaddr : SeLe4n.VAddr) : Kernel SeLe4n.PAddr :=
+  fun st =>
+    if asidRootUnique st asid then
+      SeLe4n.Kernel.Architecture.vspaceLookup asid vaddr st
+    else
+      .error .illegalState
+
+end SeLe4n.Kernel

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -55,3 +55,5 @@ When a claim changes:
 2. update GitBook mirror(s) in the same PR,
 3. refresh this table row(s) for changed claims,
 4. run `./scripts/test_docs_sync.sh` and at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).
+
+| Hardened external entrypoints reject sentinel IDs, enforce IPC TCB presence, and gate strict VSpace uniqueness checks. | `SeLe4n/Kernel/SecureAPI.lean`; `tests/NegativeStateSuite.lean` secure-wrapper negative checks | `./scripts/test_smoke.sh` | Verified by executable negative-state suite scenarios and smoke pipeline. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -148,3 +148,9 @@ A change is done when all are true:
 - [ ] Invariant/theorem updates are paired with implementation changes.
 - [ ] Required validation commands were run.
 - [ ] Documentation was synchronized.
+
+
+## L-09 secure entrypoint wrappers
+
+- `SeLe4n/Kernel/SecureAPI.lean` adds hardened wrappers for external consumers.
+- Guards include sentinel-ID rejection, IPC sender/receiver TCB-presence checks, IFC-checked entrypoints (`endpointSendSecure`, `cspaceMintSecure`, `serviceRestartSecure`), and strict ASID-root uniqueness wrappers for VSpace operations.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -110,6 +110,8 @@ WS-D portfolio (WS-D5/D6).
 
 - **WS-E6:** Model completeness and documentation (low; **completed** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 
+- L-09 secure wrappers (`SeLe4n/Kernel/SecureAPI.lean`) provide hardened entrypoints: sentinel-ID rejection, mandatory sender/receiver TCB-presence checks for IPC/notification waits, and strict ASID-uniqueness guards for VSpace map/unmap/lookup.
+
 Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md).
 

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -366,6 +366,33 @@ private def runNegativeChecks : IO Unit := do
   | .error err =>
     throw <| IO.userError s!"service dependency A→B registration failed: {reprStr err}"
 
+  -- ==========================================================================
+  -- L-09/WS-E6: Secure API wrapper checks
+  -- ==========================================================================
+
+  let ctx := SeLe4n.Kernel.defaultLabelingContext
+  expectError "secure endpoint send missing sender tcb"
+    (SeLe4n.Kernel.endpointSendSecure ctx endpointId (SeLe4n.ThreadId.ofNat 777) baseState)
+    .objectNotFound
+
+  expectError "secure endpoint send reserved ids"
+    (SeLe4n.Kernel.endpointSendSecure ctx 0 (SeLe4n.ThreadId.ofNat 7) baseState)
+    .invalidCapability
+
+  let dupAsidState : SystemState :=
+    { baseState with
+      objects := fun oid =>
+        if oid = 21 then
+          some (.vspaceRoot { asid := asidPrimary, mappings := [] })
+        else
+          baseState.objects oid
+      objectIndex := 21 :: baseState.objectIndex
+    }
+
+  expectError "secure vspace lookup rejects duplicate asid roots"
+    (SeLe4n.Kernel.vspaceLookupSecure asidPrimary vaddrPrimary dupAsidState)
+    .illegalState
+
 end SeLe4n.Testing
 
 def main : IO Unit :=


### PR DESCRIPTION
### Motivation

- Harden external kernel entrypoints to reject sentinel/reserved identifiers, enforce presence of sender/receiver TCBs for IPC/notification operations, and add strict ASID-root uniqueness checks for VSpace operations as part of WS-E6 L-09. 
- Surface the hardening in documentation and evidence indices so the model, spec, and developer guidance reflect the new secure wrappers. 

### Description

- Add `SeLe4n/Kernel/SecureAPI.lean` implementing secure wrappers: `endpointSendSecure`, `endpointAwaitReceiveSecure`, `notificationWaitSecure`, `cspaceMintSecure`, `serviceRestartSecure`, `vspaceMapPageSecure`, `vspaceUnmapPageSecure`, and `vspaceLookupSecure`, which perform sentinel-ID rejection, TCB existence checks, IFC-checked delegation to `_Checked` variants, and ASID-root uniqueness checks. 
- Import the new `SecureAPI` module in `SeLe4n.lean` and retain existing checked entrypoints for internal use. 
- Update `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, and `docs/CLAIM_EVIDENCE_INDEX.md` to document the new hardened wrappers and link the change into the WS-E workstream evidence surface. 
- Extend `tests/NegativeStateSuite.lean` with negative-case scenarios exercising the secure wrappers, including missing sender TCB, reserved identifier rejection, and duplicate-ASID rejection for VSpace lookup. 

### Testing

- Ran the negative-state test suite entry `tests/NegativeStateSuite.lean` which includes the new secure-wrapper checks and observed the expected rejections. 
- Executed the smoke pipeline via `./scripts/test_smoke.sh` to validate end-to-end smoke expectations and docs synchronization anchors, and the run completed successfully. 
- All automated checks referenced in the workstream evidence (`tests/NegativeStateSuite.lean` and smoke pipeline) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd04fd500832bbcc5718af2e503b9)