### PR TITLE
Deduplicate SeLe4n top-level imports and align invariant gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Additional resources:
 | `SeLe4n/Kernel/Architecture/*` | Architecture assumptions, adapter semantics, boundary invariants |
 | `SeLe4n/Kernel/InformationFlow/*` | Information-flow policy, projection, and low-equivalence |
 | `SeLe4n/Kernel/API.lean` | Unified public API surface, invariant bundle alias, stability table |
+| `SeLe4n.lean` | Top-level import barrel; keep imports minimal/non-duplicated and defer subsystem coverage to `Kernel/API.lean` |
 | `Main.lean` | Executable trace/demo harness |
 | `tests/fixtures/main_trace_smoke.expected` | Stable trace expectation anchors |
 | `scripts/test_tier*.sh` | Tiered quality gates used by CI and local workflows |

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -3,12 +3,3 @@ import SeLe4n.Machine
 import SeLe4n.Model.Object
 import SeLe4n.Model.State
 import SeLe4n.Kernel.API
-
-import SeLe4n.Kernel.Architecture.Assumptions
-
-import SeLe4n.Kernel.Architecture.Adapter
-import SeLe4n.Kernel.Architecture.Invariant
-import SeLe4n.Kernel.Architecture.VSpace
-import SeLe4n.Kernel.Architecture.VSpaceInvariant
-
-import SeLe4n.Kernel.InformationFlow.Enforcement

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,7 +25,8 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 4. domain-aware scheduling semantics (`schedule` only chooses from `activeDomain`; `scheduleDomain` switch/tick behavior is regression-tested),
 5. theorem discoverability through stable naming,
 6. fixture-backed executable evidence (`Main.lean` + trace fixture),
-7. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`).
+7. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`),
+8. top-level import hygiene: keep `SeLe4n.lean` free of duplicate/redundant subsystem imports by relying on `SeLe4n/Kernel/API.lean` as the canonical aggregate surface.
 
 ---
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -25,8 +25,9 @@ Current milestone state:
 3. architecture-boundary assumption/adapter interfaces from M6,
 4. domain-aware scheduler policy (`chooseThread`/`schedule` are active-domain only; no cross-domain fallback) with `currentThreadInActiveDomain` in the canonical scheduler bundle and `scheduleDomain` switch/tick consistency checks,
 5. fixture-backed executable evidence,
-6. tiered testing gates used in CI and local workflows.
-7. WS-E4 dual endpoint queues remain intrusive-list backed (`Endpoint.sendQ`/`receiveQ` + `TCB.queuePrev`/`queuePPrev`/`queueNext`) with runtime intrusive-queue invariant checks (head/tail coherence, cycle-free traversal, prev/pprev/next linkage), malformed-`queuePPrev` rejection (`illegalState`), and duplicate-wait rejection (`alreadyWaiting`).
+6. tiered testing gates used in CI and local workflows,
+7. top-level import hygiene: keep `SeLe4n.lean` minimal and avoid duplicate/redundant subsystem imports; `SeLe4n/Kernel/API.lean` is the canonical aggregate API surface,
+8. WS-E4 dual endpoint queues remain intrusive-list backed (`Endpoint.sendQ`/`receiveQ` + `TCB.queuePrev`/`queuePPrev`/`queueNext`) with runtime intrusive-queue invariant checks (head/tail coherence, cycle-free traversal, prev/pprev/next linkage), malformed-`queuePPrev` rejection (`illegalState`), and duplicate-wait rejection (`alreadyWaiting`).
 
 ## 3) Active workstream portfolio (WS-E)
 

--- a/docs/gitbook/06-development-workflow.md
+++ b/docs/gitbook/06-development-workflow.md
@@ -3,7 +3,7 @@
 ## Daily contributor loop
 
 1. Pick one coherent WS-E target (prioritize next planned workstream in current phase).
-2. Implement minimal code/proof changes.
+2. Implement minimal code/proof changes (including import hygiene in `SeLe4n.lean`: no duplicate/redundant top-level subsystem imports).
 3. Run tiered checks from smallest scope upward.
 4. Synchronize docs in the same PR.
 5. Re-run validations before merge.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -179,7 +179,8 @@ Unless a PR explicitly proposes spec-level change control, preserve:
    - canonical IPC/lifecycle composition surfaces: `coreIpcInvariantBundle`, `ipcSchedulerCouplingInvariantBundle`, `lifecycleCompositionInvariantBundle`,
    - canonical trace helper surfaces: `runCapabilityIpcTrace`, `runSchedulerTimingDomainTrace`,
 6. fixture-backed executable evidence (`Main.lean` + trace fixture),
-7. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`).
+7. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`),
+8. top-level import hygiene: keep `SeLe4n.lean` minimal and avoid duplicate/redundant subsystem imports; `SeLe4n/Kernel/API.lean` is the canonical aggregate API surface.
 
 ---
 

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -113,7 +113,7 @@ run_check "INVARIANT" rg -n '^theorem adapterAdvanceTimer_error_unsupportedBindi
 run_check "INVARIANT" rg -n '^theorem adapterWriteRegister_error_unsupportedBinding_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem adapterReadMemory_error_unsupportedBinding_preserves_proofLayerInvariantBundle' SeLe4n/Kernel/Architecture/Invariant.lean
 run_check "INVARIANT" rg -n '^import SeLe4n\.Kernel\.Architecture\.Invariant$' SeLe4n/Kernel/API.lean
-run_check "INVARIANT" rg -n '^import SeLe4n\.Kernel\.Architecture\.Invariant$' SeLe4n.lean
+run_check "INVARIANT" bash -lc "if rg -n '^import SeLe4n\\.Kernel\\.Architecture\\.Invariant$' SeLe4n.lean; then exit 1; fi"
 
 run_check "INVARIANT" rg -n '^inductive ArchAssumption' SeLe4n/Kernel/Architecture/Assumptions.lean
 run_check "INVARIANT" rg -n '^structure BootBoundaryContract' SeLe4n/Kernel/Architecture/Assumptions.lean


### PR DESCRIPTION
### Motivation
- The top-level `SeLe4n.lean` file duplicated subsystem imports (architecture + information-flow) that are already aggregated by `SeLe4n/Kernel/API.lean`, so the change enforces a single canonical import surface and reduces import duplication. 
- The Tier-3 invariant surface check expected the canonical architecture invariant to be present only in the API barrel, so the test gate needed to be updated to reflect the intended hygiene contract.

### Description
- Removed redundant `SeLe4n.Kernel.Architecture.*` and `SeLe4n.Kernel.InformationFlow.Enforcement` imports from `SeLe4n.lean` so the top-level barrel now only imports the minimal base pieces plus `SeLe4n.Kernel.API`. 
- Updated `scripts/test_tier3_invariant_surface.sh` to assert the architecture invariant import exists in `SeLe4n/Kernel/API.lean` and to fail if `SeLe4n.lean` contains the duplicate `Architecture.Invariant` import. 
- Synchronized contributor-facing documentation and GitBook entries to record the new top-level import hygiene rule (updated `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, `docs/gitbook/05-specification-and-roadmap.md`, and `docs/gitbook/06-development-workflow.md`). 

### Testing
- Ran the tiered validation commands `./scripts/test_fast.sh`, `./scripts/test_smoke.sh`, and `./scripts/test_full.sh`, and all returned PASS after updating the Tier-3 invariant gate. 
- Noted and fixed an initial `test_full.sh` failure from the invariant surface check that expected the removed duplicate import, then re-ran the full suite to confirm the fix. 
- The build step (`lake build`) completed successfully as part of the fast/smoke runs and the trace/invariant/flow suites in the smoke/full pipelines passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1cd327830832b939cf035c16709a4)