### PR TITLE
Remove docs-sync CI lane and consolidate Tier 3 invariant checks

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -15,48 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs-automation:
-    name: Docs Automation / Navigation + Links + DocGen Probe
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      - name: Restore Lean and Lake caches
-        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
-        with:
-          path: |
-            ~/.elan
-            .lake/packages
-            .lake/build
-          key: ${{ runner.os }}-${{ runner.arch }}-lean-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml', 'scripts/setup_lean_env.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-lean-
-
-      - name: Setup Lean toolchain
-        run: ./scripts/setup_lean_env.sh
-
-      - name: Run documentation synchronization checks
-        run: ./scripts/ci_capture_timing.sh docs-sync ./scripts/test_docs_sync.sh
-
-      - name: Upload generated API docs (if present)
-        if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: api-docs-preview
-          path: |
-            .lake/build/doc/
-            .lake/build/doc-gen4/
-          if-no-files-found: ignore
-
-      - name: Upload CI telemetry (docs lane)
-        if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: ci-telemetry-docs
-          path: .ci-artifacts/telemetry/
-          if-no-files-found: ignore
-
   test-fast:
     name: Tiered Tests / Fast (Tier 0 + Tier 1)
     runs-on: ubuntu-latest
@@ -90,9 +48,9 @@ jobs:
           if-no-files-found: ignore
 
   test-smoke:
-    name: Tiered Tests / Smoke (Tier 0 + Tier 1 + Tier 2)
+    name: Tiered Tests / Smoke (Tier 2)
     runs-on: ubuntu-latest
-    needs: [docs-automation, test-fast]
+    needs: test-fast
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -111,10 +69,16 @@ jobs:
       - name: Setup Lean toolchain
         run: ./scripts/setup_lean_env.sh
 
-      - name: Run smoke gate
+      - name: Validate scenario catalog
+        run: python3 scripts/scenario_catalog.py validate
+
+      - name: Run Tier 2 trace checks
         env:
           TRACE_ARTIFACT_DIR: .ci-artifacts/trace
-        run: ./scripts/ci_capture_timing.sh smoke ./scripts/test_smoke.sh
+        run: ./scripts/ci_capture_timing.sh smoke-trace ./scripts/test_tier2_trace.sh
+
+      - name: Run Tier 2 negative-state checks
+        run: ./scripts/ci_capture_timing.sh smoke-negative ./scripts/test_tier2_negative.sh
 
       - name: Upload trace fixture diagnostics on failure
         if: failure()
@@ -134,7 +98,7 @@ jobs:
           if-no-files-found: ignore
 
   test-full:
-    name: Tiered Tests / Full (Tier 0 + Tier 1 + Tier 2 + Tier 3)
+    name: Tiered Tests / Full (Tier 3)
     runs-on: ubuntu-latest
     needs: test-smoke
 
@@ -155,8 +119,8 @@ jobs:
       - name: Setup Lean toolchain
         run: ./scripts/setup_lean_env.sh
 
-      - name: Run full gate
-        run: ./scripts/ci_capture_timing.sh full ./scripts/test_full.sh
+      - name: Run Tier 3 invariant surface checks
+        run: ./scripts/ci_capture_timing.sh full ./scripts/test_tier3_invariant_surface.sh
 
       - name: Upload CI telemetry (full lane)
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,12 @@ lake exe sele4n
 ```bash
 ./scripts/test_fast.sh      # Tier 0+1: hygiene + build
 ./scripts/test_smoke.sh     # Tier 0-2: + trace + negative-state
-./scripts/test_full.sh      # Tier 0-3: + invariant/doc anchors
+./scripts/test_full.sh      # Tier 0-3: + invariant surface anchors
 NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh  # Tier 0-4
 ```
 
 Run at least `test_smoke.sh` before any PR. Run `test_full.sh` when changing
-theorems, invariants, or documentation anchors.
+theorems or invariants.
 
 ## Source layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ lake exe sele4n
 ```bash
 ./scripts/test_fast.sh      # Tier 0+1: hygiene + build
 ./scripts/test_smoke.sh     # Tier 0-2: + trace + negative-state
-./scripts/test_full.sh      # Tier 0-3: + invariant/doc anchors
+./scripts/test_full.sh      # Tier 0-3: + invariant surface anchors
 NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh  # Tier 0-4
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Full handbook: [`docs/gitbook/README.md`](docs/gitbook/README.md)
 
 ```bash
 ./scripts/test_smoke.sh     # minimum gate (Tier 0-2)
-./scripts/test_full.sh      # required for theorem/invariant/doc changes (Tier 0-3)
+./scripts/test_full.sh      # required for theorem/invariant changes (Tier 0-3)
 ```
 
 ## PR requirements

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Additional resources:
 ```bash
 ./scripts/test_fast.sh      # Tier 0 + Tier 1 (hygiene + build)
 ./scripts/test_smoke.sh     # + Tier 2 (trace + negative-state checks)
-./scripts/test_full.sh      # + Tier 3 (invariant/doc anchor surface)
+./scripts/test_full.sh      # + Tier 3 (invariant surface anchors)
 ./scripts/test_nightly.sh   # + Tier 4 (staged nightly; opt-in via NIGHTLY_ENABLE_EXPERIMENTAL=1)
 ```
 

--- a/docs/CI_POLICY.md
+++ b/docs/CI_POLICY.md
@@ -6,17 +6,17 @@ This document is the canonical CI policy artifact for WS-A1, WS-A8, and WS-B10 C
 
 For pull requests into `main`, branch protection should require all of the following checks:
 
-1. `Docs Automation / Navigation + Links + DocGen Probe`
-2. `Tiered Tests / Fast (Tier 0 + Tier 1)`
-3. `Tiered Tests / Smoke (Tier 0 + Tier 1 + Tier 2)`
-4. `Tiered Tests / Full (Tier 0 + Tier 1 + Tier 2 + Tier 3)`
+1. `Tiered Tests / Fast (Tier 0 + Tier 1)`
+2. `Tiered Tests / Smoke (Tier 2)`
+3. `Tiered Tests / Full (Tier 3)`
 
-These checks are produced by `.github/workflows/lean_action_ci.yml` and enforce the repository scripts directly:
+These checks are produced by `.github/workflows/lean_action_ci.yml`. Each CI job runs only its incremental tier; earlier tiers are gated by job dependencies:
 
-- `./scripts/test_docs_sync.sh`
-- `./scripts/test_fast.sh`
-- `./scripts/test_smoke.sh`
-- `./scripts/test_full.sh`
+- `test-fast`: `./scripts/test_fast.sh` (Tier 0 + Tier 1)
+- `test-smoke` (after test-fast): `./scripts/test_tier2_trace.sh` + `./scripts/test_tier2_negative.sh`
+- `test-full` (after test-smoke): `./scripts/test_tier3_invariant_surface.sh`
+
+Documentation sync (`./scripts/test_docs_sync.sh`) is available for local use but is not part of CI gates.
 
 ## 2. Deterministic replay evidence (Tier 4)
 
@@ -43,10 +43,9 @@ In GitHub repository settings for `main`:
 1. Enable **Require a pull request before merging**.
 2. Enable **Require status checks to pass before merging**.
 3. Mark these checks as required:
-   - `Docs Automation / Navigation + Links + DocGen Probe`
    - `Tiered Tests / Fast (Tier 0 + Tier 1)`
-   - `Tiered Tests / Smoke (Tier 0 + Tier 1 + Tier 2)`
-   - `Tiered Tests / Full (Tier 0 + Tier 1 + Tier 2 + Tier 3)`
+   - `Tiered Tests / Smoke (Tier 2)`
+   - `Tiered Tests / Full (Tier 3)`
 4. Enable **Require branches to be up to date before merging**.
 5. Disable direct pushes to `main` for non-admin contributors.
 

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -56,4 +56,4 @@ When a claim changes:
 1. update canonical root source first,
 2. update GitBook mirror(s) in the same PR,
 3. refresh this table row(s) for changed claims,
-4. run `./scripts/test_docs_sync.sh` and at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).
+4. run at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).

--- a/docs/DOCS_DEDUPLICATION_MAP.md
+++ b/docs/DOCS_DEDUPLICATION_MAP.md
@@ -29,8 +29,7 @@ WS-C8 automation is intentionally simple and reproducible:
 
 1. `scripts/generate_doc_navigation.py` generates `docs/gitbook/README.md` and `docs/gitbook/SUMMARY.md` from `docs/gitbook/navigation_manifest.json`.
 2. `scripts/check_markdown_links.py` validates local markdown links across tracked `*.md` files.
-3. `scripts/test_docs_sync.sh` runs navigation generation, verifies generated files are committed, runs markdown-link validation, and opportunistically invokes `doc-gen4` when available.
-4. `scripts/test_tier0_hygiene.sh` includes `test_docs_sync.sh` so doc-sync checks run in fast/smoke/full gates and CI.
+3. `scripts/test_docs_sync.sh` runs navigation generation, verifies generated files are committed, runs markdown-link validation, and opportunistically invokes `doc-gen4` when available. It is available as a standalone local tool and is not part of CI gates.
 
 ## 4) PR checklist additions (planning/doc changes)
 

--- a/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
+++ b/docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
@@ -31,12 +31,12 @@ Use this file during planning and PR review to keep documentation status aligned
 
 | Validation area | Command | What it verifies |
 |---|---|---|
-| Hygiene + forbidden markers + fixture isolation | `./scripts/test_tier0_hygiene.sh` | No `sorry`/`axiom` debt in proof surface; no test contract leakage into production kernel modules. |
-| Documentation sync automation | `./scripts/test_docs_sync.sh` | GitBook navigation generation is reproducible/committed and local markdown links resolve. |
+| Hygiene + forbidden markers + fixture isolation | `./scripts/test_tier0_hygiene.sh` | No `sorry`/`axiom` debt in proof surface; no test contract leakage into production kernel modules; theorem-body spot-check; SHA-pinning regression guard. |
 | Lean build soundness | `./scripts/test_tier1_build.sh` | Project compiles successfully via `lake build`. |
 | End-to-end executable trace fixture | `./scripts/test_tier2_trace.sh` | Runtime trace still satisfies fixture expectations and scenario/risk-tagged entries. |
 | Negative/adversarial malformed-state suite | `./scripts/test_tier2_negative.sh` | Malformed capability/object/IPC/VSpace/scheduler states fail safely with explicit modeled errors. |
-| Invariant/doc anchor surface | `./scripts/test_tier3_invariant_surface.sh` | Critical theorem/definition/document anchors still exist after refactors. |
+| Invariant surface anchors | `./scripts/test_tier3_invariant_surface.sh` | Critical theorem/definition/trace anchors still exist after refactors. |
+| Documentation sync (local tool) | `./scripts/test_docs_sync.sh` | GitBook navigation generation is reproducible and local markdown links resolve. Not part of CI gates. |
 | Nightly candidates / determinism replay | `./scripts/test_tier4_nightly_candidates.sh` and `NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh` | Multi-run determinism, nightly artifacts, and seeded stochastic probe replay. |
 | Fast lane | `./scripts/test_fast.sh` | Tier 0 + Tier 1 quick validation. |
 | Smoke lane | `./scripts/test_smoke.sh` | Tier 0 + Tier 1 + Tier 2 trace + Tier 2 negative-state validation. |

--- a/docs/TESTING_FRAMEWORK_PLAN.md
+++ b/docs/TESTING_FRAMEWORK_PLAN.md
@@ -8,12 +8,14 @@ Current stage context: **v0.11.6 codebase audit (WS-E portfolio) is active. Test
 
 ## 2. Current enforced tiers
 
-- **Tier 0** hygiene (`scripts/test_tier0_hygiene.sh`, including docs-sync automation via `scripts/test_docs_sync.sh` with best-effort Lean setup for doc-gen4 probe when `lake` is missing (strict mode via `DOCS_SYNC_REQUIRE_LEAN_SETUP=1`))
+- **Tier 0** hygiene (`scripts/test_tier0_hygiene.sh`: forbidden-marker scan, fixture-isolation guard, wrapper-structure regression, theorem-body spot-check, SHA-pinning regression, optional shellcheck)
 - **Tier 1** build/theorem compile (`scripts/test_tier1_build.sh`)
 - **Tier 2** executable smoke (`scripts/test_tier2_trace.sh` + `scripts/test_tier2_negative.sh`, including `negative_state_suite` + `information_flow_suite`)
-- **Tier 3** invariant/doc-surface checks (`scripts/test_tier3_invariant_surface.sh`, via full suite),
-  including M4-A executable-anchor checks for lifecycle unauthorized/illegal-state/success trace fragments.
+- **Tier 3** invariant surface checks (`scripts/test_tier3_invariant_surface.sh`, via full suite),
+  including code/theorem/trace anchor verification for all milestone surfaces.
 - **Tier 4** staged nightly candidates (`scripts/test_tier4_nightly_candidates.sh` via `scripts/test_nightly.sh`; explicit opt-in extension point with mode-aware status messaging for default vs enabled runs)
+
+Documentation sync (`scripts/test_docs_sync.sh`) is available as a standalone local tool for verifying GitBook navigation generation, markdown link integrity, and optional doc-gen4 probes. It is not part of the CI gate pipeline.
 
 ## 3. Required entrypoints and CI contract
 
@@ -33,7 +35,7 @@ Recommended audit entrypoint for release/closeout confidence:
 
 PR CI must call repository scripts directly and keep workflow logic thin.
 
-Branch-protection and required-check policy is documented in `docs/CI_POLICY.md` (including the docs-automation CI lane).
+Branch-protection and required-check policy is documented in `docs/CI_POLICY.md`.
 
 WS-A8 platform/security baseline automation is provided by `.github/workflows/platform_security_baseline.yml` (ARM64 fast gate + baseline security scanning controls).
 
@@ -96,11 +98,11 @@ Primary risks protected:
 - executable semantic drift in integration scenarios,
 - stale milestone claims not reflected in runtime evidence.
 
-### Tier 3 (invariant/doc-surface anchors)
+### Tier 3 (invariant surface anchors)
 
 Primary risks protected:
 
-- silent loss of required theorem/bundle/doc symbols used as milestone acceptance anchors.
+- silent loss of required theorem/bundle/trace symbols used as milestone acceptance anchors.
 
 ### Tier 4 (nightly extension)
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -93,8 +93,7 @@ Hardening changes are validated by the standard gates:
 - `./scripts/test_fast.sh`
 - `./scripts/test_full.sh`
 
-Tier 3 invariant/document anchors additionally check for:
+Tier 3 invariant surface anchors additionally check for:
 
-- threat-model publication,
 - setup-script checksum verification symbols,
-- synchronized active-slice status language across canonical docs.
+- SHA-pinning of all GitHub Actions workflow references.

--- a/docs/gitbook/07-testing-and-ci.md
+++ b/docs/gitbook/07-testing-and-ci.md
@@ -6,7 +6,10 @@ Current stage context: **WS-E portfolio (v0.11.6 audit remediation) with WS-E1..
 
 - **Tier 0 (hygiene)**
   - marker scan for forbidden placeholders (`axiom|sorry|TODO`) in tracked proof surface,
-  - documentation synchronization automation (`scripts/test_docs_sync.sh`: navigation generation + markdown-link checks + best-effort Lean setup for doc-gen4 probe when `lake` is missing (strict mode via `DOCS_SYNC_REQUIRE_LEAN_SETUP=1`)),
+  - fixture-isolation guard (test-only contracts must not leak into production kernel modules),
+  - wrapper-structure regression guard (scalar wrappers must remain structure-based),
+  - theorem-body spot-check (L-08: no `sorry`, no trivial `rfl`-only preservation theorems),
+  - SHA-pinning regression guard (F-14: all GitHub Actions must be SHA-pinned),
   - optional shell-quality checks.
 - **Tier 1 (build/proof compile)**
   - full `lake build` to verify definitions, theorem scripts, and module integration.
@@ -16,11 +19,11 @@ Current stage context: **WS-E portfolio (v0.11.6 audit remediation) with WS-E1..
   - fixture lines support scenario/risk tags (`scenario_id | risk_class | expected_trace_fragment`) for audit traceability.
   - fixtures include WS-A4 scale scenarios for deep CNode radix, large runnable queues, multi-endpoint IPC, depth-5 service dependencies, and boundary memory addresses.
   - WS-B11 scenario metadata is maintained in `tests/scenarios/scenario_catalog.json` and validated by `scripts/scenario_catalog.py` in smoke/nightly gates.
-- **Tier 3 (invariant and documentation anchor surface)**
-  - validates critical theorem/bundle/doc anchors expected for active milestone slices,
+- **Tier 3 (invariant surface anchors)**
+  - validates critical theorem/bundle/trace anchors expected for active milestone slices,
   - includes executable-trace anchor checks for milestone-critical lifecycle fragments.
 - **Tier 4 (nightly staged extension candidates)**
-  - `./scripts/test_tier4_nightly_candidates.sh` stages repeat-run determinism + full-suite replay candidates,
+  - `./scripts/test_tier4_nightly_candidates.sh` stages repeat-run determinism + seeded sequence-diversity candidates,
   - `./scripts/test_nightly.sh` uses mode-aware status messaging (default extension-point guidance vs explicit executed signal when `NIGHTLY_ENABLE_EXPERIMENTAL=1`),
   - includes seeded `trace_sequence_probe` sequence-diversity checks in experimental mode,
   - default remains explicit extension-point behavior unless `NIGHTLY_ENABLE_EXPERIMENTAL=1` is set.
@@ -38,7 +41,9 @@ Current stage context: **WS-E portfolio (v0.11.6 audit remediation) with WS-E1..
 
 CI should execute these repository scripts directly to avoid local/CI drift.
 
-Required branch-protection checks and reproducible setup instructions are documented in [`docs/CI_POLICY.md`](../CI_POLICY.md), including the `Docs Automation / Navigation + Links + DocGen Probe` required lane.
+Required branch-protection checks and reproducible setup instructions are documented in [`docs/CI_POLICY.md`](../CI_POLICY.md). CI jobs run each tier incrementally (earlier tiers gated by job dependencies) to eliminate redundant re-execution.
+
+Documentation sync (`scripts/test_docs_sync.sh`) is available as a standalone local tool but is not part of CI gates.
 
 WS-A8 baseline maturity automation is implemented in `.github/workflows/platform_security_baseline.yml`, adding an ARM64 fast-gate CI signal and automated baseline security scanning controls.
 
@@ -83,5 +88,5 @@ stories remain visible and intentional, especially for milestone claims tied to 
 - **Tier 0 fails:** remove placeholder markers or fix script-level lint/hygiene issues.
 - **Tier 1 fails:** resolve first Lean compile/proof failure before chasing downstream errors.
 - **Tier 2 fails:** if `test_tier2_trace.sh` fails, inspect missing fixture lines; if `test_tier2_negative.sh` fails, inspect malformed-state or IF-M1 runtime assertions (`negative_state_suite` / `information_flow_suite`) and expected branch behavior.
-- **Tier 3 fails (`./scripts/test_tier3_invariant_surface.sh`):** verify theorem/bundle/doc anchor names are still present after refactor, then repair the exact missing anchor in the referenced file.
-- **Tier 4 fails (`./scripts/test_nightly.sh` / `./scripts/test_tier4_nightly_candidates.sh`):** inspect `tests/artifacts/nightly/` traces + determinism diff and decide whether the drift is semantic regression or an intentional behavior change that needs fixture/doc updates.
+- **Tier 3 fails (`./scripts/test_tier3_invariant_surface.sh`):** verify theorem/bundle/trace anchor names are still present after refactor, then repair the exact missing anchor in the referenced file.
+- **Tier 4 fails (`./scripts/test_nightly.sh` / `./scripts/test_tier4_nightly_candidates.sh`):** inspect `tests/artifacts/nightly/` traces + determinism diff and decide whether the drift is semantic regression or an intentional behavior change that needs fixture updates.

--- a/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
+++ b/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
@@ -33,8 +33,8 @@ The project's active quality gates are:
    - Lean build closure for entire module graph.
 3. **Tier 2 (trace fixtures)**
    - executable scenario output compared to expected semantic lines.
-4. **Tier 3 (invariant/proof/doc anchors)**
-   - required symbol and documentation anchor presence checks.
+4. **Tier 3 (invariant/proof/trace anchors)**
+   - required symbol and trace anchor presence checks.
 5. **Tier 4 (nightly extension point)**
    - staged deterministic replay and full-suite expansion checks.
 

--- a/scripts/test_tier0_hygiene.sh
+++ b/scripts/test_tier0_hygiene.sh
@@ -31,8 +31,6 @@ else
   run_check "HYGIENE" bash -lc 'if grep -nE "abbrev (DomainId|Priority|Irq|Badge|ASID|VAddr|PAddr) := Nat" SeLe4n/Prelude.lean; then echo "WS-B4 regression: remaining scalar wrappers must stay structure-based." >&2; exit 1; fi'
 fi
 
-run_check "HYGIENE" "${SCRIPT_DIR}/test_docs_sync.sh"
-
 # L-08 (WS-E1): spot-check theorem-body validation.
 # Verify that sampled key preservation theorems have non-trivial proof bodies.
 # A theorem is flagged if its body is only `:= by rfl`, `:= rfl`, or contains sorry.

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -8,7 +8,6 @@ source "${SCRIPT_DIR}/test_lib.sh"
 parse_common_args "$@"
 cd "${REPO_ROOT}"
 
-# M6 WS-M6-A assumption inventory anchors.
 # WS-B1 closure anchors: VSpace transitions, invariants, and ADR publication.
 run_check "INVARIANT" rg -n '^structure VSpaceRoot' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^def resolveAsidRoot' SeLe4n/Kernel/Architecture/VSpace.lean
@@ -21,8 +20,6 @@ run_check "INVARIANT" rg -n 'WS-C3 proof-surface note:' SeLe4n/Kernel/Architectu
 run_check "INVARIANT" bash -lc "! rg -n '^theorem projectState_deterministic' SeLe4n/Kernel/InformationFlow/Projection.lean"
 run_check "INVARIANT" rg -n 'WS-C3 proof-surface note:' SeLe4n/Kernel/InformationFlow/Projection.lean
 run_check "INVARIANT" rg -n '^def vspaceInvariantBundle' SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
-run_check "DOC" rg -n '^# ADR: WS-B1 VSpace \+ Bounded Memory Model Foundation' docs/VSPACE_MEMORY_MODEL_ADR.md
-run_check "DOC" rg -n '^# WS-B1 ADR: VSpace \+ Bounded Memory Model Foundation' docs/gitbook/26-ws-b1-vspace-memory-adr.md
 # WS-B4 closure anchors: wrapper structures must remain explicit.
 run_check "INVARIANT" rg -n '^structure DomainId' SeLe4n/Prelude.lean
 run_check "INVARIANT" rg -n '^structure Priority' SeLe4n/Prelude.lean
@@ -37,7 +34,6 @@ run_check "INVARIANT" rg -n '^inductive ResolveError' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^def resolveSlot' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^def cspaceResolvePath' SeLe4n/Kernel/Capability/Operations.lean
 run_check "INVARIANT" rg -n '^def cspaceLookupPath' SeLe4n/Kernel/Capability/Operations.lean
-run_check "DOC" rg -n '^### WS-B5 — CSpace semantics completion \(Completed\)' docs/dev_history/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
 
 # WS-B6 closure anchors: notification IPC object model and transition surface.
 run_check "INVARIANT" rg -n '^inductive NotificationState' SeLe4n/Model/Object.lean
@@ -45,7 +41,6 @@ run_check "INVARIANT" rg -n '^structure Notification' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^def notificationSignal' SeLe4n/Kernel/IPC/Operations.lean
 run_check "INVARIANT" rg -n '^def notificationWait' SeLe4n/Kernel/IPC/Operations.lean
 run_check "INVARIANT" rg -n '^def notificationInvariant' SeLe4n/Kernel/IPC/Invariant.lean
-run_check "DOC" rg -n '^### WS-B6 — IPC completeness with notifications \(Completed\)' docs/dev_history/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
 
 # WS-B7 closure anchors: information-flow policy/projection baseline and milestone docs.
 run_check "INVARIANT" rg -n '^inductive Confidentiality' SeLe4n/Kernel/InformationFlow/Policy.lean
@@ -57,31 +52,9 @@ run_check "INVARIANT" rg -n '^def lowEquivalent' SeLe4n/Kernel/InformationFlow/P
 run_check "INVARIANT" rg -n '^theorem lowEquivalent_trans' SeLe4n/Kernel/InformationFlow/Projection.lean
 run_check "INVARIANT" rg -n '^private def runInformationFlowChecks' tests/InformationFlowSuite.lean
 run_check "INVARIANT" rg -n '^run_check "TRACE" lake exe information_flow_suite' scripts/test_tier2_negative.sh
-run_check "DOC" rg -n '^### WS-B7 — Information-flow proof track start \(Completed\)' docs/dev_history/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
-run_check "DOC" rg -n '^## IF-M1 — Policy lattice and labeling primitives ✅ completed \(WS-B7\)' docs/INFORMATION_FLOW_ROADMAP.md
-run_check "DOC" rg -n '^# IF-M1 Baseline Package \(WS-B7\)' docs/dev_history/IF_M1_BASELINE_PACKAGE.md
-# shellcheck disable=SC2016
-run_check "DOC" rg -n '(^- \*\*Active findings baseline:\*\* `docs/audits/AUDIT_CODEBASE_v0\.11\.6\.md`$)|(^- \*\*Active findings baseline:\*\* `docs/audits/AUDIT_v0\.11\.0\.md`$)|(^- \*\*Active findings baseline:\*\* `docs/audits/AUDIT_v0\.9\.32\.md`$)' README.md
-run_check "DOC" rg -n '(^- \*\*Current active portfolio:\*\* WS-E1\.\.WS-E6)|(^- \*\*Current active portfolio:\*\* WS-D1\.\.WS-D6)|(^- \*\*Current active portfolio:\*\* WS-C1\.\.WS-C8)' docs/spec/SELE4N_SPEC.md
-run_check "DOC" rg -n '(^- \*\*Comprehensive Audit 2026-02 execution \(WS-B portfolio\)\*\* with WS-B1 through WS-B11 completed\.$)|(^Current completed slice:$)' docs/gitbook/01-project-overview.md
-run_check "DOC" rg -n '(^1\. Pick one coherent WS-E target \(prioritize next planned workstream in current phase\)\.$)|(^- \*\*Phase P1:\*\* WS-E1 \(test/CI\))|(^1\. Pick one coherent WS-D target \(prioritize Phase P1 blockers first\)\.$)|(^- \*\*Phase P1:\*\* WS-D1 test validity restoration)|(^1\. Pick one coherent WS-C target \(prioritize Phase P1 blockers first\)\.$)|(^- \*\*Phase P2:\*\* WS-C5 assurance expansion \(completed\)$)' docs/gitbook/06-development-workflow.md
-run_check "DOC" rg -n '(^See the workstream plan for WS-E1\.\.WS-E6)|(^- \*\*WS-D1:\*\* Test error handling and validity)|(^- \*\*WS-C1:\*\* IPC handshake correctness -- completed$)' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
-run_check "DOC" rg -n '(^1\. Sync branch and choose one coherent WS-E slice \(prefer next priority in the active plan, starting with current phase targets\)\.$)|(^## 3\) Current execution slice \(WS-E portfolio\)$)|(^1\. Sync branch and choose one coherent WS-D slice \(prefer next priority in the active plan, starting with P1 blockers\)\.$)|(^## 3\) Current execution slice \(WS-D portfolio\)$)|(^1\. Sync branch and choose one coherent WS-C slice \(prefer next priority in the active plan, starting with P1 blockers\)\.$)|(^## 3\) Current execution slice \(WS-C portfolio\)$)' docs/DEVELOPMENT.md
-run_check "DOC" rg -n '^### WS-B8 — Documentation automation \+ consolidation \(Completed\)' docs/dev_history/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
-run_check "DOC" rg -n '^### WS-B9 — Threat model and security hardening \(Completed\)' docs/dev_history/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
-run_check "DOC" rg -n '^# Threat Model and Security Hardening Baseline \(WS-B9\)' docs/THREAT_MODEL.md
-run_check "DOC" rg -n '^# Threat Model and Security Hardening \(WS-B9\)' docs/gitbook/28-threat-model-and-security-hardening.md
 run_check "INVARIANT" rg -n '^ELAN_INSTALLER_SHA256=' scripts/setup_lean_env.sh
 run_check "INVARIANT" rg -n '^compute_sha256\(\)' scripts/setup_lean_env.sh
 # shellcheck disable=SC2016
-# shellcheck disable=SC2016
-run_check "DOC" rg -n '(^- Active planning baseline: `AUDIT_v0.11.6_WORKSTREAM_PLAN.md`)|(^- Active planning baseline: `AUDIT_v0.11.0_WORKSTREAM_PLAN.md`)|(^- Active planning baseline: `AUDIT_v0.9.32_WORKSTREAM_PLAN.md`)' docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md
-run_check "DOC" rg -n '(^# Documentation Deduplication Map \(WS-B8\)$)|(^# Documentation Deduplication Map \(WS-C8\)$)' docs/DOCS_DEDUPLICATION_MAP.md
-run_check "DOC" rg -n '^# Documentation Deduplication Map' docs/gitbook/27-documentation-deduplication-map.md
-run_check "INVARIANT" rg -n '^#!/usr/bin/env python3' scripts/generate_doc_navigation.py
-run_check "INVARIANT" rg -n '^#!/usr/bin/env python3' scripts/check_markdown_links.py
-run_check "INVARIANT" rg -n '^run_check "HYGIENE" "\$\{SCRIPT_DIR\}/test_docs_sync\.sh"' scripts/test_tier0_hygiene.sh
-run_check "INVARIANT" rg -n '^[[:space:]]+name: Docs Automation / Navigation \+ Links \+ DocGen Probe' .github/workflows/lean_action_ci.yml
 
 # WS-B2 closure anchors: bootstrap DSL, negative suite, and nightly replay artifacts.
 run_check "INVARIANT" rg -n '^structure BootstrapBuilder' SeLe4n/Testing/StateBuilder.lean
@@ -136,9 +109,6 @@ run_check "INVARIANT" rg -n '^import SeLe4n\.Testing\.MainTraceHarness$' Main.le
 run_check "INVARIANT" rg -n '^import SeLe4n\.Testing\.RuntimeContractFixtures$' SeLe4n/Testing/MainTraceHarness.lean
 run_check "INVARIANT" rg -n '^def runtimeContractAcceptAll' SeLe4n/Testing/RuntimeContractFixtures.lean
 run_check "INVARIANT" rg -n '^def runtimeContractDenyAll' SeLe4n/Testing/RuntimeContractFixtures.lean
-run_check "DOC" rg -n '^# Hardware Boundary Contract Policy' docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md
-run_check "DOC" rg -n 'SeLe4n/Kernel.*must not reference test-only runtime contract' docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md
-run_check "DOC" rg -n 'scripts/test_tier0_hygiene\.sh' docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md
 
 # WS-A3 boundary hardening anchors must remain explicit.
 run_check "INVARIANT" rg -n '^@\[inline\] def toObjId' SeLe4n/Prelude.lean
@@ -168,7 +138,6 @@ run_check "INVARIANT" rg -n '^theorem cspaceMint_preserves_capabilityInvariantBu
 run_check "INVARIANT" rg -n '^theorem cspaceDeleteSlot_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 run_check "INVARIANT" rg -n '^theorem cspaceRevoke_preserves_capabilityInvariantBundle' SeLe4n/Kernel/Capability/Invariant.lean
 
-# WS-E2 closure anchors: proof quality and invariant strengthening.
 # C-01 remediation: non-tautological slot-uniqueness infrastructure at CNode level.
 run_check "INVARIANT" rg -n '^def slotsUnique' SeLe4n/Model/Object.lean
 run_check "INVARIANT" rg -n '^theorem insert_slotsUnique' SeLe4n/Model/Object.lean
@@ -450,57 +419,15 @@ run_check "TRACE" rg -n 'composed revoke/delete/retype success' tests/fixtures/m
 run_check "TRACE" rg -n 'post-revoke sibling lookup: SeLe4n.Model.KernelError.invalidCapability' tests/fixtures/main_trace_smoke.expected
 run_check "TRACE" rg -n 'post-delete lookup \(expected error\): SeLe4n.Model.KernelError.invalidCapability' tests/fixtures/main_trace_smoke.expected
 
-# Active milestone docs should stay synchronized for both current and next slices.
-run_check "DOC" rg -n 'M3\.5' README.md docs/spec/SELE4N_SPEC.md docs/DEVELOPMENT.md
-run_check "DOC" rg -n 'M4-A|M4-B|M5|M6|M7' docs/spec/SELE4N_SPEC.md
-run_check "DOC" rg -n 'WS-B1\.\.WS-B11|WS-B portfolio|Comprehensive Audit 2026-02' README.md docs/spec/SELE4N_SPEC.md docs/DEVELOPMENT.md docs/gitbook/README.md docs/gitbook/05-specification-and-roadmap.md docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
-run_check "DOC" rg -n 'Most recently completed slice:.*M7|M7 remediation is complete|M7 is complete and archived' README.md docs/gitbook/README.md docs/dev_history/gitbook/23-m7-remediation-closeout-packet.md docs/dev_history/gitbook/21-m7-current-slice-outcomes-and-workstreams.md
-run_check "DOC" rg -n 'Previous completed slice:.*M6|M6 architecture-boundary|WS-M6-A through WS-M6-E|docs/dev_history/|M6 architecture-boundary assumptions/adapters' README.md docs/gitbook/README.md docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/05-specification-and-roadmap.md
-run_check "DOC" rg -n 'test_tier4_nightly_candidates\.sh' docs/TESTING_FRAMEWORK_PLAN.md docs/gitbook/07-testing-and-ci.md scripts/test_nightly.sh
-# shellcheck disable=SC2016
-run_check "DOC" rg -n 'Tier 3 fails \(`\./scripts/test_tier3_invariant_surface\.sh`\)' docs/gitbook/07-testing-and-ci.md
-# shellcheck disable=SC2016
-run_check "DOC" rg -n 'Tier 4 fails \(`\./scripts/test_nightly\.sh` / `\./scripts/test_tier4_nightly_candidates\.sh`\)' docs/gitbook/07-testing-and-ci.md
 
 # Full-suite contract should continue to include Tier 3.
-run_check "DOC" rg -n 'test_tier3_invariant_surface\.sh' scripts/test_full.sh
 
-run_check "DOC" rg -n '^# M7 Remediation Closeout Packet' docs/dev_history/M7_CLOSEOUT_PACKET.md docs/dev_history/gitbook/23-m7-remediation-closeout-packet.md
-run_check "DOC" rg -n 'Next-slice kickoff dependencies and owners|Exit-gate checklist' docs/dev_history/M7_CLOSEOUT_PACKET.md
-run_check "DOC" rg -n 'M7 Remediation Closeout Packet' docs/dev_history/gitbook/23-m7-remediation-closeout-packet.md
-run_check "DOC" rg -n 'Contribution guide|Change history' README.md
-run_check "DOC" test -f CONTRIBUTING.md
-run_check "DOC" test -f CHANGELOG.md
-run_check "DOC" rg -n 'Required checks \(Tier 0–3\)|Deterministic replay evidence' docs/CI_POLICY.md
-run_check "DOC" rg -n 'Docs Automation / Navigation \+ Links \+ DocGen Probe' .github/workflows/lean_action_ci.yml docs/CI_POLICY.md docs/gitbook/07-testing-and-ci.md
-run_check "DOC" rg -n 'Tier 0.*docs-sync automation' docs/TESTING_FRAMEWORK_PLAN.md
-run_check "DOC" rg -n 'Tiered Tests / Full \(Tier 0 \+ Tier 1 \+ Tier 2 \+ Tier 3\)' .github/workflows/lean_action_ci.yml docs/CI_POLICY.md
-run_check "DOC" rg -n 'Nightly Determinism|NIGHTLY_ENABLE_EXPERIMENTAL' .github/workflows/nightly_determinism.yml docs/CI_POLICY.md
-run_check "DOC" rg -n 'WS-B10 CodeQL policy decision|informational/non-blocking' docs/CI_POLICY.md
-run_check "DOC" rg -n 'lean_toolchain_update_proposal\.yml|dependabot\.yml' docs/CI_POLICY.md docs/CI_TELEMETRY_BASELINE.md
-run_check "DOC" rg -n 'ci_capture_timing\.sh|ci_flake_probe\.sh' docs/CI_TELEMETRY_BASELINE.md .github/workflows/lean_action_ci.yml .github/workflows/nightly_determinism.yml
-run_check "DOC" rg -n '^# CI Maturity and Telemetry Baseline \(WS-B10\)' docs/gitbook/29-ci-maturity-and-telemetry-baseline.md
-run_check "DOC" rg -n 'WS-B10 — CI maturity upgrades \(Completed\)|WS-B11 — Scenario framework finalization \(Completed\)' docs/dev_history/audits/AUDIT_v0.9.0_WORKSTREAM_PLAN.md
 
-run_check "DOC" rg -n '^# Scenario framework \(WS-B11\)' tests/scenarios/README.md
-run_check "DOC" rg -n '(^## Active planning \(v0\.11\.6 — WS-E\)$)|(^## Active planning \(v0\.11\.0 — WS-D\)$)|(^## 16\) WS-B11 closure evidence$)|(^## 2\) Active workstreams \(WS-C portfolio\)$)' docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
 run_check "INVARIANT" rg -n '^\s*"schema_version": "1\.0\.0"' tests/scenarios/scenario_catalog.json
 run_check "INVARIANT" rg -n '^def validate_catalog' scripts/scenario_catalog.py
 run_check "INVARIANT" rg -n '^def nightly_seeds' scripts/scenario_catalog.py
 run_check "INVARIANT" rg -n '^run_check "META" python3 "\$\{SCRIPT_DIR\}/scenario_catalog.py" validate' scripts/test_smoke.sh
 
-# WS-A8 closure anchors: platform/security baseline workflow + information-flow roadmap visibility.
-run_check "DOC" rg -n '^name: Platform and Security Baseline' .github/workflows/platform_security_baseline.yml
-run_check "DOC" rg -n '^\s*name: Platform Signal / ARM64 Fast Gate' .github/workflows/platform_security_baseline.yml
-run_check "DOC" rg -n '^\s*name: Security Signal / Secret \+ Dependency \+ CodeQL' .github/workflows/platform_security_baseline.yml
-run_check "DOC" rg -n "if: github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository" .github/workflows/platform_security_baseline.yml
-run_check "DOC" rg -n "^\s*pull-requests:\s*read" .github/workflows/platform_security_baseline.yml
-run_check "DOC" rg -n "^\s*fetch-depth:\s*0" .github/workflows/platform_security_baseline.yml
-run_check "DOC" rg -n "^\s*continue-on-error:\s*true" .github/workflows/platform_security_baseline.yml
-run_check "DOC" rg -n '^# Information-Flow Proof Roadmap' docs/INFORMATION_FLOW_ROADMAP.md
-run_check "DOC" rg -n '^## IF-M1' docs/INFORMATION_FLOW_ROADMAP.md
-run_check "DOC" rg -n '^## IF-M5' docs/INFORMATION_FLOW_ROADMAP.md
-run_check "DOC" rg -n 'INFORMATION_FLOW_ROADMAP\.md' README.md docs/CI_POLICY.md docs/dev_history/M7_CLOSEOUT_PACKET.md docs/dev_history/gitbook/21-m7-current-slice-outcomes-and-workstreams.md docs/dev_history/gitbook/20-repository-audit-remediation-workstreams.md
 
 # WS-E1 F-14 SHA-pinning anchors: all workflow action refs must be SHA-pinned.
 run_check "INVARIANT" rg -n '@[0-9a-f]{40}' .github/workflows/lean_action_ci.yml
@@ -526,8 +453,5 @@ run_check "TRACE" rg -n '^[A-Z]+-[0-9]+\s+\|' tests/fixtures/main_trace_smoke.ex
 
 # WS-E1 L-08 theorem-body validation anchors.
 run_check "HYGIENE" rg -n 'L-08.*theorem-body spot-check' scripts/test_tier0_hygiene.sh
-
-# WS-E1 documentation anchors.
-run_check "DOC" rg -n 'WS-E1' docs/audits/AUDIT_v0.11.6_WORKSTREAM_PLAN.md
 
 finalize_report

--- a/scripts/test_tier4_nightly_candidates.sh
+++ b/scripts/test_tier4_nightly_candidates.sh
@@ -33,6 +33,5 @@ run_check "TRACE" rg -n 'service isolation api↔denied: true' tests/artifacts/n
 run_check "TRACE" bash -lc 'while read -r seed; do [[ -z "${seed}" ]] && continue; lake exe trace_sequence_probe "${seed}" 320 | tee "tests/artifacts/nightly/trace_sequence_probe_seed_${seed}.log"; done < tests/artifacts/nightly/scenario_seeds.txt'
 # shellcheck disable=SC2016
 run_check "TRACE" bash -lc 'printf "seed,steps\n" > tests/artifacts/nightly/trace_sequence_probe_manifest.csv; while read -r seed; do [[ -z "${seed}" ]] && continue; printf "%s,320\n" "${seed}" >> tests/artifacts/nightly/trace_sequence_probe_manifest.csv; done < tests/artifacts/nightly/scenario_seeds.txt'
-run_check "META" "${SCRIPT_DIR}/test_full.sh"
 
 finalize_report


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: WS-E1 (CI maturity simplification)
- Recommendation IDs closed: N/A
- Scope notes: Removes the standalone `docs-automation` CI job and all documentation-anchor checks from Tier 3 invariant surface validation. Documentation sync (`scripts/test_docs_sync.sh`) is now available only as a local development tool, not a CI gate. Tier 2 and Tier 3 CI jobs are restructured to run only their incremental tier (no redundant re-execution of earlier tiers).

## Changes

### CI workflow restructuring (`.github/workflows/lean_action_ci.yml`)
- **Removed** `docs-automation` job entirely (was running `test_docs_sync.sh`)
- **Renamed** `test-smoke` from "Tier 0 + Tier 1 + Tier 2" to "Tier 2" (now runs only `test_tier2_trace.sh` + `test_tier2_negative.sh`)
- **Renamed** `test-full` from "Tier 0 + Tier 1 + Tier 2 + Tier 3" to "Tier 3" (now runs only `test_tier3_invariant_surface.sh`)
- **Updated** job dependencies: `test-smoke` depends only on `test-fast`; `test-full` depends only on `test-smoke`
- **Removed** `docs-automation` from `test-smoke` job dependencies

### Tier 3 invariant surface cleanup (`scripts/test_tier3_invariant_surface.sh`)
- **Removed** all documentation-anchor checks (e.g., ADR presence, workstream plan markers, threat model publication, CI policy synchronization, milestone status language)
- **Removed** checks for generated navigation files and doc-gen4 probes
- **Removed** checks for documentation deduplication map and platform/security baseline workflow documentation
- **Kept** all code/theorem/trace anchor checks (structure definitions, theorem proofs, executable trace fixtures)
- **Removed** comment headers for completed workstreams (WS-M6-A, WS-E2, WS-A8)

### Documentation updates
- **`docs/CI_POLICY.md`**: Updated required checks list (removed docs-automation); clarified that each CI job runs only its incremental tier with earlier tiers gated by dependencies; noted that docs-sync is available locally but not part of CI gates
- **`docs/gitbook/07-testing-and-ci.md`**: Removed docs-sync from Tier 0 description; updated Tier 3 description to focus on invariant/trace anchors (removed doc anchors); clarified docs-sync is a standalone local tool
- **`docs/TESTING_FRAMEWORK_PLAN.md`**: Updated Tier 0 description; added note that docs-sync is available locally but not part of CI gates
- **`docs/DOCUMENTATION_SYNC_AND_COVERAGE_MATRIX.md`**: Removed docs-sync from validation table; updated Tier 3 description
- **`docs/THREAT_MODEL.md`**: Updated Tier 3 description to remove threat-model publication check and synchronized status language check
- **`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`**: Updated references from "invariant/doc anchors" to "invariant surface anchors"
- **`docs/CLAIM_EVIDENCE_INDEX.md`**: Removed reference to `test_docs_sync.sh`
- **`docs/gitbook/19-end-to-end-audit-and-quality-gates.md`**: Updated Tier 4 description from "invariant/proof/doc anchors" to "invariant/proof/trace anchors"
- **`docs/DOCS_DEDUPLICATION_MAP.md`**: Clarified that docs-sync is not part of CI gates
- **`scripts/test_tier0_hygiene.sh`**: Removed call to `test_docs_sync.sh`
- **`scripts/test_tier4_nightly_candidates.sh`**:

https://claude.ai/code/session_01XZih7frmyiewnvgfCrkf8G