### PR TITLE
docs: realign WS-E roadmap status to active P3/WS-E4 phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **Active findings baseline:** `docs/audits/AUDIT_CODEBASE_v0.11.6.md`
 - **Active execution baseline:** `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`
 - **Current package version:** `0.12.0` (`lakefile.toml`)
-- **Current active portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)
+- **Current active portfolio:** WS-E (v0.11.6 codebase audit remediation), currently executing **Phase P3 / WS-E4**
 - **Prior completed portfolio:** WS-D1..WS-D4 (completed); WS-D5/D6 absorbed into WS-E
 
 ## Specifications
@@ -72,9 +72,9 @@ Quick index. Full contracts and dependencies are in the v0.11.6 planning backbon
 - **WS-E1:** Test infrastructure and CI hardening -- **completed** (Medium; M-10, M-11, F-14, L-07, L-08)
 - **WS-E2:** Proof quality and invariant strengthening -- **completed** (High; C-01, H-01, H-03)
 - **WS-E3:** Kernel semantic hardening -- **completed** (High; H-06, H-07, H-08, H-09, M-09, L-06)
-- **WS-E4:** Capability and IPC model completion -- **completed** (Critical; C-02, C-03, C-04, H-02, M-01, M-02, M-12)
-- **WS-E5:** Information-flow maturity -- **completed** (High; H-04, H-05, M-07)
-- **WS-E6:** Model completeness and documentation -- **completed** (Low; M-03, M-04, M-05, M-08, F-17, L-01–L-05)
+- **WS-E4:** Capability and IPC model completion -- **in progress (current phase)** (Critical; C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E5:** Information-flow maturity -- **planned (next)** (High; H-04, H-05, M-07)
+- **WS-E6:** Model completeness and documentation -- **planned** (Low; M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 
 Primary references:
 - [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide is the day-to-day operating manual for contributors.
 
 It is aligned to the **current active slice**:
 
-- active: **v0.11.6 Codebase Audit Remediation WS-E portfolio (WS-E1 through WS-E6 completed)**,
+- active: **v0.11.6 Codebase Audit Remediation WS-E portfolio (current phase: P3 / WS-E4)**,
 - completed predecessor: **WS-D portfolio (WS-D1..WS-D4 completed; WS-D5/D6 absorbed into WS-E)**,
 - completed predecessor before that: **WS-C portfolio (WS-C1..WS-C8)**.
 
@@ -35,9 +35,9 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-E1** — Test infrastructure and CI hardening (**completed** — M-10, M-11, F-14, L-07, L-08)
 - **WS-E2** — Proof quality and invariant strengthening (**completed** — C-01, H-01, H-03)
 - **WS-E3** — Kernel semantic hardening (**completed** — H-06, H-07, H-08, H-09, M-09, L-06)
-- **WS-E4** — Capability and IPC model completion (**completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
-- **WS-E5** — Information-flow maturity (**completed** — H-04, H-05, M-07)
-- **WS-E6** — Model completeness and documentation (**completed** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
+- **WS-E4** — Capability and IPC model completion (**in progress — current phase**; C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E5** — Information-flow maturity (**planned next** — H-04, H-05, M-07)
+- **WS-E6** — Model completeness and documentation (**planned** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 
 Canonical detail: [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md).
 
@@ -48,9 +48,9 @@ Use the planning phases from the workstream backbone:
 - **Phase P0:** Baseline — close quick fixes, publish WS-E backbone (**completed**)
 - **Phase P1:** WS-E1 (test/CI — **completed**) + WS-E2 (proof quality — **completed**) — **completed**
 - **Phase P2:** WS-E3 (kernel hardening) — **completed**
-- **Phase P3:** WS-E4 (capability/IPC completion) — **completed**
-- **Phase P4:** WS-E5 (information-flow maturity) — **completed**
-- **Phase P5:** WS-E6 (model completeness/docs) — **completed**
+- **Phase P3:** WS-E4 (capability/IPC completion) — **in progress (current)**
+- **Phase P4:** WS-E5 (information-flow maturity) — **planned**
+- **Phase P5:** WS-E6 (model completeness/docs) — **planned**
 
 ### 3.3 Prior completed portfolios (historical)
 

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -41,7 +41,7 @@ Completed audit portfolios (continued):
 
 Current active portfolio:
 
-- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1 through WS-E6 completed.
+- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1..WS-E3 completed; WS-E4 in progress (current phase); WS-E5/WS-E6 planned.
 
 ## 4. Architecture mental model
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -16,7 +16,7 @@ Current milestone state:
 - WS-B portfolio (v0.9.0): all completed
 - WS-C portfolio (v0.9.32): all completed
 - WS-D portfolio (v0.11.0): WS-D1..WS-D4 completed; WS-D5/WS-D6 absorbed into WS-E
-- **Active:** WS-E portfolio (v0.11.6 audit remediation) — WS-E1 through WS-E6 completed
+- **Active:** WS-E portfolio (v0.11.6 audit remediation) — WS-E1..WS-E3 completed; WS-E4 in progress (Phase P3); WS-E5/WS-E6 planned
 
 ## 2) Stable contracts contributors must preserve
 
@@ -49,8 +49,8 @@ Security baseline reference:
 - **Phase P0:** Baseline transition — publish v0.11.6 planning backbone, demote WS-D to historical — **completed**
 - **Phase P1:** WS-E1 + WS-E2 (test/CI hardening + proof quality) — **completed**
 - **Phase P2:** WS-E3 (kernel semantic hardening) — **completed**
-- **Phase P3:** WS-E4 (capability/IPC completion) — **completed**
-- **Phase P4:** WS-E5 (information-flow maturity) — **completed**
+- **Phase P3:** WS-E4 (capability/IPC completion) — **in progress (current)**
+- **Phase P4:** WS-E5 (information-flow maturity) — **planned**
 
 See [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md) for full WS-E phase sequencing.
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -6,7 +6,7 @@ This GitBook is the long-form guide for architecture, workflow, and milestone co
 
 ## Current project state
 - **Active findings baseline:** AUDIT v0.11.6 (codebase audit).
-- **Active execution baseline:** WS-E portfolio (v0.11.6 workstream plan). WS-E1 through WS-E6 completed.
+- **Active execution baseline:** WS-E portfolio (v0.11.6 workstream plan). WS-E1..WS-E3 completed; WS-E4 in progress (Phase P3); WS-E5/WS-E6 planned.
 - **Historical records:** Milestone closeouts, prior audits, and completed workstream plans are in [`docs/dev_history/`](../dev_history/README.md).
 
 Specification documents:

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -2,7 +2,7 @@
   "description": "This GitBook is the long-form guide for architecture, workflow, and milestone context.",
   "current_state_bullets": [
     "**Active findings baseline:** AUDIT v0.11.6 (codebase audit).",
-    "**Active execution baseline:** WS-E portfolio (v0.11.6 workstream plan). WS-E1 through WS-E6 completed.",
+    "**Active execution baseline:** WS-E portfolio (v0.11.6 workstream plan). WS-E1..WS-E3 completed; WS-E4 in progress (Phase P3); WS-E5/WS-E6 planned.",
     "**Historical records:** Milestone closeouts, prior audits, and completed workstream plans are in [`docs/dev_history/`](../dev_history/README.md)."
   ],
   "recommended_reading": [

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -43,7 +43,7 @@ claims, and planning artifacts.
 - **Current package version:** `0.12.0` (`lakefile.toml`)
 - **Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.11.6.md`](../audits/AUDIT_CODEBASE_v0.11.6.md)
 - **Active execution baseline:** [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md)
-- **Current active portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)
+- **Current active portfolio:** WS-E (v0.11.6 codebase audit remediation), currently executing **Phase P3 / WS-E4**
 - **Prior completed portfolio:** WS-D1..WS-D4 (completed); WS-D5/D6 absorbed into WS-E
 
 ---
@@ -79,7 +79,7 @@ on the semantic and proof foundations of the previous one.
 
 ### 3.4 Active Audit Portfolio (WS-E)
 
-- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1 through WS-E6 completed.
+- **WS-E portfolio** (v0.11.6 workstream plan): WS-E1..WS-E3 completed; WS-E4 in progress; WS-E5/WS-E6 planned.
 
 ---
 
@@ -100,15 +100,15 @@ WS-D portfolio (WS-D5/D6).
 
 ### 4.3 Critical — Model Completion
 
-- **WS-E4:** Capability and IPC model completion (critical; **completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4:** Capability and IPC model completion (critical; **in progress — current phase** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
 
 ### 4.4 High — Security Assurance
 
-- **WS-E5:** Information-flow maturity (high; **completed** — H-04, H-05, M-07)
+- **WS-E5:** Information-flow maturity (high; **planned next** — H-04, H-05, M-07)
 
 ### 4.5 Low — Model Completeness and Documentation
 
-- **WS-E6:** Model completeness and documentation (low; **completed** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
+- **WS-E6:** Model completeness and documentation (low; **planned** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 
 Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md).
@@ -129,9 +129,9 @@ Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 - **Phase P0:** Baseline — close quick fixes, publish WS-E backbone, update docs (**completed**)
 - **Phase P1:** WS-E1 (test/CI — **completed**) + WS-E2 (proof quality — **completed**) — **completed**
 - **Phase P2:** WS-E3 (kernel hardening) — **completed**
-- **Phase P3:** WS-E4 (capability/IPC completion) — **completed**
-- **Phase P4:** WS-E5 (information-flow maturity) — **completed**
-- **Phase P5:** WS-E6 (model completeness/docs) — **completed**
+- **Phase P3:** WS-E4 (capability/IPC completion) — **in progress (current)**
+- **Phase P4:** WS-E5 (information-flow maturity) — **planned**
+- **Phase P5:** WS-E6 (model completeness/docs) — **planned**
 
 ---
 


### PR DESCRIPTION
### Motivation
- The repository documentation incorrectly reported WS-E as fully completed; the intent of this change is to realign the canonical docs to the actual active execution phase (Phase P3 / WS-E4) so contributors and CI reflect the current project state. 
- The change ensures downstream GitBook navigation and generated handbook text remain consistent with the normative spec and development guide. 
- Keeping roadmap text accurate reduces contributor confusion and preserves the contract that docs and validation evidence remain synchronized.

### Description
- Updated the workstream status text to mark `WS-E4` as **in progress (Phase P3)** and to reclassify `WS-E5`/`WS-E6` as **planned** across `README.md`, `docs/DEVELOPMENT.md`, and `docs/spec/SELE4N_SPEC.md`. 
- Synchronized the GitBook-facing mirrors by updating `docs/gitbook/01-project-overview.md` and `docs/gitbook/05-specification-and-roadmap.md`. 
- Updated the GitBook navigation source `docs/gitbook/navigation_manifest.json` and regenerated the GitBook README via the docs-sync task so generated handbook text matches canonical docs. 
- All edits are textual/documentation-only and do not change Lean source or proof surfaces.

### Testing
- Ran documentation generation with `./scripts/test_docs_sync.sh` and the generated GitBook navigation and summary artifacts were produced successfully (link check passed). 
- Ran the project smoke validation with `./scripts/test_smoke.sh`, which executes tiered checks (hygiene, build, trace, negative-state and information-flow suites), and the script completed with all automated checks passing. 
- Attempted to fetch remote PR metadata for `#228-#232` via the GitHub API as an automated check and received `Not Found`/404 responses so direct PR diffs could not be analyzed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fed20da4c832bb4d73920aa4feb58)