### PR TITLE
Add runtime intrusive-endpoint-queue invariants and sync documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Additional resources:
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace and probe harnesses now exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
 - WS-E4 dual-queue endpoint operations (`endpointSendDual`/`endpointReceiveDual`) use intrusive-list queue boundaries (`sendQ`/`receiveQ`) with per-thread links stored in `TCB.queuePrev`/`TCB.queueNext`; `negative_state_suite` covers enqueue/block, rendezvous/dequeue, FIFO ordering, queue drain, and dual-queue double-wait rejection (`alreadyWaiting`).
+- Runtime invariant checks now validate intrusive endpoint queue linkage coherence (`sendQ`/`receiveQ` boundaries, `queuePrev`/`queueNext` chain integrity, acyclic traversal, and tail agreement).
 
 ## Stable naming updates (trace + invariant surface)
 

--- a/SeLe4n/Testing/InvariantChecks.lean
+++ b/SeLe4n/Testing/InvariantChecks.lean
@@ -15,6 +15,33 @@ private def endpointObjectValidB (ep : Endpoint) : Bool :=
   | none => ep.state != .receive
   | some _ => ep.state == .receive
 
+private def intrusiveQueueWellFormedB (st : SystemState) (q : IntrusiveQueue) : Bool :=
+  match q.head, q.tail with
+  | none, none => true
+  | some _, none => false
+  | none, some _ => false
+  | some head, some tail =>
+      let fuel := st.objectIndex.length + 1
+      let rec walk (current : SeLe4n.ThreadId) (prev : Option SeLe4n.ThreadId)
+          (seen : List SeLe4n.ThreadId) (remaining : Nat) : Bool × Option SeLe4n.ThreadId :=
+        match remaining with
+        | 0 => (false, none)
+        | n + 1 =>
+            if current ∈ seen then
+              (false, none)
+            else
+              match st.objects current.toObjId with
+              | some (.tcb tcb) =>
+                  if tcb.queuePrev != prev then
+                    (false, none)
+                  else
+                    match tcb.queueNext with
+                    | none => (true, some current)
+                    | some next => walk next (some current) (current :: seen) n
+              | _ => (false, none)
+      let (ok, last) := walk head none [] fuel
+      ok && last == some tail
+
 private def notificationQueueWellFormedB (ntfn : Notification) : Bool :=
   match ntfn.state with
   | .idle => ntfn.waitingThreads.isEmpty && !ntfn.pendingBadge.isSome
@@ -117,6 +144,8 @@ def stateInvariantChecksFor (objectIds : List SeLe4n.ObjId) (st : SystemState)
       | some (.endpoint ep) =>
           (s!"endpoint queue/state invariant: oid={oid}", endpointQueueWellFormedB ep) ::
           (s!"endpoint waiter/state invariant: oid={oid}", endpointObjectValidB ep) :: acc
+          |> List.cons (s!"endpoint sendQ intrusive-list invariant: oid={oid}", intrusiveQueueWellFormedB st ep.sendQ)
+          |> List.cons (s!"endpoint receiveQ intrusive-list invariant: oid={oid}", intrusiveQueueWellFormedB st ep.receiveQ)
       | some (.notification ntfn) =>
           (s!"notification queue/state invariant: oid={oid}", notificationQueueWellFormedB ntfn) :: acc
       | _ => acc) []

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,6 +75,7 @@ Every milestone-moving PR should include:
 - `lookupTcb` treats thread ID `0` as reserved and returns `none`, enforcing the documented sentinel policy at runtime operation boundaries.
 - Runtime harness traces now use checked information-flow wrappers by default (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`).
 - WS-E4 dual-queue endpoint operations (`endpointSendDual`/`endpointReceiveDual`) use intrusive-list queue boundaries (`sendQ`/`receiveQ`) and per-thread links (`queuePrev`/`queueNext`), with explicit coverage in `negative_state_suite` (enqueue/block, rendezvous/dequeue, FIFO ordering, queue drain, duplicate-wait rejection via `alreadyWaiting`).
+- Runtime invariant checks additionally assert intrusive endpoint queue linkage coherence (queue boundary shape, acyclic chain traversal, `queuePrev`/`queueNext` consistency, and tail alignment).
 
 ## 4) Daily contributor loop
 

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -76,7 +76,7 @@ stories remain visible and intentional, especially for milestone claims tied to 
 - **M7 (complete):** audit-remediation coverage (WS-A1..WS-A8) fully integrated into tiered gates.
 - **WS-D (completed):** WS-D1 test validity, WS-D2 information-flow enforcement, WS-D3 proof gaps, WS-D4 kernel hardening all landed with updated Tier 2/3 coverage. WS-D5/WS-D6 absorbed into WS-E.
 - **WS-E (active):** v0.11.6 audit remediation workstreams (WS-E1..WS-E6) driving next round of tier coverage updates.
-- **WS-E1 (completed):** Test infrastructure and CI hardening — SHA-pinned all GitHub Actions (F-14), added 5 runtime invariant check families (M-11: CSpace coherency, capability rights, lifecycle metadata, service acyclicity, VSpace ASID uniqueness), parameterized test topologies with 3 configurations (M-10), structured trace format with scenario/risk metadata (L-07), and theorem-body spot-check validation (L-08).
+- **WS-E1 (completed):** Test infrastructure and CI hardening — SHA-pinned all GitHub Actions (F-14), added 6 runtime invariant check families (M-11: CSpace coherency, capability rights, lifecycle metadata, service acyclicity, VSpace ASID uniqueness, endpoint intrusive-queue linkage coherence), parameterized test topologies with 3 configurations (M-10), structured trace format with scenario/risk metadata (L-07), and theorem-body spot-check validation (L-08).
 
 ## Practical failure triage
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -89,6 +89,7 @@ on the semantic and proof foundations of the previous one.
 - Sentinel ID `0` is rejected at IPC TCB lookup/update boundaries (`lookupTcb`/`storeTcbIpcState`) rather than silently treated as a valid runtime thread identity.
 - Trace/probe harnesses exercise policy-checked wrappers (`endpointSendChecked`, `cspaceMintChecked`, `serviceRestartChecked`) by default; unchecked operations remain available for research experiments.
 - WS-E4 dual-queue endpoint operations (`endpointSendDual`/`endpointReceiveDual`) use intrusive-list queue boundaries (`Endpoint.sendQ`/`Endpoint.receiveQ`) with per-thread links (`TCB.queuePrev`/`TCB.queueNext`); executable coverage is enforced in `negative_state_suite` (block, rendezvous, FIFO, drain, duplicate-wait rejection via `alreadyWaiting`).
+- Runtime invariant checks also enforce intrusive queue linkage coherence (boundary shape, acyclic traversal, per-link `queuePrev`/`queueNext` consistency, and tail agreement for non-empty chains).
 
 ## 4. Active Workstream Portfolio (WS-E)
 


### PR DESCRIPTION
### Motivation
- Ensure the executable invariant surface covers WS-E4 intrusive endpoint queues so structural queue/link corruptions are detected at runtime. 
- Capture common integrity properties (boundary shape, acyclic traversal, per-node link consistency, and tail agreement) as concrete invariant checks. 
- Keep documentation and milestone claims synchronized with the implemented invariant-surface improvements.

### Description
- Added `intrusiveQueueWellFormedB : SystemState -> IntrusiveQueue -> Bool` in `SeLe4n/Testing/InvariantChecks.lean` to validate head/tail shape, perform a bounded acyclic traversal from `head`, check that each node's `queuePrev` matches the predecessor, and confirm the final node equals the endpoint `tail`. 
- Wired the new intrusive-list checks into `stateInvariantChecksFor` so both `Endpoint.sendQ` and `Endpoint.receiveQ` are validated for every endpoint object. 
- Updated documentation to reflect the new runtime invariant family in `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/07-testing-and-ci.md`. 
- Verified the changed Lean module builds cleanly and integrated with the existing invariant check surface.

### Testing
- Built the modified invariant module with `source ~/.elan/env && lake build SeLe4n.Testing.InvariantChecks`, which completed successfully. 
- Executed the Tier-2 smoke gate with `./scripts/test_smoke.sh`, which completed and reported all checks passing. 
- Executed the Tier-3/full gate with `./scripts/test_full.sh`, which completed and reported all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0eec47ac0832bac952e6a28be159c)