### PR TITLE
Add intrusive TCB queue link fields (next/prev) and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- TCBs now carry intrusive runnable-list link fields (`next`/`prev`) so queue linkage can be represented inside the TCB record without introducing standalone list-node objects.
 
 ## Stable naming updates (trace + invariant surface)
 
@@ -86,7 +87,7 @@ Quick index. Full contracts and dependencies are in the v0.11.6 planning backbon
 - **WS-E1:** Test infrastructure and CI hardening -- **completed** (Medium; M-10, M-11, F-14, L-07, L-08)
 - **WS-E2:** Proof quality and invariant strengthening -- **completed** (High; C-01, H-01, H-03)
 - **WS-E3:** Kernel semantic hardening -- **completed** (High; H-06, H-07, H-08, H-09, M-09, L-06)
-- **WS-E4:** Capability and IPC model completion -- **completed** (Critical; C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4:** Capability and IPC model completion -- **completed** (Critical; C-02, C-03, C-04, H-02, M-01, M-02, M-12, M-13)
 - **WS-E5:** Information-flow maturity -- **completed** (High; H-04, H-05, M-07)
 - **WS-E6:** Model completeness and documentation -- **completed** (Low; M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -102,6 +102,12 @@ structure TCB where
       priority level. 0 = no deadline (lowest urgency). Lower nonzero
       values are more urgent. -/
   deadline : SeLe4n.Deadline := 0
+  /-- WS-E4/M-13: Intrusive runnable-list forward link.
+      `none` indicates no known successor in the queue view. -/
+  next : Option SeLe4n.ThreadId := none
+  /-- WS-E4/M-13: Intrusive runnable-list backward link.
+      `none` indicates no known predecessor in the queue view. -/
+  prev : Option SeLe4n.ThreadId := none
   deriving Repr, DecidableEq
 
 inductive EndpointState where

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -35,7 +35,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 - **WS-E1** — Test infrastructure and CI hardening (**completed** — M-10, M-11, F-14, L-07, L-08)
 - **WS-E2** — Proof quality and invariant strengthening (**completed** — C-01, H-01, H-03)
 - **WS-E3** — Kernel semantic hardening (**completed** — H-06, H-07, H-08, H-09, M-09, L-06)
-- **WS-E4** — Capability and IPC model completion (**completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4** — Capability and IPC model completion (**completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12, M-13)
 - **WS-E5** — Information-flow maturity (**completed** — H-04, H-05, M-07)
 - **WS-E6** — Model completeness and documentation (**completed** — M-03, M-04, M-05, M-08, F-17, L-01–L-05)
 
@@ -72,6 +72,7 @@ Every milestone-moving PR should include:
 ## 3.1 Security hardening defaults
 
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
+- TCB objects now include intrusive queue-link fields (`next`, `prev`) so queue linkage can be captured directly in-thread without allocating separate list-node objects.
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -46,7 +46,7 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 
 - `SeLe4n/Model/Object.lean`
   - capability rights/targets,
-  - TCB structure + IPC state,
+  - TCB structure + IPC state + intrusive queue links (`next`/`prev`),
   - endpoint protocol fields,
   - CNode slot store and local revoke helper,
   - `KernelObject` discriminated union.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -88,6 +88,7 @@ on the semantic and proof foundations of the previous one.
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- TCB records include intrusive queue-link fields (`next`/`prev`), eliminating any need for separate scheduler list-node object allocation in queue representation.
 
 ## 4. Active Workstream Portfolio (WS-E)
 
@@ -106,7 +107,7 @@ WS-D portfolio (WS-D5/D6).
 
 ### 4.3 Critical — Model Completion
 
-- **WS-E4:** Capability and IPC model completion (critical; **completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12)
+- **WS-E4:** Capability and IPC model completion (critical; **completed** — C-02, C-03, C-04, H-02, M-01, M-02, M-12, M-13)
 
 ### 4.4 High — Security Assurance
 


### PR DESCRIPTION
### Motivation

- Represent runnable-queue linkage inside the TCB record (intrusive list) so the model no longer requires separate list-node objects to represent queue membership.
- Preserve existing semantics and determinism by defaulting links to `none` and documenting the change in the project spec and guides.

### Description

- Added `next : Option ThreadId := none` and `prev : Option ThreadId := none` fields to `TCB` in `SeLe4n/Model/Object.lean` with explanatory WS-E4/M-13 comments.
- Synced documentation to reflect the intrusive-queue design and workstream scope by updating `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/03-architecture-and-module-map.md` (add M-13 and note `next`/`prev` presence).
- Kept defaults as `none` to avoid behavioral regressions; no scheduler/IPC transitions were changed in this PR.

### Testing

- Ran the project smoke validation via `./scripts/test_smoke.sh`, which performed a full build and exercised trace, negative-state, and information-flow suites, and observed all automated checks pass (build succeeded and suites reported PASS).
- No additional automated tests were added in this PR; existing test harnesses passed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0dc55a7a8832b8df089a1e738cf41)