### PR TITLE
Harden IPC TCB state updates and move harness traces to checked flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Additional resources:
 ./scripts/test_nightly.sh   # + Tier 4 (staged nightly; opt-in via NIGHTLY_ENABLE_EXPERIMENTAL=1)
 ```
 
+## Security hardening defaults
+
+- IPC/notification thread-state writes are now **strict**: `storeTcbIpcState` returns `objectNotFound` when the target TCB does not exist, rather than silently succeeding.
+- `lookupTcb` now rejects reserved sentinel thread IDs (`ThreadId = 0`) at the lookup boundary.
+- The executable trace harness now exercises information-flow policy-checked entrypoints (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default using `defaultLabelingContext`; unchecked operations remain available for proof/research slices.
+
 ## Active workstreams (WS-E)
 
 Quick index. Full contracts and dependencies are in the v0.11.6 planning backbone.

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1295,7 +1295,7 @@ private theorem cspaceSlotUnique_of_storeTcbIpcState
     cspaceSlotUnique st' := by
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
-  | none => simp [hLookup] at hStep; subst hStep; exact hUniq
+  | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -23,13 +23,16 @@ def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
     | _ => st
 
 def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=
-  match st.objects tid.toObjId with
-  | some (.tcb tcb) => some tcb
-  | _ => none
+  if tid.isReserved then
+    none
+  else
+    match st.objects tid.toObjId with
+    | some (.tcb tcb) => some tcb
+    | _ => none
 
 def storeTcbIpcState (st : SystemState) (tid : SeLe4n.ThreadId) (ipcState : ThreadIpcState) : Except KernelError SystemState :=
   match lookupTcb st tid with
-  | none => .ok st
+  | none => .error .objectNotFound
   | some tcb =>
       match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState }) st with
       | .error e => .error e
@@ -216,7 +219,6 @@ theorem storeTcbIpcState_preserves_objects_ne
   cases hTcb : lookupTcb st tid with
   | none =>
     simp [hTcb] at hStep
-    subst hStep; rfl
   | some tcb =>
     simp only [hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -244,8 +246,6 @@ theorem storeTcbIpcState_preserves_notification
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hNtfn]
     simp [hLookup] at hStep
-    subst hStep
-    exact hNtfn
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc notifId hEq hStep]
     exact hNtfn
 
@@ -277,7 +277,6 @@ theorem storeTcbIpcState_scheduler_eq
   cases hTcb : lookupTcb st tid with
   | none =>
     simp [hTcb] at hStep
-    subst hStep; rfl
   | some tcb =>
     simp only [hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -304,8 +303,6 @@ theorem storeTcbIpcState_preserves_endpoint
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hEp]
     simp [hLookup] at hStep
-    subst hStep
-    exact hEp
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc epId hEq hStep]
     exact hEp
 
@@ -325,8 +322,6 @@ theorem storeTcbIpcState_preserves_cnode
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hCn]
     simp [hLookup] at hStep
-    subst hStep
-    exact hCn
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc cnodeId hEq hStep]
     exact hCn
 
@@ -346,8 +341,6 @@ theorem storeTcbIpcState_preserves_vspaceRoot
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hVs]
     simp [hLookup] at hStep
-    subst hStep
-    exact hVs
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep]
     exact hVs
 
@@ -367,7 +360,7 @@ theorem storeTcbIpcState_cnode_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hCn
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -393,7 +386,7 @@ theorem storeTcbIpcState_endpoint_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hEp
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -419,7 +412,7 @@ theorem storeTcbIpcState_notification_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hNtfn
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -650,8 +643,7 @@ theorem storeTcbIpcState_ipcState_eq
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep
-    unfold lookupTcb at hLookup; simp [hTcb] at hLookup
+    simp [hLookup] at hStep
   | some tcb' =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb' with ipcState := ipc }) st with
@@ -690,7 +682,14 @@ theorem storeTcbIpcState_tcb_exists_at_target
     ∃ tcb', st'.objects tid.toObjId = some (.tcb tcb') := by
   rcases hTcb with ⟨tcb, hObj⟩
   unfold storeTcbIpcState at hStep
-  have hLookup : lookupTcb st tid = some tcb := by unfold lookupTcb; simp [hObj]
+  have hNotReserved : tid.isReserved = false := by
+    by_cases hRes : tid.isReserved = true
+    · unfold lookupTcb at hStep
+      simp [hRes] at hStep
+    · simp [hRes]
+  have hLookup : lookupTcb st tid = some tcb := by
+    unfold lookupTcb
+    simp [hNotReserved, hObj]
   simp only [hLookup] at hStep
   cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
   | error e => simp [hStore] at hStep

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -196,7 +196,7 @@ private theorem storeTcbIpcState_preserves_projection
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep; rfl
+    simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -24,7 +24,7 @@ def svcRestart : ServiceId := 104
 def svcRestartBroken : ServiceId := 105
 
 def bootstrapInvariantObjectIds : List SeLe4n.ObjId :=
-  [1, 10, 11, 12, 20, demoEndpoint, demoNotification, 200]
+  [1, 2, 10, 11, 12, 20, demoEndpoint, demoNotification, 200]
 
 def bootstrapServiceIds : List ServiceId :=
   [svcDb, svcApi, svcDenied, svcBroken, svcRestart, svcRestartBroken]
@@ -38,6 +38,15 @@ def bootstrapState : SystemState :=
       cspaceRoot := 10
       vspaceRoot := 20
       ipcBuffer := 4096
+      ipcState := .ready
+    })
+    |>.withObject 2 (.tcb {
+      tid := 2
+      priority := 80
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 6144
       ipcState := .ready
     })
     |>.withObject 10 (.cnode {
@@ -106,6 +115,7 @@ def bootstrapState : SystemState :=
     }
     |>.withRunnable [1, 12]
     |>.withLifecycleObjectType 1 .tcb
+    |>.withLifecycleObjectType 2 .tcb
     |>.withLifecycleObjectType 10 .cnode
     |>.withLifecycleObjectType 12 .tcb
     |>.withLifecycleObjectType 11 .cnode
@@ -174,7 +184,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service start dependency branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service start success with unsatisfied dependencies"
-  match SeLe4n.Kernel.serviceRestart svcRestart allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked SeLe4n.Kernel.defaultLabelingContext svcRestart svcRestart allowAll allowAll st1 with
   | .error err => IO.println s!"service restart error: {reprStr err}"
   | .ok (_, stRestarted) =>
       IO.println s!"service restart status: {reprStr <| (SeLe4n.Model.lookupService stRestarted svcRestart).map ServiceGraphEntry.status}"
@@ -186,11 +196,11 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service stop illegal-state branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service stop success from stopped state"
-  match SeLe4n.Kernel.serviceRestart svcRestart denyAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked SeLe4n.Kernel.defaultLabelingContext svcRestart svcRestart denyAll allowAll st1 with
   | .error err => IO.println s!"service restart stop-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success when stop policy denies"
-  match SeLe4n.Kernel.serviceRestart svcRestartBroken allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked SeLe4n.Kernel.defaultLabelingContext svcRestartBroken svcRestartBroken allowAll allowAll st1 with
   | .error err => IO.println s!"service restart start-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success with broken dependencies"
@@ -236,12 +246,30 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
       objects := fun oid =>
         if oid = demoEndpoint then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
         else if oid = 31 then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
+        else if oid = 4 then some (.tcb {
+          tid := 4
+          priority := 40
+          domain := 0
+          cspaceRoot := 10
+          vspaceRoot := 20
+          ipcBuffer := 12288
+          ipcState := .ready
+        })
+        else if oid = 5 then some (.tcb {
+          tid := 5
+          priority := 41
+          domain := 0
+          cspaceRoot := 10
+          vspaceRoot := 20
+          ipcBuffer := 16384
+          ipcState := .ready
+        })
         else st1.objects oid
     }
-  match SeLe4n.Kernel.endpointSend demoEndpoint 4 stMultiEndpoint with
+  match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 4 stMultiEndpoint with
   | .error err => IO.println s!"multi-endpoint send A error: {reprStr err}"
   | .ok (_, stEp1) =>
-      match SeLe4n.Kernel.endpointSend 31 5 stEp1 with
+      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext 31 5 stEp1 with
       | .error err => IO.println s!"multi-endpoint send B error: {reprStr err}"
       | .ok (_, stEp2) =>
           match SeLe4n.Kernel.endpointReceive demoEndpoint stEp2 with
@@ -343,10 +371,10 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"lifecycle retype error: {reprStr err}"
   | .ok (_, stLifecycle) =>
       IO.println s!"lifecycle retype success object kind: {reprStr <| (stLifecycle.objects 12).map KernelObject.objectType}"
-  match SeLe4n.Kernel.cspaceMint rootSlot mintedSlot [.read] none st1 with
+  match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot mintedSlot [.read] none st1 with
   | .error err => IO.println s!"cspace mint error: {reprStr err}"
   | .ok (_, st2) =>
-      match SeLe4n.Kernel.cspaceMint rootSlot siblingSlot [.read] none st2 with
+      match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot siblingSlot [.read] none st2 with
       | .error err => IO.println s!"sibling mint error: {reprStr err}"
       | .ok (_, st3) =>
           IO.println "created sibling cap with the same target"
@@ -378,14 +406,14 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
               match SeLe4n.Kernel.endpointAwaitReceive demoEndpoint 2 st5 with
                   | .error err => IO.println s!"endpoint await-receive error: {reprStr err}"
                   | .ok (_, st6) =>
-                      match SeLe4n.Kernel.endpointSend demoEndpoint 1 st6 with
+                      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st6 with
                       | .error err => IO.println s!"endpoint handshake send error: {reprStr err}"
                       | .ok (_, st7) =>
                           IO.println "handshake send matched waiting receiver"
-                          match SeLe4n.Kernel.endpointSend demoEndpoint 1 st7 with
+                          match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st7 with
                           | .error err => IO.println s!"endpoint send #1 error: {reprStr err}"
                           | .ok (_, st8) =>
-                              match SeLe4n.Kernel.endpointSend demoEndpoint 2 st8 with
+                              match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 2 st8 with
                               | .error err => IO.println s!"endpoint send #2 error: {reprStr err}"
                               | .ok (_, st9) =>
                                   IO.println "queued two senders on endpoint"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,6 +57,12 @@ Use the planning phases from the workstream backbone:
 - **WS-D1..WS-D4:** completed. WS-D5/D6 absorbed into WS-E. See [`docs/audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.11.0_WORKSTREAM_PLAN.md).
 - **WS-C1..WS-C8:** completed. See [`docs/dev_history/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md`](dev_history/audits/AUDIT_v0.9.32_WORKSTREAM_PLAN.md).
 
+## 3.5 Security defaults and explicit unsafe surfaces
+
+- `storeTcbIpcState` is strict: missing target TCBs now return `objectNotFound`.
+- `lookupTcb` rejects reserved sentinel IDs (`ThreadId = 0`) at the boundary.
+- Harness/integration traces should prefer `endpointSendChecked`, `cspaceMintChecked`, and `serviceRestartChecked` (typically with an explicit labeling context). Unchecked primitives remain for explicit boundary modeling.
+
 ### 3.4 PR-to-workstream discipline
 
 Every milestone-moving PR should include:

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -83,6 +83,12 @@ on the semantic and proof foundations of the previous one.
 
 ---
 
+## 3.5 Security semantics clarifications
+
+1. IPC/notification TCB-state stores are strict: `storeTcbIpcState` returns `objectNotFound` when the target TCB is absent.
+2. Reserved sentinel thread IDs (`ThreadId = 0`) are rejected by `lookupTcb`.
+3. Information-flow checked wrappers are the default executable integration surface; unchecked operations remain available as explicit low-level semantics.
+
 ## 4. Active Workstream Portfolio (WS-E)
 
 The WS-E portfolio addresses 32 findings from the v0.11.6 codebase audit


### PR DESCRIPTION
### Motivation

- Prevent ghost/poisoned endpoint/notification queues by eliminating the silent success path when writing TCB IPC state.  This closes a realistic integrity/DoS gap where queue entries could be created without corresponding TCB state updates.  
- Make sentinel-ID handling consistent by rejecting reserved ThreadId 0 at the lookup boundary to avoid accidental sentinel reuse.  
- Reduce risk in executable harnesses by exercising the policy-checked information-flow wrappers as the default integration surface so traces reflect enforced flows rather than unchecked primitives.

### Description

- `lookupTcb` now rejects the sentinel `ThreadId` (value 0) and returns `none` for reserved IDs, preventing silent sentinel reuse at object-store boundaries.  (See `SeLe4n/Kernel/IPC/Operations.lean`.)
- `storeTcbIpcState` was hardened to return `.error .objectNotFound` when the target TCB does not exist instead of returning `.ok st`, making TCB writes strict and eliminating the no-op success branch.  (See `SeLe4n/Kernel/IPC/Operations.lean`.)
- Updated dependent lemmas and invariants to follow the stricter failure semantics (removed obsolete proof branches that assumed `storeTcbIpcState` could silently succeed on missing TCBs) in IPC, capability, and information-flow invariant surfaces.  (Files touched include `SeLe4n/Kernel/Capability/Invariant.lean` and `SeLe4n/Kernel/InformationFlow/Invariant.lean`.)
- Switched the executable trace harness to use policy-checked entrypoints by default: `endpointSendChecked`, `cspaceMintChecked`, and `serviceRestartChecked` with `defaultLabelingContext`; left unchecked primitives available for low-level modeling.  (See `SeLe4n/Testing/MainTraceHarness.lean`.)
- Restored trace stability by adding explicit TCB fixtures used by the harness (added TCB entries for `tid = 2` and ad-hoc sender TCBs used in scenarios `4`/`5`) and lifecycle metadata so existing trace anchors remain valid.  (See `SeLe4n/Testing/MainTraceHarness.lean`.)
- Documented the new default security posture and guidance in `README.md`, `docs/DEVELOPMENT.md`, and `docs/spec/SELE4N_SPEC.md`.

### Testing

- Ran `./scripts/test_smoke.sh` (tiered hygiene + build + smoke traces); the suite passed after the changes.  
- Ran `./scripts/test_full.sh` (full build + invariant surface + trace anchors); the build and trace validation completed successfully with harness modifications, and information-flow tests passed.  
- The trace harness expectations were preserved by adding the required TCB fixtures rather than altering expectation anchors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe8206124832b850d8d809549edd6)