### PR TITLE
Model: add intrusive ready-queue metadata to TCB and scheduler state

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- TCBs now carry intrusive ready-queue link fields (`runQueueNext`, `runQueuePrev`), and scheduler state tracks queue endpoints (`readyHead`, `readyTail`) to support in-object run-queue linkage.
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -85,7 +85,10 @@ inductive ThreadIpcState where
 /-- Thread Control Block.
 
 M-03/WS-E6: `deadline` field for EDF tie-breaking. Default 0 = no deadline.
-M-04/WS-E6: `timeSlice` field for preemption. Default 5 ticks per quantum. -/
+M-04/WS-E6: `timeSlice` field for preemption. Default 5 ticks per quantum.
+WS-E4/P3: Added intrusive ready-queue link fields (`runQueueNext`/`runQueuePrev`)
+stored directly in each TCB. This enables queue bookkeeping without allocating
+separate queue-node objects. -/
 structure TCB where
   tid : SeLe4n.ThreadId
   priority : SeLe4n.Priority
@@ -102,6 +105,12 @@ structure TCB where
       priority level. 0 = no deadline (lowest urgency). Lower nonzero
       values are more urgent. -/
   deadline : SeLe4n.Deadline := 0
+  /-- WS-E4/P3: Intrusive doubly-linked ready-queue next pointer.
+      `none` indicates end-of-queue. -/
+  runQueueNext : Option SeLe4n.ThreadId := none
+  /-- WS-E4/P3: Intrusive doubly-linked ready-queue previous pointer.
+      `none` indicates start-of-queue. -/
+  runQueuePrev : Option SeLe4n.ThreadId := none
   deriving Repr, DecidableEq
 
 inductive EndpointState where

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -36,6 +36,12 @@ structure DomainScheduleEntry where
 structure SchedulerState where
   runnable : List SeLe4n.ThreadId
   current : Option SeLe4n.ThreadId
+  /-- WS-E4/P3: Optional intrusive ready-queue head pointer.
+      Kept as explicit scheduler metadata so queue endpoints do not require
+      scanning the runnable list. -/
+  readyHead : Option SeLe4n.ThreadId := none
+  /-- WS-E4/P3: Optional intrusive ready-queue tail pointer. -/
+  readyTail : Option SeLe4n.ThreadId := none
   /-- M-05/WS-E6: Currently active scheduling domain. Only threads in this
       domain are eligible for selection. Default domain 0. -/
   activeDomain : SeLe4n.DomainId := 0

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -55,3 +55,5 @@ When a claim changes:
 2. update GitBook mirror(s) in the same PR,
 3. refresh this table row(s) for changed claims,
 4. run `./scripts/test_docs_sync.sh` and at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).
+
+- Intrusive runnable-queue metadata is modeled in-object via `TCB.runQueueNext`/`TCB.runQueuePrev` and scheduler endpoint pointers `SchedulerState.readyHead`/`SchedulerState.readyTail` (`SeLe4n/Model/Object.lean`, `SeLe4n/Model/State.lean`).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -72,6 +72,7 @@ Every milestone-moving PR should include:
 ## 3.1 Security hardening defaults
 
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
+- TCB layout now includes intrusive ready-queue links (`runQueueNext`/`runQueuePrev`) and `SchedulerState` includes queue endpoint pointers (`readyHead`/`readyTail`) for pointer-based runnable-list bookkeeping.
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -46,7 +46,7 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 
 - `SeLe4n/Model/Object.lean`
   - capability rights/targets,
-  - TCB structure + IPC state,
+  - TCB structure + IPC state + intrusive ready-queue link pointers (`runQueueNext`, `runQueuePrev`),
   - endpoint protocol fields,
   - CNode slot store and local revoke helper,
   - `KernelObject` discriminated union.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -87,6 +87,7 @@ on the semantic and proof foundations of the previous one.
 
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
+- TCBs include intrusive ready-queue link fields (`runQueueNext` and `runQueuePrev`), while scheduler metadata now exposes ready-queue endpoints (`readyHead`, `readyTail`) for in-TCB runnable linkage.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
 
 ## 4. Active Workstream Portfolio (WS-E)


### PR DESCRIPTION
### Motivation
- Provide an intrusive-list scaffolding so runnable-queue bookkeeping can be represented by link fields inside each TCB rather than allocating separate list-node objects.
- Expose scheduler-level queue endpoints so the model can maintain head/tail pointers without scanning the `runnable` list.
- Keep existing runnable-list behavior intact while enabling a pointer-based run-queue implementation in follow-up workstream slices.

### Description
- Added `runQueueNext : Option ThreadId` and `runQueuePrev : Option ThreadId` to `TCB` with `none` defaults to model intrusive doubly-linked run-queue links (`SeLe4n/Model/Object.lean`).
- Added `readyHead : Option ThreadId` and `readyTail : Option ThreadId` to `SchedulerState` to record queue endpoints (`SeLe4n/Model/State.lean`).
- Updated canonical documentation and GitBook mirrors to document the intrusive run-queue metadata (`README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, `docs/gitbook/03-architecture-and-module-map.md`, and `docs/CLAIM_EVIDENCE_INDEX.md`).
- Changes are additive and default to `none` so existing semantics remain compatible until the intrusive run-queue algorithms are wired in later patches.

### Testing
- Ran the tiered smoke validation with `./scripts/test_smoke.sh` and observed a successful run with the expected positive/negative checks and trace suite output (exit 0).
- Ran the full validation with `./scripts/test_full.sh` and observed the trace, hygiene, and doc-anchor checks pass (exit 0).
- All automated checks in this environment passed; no test failures or warnings were introduced by these additive model and doc updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d90186c0832b815cc8f9666903af)