### PR TITLE
Bump patch version to 0.12.1 and synchronize documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.12.1] - 2026-02-27
+
+### Documentation and release metadata synchronization
+
+- Bumped patch version to **`0.12.1`** in `lakefile.toml`.
+- Updated current-version references in canonical docs (`README.md`, `docs/spec/SELE4N_SPEC.md`).
+- Updated GitBook status mirror (`docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`) to the new patch release marker.
+
 ## [0.12.0] - 2026-02-26
 
 ### WS-E6 Model completeness and documentation (completed)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.12.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.12.1-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -22,7 +22,7 @@
 
 - **Active findings baseline:** `docs/audits/AUDIT_CODEBASE_v0.11.6.md`
 - **Active execution baseline:** `docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`
-- **Current package version:** `0.12.0` (`lakefile.toml`)
+- **Current package version:** `0.12.1` (`lakefile.toml`)
 - **Current active portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)
 - **Prior completed portfolio:** WS-D1..WS-D4 (completed); WS-D5/D6 absorbed into WS-E
 

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -57,7 +57,7 @@ See the workstream plan for WS-E1..WS-E6 details and phase sequencing. WS-E1 thr
 
 ### WS-E6 completed summary
 
-**WS-E6 — Model completeness and documentation** has been completed (v0.12.0). All 10 findings resolved:
+**WS-E6 — Model completeness and documentation** has been completed (v0.12.1). All 10 findings resolved:
 
 - **M-03:** Three-level EDF scheduling (`isBetterCandidate`: priority > deadline > FIFO) with `isBetterCandidate_irrefl`/`_asymm` algebraic theorems. `Deadline` typed identifier. `TCB.deadline` field.
 - **M-04:** Time-slice preemption via `timerTick` operation (decrement/reset+reschedule). `TCB.timeSlice` field. `defaultTimeSlice` constant. `timeSlicePositive` invariant.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -40,7 +40,7 @@ claims, and planning artifacts.
 
 ## 2. Current State Snapshot
 
-- **Current package version:** `0.12.0` (`lakefile.toml`)
+- **Current package version:** `0.12.1` (`lakefile.toml`)
 - **Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.11.6.md`](../audits/AUDIT_CODEBASE_v0.11.6.md)
 - **Active execution baseline:** [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md)
 - **Current active portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.12.0"
+version = "0.12.1"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Prevent metadata drift by bumping the package patch version and ensuring all canonical docs and the GitBook mirror report the same release marker.

### Description
- Updated the package version in `lakefile.toml` from `0.12.0` to `0.12.1`.
- Synchronized the README version badge and current-version line in `README.md` to `0.12.1`.
- Updated the canonical spec snapshot in `docs/spec/SELE4N_SPEC.md` and the GitBook mirror chapter `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md` to reflect `v0.12.1`.
- Added a top-entry in `CHANGELOG.md` documenting the `0.12.1` patch release.

### Testing
- Ran the smoke tier via `./scripts/test_smoke.sh`, which completed successfully with the trace, negative-state, and information-flow suites building and all checks passing.
- Verified the repository status and committed the synchronized files (`lakefile.toml`, `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`, `CHANGELOG.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0eeaa91c0832b88b44b3280ab2ffd)