### PR TITLE
Introduce intrusive TCB queue links and scheduler head/tail metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional resources:
 - IPC thread-state updates now fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Scheduler queue metadata now tracks `runnableHead`/`runnableTail`, and TCB objects expose embedded `queuePrev`/`queueNext` link hooks for intrusive-list migration without standalone list-node objects.
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -8,10 +8,7 @@ def removeRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
   let runnable' := st.scheduler.runnable.filter (· ≠ tid)
   { st with
       scheduler := {
-        st.scheduler with
-          runnable := runnable'
-          runnableHead := runnable'.head?
-          runnableTail := runnable'.getLast?
+        st.scheduler.withRunnableQueue runnable' with
           current := if st.scheduler.current = some tid then none else st.scheduler.current
       }
   }
@@ -23,14 +20,7 @@ def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
     match st.objects tid.toObjId with
     | some (.tcb _) =>
         let runnable' := st.scheduler.runnable ++ [tid]
-        { st with
-            scheduler := {
-              st.scheduler with
-                runnable := runnable'
-                runnableHead := runnable'.head?
-                runnableTail := runnable'.getLast?
-            }
-        }
+        { st with scheduler := st.scheduler.withRunnableQueue runnable' }
     | _ => st
 
 def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=
@@ -583,7 +573,7 @@ theorem removeRunnable_scheduler_current
 theorem removeRunnable_mem
     (st : SystemState) (tid x : SeLe4n.ThreadId) :
     x ∈ (removeRunnable st tid).scheduler.runnable ↔ x ∈ st.scheduler.runnable ∧ x ≠ tid := by
-  simp [removeRunnable, List.mem_filter]
+  simp [removeRunnable, SchedulerState.withRunnableQueue, List.mem_filter]
 
 theorem removeRunnable_nodup
     (st : SystemState) (tid : SeLe4n.ThreadId)
@@ -607,7 +597,7 @@ theorem ensureRunnable_mem_self
   unfold ensureRunnable
   split
   · assumption
-  · simp only [hTcb]; simp [List.mem_append]
+  · simp [hTcb, SchedulerState.withRunnableQueue, List.mem_append]
 
 theorem ensureRunnable_mem_old
     (st : SystemState) (tid x : SeLe4n.ThreadId)
@@ -617,7 +607,7 @@ theorem ensureRunnable_mem_old
   split
   · exact hMem
   · split
-    · exact List.mem_append_left _ hMem
+    · simpa [SchedulerState.withRunnableQueue, List.mem_append] using Or.inl hMem
     · exact hMem
 
 theorem ensureRunnable_nodup
@@ -629,7 +619,8 @@ theorem ensureRunnable_nodup
   · exact hNodup
   · rename_i hNotMem
     split
-    · rw [List.nodup_append]
+    · simp [SchedulerState.withRunnableQueue]
+      rw [List.nodup_append]
       refine ⟨hNodup, ?_, ?_⟩
       · exact .cons (fun _ h => absurd h List.not_mem_nil) .nil
       · intro x hxl y hya
@@ -675,7 +666,7 @@ theorem ensureRunnable_mem_reverse
   split at hMem
   · exact .inl hMem
   · split at hMem
-    · rw [List.mem_append, List.mem_singleton] at hMem; exact hMem
+    · simpa [SchedulerState.withRunnableQueue, List.mem_append, List.mem_singleton] using hMem
     · exact .inl hMem
 
 /-- WS-E3/H-09: A thread is never in its own removeRunnable result. -/

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -5,10 +5,13 @@ namespace SeLe4n.Kernel
 open SeLe4n.Model
 
 def removeRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
+  let runnable' := st.scheduler.runnable.filter (· ≠ tid)
   { st with
       scheduler := {
         st.scheduler with
-          runnable := st.scheduler.runnable.filter (· ≠ tid)
+          runnable := runnable'
+          runnableHead := runnable'.head?
+          runnableTail := runnable'.getLast?
           current := if st.scheduler.current = some tid then none else st.scheduler.current
       }
   }
@@ -19,7 +22,15 @@ def ensureRunnable (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
   else
     match st.objects tid.toObjId with
     | some (.tcb _) =>
-        { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } }
+        let runnable' := st.scheduler.runnable ++ [tid]
+        { st with
+            scheduler := {
+              st.scheduler with
+                runnable := runnable'
+                runnableHead := runnable'.head?
+                runnableTail := runnable'.getLast?
+            }
+        }
     | _ => st
 
 def lookupTcb (st : SystemState) (tid : SeLe4n.ThreadId) : Option TCB :=

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -182,22 +182,15 @@ private theorem ensureRunnable_preserves_projection
               List.filter (threadObservable ctx observer) st.scheduler.runnable :=
             list_filter_append_singleton_unobs st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
           have hObj : projectObjects ctx observer
-              { st with scheduler := {
-                  st.scheduler with
-                  runnable := st.scheduler.runnable ++ [tid]
-                  runnableHead := some (st.scheduler.runnable.head?.getD tid)
-                  runnableTail := some tid
-                } } = projectObjects ctx observer st := rfl
+              { st with scheduler := st.scheduler.withRunnableQueue (st.scheduler.runnable ++ [tid]) } =
+              projectObjects ctx observer st := rfl
           have hSvc : projectServiceStatus ctx observer
-              { st with scheduler := {
-                  st.scheduler with
-                  runnable := st.scheduler.runnable ++ [tid]
-                  runnableHead := some (st.scheduler.runnable.head?.getD tid)
-                  runnableTail := some tid
-                } } = projectServiceStatus ctx observer st := by
+              { st with scheduler := st.scheduler.withRunnableQueue (st.scheduler.runnable ++ [tid]) } =
+              projectServiceStatus ctx observer st := by
             funext sid
             rfl
-          simp [projectState, projectCurrent, projectRunnable, hRun, hObj, hSvc]
+          simpa [projectState, projectCurrent, projectRunnable,
+            SchedulerState.withRunnableQueue, hRun] using And.intro hObj hSvc
 
 /-- storeTcbIpcState at a non-observable object preserves projection (single-state). -/
 private theorem storeTcbIpcState_preserves_projection

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -166,25 +166,38 @@ private theorem ensureRunnable_preserves_projection
     (hTidHigh : threadObservable ctx observer tid = false) :
     projectState ctx observer (ensureRunnable st tid) = projectState ctx observer st := by
   unfold ensureRunnable
-  split
-  · rfl
-  · split
-    · have hRun : projectRunnable ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
-          projectRunnable ctx observer st := by
-        simp only [projectRunnable]
-        exact list_filter_append_singleton_unobs st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
-      have hObj : projectObjects ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
-          projectObjects ctx observer st := rfl
-      have hCur : projectCurrent ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
-          projectCurrent ctx observer st := rfl
-      have hSvc : projectServiceStatus ctx observer
-          { st with scheduler := { st.scheduler with runnable := st.scheduler.runnable ++ [tid] } } =
-          projectServiceStatus ctx observer st := funext fun _ => rfl
-      simp only [projectState, hObj, hRun, hCur, hSvc]
-    · rfl
+  by_cases hMem : tid ∈ st.scheduler.runnable
+  · simp [hMem]
+  · simp [hMem]
+    cases hObjTcb : st.objects tid.toObjId with
+    | none => simp
+    | some obj =>
+      cases obj with
+      | endpoint ep => simp
+      | notification ntfn => simp
+      | cnode cn => simp
+      | vspaceRoot root => simp
+      | tcb tcb =>
+          have hRun : List.filter (threadObservable ctx observer) (st.scheduler.runnable ++ [tid]) =
+              List.filter (threadObservable ctx observer) st.scheduler.runnable :=
+            list_filter_append_singleton_unobs st.scheduler.runnable tid (threadObservable ctx observer) hTidHigh
+          have hObj : projectObjects ctx observer
+              { st with scheduler := {
+                  st.scheduler with
+                  runnable := st.scheduler.runnable ++ [tid]
+                  runnableHead := some (st.scheduler.runnable.head?.getD tid)
+                  runnableTail := some tid
+                } } = projectObjects ctx observer st := rfl
+          have hSvc : projectServiceStatus ctx observer
+              { st with scheduler := {
+                  st.scheduler with
+                  runnable := st.scheduler.runnable ++ [tid]
+                  runnableHead := some (st.scheduler.runnable.head?.getD tid)
+                  runnableTail := some tid
+                } } = projectServiceStatus ctx observer st := by
+            funext sid
+            rfl
+          simp [projectState, projectCurrent, projectRunnable, hRun, hObj, hSvc]
 
 /-- storeTcbIpcState at a non-observable object preserves projection (single-state). -/
 private theorem storeTcbIpcState_preserves_projection

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -146,7 +146,7 @@ def handleYield : Kernel Unit :=
     match rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
     | .error e => .error e
     | .ok runnable' =>
-        let st' := { st with scheduler := { st.scheduler with runnable := runnable' } }
+        let st' := { st with scheduler := st.scheduler.withRunnableQueue runnable' }
         schedule st'
 
 -- ============================================================================
@@ -187,7 +187,7 @@ def timerTick : Kernel Unit :=
               match rotateCurrentToBack (some tid) st'.scheduler.runnable with
               | .error e => .error e
               | .ok runnable' =>
-                  let st'' := { st' with scheduler := { st'.scheduler with runnable := runnable' } }
+                  let st'' := { st' with scheduler := st'.scheduler.withRunnableQueue runnable' }
                   schedule st''
             else
               -- Time-slice not expired: decrement and continue
@@ -494,7 +494,7 @@ theorem handleYield_preserves_wellFormed
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := st.scheduler.withRunnableQueue runnable' }
       have hSched : schedule stMoved = .ok ((), st') := by simpa [stMoved, hRotate] using hStep
       exact schedule_preserves_wellFormed stMoved st' hSched
 
@@ -513,7 +513,7 @@ theorem handleYield_preserves_runQueueUnique
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := st.scheduler.withRunnableQueue runnable' }
       have hMovedUnique : runQueueUnique stMoved.scheduler := by
         by_cases hCur : st.scheduler.current = none
         · have hRunEq : runnable' = st.scheduler.runnable := by
@@ -550,7 +550,7 @@ theorem handleYield_preserves_currentThreadValid
   cases hRotate : rotateCurrentToBack st.scheduler.current st.scheduler.runnable with
   | error e => simp [hRotate] at hStep
   | ok runnable' =>
-      let stMoved : SystemState := { st with scheduler := { st.scheduler with runnable := runnable' } }
+      let stMoved : SystemState := { st with scheduler := st.scheduler.withRunnableQueue runnable' }
       have hSched : schedule stMoved = .ok ((), st') := by simpa [stMoved, hRotate] using hStep
       exact schedule_preserves_currentThreadValid stMoved st' hSched
 

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -102,6 +102,12 @@ structure TCB where
       priority level. 0 = no deadline (lowest urgency). Lower nonzero
       values are more urgent. -/
   deadline : SeLe4n.Deadline := 0
+  /-- WS-E7: Intrusive doubly-linked queue hooks embedded in each TCB.
+      Queue owners (scheduler/IPC objects) maintain head/tail thread IDs,
+      while TCB-local links represent membership without allocating list-node
+      wrapper objects. `none` means no predecessor/successor in the queue. -/
+  queuePrev : Option SeLe4n.ThreadId := none
+  queueNext : Option SeLe4n.ThreadId := none
   deriving Repr, DecidableEq
 
 inductive EndpointState where

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -53,6 +53,18 @@ structure SchedulerState where
   domainScheduleIndex : Nat := 0
   deriving Repr, DecidableEq
 
+/-- WS-E7: canonical scheduler update helper for runnable-queue mutations.
+Keeps list payload and cached queue endpoints synchronized. -/
+def SchedulerState.withRunnableQueue
+    (sched : SchedulerState)
+    (queue : List SeLe4n.ThreadId) : SchedulerState :=
+  {
+    sched with
+      runnable := queue
+      runnableHead := queue.head?
+      runnableTail := queue.getLast?
+  }
+
 /-- Architecture-neutral address of a capability slot inside a CNode object. -/
 structure SlotRef where
   cnode : SeLe4n.ObjId

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -35,6 +35,11 @@ structure DomainScheduleEntry where
 
 structure SchedulerState where
   runnable : List SeLe4n.ThreadId
+  /-- WS-E7 intrusive runnable queue head pointer. Mirrors the first runnable
+      thread and allows O(1) insertion/removal bookkeeping in queue owners. -/
+  runnableHead : Option SeLe4n.ThreadId := none
+  /-- WS-E7 intrusive runnable queue tail pointer. -/
+  runnableTail : Option SeLe4n.ThreadId := none
   current : Option SeLe4n.ThreadId
   /-- M-05/WS-E6: Currently active scheduling domain. Only threads in this
       domain are eligible for selection. Default domain 0. -/

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -224,7 +224,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   let largeRunnable : List SeLe4n.ThreadId :=
     [1, 12]
   let stLargeQueue : SystemState :=
-    { st1 with scheduler := { st1.scheduler with runnable := largeRunnable, current := none } }
+    { st1 with scheduler := { st1.scheduler.withRunnableQueue largeRunnable with current := none } }
   IO.println s!"large runnable queue length: {reprStr stLargeQueue.scheduler.runnable.length}"
   match SeLe4n.Kernel.schedule stLargeQueue with
   | .error err => IO.println s!"large queue schedule error: {reprStr err}"
@@ -497,7 +497,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     else st1.objects oid
   let stEdf : SystemState := { st1 with
     objects := edfObjects,
-    scheduler := { st1.scheduler with runnable := [1, 12], current := none } }
+    scheduler := { st1.scheduler.withRunnableQueue [1, 12] with current := none } }
   match SeLe4n.Kernel.chooseThread stEdf with
   | .error err => IO.println s!"EDF choose error: {reprStr err}"
   | .ok (chosen, _) =>
@@ -512,7 +512,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     if oid = 1 then some tickTcb else st1.objects oid
   let stTick : SystemState := { st1 with
     objects := tickObjects,
-    scheduler := { st1.scheduler with runnable := [1, 12], current := some 1 } }
+    scheduler := { st1.scheduler.withRunnableQueue [1, 12] with current := some 1 } }
   match SeLe4n.Kernel.timerTick stTick with
   | .error err => IO.println s!"timer tick decrement error: {reprStr err}"
   | .ok ((), stTicked) =>
@@ -530,7 +530,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     if oid = 1 then some expiryTcb else st1.objects oid
   let stExpiry : SystemState := { st1 with
     objects := expiryObjects,
-    scheduler := { st1.scheduler with runnable := [1, 12], current := some 1 } }
+    scheduler := { st1.scheduler.withRunnableQueue [1, 12] with current := some 1 } }
   match SeLe4n.Kernel.timerTick stExpiry with
   | .error err => IO.println s!"timer tick expiry error: {reprStr err}"
   | .ok ((), stExpired) =>
@@ -545,7 +545,7 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
     [{ domain := 0, length := 3 }, { domain := 1, length := 5 }]
   let stDom : SystemState := { st1 with
     scheduler := { st1.scheduler with
-      runnable := [1, 12], current := some 1,
+      runnable := [1, 12], runnableHead := some 1, runnableTail := some 12, current := some 1,
       activeDomain := 0, domainTimeRemaining := 1,
       domainSchedule := domSchedule, domainScheduleIndex := 0 } }
   match SeLe4n.Kernel.switchDomain stDom with

--- a/SeLe4n/Testing/StateBuilder.lean
+++ b/SeLe4n/Testing/StateBuilder.lean
@@ -70,10 +70,7 @@ def build (builder : BootstrapBuilder) : SystemState :=
     objects := listLookup builder.objects
     objectIndex := builder.objects.map Prod.fst
     services := listLookup builder.services
-    scheduler := {
-      runnable := builder.runnable
-      current := builder.current
-    }
+    scheduler := { (default : SchedulerState).withRunnableQueue builder.runnable with current := builder.current }
     irqHandlers := listLookup builder.irqHandlers
     lifecycle := {
       objectTypes := listLookup builder.lifecycleObjectTypes

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -13,6 +13,7 @@ This index makes current semantic/proof/documentation claims auditable by linkin
 | Root docs and GitBook mirrors stay synchronized via canonical-first rules. | `docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`, `docs/DOCS_DEDUPLICATION_MAP.md` | `./scripts/test_docs_sync.sh` | Regenerated navigation + markdown link validation + doc-gen probe when available. |
 | IPC/scheduler/capability/info-flow invariants remain in active proof surface. | Kernel modules and invariant suites listed in `scripts/test_tier3_invariant_surface.sh` | `./scripts/test_tier3_invariant_surface.sh` | Direct symbol + theorem + doc anchor checks. |
 | Executable behavior remains fixture-backed and malformed-state safe. | `tests/fixtures/main_trace_smoke.expected`, negative/IF suites | `./scripts/test_tier2_trace.sh`, `./scripts/test_tier2_negative.sh` | Stable trace fragments + negative/IF runtime checks. |
+| Queue ownership metadata is now embedded in core kernel objects (`SchedulerState.runnableHead`/`runnableTail`, `TCB.queuePrev`/`queueNext`) to support intrusive-list migration. | `SeLe4n/Model/State.lean`, `SeLe4n/Model/Object.lean`, `SeLe4n/Kernel/IPC/Operations.lean` | `source ~/.elan/env && lake build`, `./scripts/test_smoke.sh` | Build + smoke suite validate scheduler/IPC behavior after queue metadata expansion. |
 
 ## Proof claim qualification (WS-D3/F-16, updated by v0.11.6 audit C-01/H-01; C-01/H-01 resolved by WS-E2)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -74,6 +74,7 @@ Every milestone-moving PR should include:
 - IPC thread-state writes no longer succeed silently for missing TCBs; `storeTcbIpcState` now returns `objectNotFound` when lookup fails (including sentinel thread ID `0`).
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
+- Scheduler bookkeeping now records runnable queue endpoints (`runnableHead`, `runnableTail`), and TCBs expose `queuePrev`/`queueNext` intrusive link fields so queue ownership can move away from standalone node allocation.
 
 ## 4) Daily contributor loop
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -46,13 +46,15 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 
 - `SeLe4n/Model/Object.lean`
   - capability rights/targets,
-  - TCB structure + IPC state,
+  - TCB structure + IPC state + intrusive queue link hooks (`queuePrev`/`queueNext`),
   - endpoint protocol fields,
   - CNode slot store and local revoke helper,
   - `KernelObject` discriminated union.
 
 - `SeLe4n/Model/State.lean`
   - `SystemState` (machine + object store + scheduler + IRQ handlers),
+  - scheduler runnable queue endpoints (`runnableHead`/`runnableTail`) via
+    `SchedulerState.withRunnableQueue`,
   - `lookupObject` / `storeObject` / `setCurrentThread`,
   - typed CSpace lookup/ownership helpers and supporting lemmas.
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -24,9 +24,10 @@ This chapter maps where semantics, proofs, and execution evidence live in the cu
 - `SeLe4n/Machine.lean`
   - machine-level state helpers.
 - `SeLe4n/Model/Object.lean`
-  - object-level representations.
+  - object-level representations (including TCB intrusive queue link fields).
 - `SeLe4n/Model/State.lean`
-  - global system-state composition and update helpers.
+  - global system-state composition and update helpers (including runnable
+    queue endpoint synchronization via `SchedulerState.withRunnableQueue`).
 
 ### Kernel transition/invariant families
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -88,6 +88,7 @@ on the semantic and proof foundations of the previous one.
 - IPC thread-state updates fail with `objectNotFound` when the target TCB is missing (including reserved thread ID `0`), preventing ghost queue entries in endpoint/notification paths.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
+- Scheduler state now carries intrusive-queue metadata (`runnableHead`, `runnableTail`), and each TCB includes embedded `queuePrev`/`queueNext` link fields to support linked-queue migration without separate node allocation.
 
 ## 4. Active Workstream Portfolio (WS-E)
 


### PR DESCRIPTION
### Motivation
- Move queue linkage into the TCB to enable intrusive lists (no separate list-node allocation) and to prepare for O(1) queue ownership semantics. 
- Keep the information-flow and runnable/blocked invariants intact after expanding scheduler/router metadata so proofs and projections remain valid. 

### Description
- Add `queuePrev : Option ThreadId` and `queueNext : Option ThreadId` fields to `TCB` in `SeLe4n/Model/Object.lean`. 
- Add `runnableHead : Option ThreadId` and `runnableTail : Option ThreadId` to `SchedulerState` in `SeLe4n/Model/State.lean`. 
- Update runnable-queue mutators in `SeLe4n/Kernel/IPC/Operations.lean` (`ensureRunnable` and `removeRunnable`) so they update `runnableHead`/`runnableTail` and keep the runnable list representation synchronized. 
- Adjust the information-flow projection preservation proof (`ensureRunnable_preserves_projection`) in `SeLe4n/Kernel/InformationFlow/Invariant.lean` to account for the expanded scheduler record, and keep related proof obligations unchanged in intent. 
- Update documentation and claim/evidence index entries (README, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/CLAIM_EVIDENCE_INDEX.md`) to describe the new intrusive-queue metadata and migration rationale. 

### Testing
- Ran `source ~/.elan/env && lake build` to rebuild the project and the Lean proof surface, and the build completed successfully. 
- Executed `./scripts/test_smoke.sh` (Tier 0–2 smoke checks) and all smoke checks passed. 
- Executed `./scripts/test_full.sh` (Tier 0–3 invariant/document-anchor surface) and the full-suite tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0df562dbc832b95b72a944ea8952f)