### PR TITLE
Rename trace helpers and IPC/scheduler invariant bundles to descriptive names

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Additional resources:
 - `runSchedulerTimingDomainTrace` (formerly WS-labeled trace helper) now names the EDF/time-slice/domain scheduler scenario group by function.
 - `coreIpcInvariantBundle` names the composed scheduler+capability+IPC invariant bundle.
 - `ipcSchedulerCouplingInvariantBundle` names the bundle that extends `coreIpcInvariantBundle` with runnable/blocked IPC-scheduler coherence obligations.
+- `lifecycleCompositionInvariantBundle` names the composed IPC-scheduler+lifecycle metadata bundle (previously stage-labeled as M4-A).
 
 ## Active workstreams (WS-E)
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Additional resources:
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
 
+## Stable naming updates (trace + invariant surface)
+
+- `runCapabilityIpcTrace` (formerly WS-labeled trace helper) now names the capability/IPC scenario group by function.
+- `runSchedulerTimingDomainTrace` (formerly WS-labeled trace helper) now names the EDF/time-slice/domain scheduler scenario group by function.
+- `coreIpcInvariantBundle` names the composed scheduler+capability+IPC invariant bundle.
+- `ipcSchedulerCouplingInvariantBundle` names the bundle that extends `coreIpcInvariantBundle` with runnable/blocked IPC-scheduler coherence obligations.
+
 ## Active workstreams (WS-E)
 
 Quick index. Full contracts and dependencies are in the v0.11.6 planning backbone.

--- a/SeLe4n/Kernel/Architecture/Assumptions.lean
+++ b/SeLe4n/Kernel/Architecture/Assumptions.lean
@@ -28,8 +28,8 @@ inductive TransitionSurface where
 inductive InvariantSurface where
   | schedulerInvariantBundle
   | capabilityInvariantBundle
-  | m3IpcSeedInvariantBundle
-  | m35IpcSchedulerInvariantBundle
+  | coreIpcInvariantBundle
+  | ipcSchedulerCouplingInvariantBundle
   | lifecycleInvariantBundle
   | serviceInvariantBundle
   deriving Repr, DecidableEq
@@ -83,8 +83,8 @@ def assumptionTransitionMap : ArchAssumption → List TransitionSurface
 /-- Assumption-to-invariant mapping extracted from current theorem bundles. -/
 def assumptionInvariantMap : ArchAssumption → List InvariantSurface
   | .deterministicTimerProgress => [.schedulerInvariantBundle]
-  | .deterministicRegisterContext => [.schedulerInvariantBundle, .m35IpcSchedulerInvariantBundle]
-  | .memoryAccessSafety => [.m3IpcSeedInvariantBundle, .m35IpcSchedulerInvariantBundle]
+  | .deterministicRegisterContext => [.schedulerInvariantBundle, .ipcSchedulerCouplingInvariantBundle]
+  | .memoryAccessSafety => [.coreIpcInvariantBundle, .ipcSchedulerCouplingInvariantBundle]
   | .bootObjectTyping => [.capabilityInvariantBundle, .lifecycleInvariantBundle]
   | .irqRoutingTotality => [.schedulerInvariantBundle, .serviceInvariantBundle]
 

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -40,8 +40,8 @@ but not included in the top-level composed bundle. -/
 def proofLayerInvariantBundle (st : SystemState) : Prop :=
   schedulerInvariantBundle st ∧
     capabilityInvariantBundle st ∧
-    m3IpcSeedInvariantBundle st ∧
-    m35IpcSchedulerInvariantBundle st ∧
+    coreIpcInvariantBundle st ∧
+    ipcSchedulerCouplingInvariantBundle st ∧
     lifecycleInvariantBundle st ∧
     serviceLifecycleCapabilityInvariantBundle st ∧
     vspaceInvariantBundle st
@@ -230,14 +230,14 @@ theorem default_system_state_proofLayerInvariantBundle :
            by intro oid cn s c hObj; simp at hObj,
            by intro p c r b hMint; exact cspaceAttenuationRule_holds p c r b hMint,
            by exact lifecycleAuthorityMonotonicity_holds _⟩
-  -- 3. m3IpcSeedInvariantBundle
+  -- 3. coreIpcInvariantBundle
   · exact ⟨default_schedulerInvariantBundle,
            ⟨by intro oid cn hObj; simp at hObj,
             by intro oid cn s c hObj; simp at hObj,
             by intro p c r b hMint; exact cspaceAttenuationRule_holds p c r b hMint,
             by exact lifecycleAuthorityMonotonicity_holds _⟩,
            default_ipcInvariant⟩
-  -- 4. m35IpcSchedulerInvariantBundle
+  -- 4. ipcSchedulerCouplingInvariantBundle
   · exact ⟨⟨default_schedulerInvariantBundle,
             ⟨by intro oid cn hObj; simp at hObj,
              by intro oid cn s c hObj; simp at hObj,

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -60,7 +60,7 @@ components compositionally):
 
 **Error-case preservation theorems** (trivially true — the error path returns
 unchanged state, so any pre-state invariant holds trivially in the post-state):
-- `lifecycleRevokeDeleteRetype_error_preserves_m4aLifecycleInvariantBundle`
+- `lifecycleRevokeDeleteRetype_error_preserves_lifecycleCompositionInvariantBundle`
 - `cspaceLookupSlot_preserves_capabilityInvariantBundle` (read-only, no mutation)
 
 Error-case theorems are retained for proof-surface completeness and compositional
@@ -1091,7 +1091,7 @@ def ipcSchedulerCouplingInvariantBundle (st : SystemState) : Prop :=
 
 /-- M4-A composed bundle entrypoint:
 M3.5 IPC+scheduler composition plus lifecycle metadata/invariant obligations. -/
-def m4aLifecycleInvariantBundle (st : SystemState) : Prop :=
+def lifecycleCompositionInvariantBundle (st : SystemState) : Prop :=
   ipcSchedulerCouplingInvariantBundle st ∧ lifecycleInvariantBundle st
 
 theorem lifecycleRetypeObject_preserves_schedulerInvariantBundle
@@ -1206,19 +1206,19 @@ theorem lifecycleRetypeObject_preserves_coreIpcInvariantBundle
       hNewObjCNodeUniq hStep
   · exact lifecycleRetypeObject_preserves_ipcInvariant st st' authority target newObj hIpc hNewObjEndpointInv hNewObjNotificationInv hStep
 
-theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle
+theorem lifecycleRetypeObject_preserves_lifecycleCompositionInvariantBundle
     (st st' : SystemState)
     (authority : CSpaceAddr)
     (target : SeLe4n.ObjId)
     (newObj : KernelObject)
-    (hInv : m4aLifecycleInvariantBundle st)
+    (hInv : lifecycleCompositionInvariantBundle st)
     (hNewObjEndpointInv : ∀ ep, newObj = .endpoint ep → endpointInvariant ep)
     (hNewObjNotificationInv : ∀ ntfn, newObj = .notification ntfn → notificationInvariant ntfn)
     (hNewObjCNodeUniq : ∀ cn, newObj = .cnode cn → cn.slotsUnique)
     (hCurrentValid : currentThreadValid st')
     (hCoherence' : ipcSchedulerCoherenceComponent st')
     (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
-    m4aLifecycleInvariantBundle st' := by
+    lifecycleCompositionInvariantBundle st' := by
   rcases hInv with ⟨hM35, hLifecycle⟩
   rcases hM35 with ⟨hM3, _hCoherence⟩
   have hM3' : coreIpcInvariantBundle st' :=
@@ -1275,14 +1275,14 @@ theorem lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityI
       newObj hLifecycleDeleted hRetype
   exact lifecycleCapabilityStaleAuthorityInvariant_of_bundles st' hLifecycle' hCap'
 
-theorem lifecycleRevokeDeleteRetype_error_preserves_m4aLifecycleInvariantBundle
+theorem lifecycleRevokeDeleteRetype_error_preserves_lifecycleCompositionInvariantBundle
     (st : SystemState)
     (authority cleanup : CSpaceAddr)
     (target : SeLe4n.ObjId)
     (newObj : KernelObject)
     (hAlias : authority = cleanup)
-    (hInv : m4aLifecycleInvariantBundle st) :
-    m4aLifecycleInvariantBundle st := by
+    (hInv : lifecycleCompositionInvariantBundle st) :
+    lifecycleCompositionInvariantBundle st := by
   have _hExpected : lifecycleRevokeDeleteRetype authority cleanup target newObj st = .error .illegalState :=
     lifecycleRevokeDeleteRetype_error_authority_cleanup_alias st authority cleanup target newObj hAlias
   exact hInv

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1058,7 +1058,7 @@ theorem endpointReply_preserves_capabilityInvariantBundle
                 lifecycleAuthorityMonotonicity_holds _⟩
 
 /-- M3 composed bundle entrypoint: M1 scheduler + M2 capability + M3 IPC. -/
-def m3IpcSeedInvariantBundle (st : SystemState) : Prop :=
+def coreIpcInvariantBundle (st : SystemState) : Prop :=
   schedulerInvariantBundle st ∧ capabilityInvariantBundle st ∧ ipcInvariant st
 
 /-- Named M3.5 coherence component: runnable threads stay IPC-ready. -/
@@ -1086,13 +1086,13 @@ theorem ipcSchedulerCoherenceComponent_iff_contractPredicates (st : SystemState)
 /-- M3.5 composed bundle entrypoint layered over the M3 IPC seed bundle.
 
 This is the step-4 composition target for active-slice endpoint/scheduler coupling. -/
-def m35IpcSchedulerInvariantBundle (st : SystemState) : Prop :=
-  m3IpcSeedInvariantBundle st ∧ ipcSchedulerCoherenceComponent st
+def ipcSchedulerCouplingInvariantBundle (st : SystemState) : Prop :=
+  coreIpcInvariantBundle st ∧ ipcSchedulerCoherenceComponent st
 
 /-- M4-A composed bundle entrypoint:
 M3.5 IPC+scheduler composition plus lifecycle metadata/invariant obligations. -/
 def m4aLifecycleInvariantBundle (st : SystemState) : Prop :=
-  m35IpcSchedulerInvariantBundle st ∧ lifecycleInvariantBundle st
+  ipcSchedulerCouplingInvariantBundle st ∧ lifecycleInvariantBundle st
 
 theorem lifecycleRetypeObject_preserves_schedulerInvariantBundle
     (st st' : SystemState)
@@ -1186,18 +1186,18 @@ theorem lifecycleRetypeObject_preserves_ipcInvariant
       have hNtfnSt : st.objects oid = some (.notification ntfn) := by simpa [hPreserved] using hNtfn
       exact hNotificationInv oid ntfn hNtfnSt
 
-theorem lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle
+theorem lifecycleRetypeObject_preserves_coreIpcInvariantBundle
     (st st' : SystemState)
     (authority : CSpaceAddr)
     (target : SeLe4n.ObjId)
     (newObj : KernelObject)
-    (hInv : m3IpcSeedInvariantBundle st)
+    (hInv : coreIpcInvariantBundle st)
     (hNewObjEndpointInv : ∀ ep, newObj = .endpoint ep → endpointInvariant ep)
     (hNewObjNotificationInv : ∀ ntfn, newObj = .notification ntfn → notificationInvariant ntfn)
     (hNewObjCNodeUniq : ∀ cn, newObj = .cnode cn → cn.slotsUnique)
     (hCurrentValid : currentThreadValid st')
     (hStep : lifecycleRetypeObject authority target newObj st = .ok ((), st')) :
-    m3IpcSeedInvariantBundle st' := by
+    coreIpcInvariantBundle st' := by
   rcases hInv with ⟨hSched, hCap, hIpc⟩
   refine ⟨?_, ?_, ?_⟩
   · exact lifecycleRetypeObject_preserves_schedulerInvariantBundle st st' authority target newObj hSched
@@ -1221,8 +1221,8 @@ theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle
     m4aLifecycleInvariantBundle st' := by
   rcases hInv with ⟨hM35, hLifecycle⟩
   rcases hM35 with ⟨hM3, _hCoherence⟩
-  have hM3' : m3IpcSeedInvariantBundle st' :=
-    lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle st st' authority target newObj hM3
+  have hM3' : coreIpcInvariantBundle st' :=
+    lifecycleRetypeObject_preserves_coreIpcInvariantBundle st st' authority target newObj hM3
       hNewObjEndpointInv hNewObjNotificationInv hNewObjCNodeUniq hCurrentValid hStep
   have hLifecycle' : lifecycleInvariantBundle st' :=
     SeLe4n.Kernel.lifecycleRetypeObject_preserves_lifecycleInvariantBundle st st' authority target
@@ -1449,87 +1449,87 @@ theorem endpointReceive_preserves_capabilityInvariantBundle
             have hU := cspaceSlotUnique_through_handshake_path st pair.2 st2 endpointId hd _ hUnique hStore hTcb
             exact ⟨hU, cspaceLookupSound_of_cspaceSlotUnique _ hU, hAttRule, lifecycleAuthorityMonotonicity_holds _⟩
 
-theorem endpointSend_preserves_m3IpcSeedInvariantBundle
+theorem endpointSend_preserves_coreIpcInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
-    (hInv : m3IpcSeedInvariantBundle st)
+    (hInv : coreIpcInvariantBundle st)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    m3IpcSeedInvariantBundle st' := by
+    coreIpcInvariantBundle st' := by
   rcases hInv with ⟨hSched, hCap, hIpc⟩
   refine ⟨?_, ?_, ?_⟩
   · exact endpointSend_preserves_schedulerInvariantBundle st st' endpointId sender hSched hStep
   · exact endpointSend_preserves_capabilityInvariantBundle st st' endpointId sender hCap hStep
   · exact endpointSend_preserves_ipcInvariant st st' endpointId sender hIpc hStep
 
-theorem endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle
+theorem endpointAwaitReceive_preserves_coreIpcInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (receiver : SeLe4n.ThreadId)
-    (hInv : m3IpcSeedInvariantBundle st)
+    (hInv : coreIpcInvariantBundle st)
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    m3IpcSeedInvariantBundle st' := by
+    coreIpcInvariantBundle st' := by
   rcases hInv with ⟨hSched, hCap, hIpc⟩
   refine ⟨?_, ?_, ?_⟩
   · exact endpointAwaitReceive_preserves_schedulerInvariantBundle st st' endpointId receiver hSched hStep
   · exact endpointAwaitReceive_preserves_capabilityInvariantBundle st st' endpointId receiver hCap hStep
   · exact endpointAwaitReceive_preserves_ipcInvariant st st' endpointId receiver hIpc hStep
 
-theorem endpointReceive_preserves_m3IpcSeedInvariantBundle
+theorem endpointReceive_preserves_coreIpcInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
-    (hInv : m3IpcSeedInvariantBundle st)
+    (hInv : coreIpcInvariantBundle st)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    m3IpcSeedInvariantBundle st' := by
+    coreIpcInvariantBundle st' := by
   rcases hInv with ⟨hSched, hCap, hIpc⟩
   refine ⟨?_, ?_, ?_⟩
   · exact endpointReceive_preserves_schedulerInvariantBundle st st' endpointId sender hSched hStep
   · exact endpointReceive_preserves_capabilityInvariantBundle st st' endpointId sender hCap hStep
   · exact endpointReceive_preserves_ipcInvariant st st' endpointId sender hIpc hStep
 
-theorem endpointSend_preserves_m35IpcSchedulerInvariantBundle
+theorem endpointSend_preserves_ipcSchedulerCouplingInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
-    (hInv : m35IpcSchedulerInvariantBundle st)
+    (hInv : ipcSchedulerCouplingInvariantBundle st)
     (hStep : endpointSend endpointId sender st = .ok ((), st')) :
-    m35IpcSchedulerInvariantBundle st' := by
+    ipcSchedulerCouplingInvariantBundle st' := by
   rcases hInv with ⟨hM3Seed, hIpcSched⟩
   have hContract : ipcSchedulerContractPredicates st :=
     (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
   refine ⟨?_, ?_⟩
-  · exact endpointSend_preserves_m3IpcSeedInvariantBundle st st' endpointId sender hM3Seed hStep
+  · exact endpointSend_preserves_coreIpcInvariantBundle st st' endpointId sender hM3Seed hStep
   · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
       (endpointSend_preserves_ipcSchedulerContractPredicates st st' endpointId sender hContract hStep)
 
-theorem endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle
+theorem endpointAwaitReceive_preserves_ipcSchedulerCouplingInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (receiver : SeLe4n.ThreadId)
-    (hInv : m35IpcSchedulerInvariantBundle st)
+    (hInv : ipcSchedulerCouplingInvariantBundle st)
     (hStep : endpointAwaitReceive endpointId receiver st = .ok ((), st')) :
-    m35IpcSchedulerInvariantBundle st' := by
+    ipcSchedulerCouplingInvariantBundle st' := by
   rcases hInv with ⟨hM3Seed, hIpcSched⟩
   have hContract : ipcSchedulerContractPredicates st :=
     (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
   refine ⟨?_, ?_⟩
-  · exact endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId receiver hM3Seed hStep
+  · exact endpointAwaitReceive_preserves_coreIpcInvariantBundle st st' endpointId receiver hM3Seed hStep
   · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
       (endpointAwaitReceive_preserves_ipcSchedulerContractPredicates st st' endpointId receiver hContract hStep)
 
-theorem endpointReceive_preserves_m35IpcSchedulerInvariantBundle
+theorem endpointReceive_preserves_ipcSchedulerCouplingInvariantBundle
     (st st' : SystemState)
     (endpointId : SeLe4n.ObjId)
     (sender : SeLe4n.ThreadId)
-    (hInv : m35IpcSchedulerInvariantBundle st)
+    (hInv : ipcSchedulerCouplingInvariantBundle st)
     (hStep : endpointReceive endpointId st = .ok (sender, st')) :
-    m35IpcSchedulerInvariantBundle st' := by
+    ipcSchedulerCouplingInvariantBundle st' := by
   rcases hInv with ⟨hM3Seed, hIpcSched⟩
   have hContract : ipcSchedulerContractPredicates st :=
     (ipcSchedulerCoherenceComponent_iff_contractPredicates st).1 hIpcSched
   refine ⟨?_, ?_⟩
-  · exact endpointReceive_preserves_m3IpcSeedInvariantBundle st st' endpointId sender hM3Seed hStep
+  · exact endpointReceive_preserves_coreIpcInvariantBundle st st' endpointId sender hM3Seed hStep
   · exact (ipcSchedulerCoherenceComponent_iff_contractPredicates st').2
       (endpointReceive_preserves_ipcSchedulerContractPredicates st st' endpointId sender hContract hStep)
 

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -426,7 +426,7 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
 -- ============================================================================
 
 /-- WS-E4 test: H-02 guard, cspaceCopy, dual-queue, reply operations -/
-private def runWsE4Trace (st1 : SystemState) : IO Unit := do
+private def runCapabilityIpcTrace (st1 : SystemState) : IO Unit := do
   -- H-02: Try inserting into occupied slot (slot 0 already has a cap)
   let occSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := 10, slot := 0 }
   let testCap : Capability := { target := .object 1, rights := [.read], badge := none }
@@ -481,7 +481,7 @@ private def runWsE4Trace (st1 : SystemState) : IO Unit := do
 -- ============================================================================
 
 /-- WS-E6 test: M-03 EDF tie-breaking, M-04 time-slice preemption, M-05 domain scheduling -/
-private def runWsE6Trace (st1 : SystemState) : IO Unit := do
+private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
   -- M-03: EDF tie-breaking — two threads at same priority, different deadlines
   let edfTcbA : KernelObject := .tcb {
     tid := 1, priority := 100, domain := 0,
@@ -570,8 +570,8 @@ def runMainTraceFrom (st1 : SystemState) : IO Unit := do
   runCapabilityAndArchitectureTrace st1
   runServiceAndStressTrace st1
   runLifecycleAndEndpointTrace st1
-  runWsE4Trace st1
-  runWsE6Trace st1
+  runCapabilityIpcTrace st1
+  runSchedulerTimingDomainTrace st1
 
 -- ============================================================================
 -- M-10 Parameterized test topology builder (WS-E1)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -108,6 +108,12 @@ Environment note for `./scripts/setup_lean_env.sh` on apt-based systems:
 1. Keep proofs local-first; compose afterward.
 2. Prefer explicit theorem statements and stable names.
 3. Keep invariant bundles factored and named.
+   - Current canonical IPC composition names:
+     - `coreIpcInvariantBundle`
+     - `ipcSchedulerCouplingInvariantBundle`
+   - Current canonical trace helper names for these slices:
+     - `runCapabilityIpcTrace`
+     - `runSchedulerTimingDomainTrace`
 4. Avoid hidden global simplification behavior.
 5. Never add `axiom`/`sorry` to core proof surfaces.
 6. BFS completeness proof (TPI-D07-BRIDGE): formally resolved. The core

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -111,6 +111,7 @@ Environment note for `./scripts/setup_lean_env.sh` on apt-based systems:
    - Current canonical IPC composition names:
      - `coreIpcInvariantBundle`
      - `ipcSchedulerCouplingInvariantBundle`
+     - `lifecycleCompositionInvariantBundle`
    - Current canonical trace helper names for these slices:
      - `runCapabilityIpcTrace`
      - `runSchedulerTimingDomainTrace`

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -119,7 +119,7 @@ local and composed lifecycle preservation entrypoints (`lifecycleRetypeObject_pr
 `lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant`,
 `lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant`,
 `lifecycleRetypeObject_preserves_coreIpcInvariantBundle`, and
-`lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle`), and fixture-backed executable trace evidence
+`lifecycleRetypeObject_preserves_lifecycleCompositionInvariantBundle`), and fixture-backed executable trace evidence
 for unauthorized/illegal-state/success lifecycle retype outcomes plus composed lifecycle+capability behavior.
 
 ## 8. M5 policy-surface layering (WS-M5-C complete)

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -82,7 +82,7 @@ Bundle level:
 
 - `ipcSchedulerContractPredicates`
 - `ipcSchedulerCoherenceComponent`
-- `m35IpcSchedulerInvariantBundle`
+- `ipcSchedulerCouplingInvariantBundle`
 
 Preservation shape:
 
@@ -118,7 +118,7 @@ This explicit split now includes transition-local lifecycle helper lemmas in `Li
 local and composed lifecycle preservation entrypoints (`lifecycleRetypeObject_preserves_lifecycleInvariantBundle`,
 `lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant`,
 `lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant`,
-`lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle`, and
+`lifecycleRetypeObject_preserves_coreIpcInvariantBundle`, and
 `lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle`), and fixture-backed executable trace evidence
 for unauthorized/illegal-state/success lifecycle retype outcomes plus composed lifecycle+capability behavior.
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -174,6 +174,8 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 2. M3.5 IPC-scheduler handshake coherence semantics and trace anchors,
 3. local + composed invariant layering,
 4. theorem discoverability through stable naming,
+   - canonical IPC composition surfaces: `coreIpcInvariantBundle`, `ipcSchedulerCouplingInvariantBundle`,
+   - canonical trace helper surfaces: `runCapabilityIpcTrace`, `runSchedulerTimingDomainTrace`,
 5. fixture-backed executable evidence (`Main.lean` + trace fixture),
 6. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`).
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -174,7 +174,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 2. M3.5 IPC-scheduler handshake coherence semantics and trace anchors,
 3. local + composed invariant layering,
 4. theorem discoverability through stable naming,
-   - canonical IPC composition surfaces: `coreIpcInvariantBundle`, `ipcSchedulerCouplingInvariantBundle`,
+   - canonical IPC/lifecycle composition surfaces: `coreIpcInvariantBundle`, `ipcSchedulerCouplingInvariantBundle`, `lifecycleCompositionInvariantBundle`,
    - canonical trace helper surfaces: `runCapabilityIpcTrace`, `runSchedulerTimingDomainTrace`,
 5. fixture-backed executable evidence (`Main.lean` + trace fixture),
 6. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`).

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -147,7 +147,7 @@ run_check "INVARIANT" bash -lc "if rg -n '^instance : Coe ThreadId ObjId where' 
 # Invariant bundle surface anchors (M1/M2/M3 composed entrypoints).
 run_check "INVARIANT" rg -n '^(def|abbrev) schedulerInvariantBundle' SeLe4n/Kernel/Scheduler/Invariant.lean
 run_check "INVARIANT" rg -n '^def capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^def m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^def coreIpcInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M1 closure anchors: scheduler transition APIs + preservation theorem entrypoints.
 run_check "INVARIANT" rg -n '^def chooseThread' SeLe4n/Kernel/Scheduler/Operations.lean
@@ -191,14 +191,14 @@ run_check "INVARIANT" rg -n '^theorem badge_notification_routing_consistent' SeL
 run_check "INVARIANT" rg -n '^theorem badge_merge_idempotent' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M3 seed IPC preservation theorem anchors.
-run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_coreIpcInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_coreIpcInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M3.5 step-2 transition anchors must remain present.
 run_check "INVARIANT" rg -n '^def endpointSend' SeLe4n/Kernel/IPC/Operations.lean
 run_check "INVARIANT" rg -n '^def endpointAwaitReceive' SeLe4n/Kernel/IPC/Operations.lean
 run_check "INVARIANT" rg -n '^def endpointReceive' SeLe4n/Kernel/IPC/Operations.lean
-run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_coreIpcInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M3.5 step-3 scheduler-contract predicate anchors must remain present.
 run_check "INVARIANT" rg -n '^def runnableThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
@@ -215,10 +215,10 @@ run_check "INVARIANT" rg -n '^def ipcSchedulerBlockedSendComponent' SeLe4n/Kerne
 run_check "INVARIANT" rg -n '^def ipcSchedulerBlockedReceiveComponent' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^def ipcSchedulerCoherenceComponent' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem ipcSchedulerCoherenceComponent_iff_contractPredicates' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^def m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_m35IpcSchedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^def ipcSchedulerCouplingInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_ipcSchedulerCouplingInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointAwaitReceive_preserves_ipcSchedulerCouplingInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceive_preserves_ipcSchedulerCouplingInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M3.5 step-6 local-first preservation-theorem anchors must remain present.
 run_check "INVARIANT" rg -n '^theorem endpointSend_preserves_runnableThreadIpcReady' SeLe4n/Kernel/IPC/Invariant.lean
@@ -280,7 +280,7 @@ run_check "INVARIANT" rg -n '^def m4aLifecycleInvariantBundle' SeLe4n/Kernel/Cap
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_schedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_ipcInvariant' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_m3IpcSeedInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_coreIpcInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M4-B WS-C preservation theorem expansion anchors must remain present.

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -276,18 +276,18 @@ run_check "INVARIANT" rg -n '^theorem lifecycleCapabilityStaleAuthorityInvariant
 
 # M4-A step-5 lifecycle preservation entrypoint anchors must remain present.
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_lifecycleInvariantBundle' SeLe4n/Kernel/Lifecycle/Invariant.lean
-run_check "INVARIANT" rg -n '^def m4aLifecycleInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^def lifecycleCompositionInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_schedulerInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_ipcInvariant' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_coreIpcInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_m4aLifecycleInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRetypeObject_preserves_lifecycleCompositionInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M4-B WS-C preservation theorem expansion anchors must remain present.
 run_check "INVARIANT" rg -n '^theorem lifecycleRevokeDeleteRetype_ok_implies_staged_steps' SeLe4n/Kernel/Lifecycle/Operations.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityInvariant' SeLe4n/Kernel/Capability/Invariant.lean
-run_check "INVARIANT" rg -n '^theorem lifecycleRevokeDeleteRetype_error_preserves_m4aLifecycleInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem lifecycleRevokeDeleteRetype_error_preserves_lifecycleCompositionInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
 # M4-B WS-A composition transition anchors must remain present.
 run_check "INVARIANT" rg -n '^def lifecycleRevokeDeleteRetype' SeLe4n/Kernel/Lifecycle/Operations.lean


### PR DESCRIPTION
### Motivation

- Improve discoverability and convey precise functionality by replacing workstream-labeled identifiers with semantics-focused names for trace helpers and composed invariant bundles. 
- Keep theorem/invariant semantics and proof structure unchanged while making names stable and search-friendly for long-term maintenance.

### Description

- Renamed trace helper functions in `SeLe4n/Testing/MainTraceHarness.lean` from `runWsE4Trace` to `runCapabilityIpcTrace` and from `runWsE6Trace` to `runSchedulerTimingDomainTrace`, and updated their call sites in `runMainTraceFrom`.
- Renamed composed IPC/scheduler invariant bundle symbols in `SeLe4n/Kernel/Capability/Invariant.lean`: `m3IpcSeedInvariantBundle` → `coreIpcInvariantBundle` and `m35IpcSchedulerInvariantBundle` → `ipcSchedulerCouplingInvariantBundle`.
- Updated preservation-theorem entrypoints and their signatures to reflect the new bundle names (for example, `endpointSend_preserves_m3IpcSeedInvariantBundle` → `endpointSend_preserves_coreIpcInvariantBundle`, and the corresponding `..._preserves_ipcSchedulerCouplingInvariantBundle` variants), and adjusted all dependent uses across the codebase.
- Synchronized documentation and discoverability anchors and tests by updating references in `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, `docs/gitbook/12-proof-and-invariant-map.md`, and the invariant-surface anchor script `scripts/test_tier3_invariant_surface.sh` to the new identifiers; also updated the `InvariantSurface` enum and architecture maps that referenced the old names.

### Testing

- Ran smoke-tier validation with `./scripts/test_smoke.sh` and observed success (trace harnesses and negative-state checks passed).
- Ran full-tier validation with `./scripts/test_full.sh` and observed success (invariant/doc anchor surface checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b95db4f4832bb3c1795927b95046)