### PR TITLE
Add intrusive runnable-queue metadata to TCB and SchedulerState

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- TCBs now carry intrusive runnable-link metadata (`runQueueNext`/`runQueuePrev`), and scheduler state records runnable queue endpoints (`runnableHead`/`runnableTail`) for queue-topology reasoning without external node objects.
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -102,6 +102,12 @@ structure TCB where
       priority level. 0 = no deadline (lowest urgency). Lower nonzero
       values are more urgent. -/
   deadline : SeLe4n.Deadline := 0
+  /-- WS-E4/P3: Intrusive run-queue next pointer.
+      `none` means this TCB is either not queued or currently at queue tail. -/
+  runQueueNext : Option SeLe4n.ThreadId := none
+  /-- WS-E4/P3: Intrusive run-queue previous pointer.
+      `none` means this TCB is either not queued or currently at queue head. -/
+  runQueuePrev : Option SeLe4n.ThreadId := none
   deriving Repr, DecidableEq
 
 inductive EndpointState where

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -35,6 +35,10 @@ structure DomainScheduleEntry where
 
 structure SchedulerState where
   runnable : List SeLe4n.ThreadId
+  /-- WS-E4/P3: Head pointer for intrusive runnable queue. -/
+  runnableHead : Option SeLe4n.ThreadId := none
+  /-- WS-E4/P3: Tail pointer for intrusive runnable queue. -/
+  runnableTail : Option SeLe4n.ThreadId := none
   current : Option SeLe4n.ThreadId
   /-- M-05/WS-E6: Currently active scheduling domain. Only threads in this
       domain are eligible for selection. Default domain 0. -/
@@ -92,7 +96,7 @@ structure SystemState where
 abbrev CSpaceOwner := SeLe4n.ObjId
 
 instance : Inhabited SchedulerState where
-  default := { runnable := [], current := none }
+  default := { runnable := [], runnableHead := none, runnableTail := none, current := none }
 
 instance : Inhabited SystemState where
   default := {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -72,6 +72,7 @@ Every milestone-moving PR should include:
 ## 3.1 Security hardening defaults
 
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
+- TCB and scheduler model structs expose intrusive runnable-queue metadata (`TCB.runQueueNext`/`runQueuePrev`, `SchedulerState.runnableHead`/`runnableTail`) to support queue-link proofs and future O(1) queue operations.
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -46,7 +46,7 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 
 - `SeLe4n/Model/Object.lean`
   - capability rights/targets,
-  - TCB structure + IPC state,
+  - TCB structure + IPC state + intrusive runnable links (`runQueueNext`/`runQueuePrev`),
   - endpoint protocol fields,
   - CNode slot store and local revoke helper,
   - `KernelObject` discriminated union.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -87,6 +87,7 @@ on the semantic and proof foundations of the previous one.
 
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
+- The executable model now includes intrusive runnable-queue metadata fields in TCB and scheduler records (`runQueueNext`/`runQueuePrev`, `runnableHead`/`runnableTail`) as the canonical queue-link surface for WS-E4/P3 follow-on work.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
 
 ## 4. Active Workstream Portfolio (WS-E)


### PR DESCRIPTION
### Motivation

- Provide an in-model canonical link surface for intrusive run-queue semantics to enable pointer-style queue topology reasoning and prepare for O(1) queue operations (WS-E4/P3 follow-on work).

### Description

- Added intrusive run-queue link fields to `TCB`: `runQueueNext : Option ThreadId` and `runQueuePrev : Option ThreadId` to represent per-thread queue links. 
- Added scheduler-side runnable queue endpoints to `SchedulerState`: `runnableHead : Option ThreadId` and `runnableTail : Option ThreadId`, and updated the `Inhabited` default to initialize these fields. 
- Updated documentation to describe the new intrusive queue metadata: `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, and `docs/gitbook/03-architecture-and-module-map.md`. 
- No external API or invariant semantics were removed; this change is a model surface extension (fields default to `none`) to enable subsequent intrusive-list implementations.

### Testing

- Ran a full build with `lake build`, which completed successfully (all targets built).
- Executed the smoke suite via `./scripts/test_smoke.sh`, which passed (trace, negative-state checks, information-flow checks reported as passing).
- Executed the full validation suite via `./scripts/test_full.sh`, which passed the invariant and doc-anchor checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d90186c0832b815cc8f9666903af)