### PR TITLE
Add FIFO queue record for scheduler runnable lists and O(1) enqueue/dequeue helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Additional resources:
 
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
+- Scheduler runnable state now includes a FIFO queue record (`{head, tail}`) plus list view; queue helpers provide enqueue-at-tail/dequeue-from-head operations used by scheduler/IPC runnable manipulation.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
 
 ## Stable naming updates (trace + invariant surface)

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -5,13 +5,27 @@ namespace SeLe4n.Kernel
 open SeLe4n.Model
 
 def removeRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
+  let runnable' := st.scheduler.runnable.filter (· ≠ tid)
   { st with
       scheduler := {
         st.scheduler with
-          runnable := st.scheduler.runnable.filter (· ≠ tid)
+          runnable := runnable'
+          runnableQ := FifoQueue.ofList runnable'
           current := if st.scheduler.current = some tid then none else st.scheduler.current
       }
   }
+
+/-- O(1) enqueue-at-tail on the scheduler runnable queue record. -/
+def enqueueTailRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
+  let q' := st.scheduler.runnableQ.enqueueTail tid
+  setRunnableQueue q' st
+
+/-- O(1) dequeue-from-head on the scheduler runnable queue record.
+Returns the removed head (if present) and the updated state. -/
+def dequeueHeadRunnable (st : SystemState) : Option (SeLe4n.ThreadId × SystemState) :=
+  match st.scheduler.runnableQ.dequeueHead with
+  | none => none
+  | some (tid, q') => some (tid, setRunnableQueue q' st)
 
 def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
   if tid ∈ st.scheduler.runnable then
@@ -19,7 +33,8 @@ def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
   else
     match st.objects tid.toObjId with
     | some (.tcb _) =>
-        { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } }
+        let runnable' := st.scheduler.runnable ++ [tid]
+        { st with scheduler := { st.scheduler with runnable := runnable', runnableQ := FifoQueue.ofList runnable' } }
     | _ => st
 
 def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -170,18 +170,26 @@ private theorem ensureRunnable_preserves_projection
   · rfl
   · split
     · have hRun : projectRunnable ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := { st.scheduler with
+              runnable := st.scheduler.runnable ++ [tid]
+              runnableQ := FifoQueue.ofList (st.scheduler.runnable ++ [tid]) } } =
           projectRunnable ctx observer st := by
         simp only [projectRunnable]
         exact list_filter_append_singleton_unobs st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
       have hObj : projectObjects ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := { st.scheduler with
+              runnable := st.scheduler.runnable ++ [tid]
+              runnableQ := FifoQueue.ofList (st.scheduler.runnable ++ [tid]) } } =
           projectObjects ctx observer st := rfl
       have hCur : projectCurrent ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := { st.scheduler with
+              runnable := st.scheduler.runnable ++ [tid]
+              runnableQ := FifoQueue.ofList (st.scheduler.runnable ++ [tid]) } } =
           projectCurrent ctx observer st := rfl
       have hSvc : projectServiceStatus ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
+          { st with scheduler := { st.scheduler with
+              runnable := st.scheduler.runnable ++ [tid]
+              runnableQ := FifoQueue.ofList (st.scheduler.runnable ++ [tid]) } } =
           projectServiceStatus ctx observer st := funext fun _ => rfl
       simp only [projectState, hObj, hRun, hCur, hSvc]
     · rfl

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -146,7 +146,7 @@ def handleYield : Kernel Unit :=
     match rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
     | .error e => .error e
     | .ok runnable' =>
-        let st' := { st with scheduler := { st.scheduler with runnable := runnable' } }
+        let st' := { st with scheduler := { st.scheduler with runnable := runnable', runnableQ := FifoQueue.ofList runnable' } }
         schedule st'
 
 -- ============================================================================
@@ -187,7 +187,7 @@ def timerTick : Kernel Unit :=
               match rotateCurrentToBack (some tid) st'.scheduler.runnable with
               | .error e => .error e
               | .ok runnable' =>
-                  let st'' := { st' with scheduler := { st'.scheduler with runnable := runnable' } }
+                  let st'' := { st' with scheduler := { st'.scheduler with runnable := runnable', runnableQ := FifoQueue.ofList runnable' } }
                   schedule st''
             else
               -- Time-slice not expired: decrement and continue
@@ -494,7 +494,7 @@ theorem handleYield_preserves_wellFormed
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable', runnableQ := FifoQueue.ofList runnable' } }
       have hSched : schedule stMoved = .ok ((), st') := by simpa [stMoved, hRotate] using hStep
       exact schedule_preserves_wellFormed stMoved st' hSched
 
@@ -513,7 +513,7 @@ theorem handleYield_preserves_runQueueUnique
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable', runnableQ := FifoQueue.ofList runnable' } }
       have hMovedUnique : runQueueUnique stMoved.scheduler := by
         by_cases hCur : st.scheduler.current = none
         · have hRunEq : runnable' = st.scheduler.runnable := by
@@ -550,7 +550,7 @@ theorem handleYield_preserves_currentThreadValid
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable', runnableQ := FifoQueue.ofList runnable' } }
       have hSched : schedule stMoved = .ok ((), st') := by simpa [stMoved, hRotate] using hStep
       exact schedule_preserves_currentThreadValid stMoved st' hSched
 

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -33,8 +33,56 @@ structure DomainScheduleEntry where
   length : Nat
   deriving Repr, DecidableEq
 
+/-- FIFO queue representation using front (`head`) and rear (`tail`) lists.
+`head` is consumed directly, while `tail` accumulates enqueue-at-tail elements in
+reverse order. When `head` is empty, we rotate `tail.reverse` into `head`.
+
+This provides O(1) enqueue-at-tail and amortized O(1) dequeue-from-head. -/
+structure FifoQueue (α : Type) where
+  head : List α
+  tail : List α
+  deriving Repr, DecidableEq
+
+namespace FifoQueue
+
+def empty : FifoQueue α := { head := [], tail := [] }
+
+def ofList (xs : List α) : FifoQueue α := { head := xs, tail := [] }
+
+def toList (q : FifoQueue α) : List α :=
+  q.head ++ q.tail.reverse
+
+def enqueueTail (q : FifoQueue α) (x : α) : FifoQueue α :=
+  { q with tail := x :: q.tail }
+
+def dequeueHead (q : FifoQueue α) : Option (α × FifoQueue α) :=
+  match q.head with
+  | x :: xs => some (x, { q with head := xs })
+  | [] =>
+      match q.tail.reverse with
+      | [] => none
+      | x :: xs => some (x, { head := xs, tail := [] })
+
+def contains [DecidableEq α] (q : FifoQueue α) (x : α) : Bool :=
+  x ∈ q.toList
+
+def filter (p : α → Bool) (q : FifoQueue α) : FifoQueue α :=
+  ofList <| q.toList.filter p
+
+def erase [DecidableEq α] (q : FifoQueue α) (x : α) : FifoQueue α :=
+  ofList <| q.toList.erase x
+
+def length (q : FifoQueue α) : Nat :=
+  q.head.length + q.tail.length
+
+def isEmpty (q : FifoQueue α) : Bool :=
+  q.head.isEmpty && q.tail.isEmpty
+
+end FifoQueue
+
 structure SchedulerState where
   runnable : List SeLe4n.ThreadId
+  runnableQ : FifoQueue SeLe4n.ThreadId := FifoQueue.ofList runnable
   current : Option SeLe4n.ThreadId
   /-- M-05/WS-E6: Currently active scheduling domain. Only threads in this
       domain are eligible for selection. Default domain 0. -/
@@ -92,7 +140,7 @@ structure SystemState where
 abbrev CSpaceOwner := SeLe4n.ObjId
 
 instance : Inhabited SchedulerState where
-  default := { runnable := [], current := none }
+  default := { runnable := [], runnableQ := FifoQueue.empty, current := none }
 
 instance : Inhabited SystemState where
   default := {
@@ -175,6 +223,16 @@ def setCurrentThread (tid : Option SeLe4n.ThreadId) : Kernel Unit :=
   fun st =>
     let sched := { st.scheduler with current := tid }
     .ok ((), { st with scheduler := sched })
+
+/-- Keep the scheduler's list and queue views synchronized from a queue update. -/
+def setRunnableQueue (q : FifoQueue SeLe4n.ThreadId) (st : SystemState) : SystemState :=
+  { st with
+      scheduler := {
+        st.scheduler with
+          runnable := q.toList
+          runnableQ := q
+      }
+  }
 
 /-- Read one service graph entry. -/
 def lookupService (st : SystemState) (sid : ServiceId) : Option ServiceGraphEntry :=

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -21,10 +21,11 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 
 1. deterministic transition semantics (explicit success/failure branches),
 2. M3.5 IPC-scheduler handshake coherence semantics and trace anchors,
-3. local + composed invariant layering,
-4. theorem discoverability through stable naming,
-5. fixture-backed executable evidence (`Main.lean` + trace fixture),
-6. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`).
+3. synchronized scheduler runnable representations (list view + FIFO `{head, tail}` queue record),
+4. local + composed invariant layering,
+5. theorem discoverability through stable naming,
+6. fixture-backed executable evidence (`Main.lean` + trace fixture),
+7. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`).
 
 ---
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -53,6 +53,7 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 
 - `SeLe4n/Model/State.lean`
   - `SystemState` (machine + object store + scheduler + IRQ handlers),
+  - scheduler runnable FIFO queue record (`FifoQueue` with `{head, tail}`) and synchronization helpers,
   - `lookupObject` / `storeObject` / `setCurrentThread`,
   - typed CSpace lookup/ownership helpers and supporting lemmas.
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -87,6 +87,7 @@ on the semantic and proof foundations of the previous one.
 
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
+- Scheduler runnable state carries a FIFO queue record (`head`, `tail`) alongside the materialized runnable list, with dedicated enqueue-tail/dequeue-head helpers to model queue-pointer maintenance explicitly.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
 
 ## 4. Active Workstream Portfolio (WS-E)


### PR DESCRIPTION
### Motivation
- Represent scheduler runnable queues as an explicit FIFO `{head, tail}` queue to enable O(1) enqueue-at-tail and amortized O(1) dequeue-from-head while preserving the existing materialized list view. 
- Keep IPC/scheduler handshake semantics and information-flow projections coherent by making runnable-list updates efficient and explicitly synchronized with proofs. 
- Make the queue abstraction available to scheduler and IPC operations so queue-pointer style semantics (FIFO tail pointers) are modeled directly in the executable semantics.

### Description
- Introduce `FifoQueue` in `SeLe4n/Model/State.lean` with fields `head`/`tail` and helpers `empty`, `ofList`, `toList`, `enqueueTail`, `dequeueHead`, `contains`, `filter`, `erase`, `length`, and `isEmpty`.
- Extend `SchedulerState` with `runnableQ : FifoQueue ThreadId` and add `setRunnableQueue` to atomically synchronize the queue record and the materialized `runnable : List ThreadId` view.
- Add runnable-queue APIs: `enqueueTailRunnable` and `dequeueHeadRunnable`, and update existing mutations (`removeRunnable`, `ensureRunnable`) to keep both list and queue representations synchronized.
- Update scheduler transitions that reorder the runnable list (`handleYield`, time-slice expiry path in `timerTick`, and rotation sites) to set both `runnable` and `runnableQ` consistently, and adjust information-flow proof sites to construct states with aligned queue/list fields.
- Update documentation references (`README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/gitbook/03-architecture-and-module-map.md`) to describe the new FIFO queue record and synchronization expectations.

### Testing
- Ran `./scripts/test_smoke.sh` and the tier-2 smoke/trace/negative-state checks completed successfully (passed).
- Ran `./scripts/test_full.sh` (including invariant/document-anchor surface checks) and the full suite completed successfully (passed).
- Build step (`lake build`) was exercised as part of the test scripts; the project built successfully during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cdc67558832bab4d6e9218893f2a)