### PR TITLE
Harden IPC TCB-state updates and default harnesses to checked IFC operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Additional resources:
 - Contribution guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Change history: [`CHANGELOG.md`](CHANGELOG.md)
 
+## Security hardening defaults
+
+- IPC state writes are strict: `storeTcbIpcState` now returns `objectNotFound` when the target TCB is missing, instead of silently succeeding.
+- ID-0 remains a reserved sentinel. Use checked conversion helpers (for example `ThreadId.toObjIdChecked`) at boundaries that ingest external IDs.
+- Information-flow checked entry points (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) are the recommended default for integration and trace harnesses.
+
 ## Validation commands
 
 ```bash

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1295,7 +1295,7 @@ private theorem cspaceSlotUnique_of_storeTcbIpcState
     cspaceSlotUnique st' := by
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
-  | none => simp [hLookup] at hStep; subst hStep; exact hUniq
+  | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -29,7 +29,7 @@ def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=
 
 def storeTcbIpcState (st : SystemState) (tid : SeLe4n.ThreadId) (ipcState : ThreadIpcState) : Except KernelError SystemState :=
   match lookupTcb st tid with
-  | none => .ok st
+  | none => .error .objectNotFound
   | some tcb =>
       match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState }) st with
       | .error e => .error e
@@ -216,7 +216,6 @@ theorem storeTcbIpcState_preserves_objects_ne
   cases hTcb : lookupTcb st tid with
   | none =>
     simp [hTcb] at hStep
-    subst hStep; rfl
   | some tcb =>
     simp only [hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -244,8 +243,6 @@ theorem storeTcbIpcState_preserves_notification
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hNtfn]
     simp [hLookup] at hStep
-    subst hStep
-    exact hNtfn
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc notifId hEq hStep]
     exact hNtfn
 
@@ -277,7 +274,6 @@ theorem storeTcbIpcState_scheduler_eq
   cases hTcb : lookupTcb st tid with
   | none =>
     simp [hTcb] at hStep
-    subst hStep; rfl
   | some tcb =>
     simp only [hTcb] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -304,8 +300,6 @@ theorem storeTcbIpcState_preserves_endpoint
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hEp]
     simp [hLookup] at hStep
-    subst hStep
-    exact hEp
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc epId hEq hStep]
     exact hEp
 
@@ -325,8 +319,6 @@ theorem storeTcbIpcState_preserves_cnode
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hCn]
     simp [hLookup] at hStep
-    subst hStep
-    exact hCn
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc cnodeId hEq hStep]
     exact hCn
 
@@ -346,8 +338,6 @@ theorem storeTcbIpcState_preserves_vspaceRoot
     have hLookup : lookupTcb st tid = none := by
       unfold lookupTcb; simp [hVs]
     simp [hLookup] at hStep
-    subst hStep
-    exact hVs
   · rw [storeTcbIpcState_preserves_objects_ne st st' tid ipc oid hEq hStep]
     exact hVs
 
@@ -367,7 +357,7 @@ theorem storeTcbIpcState_cnode_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hCn
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -393,7 +383,7 @@ theorem storeTcbIpcState_endpoint_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hEp
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -419,7 +409,7 @@ theorem storeTcbIpcState_notification_backward
     unfold storeTcbIpcState at hStep
     cases hLookup : lookupTcb st tid with
     | none =>
-      simp [hLookup] at hStep; subst hStep; exact hNtfn
+      simp [hLookup] at hStep
     | some tcb =>
       simp only [hLookup] at hStep
       cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
@@ -650,8 +640,7 @@ theorem storeTcbIpcState_ipcState_eq
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep
-    unfold lookupTcb at hLookup; simp [hTcb] at hLookup
+    simp [hLookup] at hStep
   | some tcb' =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb' with ipcState := ipc }) st with
@@ -688,16 +677,18 @@ theorem storeTcbIpcState_tcb_exists_at_target
     (hStep : storeTcbIpcState st tid ipc = .ok st')
     (hTcb : ∃ tcb, st.objects tid.toObjId = some (.tcb tcb)) :
     ∃ tcb', st'.objects tid.toObjId = some (.tcb tcb') := by
-  rcases hTcb with ⟨tcb, hObj⟩
   unfold storeTcbIpcState at hStep
-  have hLookup : lookupTcb st tid = some tcb := by unfold lookupTcb; simp [hObj]
-  simp only [hLookup] at hStep
-  cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
-  | error e => simp [hStore] at hStep
-  | ok pair =>
-    simp only [hStore] at hStep
-    have := Except.ok.inj hStep; subst this
-    exact ⟨{ tcb with ipcState := ipc }, storeObject_objects_eq st pair.2 tid.toObjId _ hStore⟩
+  cases hLookup : lookupTcb st tid with
+  | none =>
+    simp [hLookup] at hStep
+  | some tcb =>
+    simp only [hLookup] at hStep
+    cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with
+    | error e => simp [hStore] at hStep
+    | ok pair =>
+      simp only [hStore] at hStep
+      have := Except.ok.inj hStep; subst this
+      exact ⟨{ tcb with ipcState := ipc }, storeObject_objects_eq st pair.2 tid.toObjId _ hStore⟩
 
 -- ============================================================================
 -- WS-E4/M-01: Dual-queue endpoint operations (send/receive queue separation)

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -196,7 +196,7 @@ private theorem storeTcbIpcState_preserves_projection
   unfold storeTcbIpcState at hStep
   cases hLookup : lookupTcb st tid with
   | none =>
-    simp [hLookup] at hStep; subst hStep; rfl
+    simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
     cases hStore : storeObject tid.toObjId (.tcb { tcb with ipcState := ipc }) st with

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -64,6 +64,33 @@ def bootstrapState : SystemState :=
       ipcBuffer := 8192
       ipcState := .ready
     })
+    |>.withObject 2 (.tcb {
+      tid := 2
+      priority := 50
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 4352
+      ipcState := .ready
+    })
+    |>.withObject 4 (.tcb {
+      tid := 4
+      priority := 40
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 4608
+      ipcState := .ready
+    })
+    |>.withObject 5 (.tcb {
+      tid := 5
+      priority := 30
+      domain := 0
+      cspaceRoot := 10
+      vspaceRoot := 20
+      ipcBuffer := 4864
+      ipcState := .ready
+    })
     |>.withObject 11 (.cnode CNode.empty)
     |>.withObject 20 (.vspaceRoot { asid := 1, mappings := [] })
     |>.withObject demoEndpoint (.endpoint { state := .idle, queue := [], waitingReceiver := none })
@@ -104,10 +131,13 @@ def bootstrapState : SystemState :=
       dependencies := [999]
       isolatedFrom := []
     }
-    |>.withRunnable [1, 12]
+    |>.withRunnable [1, 2, 4, 5, 12]
     |>.withLifecycleObjectType 1 .tcb
     |>.withLifecycleObjectType 10 .cnode
     |>.withLifecycleObjectType 12 .tcb
+    |>.withLifecycleObjectType 2 .tcb
+    |>.withLifecycleObjectType 4 .tcb
+    |>.withLifecycleObjectType 5 .tcb
     |>.withLifecycleObjectType 11 .cnode
     |>.withLifecycleObjectType 20 .vspaceRoot
     |>.withLifecycleObjectType demoEndpoint .endpoint
@@ -160,6 +190,7 @@ private def runCapabilityAndArchitectureTrace (st1 : SystemState) : IO Unit := d
       IO.println "unexpected adapter register write success under denied contract"
 
 private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
+  let allowFlowCtx : SeLe4n.Kernel.LabelingContext := SeLe4n.Kernel.defaultLabelingContext
   let allowAll : SeLe4n.Kernel.ServicePolicy := fun _ => true
   let denyAll : SeLe4n.Kernel.ServicePolicy := fun _ => false
   match SeLe4n.Kernel.serviceStart svcApi allowAll st1 with
@@ -174,7 +205,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service start dependency branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service start success with unsatisfied dependencies"
-  match SeLe4n.Kernel.serviceRestart svcRestart allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked allowFlowCtx svcApi svcRestart allowAll allowAll st1 with
   | .error err => IO.println s!"service restart error: {reprStr err}"
   | .ok (_, stRestarted) =>
       IO.println s!"service restart status: {reprStr <| (SeLe4n.Model.lookupService stRestarted svcRestart).map ServiceGraphEntry.status}"
@@ -186,11 +217,11 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"service stop illegal-state branch: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service stop success from stopped state"
-  match SeLe4n.Kernel.serviceRestart svcRestart denyAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked allowFlowCtx svcApi svcRestart denyAll allowAll st1 with
   | .error err => IO.println s!"service restart stop-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success when stop policy denies"
-  match SeLe4n.Kernel.serviceRestart svcRestartBroken allowAll allowAll st1 with
+  match SeLe4n.Kernel.serviceRestartChecked allowFlowCtx svcApi svcRestartBroken allowAll allowAll st1 with
   | .error err => IO.println s!"service restart start-stage failure: {reprStr err}"
   | .ok _ =>
       IO.println "unexpected service restart success with broken dependencies"
@@ -238,10 +269,10 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
         else if oid = 31 then some (.endpoint { state := .idle, queue := [], waitingReceiver := none })
         else st1.objects oid
     }
-  match SeLe4n.Kernel.endpointSend demoEndpoint 4 stMultiEndpoint with
+  match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 4 stMultiEndpoint with
   | .error err => IO.println s!"multi-endpoint send A error: {reprStr err}"
   | .ok (_, stEp1) =>
-      match SeLe4n.Kernel.endpointSend 31 5 stEp1 with
+      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext 31 5 stEp1 with
       | .error err => IO.println s!"multi-endpoint send B error: {reprStr err}"
       | .ok (_, stEp2) =>
           match SeLe4n.Kernel.endpointReceive demoEndpoint stEp2 with
@@ -343,10 +374,10 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"lifecycle retype error: {reprStr err}"
   | .ok (_, stLifecycle) =>
       IO.println s!"lifecycle retype success object kind: {reprStr <| (stLifecycle.objects 12).map KernelObject.objectType}"
-  match SeLe4n.Kernel.cspaceMint rootSlot mintedSlot [.read] none st1 with
+  match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot mintedSlot [.read] none st1 with
   | .error err => IO.println s!"cspace mint error: {reprStr err}"
   | .ok (_, st2) =>
-      match SeLe4n.Kernel.cspaceMint rootSlot siblingSlot [.read] none st2 with
+      match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot siblingSlot [.read] none st2 with
       | .error err => IO.println s!"sibling mint error: {reprStr err}"
       | .ok (_, st3) =>
           IO.println "created sibling cap with the same target"
@@ -378,14 +409,14 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
               match SeLe4n.Kernel.endpointAwaitReceive demoEndpoint 2 st5 with
                   | .error err => IO.println s!"endpoint await-receive error: {reprStr err}"
                   | .ok (_, st6) =>
-                      match SeLe4n.Kernel.endpointSend demoEndpoint 1 st6 with
+                      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st6 with
                       | .error err => IO.println s!"endpoint handshake send error: {reprStr err}"
                       | .ok (_, st7) =>
                           IO.println "handshake send matched waiting receiver"
-                          match SeLe4n.Kernel.endpointSend demoEndpoint 1 st7 with
+                          match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 1 st7 with
                           | .error err => IO.println s!"endpoint send #1 error: {reprStr err}"
                           | .ok (_, st8) =>
-                              match SeLe4n.Kernel.endpointSend demoEndpoint 2 st8 with
+                              match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext demoEndpoint 2 st8 with
                               | .error err => IO.println s!"endpoint send #2 error: {reprStr err}"
                               | .ok (_, st9) =>
                                   IO.println "queued two senders on endpoint"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -67,6 +67,14 @@ Every milestone-moving PR should include:
 4. synchronized docs updates (README/spec/development/GitBook as needed),
 5. explicit deferrals (if any) and destination workstream.
 
+### 3.5 Security hardening defaults
+
+- Treat identifier value `0` as reserved sentinel input; use checked conversions (for example `ThreadId.toObjIdChecked`) when crossing trust boundaries.
+- `storeTcbIpcState` must return `objectNotFound` when the target TCB does not exist; silent success is forbidden.
+- For integration and harness code, default to checked IFC entry points (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
+
+---
+
 ---
 
 ## 4) Daily contributor loop

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -135,6 +135,14 @@ Authoritative detail for per-workstream goals, dependencies, and evidence gates:
 
 ---
 
+## Security boundary defaults
+
+1. Sentinel discipline: identifier value `0` is reserved and should be rejected/filtered at API boundaries.
+2. IPC state update strictness: missing-TCB updates must return `objectNotFound` (no silent no-op success).
+3. IFC-by-default guidance: integration surfaces should prefer policy-checked operations (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
+
+---
+
 ## 6. Acceptance Expectations
 
 ### 6.1 Per-Workstream Acceptance Gates

--- a/tests/TraceSequenceProbe.lean
+++ b/tests/TraceSequenceProbe.lean
@@ -104,7 +104,7 @@ this function classifies each error and returns a structured outcome. -/
 def stepOp (op : ProbeOp) (tid : SeLe4n.ThreadId) (st : SystemState) : StepOutcome :=
   match op with
   | .send =>
-      match SeLe4n.Kernel.endpointSend probeEndpointId tid st with
+      match SeLe4n.Kernel.endpointSendChecked SeLe4n.Kernel.defaultLabelingContext probeEndpointId tid st with
       | .ok (_, st') => .mutated st'
       | .error err => classifyError .send err
   | .awaitReceive =>


### PR DESCRIPTION
### Motivation

- Prevent ghost waiters / queue poisoning by making TCB IPC-state writes strict instead of silently succeeding for missing thread IDs.
- Reduce accidental sentinel-ID reuse by encouraging checked conversions at object-store boundaries and documenting ID-0 sentinel discipline.
- Make information-flow enforcement the safe default for harnesses so consumers do not accidentally bypass IFC checks.

### Description

- `storeTcbIpcState` now fails with `.error .objectNotFound` when the target TCB does not exist instead of returning a no-op `.ok st` (SeLe4n/Kernel/IPC/Operations.lean). 
- Adjusted supporting lemmas and proofs in IPC / Capability / InformationFlow invariant files to account for the stricter `storeTcbIpcState` semantics (remove impossible success/no-op branches and adapt proofs). 
- Switched test/harness call-sites to policy-checked entry points: `endpointSendChecked`, `cspaceMintChecked`, and `serviceRestartChecked` are now used by the main trace harness and probe code (SeLe4n/Testing/MainTraceHarness.lean, tests/TraceSequenceProbe.lean). 
- Added bootstrap TCB fixtures (thread IDs used by traces) so IPC transitions still exercise real TCB objects in traces and do not trigger missing-TCB errors. 
- Documented the new defaults and guidance in `README.md`, `docs/DEVELOPMENT.md`, and `docs/spec/SELE4N_SPEC.md` (sentinel ID-0 guidance, strict missing-TCB behavior, IFC-checked defaults).

### Testing

- Ran `./scripts/setup_lean_env.sh --build` (performs `lake build`); build completed successfully.
- Ran the smoke-tier test suite `./scripts/test_smoke.sh`; all smoke-tier checks passed (trace fixtures, negative-state and information-flow suites succeeded).
- Observed a Lean linter warning remaining (`unused variable hTcb` in `SeLe4n/Kernel/IPC/Operations.lean`), which does not block the build or smoke tests but is noted for follow-up cleanup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff36ac8e0832b87ce515c8a8afc69)