### PR TITLE
Introduce intrusive runnable-list link fields on TCB and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- TCBs now carry intrusive runnable-list link metadata (`runnablePrev`/`runnableNext`) in the object model, removing the need for a separate runnable list-node object type in scheduler-facing state.
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -22,6 +22,16 @@ def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
         { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } }
     | _ => st
 
+/-- WS-E4/M-13: expose runnable intrusive links carried in the TCB.
+
+The scheduler queue is still represented canonically by `st.scheduler.runnable`.
+These accessors provide a typed bridge for transitions/proofs that operate on
+intrusive list metadata without introducing separate list-node allocations. -/
+def runnableLinks (st : SystemState) (tid : SeLe4n.ThreadId) : Option (Option SeLe4n.ThreadId × Option SeLe4n.ThreadId) :=
+  match st.objects tid.toObjId with
+  | some (.tcb tcb) => some (tcb.runnablePrev, tcb.runnableNext)
+  | _ => none
+
 def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=
   if tid.isReserved then
     none

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -85,7 +85,10 @@ inductive ThreadIpcState where
 /-- Thread Control Block.
 
 M-03/WS-E6: `deadline` field for EDF tie-breaking. Default 0 = no deadline.
-M-04/WS-E6: `timeSlice` field for preemption. Default 5 ticks per quantum. -/
+M-04/WS-E6: `timeSlice` field for preemption. Default 5 ticks per quantum.
+WS-E4/M-13: intrusive runnable-list link fields (`runnablePrev`, `runnableNext`)
+live directly in the TCB. This enables queue modelling without separate
+list-node objects. -/
 structure TCB where
   tid : SeLe4n.ThreadId
   priority : SeLe4n.Priority
@@ -102,6 +105,10 @@ structure TCB where
       priority level. 0 = no deadline (lowest urgency). Lower nonzero
       values are more urgent. -/
   deadline : SeLe4n.Deadline := 0
+  /-- WS-E4/M-13: previous thread in the intrusive runnable list, if any. -/
+  runnablePrev : Option SeLe4n.ThreadId := none
+  /-- WS-E4/M-13: next thread in the intrusive runnable list, if any. -/
+  runnableNext : Option SeLe4n.ThreadId := none
   deriving Repr, DecidableEq
 
 inductive EndpointState where

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -74,6 +74,7 @@ Every milestone-moving PR should include:
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
+- TCB structure now includes intrusive runnable-list link fields (`runnablePrev`, `runnableNext`) to model queue linkage directly inside thread objects.
 
 ## 4) Daily contributor loop
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -24,7 +24,7 @@ This chapter maps where semantics, proofs, and execution evidence live in the cu
 - `SeLe4n/Machine.lean`
   - machine-level state helpers.
 - `SeLe4n/Model/Object.lean`
-  - object-level representations.
+  - object-level representations (including intrusive runnable-list links embedded in TCBs).
 - `SeLe4n/Model/State.lean`
   - global system-state composition and update helpers.
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -88,6 +88,7 @@ on the semantic and proof foundations of the previous one.
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- TCB objects include intrusive runnable-list link metadata (`runnablePrev`, `runnableNext`), aligning scheduler-visible queue linkage with in-object thread state.
 
 ## 4. Active Workstream Portfolio (WS-E)
 


### PR DESCRIPTION
### Motivation
- Provide an intrusive-list foundation by embedding runnable-list link metadata inside `TCB` so scheduler/IPC code can model queue linkage without allocating separate list-node objects.
- Make a minimal, proof-friendly change that exposes the in-object links for later transitions/invariant work while keeping the canonical `scheduler.runnable` queue representation unchanged.

### Description
- Add `runnablePrev : Option ThreadId` and `runnableNext : Option ThreadId` fields to the `TCB` structure in `SeLe4n/Model/Object.lean` with `none` defaults and document the change as WS-E4/M-13.
- Add `runnableLinks` accessor in `SeLe4n/Kernel/IPC/Operations.lean` to read the intrusive link pair `(runnablePrev, runnableNext)` from a TCB stored in the object store.
- Update documentation to reflect the model change in `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, and `docs/gitbook/11-codebase-reference.md`.
- Keep canonical scheduler semantics intact (no changes to `st.scheduler.runnable` or existing scheduler/IPC transitions) so the change is incremental and proof-safe.

### Testing
- Ran `./scripts/test_smoke.sh` and the smoke suite completed successfully (build passed, scenario catalog validation passed, main trace fixture comparison passed, negative-state suite passed, and information-flow suite passed).
- The Lean build and trace-based tests invoked by the smoke script succeeded (`lake exe sele4n` and test executables built and ran as part of the smoke runner).
- No automated test failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0dc55a7a8832b8df089a1e738cf41)