### PR TITLE
Implement FifoQueue `{head, tail}` for scheduler runnable queues with O(1) enqueue/dequeue

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Scheduler run queues are now represented as FIFO records `{head, tail}` (`FifoQueue`) with explicit `enqueueTail` / `dequeueHead` operations; runnable-list views are derived via `SchedulerState.runnable` for proof and trace compatibility.
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -7,8 +7,7 @@ open SeLe4n.Model
 def removeRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
   { st with
       scheduler := {
-        st.scheduler with
-          runnable := st.scheduler.runnable.filter (· ≠ tid)
+        st.scheduler.withRunnable (st.scheduler.runnable.filter (· ≠ tid)) with
           current := if st.scheduler.current = some tid then none else st.scheduler.current
       }
   }
@@ -19,7 +18,7 @@ def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
   else
     match st.objects tid.toObjId with
     | some (.tcb _) =>
-        { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } }
+        { st with scheduler := st.scheduler.enqueueTail tid }
     | _ => st
 
 def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=
@@ -572,13 +571,15 @@ theorem removeRunnable_scheduler_current
 theorem removeRunnable_mem
     (st : SystemState) (tid x : SeLe4n.ThreadId) :
     x ∈ (removeRunnable st tid).scheduler.runnable ↔ x ∈ st.scheduler.runnable ∧ x ≠ tid := by
-  simp [removeRunnable, List.mem_filter]
+  simp [removeRunnable]
 
 theorem removeRunnable_nodup
     (st : SystemState) (tid : SeLe4n.ThreadId)
     (hNodup : st.scheduler.runnable.Nodup) :
     (removeRunnable st tid).scheduler.runnable.Nodup := by
-  exact hNodup.sublist List.filter_sublist
+  have hSub : (st.scheduler.runnable.filter (· ≠ tid)).Sublist st.scheduler.runnable :=
+    List.filter_sublist
+  simpa [removeRunnable] using hNodup.sublist hSub
 
 theorem ensureRunnable_scheduler_current
     (st : SystemState) (tid : SeLe4n.ThreadId) :
@@ -606,7 +607,7 @@ theorem ensureRunnable_mem_old
   split
   · exact hMem
   · split
-    · exact List.mem_append_left _ hMem
+    · simpa [runnable_enqueueTail] using (List.mem_append_left [tid] hMem)
     · exact hMem
 
 theorem ensureRunnable_nodup
@@ -618,12 +619,12 @@ theorem ensureRunnable_nodup
   · exact hNodup
   · rename_i hNotMem
     split
-    · rw [List.nodup_append]
-      refine ⟨hNodup, ?_, ?_⟩
-      · exact .cons (fun _ h => absurd h List.not_mem_nil) .nil
-      · intro x hxl y hya
-        rw [List.mem_singleton] at hya; subst hya
-        exact fun heq => hNotMem (heq ▸ hxl)
+    · rw [runnable_enqueueTail, List.nodup_append]
+      refine ⟨hNodup, by simp, ?_⟩
+      intro x hx y hy
+      simp at hy
+      subst hy
+      exact fun hEq => hNotMem (hEq ▸ hx)
     · exact hNodup
 
 /-- Alias referencing the canonical `ThreadId.toObjId_injective` in Prelude. -/
@@ -664,7 +665,8 @@ theorem ensureRunnable_mem_reverse
   split at hMem
   · exact .inl hMem
   · split at hMem
-    · rw [List.mem_append, List.mem_singleton] at hMem; exact hMem
+    · rw [runnable_enqueueTail, List.mem_append, List.mem_singleton] at hMem
+      exact hMem
     · exact .inl hMem
 
 /-- WS-E3/H-09: A thread is never in its own removeRunnable result. -/

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -144,7 +144,7 @@ private theorem removeRunnable_preserves_projection
     (hTidHigh : threadObservable ctx observer tid = false) :
     projectState ctx observer (removeRunnable st tid) = projectState ctx observer st := by
   have hRun : projectRunnable ctx observer (removeRunnable st tid) = projectRunnable ctx observer st := by
-    simp only [projectRunnable, removeRunnable]
+    simp only [projectRunnable, removeRunnable, runnable_withRunnable, runnable_setCurrent]
     exact list_filter_ne_then_filter_eq st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
   have hCur : projectCurrent ctx observer (removeRunnable st tid) = projectCurrent ctx observer st := by
     simp only [projectCurrent, removeRunnable]
@@ -170,18 +170,18 @@ private theorem ensureRunnable_preserves_projection
   · rfl
   · split
     · have hRun : projectRunnable ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := st.scheduler.enqueueTail tid } =
           projectRunnable ctx observer st := by
-        simp only [projectRunnable]
+        simp only [projectRunnable, runnable_enqueueTail]
         exact list_filter_append_singleton_unobs st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
       have hObj : projectObjects ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := st.scheduler.enqueueTail tid } =
           projectObjects ctx observer st := rfl
       have hCur : projectCurrent ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := st.scheduler.enqueueTail tid } =
           projectCurrent ctx observer st := rfl
       have hSvc : projectServiceStatus ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := st.scheduler.enqueueTail tid } =
           projectServiceStatus ctx observer st := funext fun _ => rfl
       simp only [projectState, hObj, hRun, hCur, hSvc]
     · rfl

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -146,7 +146,7 @@ def handleYield : Kernel Unit :=
     match rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
     | .error e => .error e
     | .ok runnable' =>
-        let st' := { st with scheduler := { st.scheduler with runnable := runnable' } }
+        let st' := { st with scheduler := st.scheduler.withRunnable runnable' }
         schedule st'
 
 -- ============================================================================
@@ -187,7 +187,7 @@ def timerTick : Kernel Unit :=
               match rotateCurrentToBack (some tid) st'.scheduler.runnable with
               | .error e => .error e
               | .ok runnable' =>
-                  let st'' := { st' with scheduler := { st'.scheduler with runnable := runnable' } }
+                  let st'' := { st' with scheduler := st'.scheduler.withRunnable runnable' }
                   schedule st''
             else
               -- Time-slice not expired: decrement and continue
@@ -305,7 +305,7 @@ theorem setCurrentThread_preserves_queueCurrentConsistent
     queueCurrentConsistent st'.scheduler := by
   simp [setCurrentThread] at hStep
   cases hStep
-  simp [queueCurrentConsistent, hMem]
+  simpa [queueCurrentConsistent, SchedulerState.runnable] using hMem
 
 theorem setCurrentThread_preserves_runQueueUnique
     (st st' : SystemState)
@@ -494,7 +494,7 @@ theorem handleYield_preserves_wellFormed
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := st.scheduler.withRunnable runnable' }
       have hSched : schedule stMoved = .ok ((), st') := by simpa [stMoved, hRotate] using hStep
       exact schedule_preserves_wellFormed stMoved st' hSched
 
@@ -513,7 +513,7 @@ theorem handleYield_preserves_runQueueUnique
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := st.scheduler.withRunnable runnable' }
       have hMovedUnique : runQueueUnique stMoved.scheduler := by
         by_cases hCur : st.scheduler.current = none
         · have hRunEq : runnable' = st.scheduler.runnable := by
@@ -550,7 +550,7 @@ theorem handleYield_preserves_currentThreadValid
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := st.scheduler.withRunnable runnable' }
       have hSched : schedule stMoved = .ok ((), st') := by simpa [stMoved, hRotate] using hStep
       exact schedule_preserves_currentThreadValid stMoved st' hSched
 

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -33,8 +33,46 @@ structure DomainScheduleEntry where
   length : Nat
   deriving Repr, DecidableEq
 
+/-- Functional FIFO queue with explicit `{head, tail}` lists.
+
+`head` stores the dequeue frontier in-order; `tail` stores newly enqueued
+elements in reverse order so `enqueueTail` is constant-time. -/
+structure FifoQueue (α : Type) where
+  head : List α
+  tail : List α
+  deriving Repr, DecidableEq
+
+namespace FifoQueue
+
+def empty : FifoQueue α := { head := [], tail := [] }
+
+def toList (q : FifoQueue α) : List α :=
+  q.head ++ q.tail.reverse
+
+def ofList (xs : List α) : FifoQueue α :=
+  { head := xs, tail := [] }
+
+def enqueueTail (q : FifoQueue α) (x : α) : FifoQueue α :=
+  if q.head.isEmpty then
+    { head := q.tail.reverse ++ [x], tail := [] }
+  else
+    { q with tail := x :: q.tail }
+
+def dequeueHead (q : FifoQueue α) : Option (α × FifoQueue α) :=
+  match q.head with
+  | x :: xs =>
+      let q' :=
+        if xs.isEmpty then
+          { head := q.tail.reverse, tail := [] }
+        else
+          { q with head := xs }
+      some (x, q')
+  | [] => none
+
+end FifoQueue
+
 structure SchedulerState where
-  runnable : List SeLe4n.ThreadId
+  runnableQueue : FifoQueue SeLe4n.ThreadId
   current : Option SeLe4n.ThreadId
   /-- M-05/WS-E6: Currently active scheduling domain. Only threads in this
       domain are eligible for selection. Default domain 0. -/
@@ -47,6 +85,48 @@ structure SchedulerState where
   /-- M-05/WS-E6: Current index into `domainSchedule`. -/
   domainScheduleIndex : Nat := 0
   deriving Repr, DecidableEq
+
+namespace SchedulerState
+
+def runnable (s : SchedulerState) : List SeLe4n.ThreadId :=
+  s.runnableQueue.toList
+
+def withRunnable (s : SchedulerState) (runnable : List SeLe4n.ThreadId) : SchedulerState :=
+  { s with runnableQueue := FifoQueue.ofList runnable }
+
+def enqueueTail (s : SchedulerState) (tid : SeLe4n.ThreadId) : SchedulerState :=
+  { s with runnableQueue := s.runnableQueue.enqueueTail tid }
+
+def dequeueHead (s : SchedulerState) : Option (SeLe4n.ThreadId × SchedulerState) :=
+  match s.runnableQueue.dequeueHead with
+  | none => none
+  | some (tid, queue') => some (tid, { s with runnableQueue := queue' })
+
+end SchedulerState
+
+
+@[simp] theorem toList_ofList (xs : List α) : (FifoQueue.ofList xs).toList = xs := by
+  simp [FifoQueue.ofList, FifoQueue.toList]
+
+@[simp] theorem toList_enqueueTail (q : FifoQueue α) (x : α) :
+    (q.enqueueTail x).toList = q.toList ++ [x] := by
+  cases hList : q.head with
+  | nil =>
+      simp [FifoQueue.enqueueTail, FifoQueue.toList, hList]
+  | cons y ys =>
+      simp [FifoQueue.enqueueTail, FifoQueue.toList, hList, List.reverse_cons, List.append_assoc]
+
+@[simp] theorem runnable_withRunnable (s : SchedulerState) (runnable : List SeLe4n.ThreadId) :
+    (s.withRunnable runnable).runnable = runnable := by
+  simp [SchedulerState.withRunnable, SchedulerState.runnable]
+
+@[simp] theorem runnable_setCurrent (s : SchedulerState) (current : Option SeLe4n.ThreadId) :
+    ({ s with current := current }).runnable = s.runnable := by
+  rfl
+
+@[simp] theorem runnable_enqueueTail (s : SchedulerState) (tid : SeLe4n.ThreadId) :
+    (s.enqueueTail tid).runnable = s.runnable ++ [tid] := by
+  simp [SchedulerState.enqueueTail, SchedulerState.runnable]
 
 /-- Architecture-neutral address of a capability slot inside a CNode object. -/
 structure SlotRef where
@@ -92,7 +172,7 @@ structure SystemState where
 abbrev CSpaceOwner := SeLe4n.ObjId
 
 instance : Inhabited SchedulerState where
-  default := { runnable := [], current := none }
+  default := { runnableQueue := .empty, current := none }
 
 instance : Inhabited SystemState where
   default := {

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -224,7 +224,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   let largeRunnable : List SeLe4n.ThreadId :=
     [1, 12]
   let stLargeQueue : SystemState :=
-    { st1 with scheduler := { st1.scheduler with runnable := largeRunnable, current := none } }
+    { st1 with scheduler := { st1.scheduler.withRunnable largeRunnable with current := none } }
   IO.println s!"large runnable queue length: {reprStr stLargeQueue.scheduler.runnable.length}"
   match SeLe4n.Kernel.schedule stLargeQueue with
   | .error err => IO.println s!"large queue schedule error: {reprStr err}"
@@ -468,7 +468,7 @@ private def runCapabilityIpcTrace (st1 : SystemState) : IO Unit := do
   let replyObjects : SeLe4n.ObjId → Option KernelObject := fun oid =>
     if oid = replyTarget.toObjId then some replyTcb else st1.objects oid
   let replySched := { st1.scheduler with
-    runnable := st1.scheduler.runnable.filter (· != replyTarget) }
+    runnableQueue := FifoQueue.ofList (st1.scheduler.runnable.filter (· != replyTarget)) }
   let stReply : SystemState := { st1 with objects := replyObjects, scheduler := replySched }
   match SeLe4n.Kernel.endpointReply replyTarget stReply with
   | .error err => IO.println s!"endpointReply error: {reprStr err}"
@@ -497,7 +497,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     else st1.objects oid
   let stEdf : SystemState := { st1 with
     objects := edfObjects,
-    scheduler := { st1.scheduler with runnable := [1, 12], current := none } }
+    scheduler := { st1.scheduler.withRunnable [1, 12] with current := none } }
   match SeLe4n.Kernel.chooseThread stEdf with
   | .error err => IO.println s!"EDF choose error: {reprStr err}"
   | .ok (chosen, _) =>
@@ -512,7 +512,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     if oid = 1 then some tickTcb else st1.objects oid
   let stTick : SystemState := { st1 with
     objects := tickObjects,
-    scheduler := { st1.scheduler with runnable := [1, 12], current := some 1 } }
+    scheduler := { st1.scheduler.withRunnable [1, 12] with current := some 1 } }
   match SeLe4n.Kernel.timerTick stTick with
   | .error err => IO.println s!"timer tick decrement error: {reprStr err}"
   | .ok ((), stTicked) =>
@@ -530,7 +530,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     if oid = 1 then some expiryTcb else st1.objects oid
   let stExpiry : SystemState := { st1 with
     objects := expiryObjects,
-    scheduler := { st1.scheduler with runnable := [1, 12], current := some 1 } }
+    scheduler := { st1.scheduler.withRunnable [1, 12] with current := some 1 } }
   match SeLe4n.Kernel.timerTick stExpiry with
   | .error err => IO.println s!"timer tick expiry error: {reprStr err}"
   | .ok ((), stExpired) =>
@@ -545,7 +545,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     [{ domain := 0, length := 3 }, { domain := 1, length := 5 }]
   let stDom : SystemState := { st1 with
     scheduler := { st1.scheduler with
-      runnable := [1, 12], current := some 1,
+      runnableQueue := FifoQueue.ofList [1, 12], current := some 1,
       activeDomain := 0, domainTimeRemaining := 1,
       domainSchedule := domSchedule, domainScheduleIndex := 0 } }
   match SeLe4n.Kernel.switchDomain stDom with

--- a/SeLe4n/Testing/StateBuilder.lean
+++ b/SeLe4n/Testing/StateBuilder.lean
@@ -71,7 +71,7 @@ def build (builder : BootstrapBuilder) : SystemState :=
     objectIndex := builder.objects.map Prod.fst
     services := listLookup builder.services
     scheduler := {
-      runnable := builder.runnable
+      runnableQueue := FifoQueue.ofList builder.runnable
       current := builder.current
     }
     irqHandlers := listLookup builder.irqHandlers

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -74,6 +74,7 @@ Every milestone-moving PR should include:
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
+- Scheduler queue mechanics use a `{head, tail}` FIFO record (`FifoQueue`) and explicit `enqueueTail`/`dequeueHead` helpers; contributors should mutate run queues via `SchedulerState.withRunnable`, `enqueueTail`, or `dequeueHead` rather than direct list-field updates.
 
 ## 4) Daily contributor loop
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -62,6 +62,10 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
   - M1 component invariants and scheduler bundle alias.
 - `SeLe4n/Kernel/Scheduler/Operations.lean`
   - scheduling transitions + preservation theorem families.
+- `SeLe4n/Model/State.lean`
+  - scheduler FIFO queue record (`FifoQueue {head, tail}`),
+  - queue primitives (`enqueueTail`, `dequeueHead`) and runnable-view compatibility helpers.
+
 
 ### Capability subsystem
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -88,6 +88,7 @@ on the semantic and proof foundations of the previous one.
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Scheduler runnable queues are implemented as FIFO records `{head, tail}` with explicit `enqueueTail`/`dequeueHead` transition helpers; the observable runnable order remains `SchedulerState.runnable` to preserve existing theorem and fixture surfaces.
 
 ## 4. Active Workstream Portfolio (WS-E)
 


### PR DESCRIPTION
### Motivation
- Replace the scheduler's plain `List ThreadId` runnable representation with a functional FIFO record to enable asymptotically O(1) enqueue-tail semantics and clearer dequeue-head semantics. 
- Preserve existing observable runnable-order and theorem surfaces while making queue updates more efficient and explicit for proofs and trace harnesses. 
- Localize the change to the scheduler/IPC/information-flow call sites and the test harness so proofs and fixtures remain stable. 
- Keep documentation synchronized so contributors use the new helpers rather than mutating list fields directly.

### Description
- Introduced `FifoQueue` in `SeLe4n/Model/State.lean` with fields `{ head, tail }` and operations `empty`, `toList`, `ofList`, `enqueueTail`, and `dequeueHead`, plus simp lemmas for the view functions. 
- Reworked `SchedulerState` to store `runnableQueue : FifoQueue ThreadId` and added `SchedulerState.runnable`, `withRunnable`, `enqueueTail`, and `dequeueHead` compatibility helpers. 
- Updated all scheduler and IPC mutation sites (e.g., `handleYield`, `timerTick`, `removeRunnable`, `ensureRunnable`, `endpointReply` helpers, and harness builders) to use `withRunnable` / `enqueueTail` / `dequeueHead` rather than direct `runnable` list field updates. 
- Adjusted information-flow projection lemmas and related proofs to reason over `SchedulerState.runnable` (the list view) so observable semantics and low-equivalence are preserved without changing external behavior. 
- Updated bootstrap/test builders and trace harnesses to construct `SchedulerState` via `FifoQueue.ofList` and kept fixture trace output unchanged. 
- Synchronized docs: `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, and GitBook architecture map to describe the new queue model and recommended helper usage.

### Testing
- Ran the build-tier and invariant checks: `./scripts/test_tier1_build.sh` completed successfully. 
- Ran smoke-level trace and negative-state checks: `./scripts/test_smoke.sh` completed successfully and trace fixtures matched expectations. 
- Ran the full tier including invariant surface checks: `./scripts/test_full.sh` completed successfully. 
- All automated tests executed in this environment passed (build, smoke, and full tiers); no test failures remain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cdc67558832bab4d6e9218893f2a)