### PR TITLE
Model intrusive scheduler queue links inside TCBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Scheduler run-queue metadata now has intrusive representation support: each TCB carries `rqPrev`/`rqNext` link fields and scheduler state tracks `runQueueHead`/`runQueueTail` (with `rebuildIntrusiveRunQueue` to synchronize links from canonical runnable order).
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -85,7 +85,10 @@ inductive ThreadIpcState where
 /-- Thread Control Block.
 
 M-03/WS-E6: `deadline` field for EDF tie-breaking. Default 0 = no deadline.
-M-04/WS-E6: `timeSlice` field for preemption. Default 5 ticks per quantum. -/
+M-04/WS-E6: `timeSlice` field for preemption. Default 5 ticks per quantum.
+WS-E4/M-13: intrusive run-queue links (`rqPrev`/`rqNext`) are stored directly
+inside each TCB, eliminating any need for separately allocated queue-node
+objects. -/
 structure TCB where
   tid : SeLe4n.ThreadId
   priority : SeLe4n.Priority
@@ -102,6 +105,10 @@ structure TCB where
       priority level. 0 = no deadline (lowest urgency). Lower nonzero
       values are more urgent. -/
   deadline : SeLe4n.Deadline := 0
+  /-- WS-E4/M-13: previous thread in the intrusive scheduler run queue. -/
+  rqPrev : Option SeLe4n.ThreadId := none
+  /-- WS-E4/M-13: next thread in the intrusive scheduler run queue. -/
+  rqNext : Option SeLe4n.ThreadId := none
   deriving Repr, DecidableEq
 
 inductive EndpointState where

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -35,6 +35,10 @@ structure DomainScheduleEntry where
 
 structure SchedulerState where
   runnable : List SeLe4n.ThreadId
+  /-- WS-E4/M-13: intrusive run-queue head pointer (into TCB `rqNext` chain). -/
+  runQueueHead : Option SeLe4n.ThreadId := none
+  /-- WS-E4/M-13: intrusive run-queue tail pointer (into TCB `rqPrev` chain). -/
+  runQueueTail : Option SeLe4n.ThreadId := none
   current : Option SeLe4n.ThreadId
   /-- M-05/WS-E6: Currently active scheduling domain. Only threads in this
       domain are eligible for selection. Default domain 0. -/
@@ -92,7 +96,7 @@ structure SystemState where
 abbrev CSpaceOwner := SeLe4n.ObjId
 
 instance : Inhabited SchedulerState where
-  default := { runnable := [], current := none }
+  default := { runnable := [], runQueueHead := none, runQueueTail := none, current := none }
 
 instance : Inhabited SystemState where
   default := {
@@ -110,6 +114,43 @@ instance : Inhabited SystemState where
   }
 
 abbrev Kernel := SeLe4n.KernelM SystemState KernelError
+
+/-- WS-E4/M-13: overwrite intrusive run-queue links for one TCB if it exists. -/
+def storeTcbRunQueueLinks
+    (objects : SeLe4n.ObjId → Option KernelObject)
+    (tid : SeLe4n.ThreadId)
+    (prev next : Option SeLe4n.ThreadId) : SeLe4n.ObjId → Option KernelObject :=
+  fun oid =>
+    if oid = tid.toObjId then
+      match objects oid with
+      | some (.tcb tcb) => some (.tcb { tcb with rqPrev := prev, rqNext := next })
+      | other => other
+    else
+      objects oid
+
+private def rebuildIntrusiveRunQueueLinksLoop
+    (objects : SeLe4n.ObjId → Option KernelObject)
+    (runnable : List SeLe4n.ThreadId)
+    (prev : Option SeLe4n.ThreadId)
+    : SeLe4n.ObjId → Option KernelObject :=
+  match runnable with
+  | [] => objects
+  | tid :: rest =>
+      let next := rest.head?
+      let objects' := storeTcbRunQueueLinks objects tid prev next
+      rebuildIntrusiveRunQueueLinksLoop objects' rest (some tid)
+
+/-- WS-E4/M-13: materialize intrusive run-queue metadata from the canonical
+`scheduler.runnable` ordering.
+
+This keeps the executable/proof surface backward-compatible (the list remains
+the source of truth) while eliminating external queue-node allocation by
+embedding queue links in each TCB. -/
+def rebuildIntrusiveRunQueue (st : SystemState) : SystemState :=
+  let runnable := st.scheduler.runnable
+  let objects' := rebuildIntrusiveRunQueueLinksLoop st.objects runnable none
+  let sched' := { st.scheduler with runQueueHead := runnable.head?, runQueueTail := runnable.getLast? }
+  { st with objects := objects', scheduler := sched' }
 
 def lookupObject (id : SeLe4n.ObjId) : Kernel KernelObject :=
   fun st =>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -74,6 +74,7 @@ Every milestone-moving PR should include:
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
+- Intrusive run-queue metadata is modeled in-core: TCBs expose `rqPrev`/`rqNext`, scheduler state exposes `runQueueHead`/`runQueueTail`, and `rebuildIntrusiveRunQueue` materializes links from the runnable list without external queue-node allocation.
 
 ## 4) Daily contributor loop
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -46,13 +46,13 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 
 - `SeLe4n/Model/Object.lean`
   - capability rights/targets,
-  - TCB structure + IPC state,
+  - TCB structure + IPC state + intrusive run-queue links (`rqPrev`/`rqNext`),
   - endpoint protocol fields,
   - CNode slot store and local revoke helper,
   - `KernelObject` discriminated union.
 
 - `SeLe4n/Model/State.lean`
-  - `SystemState` (machine + object store + scheduler + IRQ handlers),
+  - `SystemState` (machine + object store + scheduler + IRQ handlers), including scheduler intrusive queue endpoints (`runQueueHead`/`runQueueTail`) and `rebuildIntrusiveRunQueue`,
   - `lookupObject` / `storeObject` / `setCurrentThread`,
   - typed CSpace lookup/ownership helpers and supporting lemmas.
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -88,6 +88,7 @@ on the semantic and proof foundations of the previous one.
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Intrusive run-queue metadata is now first-class in the model: TCBs carry `rqPrev`/`rqNext`; scheduler state carries `runQueueHead`/`runQueueTail`; and `rebuildIntrusiveRunQueue` synchronizes these links from runnable order.
 
 ## 4. Active Workstream Portfolio (WS-E)
 
@@ -106,7 +107,7 @@ WS-D portfolio (WS-D5/D6).
 
 ### 4.3 Critical — Model Completion
 
-- **WS-E4:** Capability and IPC model completion (critical; **completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4:** Capability and IPC model completion (critical; **completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12, M-13)
 
 ### 4.4 High — Security Assurance
 

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -78,7 +78,8 @@ private def baseState : SystemState :=
     |>.withLifecycleObjectType 20 .vspaceRoot
     |>.withLifecycleCapabilityRef slot0 (.object endpointId)
     |>.withRunnable [7, 8]
-    |>.build)
+    |>.build
+    |> SeLe4n.Model.rebuildIntrusiveRunQueue)
 
 private def invariantObjectIds : List SeLe4n.ObjId :=
   [endpointId, cnodeId, wrongTypeId, guardedCnodeId, notificationId, 20, 7, 8]
@@ -129,6 +130,15 @@ private def expectOk
 
 private def runNegativeChecks : IO Unit := do
   assertStateInvariantsFor "negative suite baseState" invariantObjectIds baseState
+
+  -- WS-E4/M-13: intrusive run-queue links are embedded in TCBs
+  match baseState.objects 7, baseState.objects 8 with
+  | some (.tcb t7), some (.tcb t8) =>
+      if t7.rqPrev = none && t7.rqNext = some 8 && t8.rqPrev = some 7 && t8.rqNext = none then
+        IO.println "positive check passed [intrusive run-queue links]: 7 <-> 8"
+      else
+        throw <| IO.userError s!"intrusive run-queue link mismatch: t7=({reprStr t7.rqPrev},{reprStr t7.rqNext}) t8=({reprStr t8.rqPrev},{reprStr t8.rqNext})"
+  | _, _ => throw <| IO.userError "expected runnable TCB fixtures for intrusive link check"
   expectError "lookup wrong object type"
     (SeLe4n.Kernel.cspaceLookupSlot badSlot baseState)
     .objectNotFound


### PR DESCRIPTION
### Motivation
- Represent scheduler run-queue links intrusively inside each TCB to eliminate separately allocated queue-node objects and make the model closer to an in-kernel intrusive list representation.
- Keep the canonical `scheduler.runnable` list as the single source of truth while exposing per-TCB link fields for proof and executable-device modeling without breaking existing proofs.

### Description
- Added intrusive run-queue link fields `rqPrev` and `rqNext` to `TCB` in `SeLe4n/Model/Object.lean` and documented the WS-E4/M-13 rationale.
- Extended `SchedulerState` in `SeLe4n/Model/State.lean` with `runQueueHead` and `runQueueTail`, provided `storeTcbRunQueueLinks`, the `rebuildIntrusiveRunQueueLinksLoop` helper, and `rebuildIntrusiveRunQueue` which materializes per-TCB links from `scheduler.runnable` while updating the head/tail pointers.
- Updated the negative-state fixture in `tests/NegativeStateSuite.lean` to call `rebuildIntrusiveRunQueue` after building the base state and added an explicit runtime assertion that validates the expected `7 <-> 8` intrusive link layout.
- Synchronized documentation (`README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, and `docs/gitbook/03-architecture-and-module-map.md`) to describe intrusive run-queue metadata and recorded this as workstream milestone `M-13` under WS-E4.

### Testing
- Ran `./scripts/test_smoke.sh` which completed successfully and includes the trace and negative-state checks that exercise the modified fixtures and operations.
- Ran `./scripts/test_full.sh` which completed successfully and includes build, invariant-surface, trace, and negative suites (the negative suite prints a passing check: `positive check passed [intrusive run-queue links]: 7 <-> 8`).
- The Lake build completed successfully during the test runs and all invariant/check probes used by the tiered scripts passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d90186c0832b815cc8f9666903af)