### PR TITLE
Scheduler: add domain-scheduling invariant preservation proofs

### DIFF
--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -658,4 +658,41 @@ theorem chooseThreadInDomain_preserves_state
           rcases (by simpa [hPick] using hStep : some tid = next ∧ st = st') with ⟨_, hSt⟩
           simpa using hSt.symm
 
+/-- M-05/WS-E6: `chooseThreadInDomain` preserves the scheduler invariant bundle
+because it is a pure read operation. -/
+theorem chooseThreadInDomain_preserves_schedulerInvariantBundle
+    (st st' : SystemState)
+    (next : Option SeLe4n.ThreadId)
+    (hInv : schedulerInvariantBundle st)
+    (hStep : chooseThreadInDomain st = .ok (next, st')) :
+    schedulerInvariantBundle st' := by
+  rcases chooseThreadInDomain_preserves_state st st' next hStep with rfl
+  simpa using hInv
+
+/-- M-05/WS-E6: `scheduleDomain` preserves the scheduler invariant bundle.
+Domain-time accounting only updates domain-local scheduler fields, and the expiry
+path composes `switchDomain` and `schedule`, each of which preserves the bundle. -/
+theorem scheduleDomain_preserves_schedulerInvariantBundle
+    (st st' : SystemState)
+    (hInv : schedulerInvariantBundle st)
+    (hStep : scheduleDomain st = .ok ((), st')) :
+    schedulerInvariantBundle st' := by
+  unfold scheduleDomain at hStep
+  by_cases hExpire : st.scheduler.domainTimeRemaining ≤ 1
+  · simp [hExpire] at hStep
+    cases hSwitch : switchDomain st with
+    | error e => simp [hSwitch] at hStep
+    | ok pair =>
+        cases pair with
+        | mk _ stSwitched =>
+            have hSwitchInv : schedulerInvariantBundle stSwitched :=
+              switchDomain_preserves_schedulerInvariantBundle st stSwitched hInv hSwitch
+            have hSched : schedule stSwitched = .ok ((), st') := by
+              simpa [hSwitch] using hStep
+            exact schedule_preserves_schedulerInvariantBundle stSwitched st' hSwitchInv hSched
+  · have hNotExpire : ¬st.scheduler.domainTimeRemaining ≤ 1 := hExpire
+    simp [hNotExpire] at hStep
+    cases hStep
+    exact hInv
+
 end SeLe4n.Kernel

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -29,6 +29,8 @@ Preservation shape:
 - `chooseThread_preserves_*`
 - `schedule_preserves_*`
 - `handleYield_preserves_*`
+- `chooseThreadInDomain_preserves_schedulerInvariantBundle`
+- `scheduleDomain_preserves_schedulerInvariantBundle`
 
 ## 3. Capability invariants (M2)
 

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -61,7 +61,7 @@ See the workstream plan for WS-E1..WS-E6 details and phase sequencing. WS-E1 thr
 
 - **M-03:** Three-level EDF scheduling (`isBetterCandidate`: priority > deadline > FIFO) with `isBetterCandidate_irrefl`/`_asymm` algebraic theorems. `Deadline` typed identifier. `TCB.deadline` field.
 - **M-04:** Time-slice preemption via `timerTick` operation (decrement/reset+reschedule). `TCB.timeSlice` field. `defaultTimeSlice` constant. `timeSlicePositive` invariant.
-- **M-05:** Domain scheduling with `DomainScheduleEntry`, `filterByDomain`, `chooseThreadInDomain`, `switchDomain`, `scheduleDomain`. `currentThreadInActiveDomain` invariant. Preservation theorems.
+- **M-05:** Domain scheduling with `DomainScheduleEntry`, `filterByDomain`, `chooseThreadInDomain`, `switchDomain`, `scheduleDomain`. `currentThreadInActiveDomain` invariant. Preservation theorems include `switchDomain_preserves_schedulerInvariantBundle`, `chooseThreadInDomain_preserves_schedulerInvariantBundle`, and `scheduleDomain_preserves_schedulerInvariantBundle`.
 - **M-08:** Architecture assumption consumption bridges connecting structural axioms to adapter preservation proofs.
 - **F-17:** O(n) design decision ADR with rationale, scope note, and migration path.
 - **L-01:** Unified `API.lean` with `apiInvariantBundle` alias, base-case theorem, and 30+ entry-point stability table.


### PR DESCRIPTION
### Motivation

- Strengthen the scheduler proof surface for M-05 (domain scheduling) by proving that domain-scoped selection and domain-time transitions preserve the scheduler invariant bundle.  
- Make the preservation guarantees explicit so higher-level invariant composition (IPC/capability bundles) can reuse them reliably.  
- Keep documentation and workstream summaries synchronized with the implemented theorem coverage.

### Description

- Added `chooseThreadInDomain_preserves_schedulerInvariantBundle` to `SeLe4n/Kernel/Scheduler/Operations.lean` to show that `chooseThreadInDomain` is a pure read and preserves `schedulerInvariantBundle`.  
- Added `scheduleDomain_preserves_schedulerInvariantBundle` to `SeLe4n/Kernel/Scheduler/Operations.lean` to prove that `scheduleDomain` preserves the scheduler bundle by composing `switchDomain` and `schedule` along the expiry and non-expiry paths.  
- Updated documentation to list the new preservation theorems in the proof map (`docs/gitbook/12-proof-and-invariant-map.md`) and to name them in the WS-E6/M-05 summary (`docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`).

### Testing

- Ran `./scripts/test_fast.sh` which includes hygiene and build checks, and it completed successfully.  
- Ran `./scripts/test_smoke.sh` (trace + negative-state checks) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fef72f540832b92dbf4e0d1b65b31)