### PR TITLE
Bump patch version to 0.12.2 and synchronize docs/gitbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.12.2] - 2026-02-27
+
+### Documentation and release metadata synchronization
+
+- Bumped patch version to **`0.12.2`** in `lakefile.toml`.
+- Updated current-version references in canonical docs (`README.md`, `docs/spec/SELE4N_SPEC.md`).
+- Updated GitBook status mirror (`docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`) to the new patch release marker.
+
 ## [0.12.1] - 2026-02-27
 
 ### Documentation and release metadata synchronization

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.12.1-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.12.2-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -20,7 +20,7 @@
 
 ## Current state (authoritative snapshot)
 
-- **Current package version:** `0.12.1` (`lakefile.toml`)
+- **Current package version:** `0.12.2` (`lakefile.toml`)
 - **Current active portfolio:** In-Planning
 - **Prior completed portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)
 - **Active findings baseline:** `docs/audits/AUDIT_CODEBASE_v0.11.6.md`

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -57,7 +57,7 @@ See the workstream plan for WS-E1..WS-E6 details and phase sequencing. WS-E1 thr
 
 ### WS-E6 completed summary
 
-**WS-E6 — Model completeness and documentation** has been completed (v0.12.1). All 10 findings resolved:
+**WS-E6 — Model completeness and documentation** has been completed (v0.12.2). All 10 findings resolved:
 
 - **M-03:** Three-level EDF scheduling (`isBetterCandidate`: priority > deadline > FIFO) with `isBetterCandidate_irrefl`/`_asymm` algebraic theorems. `Deadline` typed identifier. `TCB.deadline` field.
 - **M-04:** Time-slice preemption via `timerTick` operation (decrement/reset+reschedule). `TCB.timeSlice` field. `defaultTimeSlice` constant. `timeSlicePositive` invariant.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -40,7 +40,7 @@ claims, and planning artifacts.
 
 ## 2. Current State Snapshot
 
-- **Current package version:** `0.12.1` (`lakefile.toml`)
+- **Current package version:** `0.12.2` (`lakefile.toml`)
 - **Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.11.6.md`](../audits/AUDIT_CODEBASE_v0.11.6.md)
 - **Active execution baseline:** [`docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md)
 - **Current active portfolio:** WS-E1..WS-E6 (v0.11.6 codebase audit remediation)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.12.1"
+version = "0.12.2"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation
- Release a patch bump to `0.12.2` and keep release metadata and mirrors in sync across canonical docs and the GitBook mirror.
- Ensure package metadata (`lakefile.toml`) and user-facing documentation (README, SELE4N spec, GitBook) consistently reflect the new patch version.

### Description
- Updated package version in `lakefile.toml` to `0.12.2`.
- Updated the version badge and the authoritative “Current package version” entry in `README.md` to `0.12.2`.
- Updated the canonical spec snapshot in `docs/spec/SELE4N_SPEC.md` to `0.12.2` and the GitBook workstream status mirror in `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md` to reference `v0.12.2`.
- Prepended a `0.12.2` entry to `CHANGELOG.md` documenting the metadata/docs synchronization; no kernel code, proofs, or theorem changes were made.

### Testing
- Ran `./scripts/test_fast.sh`, which completed successfully (hygiene + build checks) and returned pass status.
- Ran `./scripts/test_tier2_trace.sh` (trace harness / fixture comparison), which passed with all fixtures matched.
- Attempted `./scripts/test_smoke.sh` (full smoke suite); the run progressed through hygiene/build/trace stages but timed out while running the `negative_state_suite` executable in this environment (timeout observed during `lake exe negative_state_suite`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f3df82a4832bb57a407c00fc822f)