### PR TITLE
Adopt head/tail FIFO Queue for dual endpoint IPC (enqueue_tail/dequeue_head O(1))

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Endpoint dual queues now use an explicit `{head, tail}` FIFO representation (`SeLe4n.Queue`) with `enqueueTail`/`dequeueHead`, replacing repeated list-appends in IPC dual-queue operations.
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -706,8 +706,8 @@ def endpointSendDual (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
   fun st =>
     match st.objects endpointId with
     | some (.endpoint ep) =>
-        match ep.receiveQueue with
-        | receiver :: restRecv =>
+        match SeLe4n.Queue.dequeueHead ep.receiveQueue with
+        | some (receiver, restRecv) =>
             -- Rendezvous: match sender with first waiting receiver
             let ep' : Endpoint := { ep with receiveQueue := restRecv }
             match storeObject endpointId (.endpoint ep') st with
@@ -716,9 +716,9 @@ def endpointSendDual (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
                 match storeTcbIpcState st' receiver .ready with
                 | .error e => .error e
                 | .ok st'' => .ok ((), ensureRunnable st'' receiver)
-        | [] =>
+        | none =>
             -- No receiver waiting: enqueue sender and block
-            let ep' : Endpoint := { ep with sendQueue := ep.sendQueue ++ [sender] }
+            let ep' : Endpoint := { ep with sendQueue := SeLe4n.Queue.enqueueTail ep.sendQueue sender }
             match storeObject endpointId (.endpoint ep') st with
             | .error e => .error e
             | .ok ((), st') =>
@@ -737,8 +737,8 @@ def endpointReceiveDual (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
   fun st =>
     match st.objects endpointId with
     | some (.endpoint ep) =>
-        match ep.sendQueue with
-        | sender :: restSend =>
+        match SeLe4n.Queue.dequeueHead ep.sendQueue with
+        | some (sender, restSend) =>
             -- Rendezvous: dequeue first waiting sender
             let ep' : Endpoint := { ep with sendQueue := restSend }
             match storeObject endpointId (.endpoint ep') st with
@@ -747,9 +747,9 @@ def endpointReceiveDual (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
                 match storeTcbIpcState st' sender .ready with
                 | .error e => .error e
                 | .ok st'' => .ok (sender, ensureRunnable st'' sender)
-        | [] =>
+        | none =>
             -- No sender waiting: enqueue receiver and block
-            let ep' : Endpoint := { ep with receiveQueue := ep.receiveQueue ++ [receiver] }
+            let ep' : Endpoint := { ep with receiveQueue := SeLe4n.Queue.enqueueTail ep.receiveQueue receiver }
             match storeObject endpointId (.endpoint ep') st with
             | .error e => .error e
             | .ok ((), st') =>
@@ -773,8 +773,8 @@ def endpointCall (endpointId : SeLe4n.ObjId) (caller : SeLe4n.ThreadId)
   fun st =>
     match st.objects endpointId with
     | some (.endpoint ep) =>
-        match ep.receiveQueue with
-        | receiver :: restRecv =>
+        match SeLe4n.Queue.dequeueHead ep.receiveQueue with
+        | some (receiver, restRecv) =>
             -- Rendezvous with receiver, then block caller for reply
             let ep' : Endpoint := { ep with receiveQueue := restRecv }
             match storeObject endpointId (.endpoint ep') st with
@@ -787,9 +787,9 @@ def endpointCall (endpointId : SeLe4n.ObjId) (caller : SeLe4n.ThreadId)
                     match storeTcbIpcState st''' caller (.blockedOnReply endpointId) with
                     | .error e => .error e
                     | .ok st4 => .ok ((), removeRunnable st4 caller)
-        | [] =>
+        | none =>
             -- No receiver: enqueue as sender, block
-            let ep' : Endpoint := { ep with sendQueue := ep.sendQueue ++ [caller] }
+            let ep' : Endpoint := { ep with sendQueue := SeLe4n.Queue.enqueueTail ep.sendQueue caller }
             match storeObject endpointId (.endpoint ep') st with
             | .error e => .error e
             | .ok ((), st') =>

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -121,8 +121,8 @@ structure Endpoint where
   state : EndpointState
   queue : List SeLe4n.ThreadId
   waitingReceiver : Option SeLe4n.ThreadId := none
-  sendQueue : List SeLe4n.ThreadId := []
-  receiveQueue : List SeLe4n.ThreadId := []
+  sendQueue : SeLe4n.Queue SeLe4n.ThreadId := .empty
+  receiveQueue : SeLe4n.Queue SeLe4n.ThreadId := .empty
   deriving Repr, DecidableEq
 
 inductive NotificationState where

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -457,4 +457,47 @@ theorem ServiceId.default_eq_sentinel : (default : ServiceId) = ServiceId.sentin
 /-- The sentinel ServiceId is reserved. -/
 theorem ServiceId.sentinel_isReserved : ServiceId.sentinel.isReserved = true := rfl
 
+-- ============================================================================
+-- WS-E7: FIFO queue representation with explicit {head, tail}
+-- ============================================================================
+
+/-- Queue represented as `{head, tail}` lists.
+
+`head` stores the dequeue-facing prefix in-order.
+`tail` stores enqueue-only elements in reverse order.
+`toList` materializes FIFO order as `head ++ tail.reverse`.
+
+`enqueueTail` is O(1); `dequeueHead` is O(1) on non-empty `head` and performs
+one `reverse` only when rotating buffered tail elements. -/
+structure Queue (α : Type) where
+  head : List α
+  tail : List α
+  deriving Repr, DecidableEq
+
+namespace Queue
+
+def empty : Queue α := { head := [], tail := [] }
+
+def toList (q : Queue α) : List α := q.head ++ q.tail.reverse
+
+def isEmpty (q : Queue α) : Bool := q.head.isEmpty && q.tail.isEmpty
+
+def enqueueTail (q : Queue α) (a : α) : Queue α :=
+  { q with tail := a :: q.tail }
+
+def dequeueHead (q : Queue α) : Option (α × Queue α) :=
+  match q.head with
+  | x :: xs => some (x, { head := xs, tail := q.tail })
+  | [] =>
+      match q.tail.reverse with
+      | [] => none
+      | x :: xs => some (x, { head := xs, tail := [] })
+
+def singleton (a : α) : Queue α := { head := [a], tail := [] }
+
+instance : Inhabited (Queue α) where
+  default := empty
+
+end Queue
+
 end SeLe4n

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -447,7 +447,7 @@ private def runCapabilityIpcTrace (st1 : SystemState) : IO Unit := do
   -- Set up fresh state with idle endpoint for dual-queue test
   let dualEp : KernelObject := .endpoint {
     state := .idle, queue := [], waitingReceiver := none,
-    sendQueue := [], receiveQueue := [] }
+    sendQueue := .empty, receiveQueue := .empty }
   let dualObjects : SeLe4n.ObjId → Option KernelObject := fun oid =>
     if oid = dualEpId then some dualEp else st1.objects oid
   let stDual : SystemState := { st1 with objects := dualObjects }
@@ -456,7 +456,7 @@ private def runCapabilityIpcTrace (st1 : SystemState) : IO Unit := do
   | .ok (_, stSent) =>
       match (stSent.objects dualEpId) with
       | some (.endpoint ep) =>
-          IO.println s!"dual-queue sender blocked on sendQueue: {!ep.sendQueue.isEmpty}"
+          IO.println s!"dual-queue sender blocked on sendQueue: {!SeLe4n.Queue.isEmpty ep.sendQueue}"
       | _ => IO.println "dual-queue endpoint missing after send"
   -- M-12: Reply operation
   -- Create a state with a thread blocked on reply

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -74,6 +74,7 @@ Every milestone-moving PR should include:
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
+- Dual endpoint wait queues are modeled as explicit `{head, tail}` FIFOs (`SeLe4n.Queue`), and IPC dual-queue transitions use `enqueueTail`/`dequeueHead` instead of list-tail append patterns.
 
 ## 4) Daily contributor loop
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -20,11 +20,11 @@ This chapter maps where semantics, proofs, and execution evidence live in the cu
 ### Foundation layer
 
 - `SeLe4n/Prelude.lean`
-  - IDs/aliases and core monadic kernel execution shape.
+  - IDs/aliases, core monadic kernel execution shape, and shared `{head, tail}` FIFO queue abstraction (`Queue`, `enqueueTail`, `dequeueHead`).
 - `SeLe4n/Machine.lean`
   - machine-level state helpers.
 - `SeLe4n/Model/Object.lean`
-  - object-level representations.
+  - object-level representations, including endpoint dual-queue state via `Queue ThreadId`.
 - `SeLe4n/Model/State.lean`
   - global system-state composition and update helpers.
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -88,6 +88,7 @@ on the semantic and proof foundations of the previous one.
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Dual endpoint queues (`sendQueue`/`receiveQueue`) are represented as explicit `{head, tail}` FIFOs and exercised through `Queue.enqueueTail`/`Queue.dequeueHead` in WS-E4 dual-queue IPC operations.
 
 ## 4. Active Workstream Portfolio (WS-E)
 


### PR DESCRIPTION
### Motivation

- Provide an explicit, efficient FIFO representation for all kernel wait/endpoint queues to avoid repeated list-appends and to make enqueue/dequeue semantics O(1) in the common case.
- Migrate dual-queue endpoint semantics (`sendQueue`/`receiveQueue`) to a stable abstraction that better matches implementation intent and simplifies proofs and reasoning about queue operations.
- Keep observable behavior and trace fixtures stable while making the internal queue representation clearer and more efficient.

### Description

- Introduced a shared `Queue` abstraction in `SeLe4n/Prelude.lean` as a `{head, tail}` structure with `empty`, `toList`, `isEmpty`, `enqueueTail`, `dequeueHead`, and `singleton` helpers, where `enqueueTail` is O(1) and `dequeueHead` rotates `tail` only when `head` is empty.
- Changed endpoint queue fields in `SeLe4n/Model/Object.lean` from `List ThreadId` to `SeLe4n.Queue ThreadId` for `sendQueue` and `receiveQueue` while preserving legacy single-queue fields for backward compatibility.
- Refactored dual-queue IPC operations in `SeLe4n/Kernel/IPC/Operations.lean` (`endpointSendDual`, `endpointReceiveDual`, `endpointCall`) to use `SeLe4n.Queue.dequeueHead` for head removal and `SeLe4n.Queue.enqueueTail` for tail insertion instead of pattern-matching lists and using `++ [x]`.
- Updated the trace harness in `SeLe4n/Testing/MainTraceHarness.lean` to initialize endpoint queues with `.empty` and to inspect emptiness via `SeLe4n.Queue.isEmpty`.
- Synchronized documentation to reflect the new queue abstraction in `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/11-codebase-reference.md`.

### Testing

- Ran `source /root/.elan/env && lake build` which completed successfully and produced a successful build of all targets including `SeLe4n.Kernel.IPC.Operations` (build passed).
- Executed `./scripts/test_smoke.sh` and observed all smoke-tier checks (trace fixtures and negative-state checks) pass successfully.
- Ran `./scripts/test_full.sh` (invariant surface/anchor checks) and observed the full validation run complete with all automated invariant and documentation checks passing; a transient apt mirror warning occurred during environment setup but the setup and builds completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d2226838832b8055cefb0a04f85b)