### PR TITLE
Harden storeTcbIpcState (reject reserved/missing TIDs) and switch harnesses to IFC-checked wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Primary references:
 - [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md)
 - [`docs/audits/AUDIT_CODEBASE_v0.11.6.md`](docs/audits/AUDIT_CODEBASE_v0.11.6.md)
 
+
+## Recent hardening notes
+
+- IPC/notification thread-state writes are now strict: `storeTcbIpcState` returns
+  `objectNotFound` when the target TCB is absent (including reserved/sentinel thread IDs),
+  preventing queue entries without corresponding TCB transitions.
+- Main trace and probe harnesses now exercise IFC-gated wrappers
+  (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default,
+  while unchecked primitives remain available for research slices.
+
 ## Completed workstreams (WS-D, historical)
 
 - **WS-D1..WS-D4:** all completed. WS-D5/D6 items absorbed into WS-E. See [`docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md).

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1294,10 +1294,13 @@ private theorem cspaceSlotUnique_of_storeTcbIpcState
     (hStep : storeTcbIpcState st tid ipc = .ok st') :
     cspaceSlotUnique st' := by
   unfold storeTcbIpcState at hStep
+  have hNotReserved : tid.isReserved = false := by
+    cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
   cases hLookup : lookupTcb st tid with
-  | none => simp [hLookup] at hStep; subst hStep; exact hUniq
+  | none =>
+    simp [hNotReserved, hLookup] at hStep
   | some tcb =>
-    simp only [hLookup] at hStep
+    simp only [hNotReserved, hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
     | error e => simp [hStore] at hStep
     | ok pair =>

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -23,13 +23,19 @@ def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
     | _ => st
 
 def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=
+  if tid.isReserved then
+    none
+  else
   match st.objects tid.toObjId with
   | some (.tcb tcb) => some tcb
   | _ => none
 
 def storeTcbIpcState (st : SystemState) (tid : SeLe4n.ThreadId) (ipcState : ThreadIpcState) : Except KernelError SystemState :=
+  if tid.isReserved then
+    .error .objectNotFound
+  else
   match lookupTcb st tid with
-  | none => .ok st
+  | none => .error .objectNotFound
   | some tcb =>
       match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState }) st with
       | .error e => .error e
@@ -213,12 +219,13 @@ theorem storeTcbIpcState_preserves_objects_ne
     (hStep : storeTcbIpcState st tid ipc = .ok st') :
     st'.objects oid = st.objects oid := by
   unfold storeTcbIpcState at hStep
+  by_cases hReserved : tid.isReserved
+  · simp [hReserved] at hStep
   cases hTcb : lookupTcb st tid with
   | none =>
-    simp [hTcb] at hStep
-    subst hStep; rfl
+    simp [hReserved, hTcb] at hStep
   | some tcb =>
-    simp only [hTcb] at hStep
+    simp only [hReserved, hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
     | error e => simp [hStore] at hStep
     | ok pair =>
@@ -243,9 +250,7 @@ theorem storeTcbIpcState_preserves_notification
     unfold storeTcbIpcState at hStep
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hNtfn]
-    simp [hLookup] at hStep
-    subst hStep
-    exact hNtfn
+    cases hTidRes : tid.isReserved <;> simp [hTidRes, hLookup] at hStep
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc notifId hEq hStep]
     exact hNtfn
 
@@ -274,12 +279,13 @@ theorem storeTcbIpcState_scheduler_eq
     (hStep : storeTcbIpcState st tid ipc = .ok st') :
     st'.scheduler = st.scheduler := by
   unfold storeTcbIpcState at hStep
+  have hNotReserved : tid.isReserved = false := by
+    cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
   cases hTcb : lookupTcb st tid with
   | none =>
-    simp [hTcb] at hStep
-    subst hStep; rfl
+    simp [hNotReserved, hTcb] at hStep
   | some tcb =>
-    simp only [hTcb] at hStep
+    simp only [hNotReserved, hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
     | error e => simp [hStore] at hStep
     | ok pair =>
@@ -303,9 +309,7 @@ theorem storeTcbIpcState_preserves_endpoint
     unfold storeTcbIpcState at hStep
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hEp]
-    simp [hLookup] at hStep
-    subst hStep
-    exact hEp
+    cases hTidRes : tid.isReserved <;> simp [hTidRes, hLookup] at hStep
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc epId hEq hStep]
     exact hEp
 
@@ -324,9 +328,7 @@ theorem storeTcbIpcState_preserves_cnode
     unfold storeTcbIpcState at hStep
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hCn]
-    simp [hLookup] at hStep
-    subst hStep
-    exact hCn
+    cases hTidRes : tid.isReserved <;> simp [hTidRes, hLookup] at hStep
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc cnodeId hEq hStep]
     exact hCn
 
@@ -345,9 +347,7 @@ theorem storeTcbIpcState_preserves_vspaceRoot
     unfold storeTcbIpcState at hStep
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hVs]
-    simp [hLookup] at hStep
-    subst hStep
-    exact hVs
+    cases hTidRes : tid.isReserved <;> simp [hTidRes, hLookup] at hStep
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep]
     exact hVs
 
@@ -365,11 +365,13 @@ theorem storeTcbIpcState_cnode_backward
   by_cases hEq : oid = tid.toObjId
   · subst hEq
     unfold storeTcbIpcState at hStep
+    have hNotReserved : tid.isReserved = false := by
+      cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hCn
+      simp [hNotReserved, hLookup] at hStep
     | some tcb =>
-      simp only [hLookup] at hStep
+      simp only [hNotReserved, hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
       | error e => simp [hStore] at hStep
       | ok pair =>
@@ -391,11 +393,13 @@ theorem storeTcbIpcState_endpoint_backward
   by_cases hEq : oid = tid.toObjId
   · subst hEq
     unfold storeTcbIpcState at hStep
+    have hNotReserved : tid.isReserved = false := by
+      cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hEp
+      simp [hNotReserved, hLookup] at hStep
     | some tcb =>
-      simp only [hLookup] at hStep
+      simp only [hNotReserved, hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
       | error e => simp [hStore] at hStep
       | ok pair =>
@@ -417,11 +421,13 @@ theorem storeTcbIpcState_notification_backward
   by_cases hEq : oid = tid.toObjId
   · subst hEq
     unfold storeTcbIpcState at hStep
+    have hNotReserved : tid.isReserved = false := by
+      cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hNtfn
+      simp [hNotReserved, hLookup] at hStep
     | some tcb =>
-      simp only [hLookup] at hStep
+      simp only [hNotReserved, hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
       | error e => simp [hStore] at hStep
       | ok pair =>
@@ -648,12 +654,13 @@ theorem storeTcbIpcState_ipcState_eq
     (tcb : TCB) (hTcb : st'.objects tid.toObjId = some (.tcb tcb)) :
     tcb.ipcState = ipc := by
   unfold storeTcbIpcState at hStep
+  have hNotReserved : tid.isReserved = false := by
+    cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep
-    unfold lookupTcb at hLookup; simp [hTcb] at hLookup
+    simp [hNotReserved, hLookup] at hStep
   | some tcb' =>
-    simp only [hLookup] at hStep
+    simp only [hNotReserved, hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb' with ipcState := ipc }) st with
     | error e => simp [hStore] at hStep
     | ok pair =>
@@ -690,8 +697,10 @@ theorem storeTcbIpcState_tcb_exists_at_target
     ∃ tcb', st'.objects tid.toObjId = some (.tcb tcb') := by
   rcases hTcb with ⟨tcb, hObj⟩
   unfold storeTcbIpcState at hStep
-  have hLookup : lookupTcb st tid = some tcb := by unfold lookupTcb; simp [hObj]
-  simp only [hLookup] at hStep
+  have hNotReserved : tid.isReserved = false := by
+    cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
+  have hLookup : lookupTcb st tid = some tcb := by unfold lookupTcb; simp [hNotReserved, hObj]
+  simp only [hNotReserved, hLookup] at hStep
   cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
   | error e => simp [hStore] at hStep
   | ok pair =>

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -194,11 +194,13 @@ private theorem storeTcbIpcState_preserves_projection
     (hStep : storeTcbIpcState st tid ipc = .ok st') :
     projectState ctx observer st' = projectState ctx observer st := by
   unfold storeTcbIpcState at hStep
+  have hNotReserved : tid.isReserved = false := by
+    cases hTidRes : tid.isReserved <;> simp [hTidRes] at hStep ⊢
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep; rfl
+    simp [hNotReserved, hLookup] at hStep
   | some tcb =>
-    simp only [hLookup] at hStep
+    simp only [hNotReserved, hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
     | error e => simp [hStore] at hStep
     | ok pair =>

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -24,7 +24,7 @@ def svcRestart : ServiceId := 104
 def svcRestartBroken : ServiceId := 105
 
 def bootstrapInvariantObjectIds : List SeLe4n.ObjId :=
-  [1, 10, 11, 12, 20, demoEndpoint, demoNotification, 200]
+  [1, 2, 4, 5, 10, 11, 12, 20, demoEndpoint, demoNotification, 200]
 
 def bootstrapServiceIds : List ServiceId :=
   [svcDb, svcApi, svcDenied, svcBroken, svcRestart, svcRestartBroken]
@@ -38,6 +38,33 @@ def bootstrapState : SystemState :=
       cspaceRoot := 10
       vspaceRoot := 20
       ipcBuffer := 4096
+      ipcState := .ready
+    })
+    |>.withObject 2 (.tcb {
+      tid := 2
+      priority := 60
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 6144
+      ipcState := .ready
+    })
+    |>.withObject 4 (.tcb {
+      tid := 4
+      priority := 55
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 7168
+      ipcState := .ready
+    })
+    |>.withObject 5 (.tcb {
+      tid := 5
+      priority := 50
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 7424
       ipcState := .ready
     })
     |>.withObject 10 (.cnode {
@@ -104,8 +131,11 @@ def bootstrapState : SystemState :=
       dependencies := [999]
       isolatedFrom := []
     }
-    |>.withRunnable [1, 12]
+    |>.withRunnable [1, 2, 4, 5, 12]
     |>.withLifecycleObjectType 1 .tcb
+    |>.withLifecycleObjectType 2 .tcb
+    |>.withLifecycleObjectType 4 .tcb
+    |>.withLifecycleObjectType 5 .tcb
     |>.withLifecycleObjectType 10 .cnode
     |>.withLifecycleObjectType 12 .tcb
     |>.withLifecycleObjectType 11 .cnode
@@ -162,6 +192,7 @@ private def runCapabilityAndArchitectureTrace (st1 : SystemState) : IO Unit := d
 private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   let allowAll : SeLe4n.Kernel.ServicePolicy := fun _ => true
   let denyAll : SeLe4n.Kernel.ServicePolicy := fun _ => false
+  let ifcCtx := SeLe4n.Kernel.defaultLabelingContext
   match SeLe4n.Kernel.serviceStart svcApi allowAll st1 with
   | .error err => IO.println s!"service start api error: {reprStr err}"
   | .ok (_, stServiceStart) =>
@@ -174,7 +205,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service start dependency branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service start success with unsatisfied dependencies"
-  match SeLe4n.Kernel.serviceRestart svcRestart allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked ifcCtx svcApi svcRestart allowAll allowAll st1 with
   | .error err => IO.println s!"service restart error: {reprStr err}"
   | .ok (_, stRestarted) =>
       IO.println s!"service restart status: {reprStr <| (SeLe4n.Model.lookupService stRestarted svcRestart).map ServiceGraphEntry.status}"
@@ -186,11 +217,11 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service stop illegal-state branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service stop success from stopped state"
-  match SeLe4n.Kernel.serviceRestart svcRestart denyAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked ifcCtx svcApi svcRestart denyAll allowAll st1 with
   | .error err => IO.println s!"service restart stop-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success when stop policy denies"
-  match SeLe4n.Kernel.serviceRestart svcRestartBroken allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked ifcCtx svcApi svcRestartBroken allowAll allowAll st1 with
   | .error err => IO.println s!"service restart start-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success with broken dependencies"
@@ -238,10 +269,10 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
         else if oid = 31 then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
         else st1.objects oid
     }
-  match SeLe4n.Kernel.endpointSend demoEndpoint 4 stMultiEndpoint with
+  match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 4 stMultiEndpoint with
   | .error err => IO.println s!"multi-endpoint send A error: {reprStr err}"
   | .ok (_, stEp1) =>
-      match SeLe4n.Kernel.endpointSend 31 5 stEp1 with
+      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext 31 5 stEp1 with
       | .error err => IO.println s!"multi-endpoint send B error: {reprStr err}"
       | .ok (_, stEp2) =>
           match SeLe4n.Kernel.endpointReceive demoEndpoint stEp2 with
@@ -343,10 +374,10 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"lifecycle retype error: {reprStr err}"
   | .ok (_, stLifecycle) =>
       IO.println s!"lifecycle retype success object kind: {reprStr <| (stLifecycle.objects 12).map KernelObject.objectType}"
-  match SeLe4n.Kernel.cspaceMint rootSlot mintedSlot [.read] none st1 with
+  match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot mintedSlot [.read] none st1 with
   | .error err => IO.println s!"cspace mint error: {reprStr err}"
   | .ok (_, st2) =>
-      match SeLe4n.Kernel.cspaceMint rootSlot siblingSlot [.read] none st2 with
+      match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot siblingSlot [.read] none st2 with
       | .error err => IO.println s!"sibling mint error: {reprStr err}"
       | .ok (_, st3) =>
           IO.println "created sibling cap with the same target"
@@ -378,14 +409,14 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
               match SeLe4n.Kernel.endpointAwaitReceive demoEndpoint 2 st5 with
                   | .error err => IO.println s!"endpoint await-receive error: {reprStr err}"
                   | .ok (_, st6) =>
-                      match SeLe4n.Kernel.endpointSend demoEndpoint 1 st6 with
+                      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st6 with
                       | .error err => IO.println s!"endpoint handshake send error: {reprStr err}"
                       | .ok (_, st7) =>
                           IO.println "handshake send matched waiting receiver"
-                          match SeLe4n.Kernel.endpointSend demoEndpoint 1 st7 with
+                          match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st7 with
                           | .error err => IO.println s!"endpoint send #1 error: {reprStr err}"
                           | .ok (_, st8) =>
-                              match SeLe4n.Kernel.endpointSend demoEndpoint 2 st8 with
+                              match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 2 st8 with
                               | .error err => IO.println s!"endpoint send #2 error: {reprStr err}"
                               | .ok (_, st9) =>
                                   IO.println "queued two senders on endpoint"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,7 +24,9 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 3. local + composed invariant layering,
 4. theorem discoverability through stable naming,
 5. fixture-backed executable evidence (`Main.lean` + trace fixture),
-6. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`).
+6. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`),
+7. strict IPC TCB updates: operations that enqueue/dequeue thread IDs must fail when
+   the referenced TCB is missing (no silent queue-only transitions).
 
 ---
 

--- a/docs/spec/SEL4_SPEC.md
+++ b/docs/spec/SEL4_SPEC.md
@@ -203,6 +203,9 @@ between sender and receiver through **Endpoint** objects acting as rendezvous po
   `seL4_NBSend`).
 - If no sender is waiting, the receiver blocks.
 - The kernel never buffers IPC data internally.
+- Model hardening rule: endpoint/notification queue transitions must fail if the
+  referenced thread TCB does not exist; queue updates are never committed without
+  a matching TCB IPC-state transition.
 
 ### 5.2 IPC Message Format
 

--- a/tests/TraceSequenceProbe.lean
+++ b/tests/TraceSequenceProbe.lean
@@ -104,7 +104,7 @@ this function classifies each error and returns a structured outcome. -/
 def stepOp (op : ProbeOp) (tid : SeLe4n.ThreadId) (st : SystemState) : StepOutcome :=
   match op with
   | .send =>
-      match SeLe4n.Kernel.endpointSend probeEndpointId tid st with
+      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext probeEndpointId tid st with
       | .ok (_, st') => .mutated st'
       | .error err => classifyError .send err
   | .awaitReceive =>


### PR DESCRIPTION
### Motivation
- Prevent silent, unsafe IPC/notification queue insertions by ensuring `storeTcbIpcState` does not succeed when the target TCB is absent or a reserved/sentinel ID is used. 
- Make the sentinel ID (value `0`) behave as an explicit invalid identifier at object-store boundaries to avoid accidental reuse of reserved IDs. 
- Reduce accidental bypass of the information-flow enforcement boundary by exercising the checked wrappers in the default trace/probe harnesses so the test traces reflect the hardened, policy-gated paths. 

### Description
- Tightened `storeTcbIpcState` and `lookupTcb` in `SeLe4n/Kernel/IPC/Operations.lean` so `ThreadId` sentinels are rejected and missing TCBs return `objectNotFound` instead of silently returning success. 
- Updated many IPC/CSP/information-flow lemmas and invariants to account for the stricter error branches (added non-reserved hypotheses / case handling where needed) in `SeLe4n/Kernel/Capability/Invariant.lean` and `SeLe4n/Kernel/InformationFlow/Invariant.lean`. 
- Switched the main trace harness and the probe harness to use checked IFC wrappers by default: `endpointSendChecked`, `cspaceMintChecked`, and `serviceRestartChecked` in `SeLe4n/Testing/MainTraceHarness.lean` and `tests/TraceSequenceProbe.lean`. 
- Added explicit bootstrap TCB fixtures (IDs used by the traces) and updated runnable lists so trace scenarios remain deterministic under the new TCB-existence checks. 
- Documented the hardening and enforcement-default behavior in `README.md`, `docs/DEVELOPMENT.md`, and `docs/spec/SEL4_SPEC.md`. 

### Testing
- Performed an incremental toolchain + build: `./scripts/setup_lean_env.sh --build` and `lake build`, which completed successfully. 
- Ran the project tiered smoke checks: `./scripts/test_fast.sh` and `./scripts/test_smoke.sh`, and the trace/negative-state suites referenced by the harness; the modified codebase built and the smoke trace comparisons passed after the harness fixture updates. 
- Ran the information-flow and negative-state test executables (`information_flow_suite`, `negative_state_suite`) as part of the smoke tier; the relevant information-flow checks and negative-state assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe48c4624832b937006a26001825c)