### PR TITLE
Harden IPC TCB-state writes; default harness to policy-checked operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Additional resources:
 - Contribution guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Change history: [`CHANGELOG.md`](CHANGELOG.md)
 
+
+## Security defaults
+
+- IPC TCB-state writes now fail with `objectNotFound` when the target thread does not exist (no silent success path).
+- ID value `0` remains a reserved sentinel; operational callers should use checked entry points or explicit `isReserved` guards.
+- Trace harness paths now use policy-checked entry points (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default.
+
 ## Validation commands
 
 ```bash

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1295,7 +1295,7 @@ private theorem cspaceSlotUnique_of_storeTcbIpcState
     cspaceSlotUnique st' := by
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
-  | none => simp [hLookup] at hStep; subst hStep; exact hUniq
+  | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -29,7 +29,7 @@ def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=
 
 def storeTcbIpcState (st : SystemState) (tid : SeLe4n.ThreadId) (ipcState : ThreadIpcState) : Except KernelError SystemState :=
   match lookupTcb st tid with
-  | none => .ok st
+  | none => .error .objectNotFound
   | some tcb =>
       match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState }) st with
       | .error e => .error e
@@ -216,7 +216,6 @@ theorem storeTcbIpcState_preserves_objects_ne
   cases hTcb : lookupTcb st tid with
   | none =>
     simp [hTcb] at hStep
-    subst hStep; rfl
   | some tcb =>
     simp only [hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -244,8 +243,6 @@ theorem storeTcbIpcState_preserves_notification
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hNtfn]
     simp [hLookup] at hStep
-    subst hStep
-    exact hNtfn
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc notifId hEq hStep]
     exact hNtfn
 
@@ -277,7 +274,6 @@ theorem storeTcbIpcState_scheduler_eq
   cases hTcb : lookupTcb st tid with
   | none =>
     simp [hTcb] at hStep
-    subst hStep; rfl
   | some tcb =>
     simp only [hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -304,8 +300,6 @@ theorem storeTcbIpcState_preserves_endpoint
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hEp]
     simp [hLookup] at hStep
-    subst hStep
-    exact hEp
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc epId hEq hStep]
     exact hEp
 
@@ -325,8 +319,6 @@ theorem storeTcbIpcState_preserves_cnode
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hCn]
     simp [hLookup] at hStep
-    subst hStep
-    exact hCn
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc cnodeId hEq hStep]
     exact hCn
 
@@ -346,8 +338,6 @@ theorem storeTcbIpcState_preserves_vspaceRoot
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hVs]
     simp [hLookup] at hStep
-    subst hStep
-    exact hVs
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep]
     exact hVs
 
@@ -367,7 +357,7 @@ theorem storeTcbIpcState_cnode_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hCn
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -393,7 +383,7 @@ theorem storeTcbIpcState_endpoint_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hEp
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -419,7 +409,7 @@ theorem storeTcbIpcState_notification_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hNtfn
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -650,15 +640,14 @@ theorem storeTcbIpcState_ipcState_eq
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep
-    unfold lookupTcb at hLookup; simp [hTcb] at hLookup
+    simp [hLookup] at hStep
   | some tcb' =>
-    simp only [hLookup] at hStep
+    simp [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb' with ipcState := ipc }) st with
     | error e => simp [hStore] at hStep
     | ok pair =>
-      simp only [hStore] at hStep
-      have hEq := Except.ok.inj hStep; subst hEq
+      simp [hStore] at hStep
+      subst hStep
       have hAt := storeObject_objects_eq st pair.2 tid.toObjId _ hStore
       rw [hAt] at hTcb; cases hTcb; rfl
 

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -196,7 +196,7 @@ private theorem storeTcbIpcState_preserves_projection
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep; rfl
+    simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -24,7 +24,7 @@ def svcRestart : ServiceId := 104
 def svcRestartBroken : ServiceId := 105
 
 def bootstrapInvariantObjectIds : List SeLe4n.ObjId :=
-  [1, 10, 11, 12, 20, demoEndpoint, demoNotification, 200]
+  [1, 2, 4, 5, 10, 11, 12, 20, demoEndpoint, demoNotification, 200]
 
 def bootstrapServiceIds : List ServiceId :=
   [svcDb, svcApi, svcDenied, svcBroken, svcRestart, svcRestartBroken]
@@ -38,6 +38,33 @@ def bootstrapState : SystemState :=
       cspaceRoot := 10
       vspaceRoot := 20
       ipcBuffer := 4096
+      ipcState := .ready
+    })
+    |>.withObject 2 (.tcb {
+      tid := 2
+      priority := 80
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 4097
+      ipcState := .ready
+    })
+    |>.withObject 4 (.tcb {
+      tid := 4
+      priority := 70
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 4098
+      ipcState := .ready
+    })
+    |>.withObject 5 (.tcb {
+      tid := 5
+      priority := 60
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 4099
       ipcState := .ready
     })
     |>.withObject 10 (.cnode {
@@ -108,6 +135,9 @@ def bootstrapState : SystemState :=
     |>.withLifecycleObjectType 1 .tcb
     |>.withLifecycleObjectType 10 .cnode
     |>.withLifecycleObjectType 12 .tcb
+    |>.withLifecycleObjectType 5 .tcb
+    |>.withLifecycleObjectType 4 .tcb
+    |>.withLifecycleObjectType 2 .tcb
     |>.withLifecycleObjectType 11 .cnode
     |>.withLifecycleObjectType 20 .vspaceRoot
     |>.withLifecycleObjectType demoEndpoint .endpoint
@@ -174,7 +204,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service start dependency branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service start success with unsatisfied dependencies"
-  match SeLe4n.Kernel.serviceRestart svcRestart allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked SeLe4n.Kernel.defaultLabelingContext svcRestart svcRestart allowAll allowAll st1 with
   | .error err => IO.println s!"service restart error: {reprStr err}"
   | .ok (_, stRestarted) =>
       IO.println s!"service restart status: {reprStr <| (SeLe4n.Model.lookupService stRestarted svcRestart).map ServiceGraphEntry.status}"
@@ -186,11 +216,11 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service stop illegal-state branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service stop success from stopped state"
-  match SeLe4n.Kernel.serviceRestart svcRestart denyAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked SeLe4n.Kernel.defaultLabelingContext svcRestart svcRestart denyAll allowAll st1 with
   | .error err => IO.println s!"service restart stop-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success when stop policy denies"
-  match SeLe4n.Kernel.serviceRestart svcRestartBroken allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked SeLe4n.Kernel.defaultLabelingContext svcRestartBroken svcRestartBroken allowAll allowAll st1 with
   | .error err => IO.println s!"service restart start-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success with broken dependencies"
@@ -238,10 +268,10 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
         else if oid = 31 then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
         else st1.objects oid
     }
-  match SeLe4n.Kernel.endpointSend demoEndpoint 4 stMultiEndpoint with
+  match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 4 stMultiEndpoint with
   | .error err => IO.println s!"multi-endpoint send A error: {reprStr err}"
   | .ok (_, stEp1) =>
-      match SeLe4n.Kernel.endpointSend 31 5 stEp1 with
+      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext 31 5 stEp1 with
       | .error err => IO.println s!"multi-endpoint send B error: {reprStr err}"
       | .ok (_, stEp2) =>
           match SeLe4n.Kernel.endpointReceive demoEndpoint stEp2 with
@@ -343,10 +373,10 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"lifecycle retype error: {reprStr err}"
   | .ok (_, stLifecycle) =>
       IO.println s!"lifecycle retype success object kind: {reprStr <| (stLifecycle.objects 12).map KernelObject.objectType}"
-  match SeLe4n.Kernel.cspaceMint rootSlot mintedSlot [.read] none st1 with
+  match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot mintedSlot [.read] none st1 with
   | .error err => IO.println s!"cspace mint error: {reprStr err}"
   | .ok (_, st2) =>
-      match SeLe4n.Kernel.cspaceMint rootSlot siblingSlot [.read] none st2 with
+      match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot siblingSlot [.read] none st2 with
       | .error err => IO.println s!"sibling mint error: {reprStr err}"
       | .ok (_, st3) =>
           IO.println "created sibling cap with the same target"
@@ -378,14 +408,14 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
               match SeLe4n.Kernel.endpointAwaitReceive demoEndpoint 2 st5 with
                   | .error err => IO.println s!"endpoint await-receive error: {reprStr err}"
                   | .ok (_, st6) =>
-                      match SeLe4n.Kernel.endpointSend demoEndpoint 1 st6 with
+                      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st6 with
                       | .error err => IO.println s!"endpoint handshake send error: {reprStr err}"
                       | .ok (_, st7) =>
                           IO.println "handshake send matched waiting receiver"
-                          match SeLe4n.Kernel.endpointSend demoEndpoint 1 st7 with
+                          match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st7 with
                           | .error err => IO.println s!"endpoint send #1 error: {reprStr err}"
                           | .ok (_, st8) =>
-                              match SeLe4n.Kernel.endpointSend demoEndpoint 2 st8 with
+                              match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 2 st8 with
                               | .error err => IO.println s!"endpoint send #2 error: {reprStr err}"
                               | .ok (_, st9) =>
                                   IO.println "queued two senders on endpoint"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -148,3 +148,7 @@ A change is done when all are true:
 - [ ] Invariant/theorem updates are paired with implementation changes.
 - [ ] Required validation commands were run.
 - [ ] Documentation was synchronized.
+
+### Secure-by-default harness calls
+
+When writing executable traces or integration-style tests, prefer `endpointSendChecked`, `cspaceMintChecked`, and `serviceRestartChecked` by default. Use unchecked operations only for explicit low-level semantics experiments.

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -203,3 +203,5 @@ This direction should be preserved to prevent proof cycles and maintain module r
 3. bundle composition should remain additive,
 4. theorem naming should remain discoverable,
 5. docs and fixtures should evolve with semantics in the same change set.
+
+> Operational note: executable harnesses should call checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for focused semantics research.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -204,3 +204,9 @@ in [`docs/THREAT_MODEL.md`](../THREAT_MODEL.md).
 The hardware-boundary contract policy governing test-only fixture separation and
 architecture-assumption interfaces is documented in
 [`docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md`](../HARDWARE_BOUNDARY_CONTRACT_POLICY.md).
+
+## Security semantics defaults
+
+- `storeTcbIpcState` is fail-closed for missing threads (`objectNotFound`), preventing queue-only ghost thread transitions in IPC/notification paths.
+- Sentinel identifier `0` is reserved; checked conversion/validation is required at operational boundaries.
+- Information-flow checked wrappers are the recommended default surface for harness/integration entry points.


### PR DESCRIPTION
### Motivation

- Prevent silent "ghost" waiters/senders: `storeTcbIpcState` previously returned `.ok st` when a target TCB did not exist, allowing queue entries with no corresponding TCB state update and creating an integrity/DoS risk. 
- Make runtime harnesses safer by default: the project provides `*Checked` wrappers for enforcement; harnesses should use them to avoid accidental unchecked cross-domain flows.
- Reduce accidental sentinel-ID reuse by documenting and encouraging checked/validated object-ID usage at operational boundaries.

### Description

- `storeTcbIpcState` now fails closed when the target thread is missing, returning `.error .objectNotFound` instead of silently succeeding, closing the queue-poisoning path. (see `SeLe4n/Kernel/IPC/Operations.lean`)
- Updated IPC/capability/info-flow proof code paths and a few lemmas to reflect the new fail-closed semantics (removed/reworked impossible `subst`/no-op branches where `lookupTcb = none` can no longer co-exist with a successful `storeTcbIpcState`). (see `SeLe4n/Kernel/Capability/Invariant.lean`, `SeLe4n/Kernel/InformationFlow/Invariant.lean`)
- Switched the main executable trace harness to call policy-checked operations by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) and updated the harness fixtures by adding explicit TCB objects and lifecycle annotations for IDs used by the trace so the harness remains deterministic and coverage-preserving. (see `SeLe4n/Testing/MainTraceHarness.lean` and updated fixtures)
- Synchronized documentation and guidance: added a short “Security defaults” section and a harness guidance note to `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, and the GitBook mirror to make the new conventions discoverable.
- Updated test expectation artifacts and scenario catalog entries to match the adjusted harness traces (`tests/fixtures/main_trace_smoke.expected`, `tests/scenarios/scenario_catalog.json`).

### Testing

- Ran build-tier and smoke tests: `./scripts/test_tier1_build.sh` completed successfully (full build of the project passed). ✅
- Ran trace + negative checks: `./scripts/test_smoke.sh` (tiered smoke trace + negative-state checks) completed successfully after fixture updates, and the executable trace matched the updated expected fixture. ✅
- Minor proof adjustments compiled: affected invariant modules rebuilt cleanly after changes (IPC, Capability, InformationFlow invariants). ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe6e7bc1c832bbe90fae6dc3b5663)