### PR TITLE
WS-F1/F2: Add IPC contract and untyped memory invariant preservation theorems

### DIFF
--- a/SeLe4n/Kernel/IPC/DualQueue.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue.lean
@@ -1371,6 +1371,144 @@ theorem endpointQueueRemoveDual_notification_backward
                           have h2 := storeTcbQueueLinks_notification_backward _ _ nextTid _ _ _ oid ntfn hLink1 h1
                           exact storeTcbQueueLinks_notification_backward _ _ prevTid _ _ _ oid ntfn hLink0 h2
 
+/-- WS-F1/TPI-D08: Backward TCB ipcState transport for endpointQueueRemoveDual.
+endpointQueueRemoveDual only calls storeObject (for endpoints) and
+storeTcbQueueLinks (which preserves ipcState). Therefore any TCB
+present in the post-state has the same ipcState as in the pre-state. -/
+theorem endpointQueueRemoveDual_tcb_ipcState_backward
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (isReceiveQ : Bool) (tid : SeLe4n.ThreadId)
+    (anyTid : SeLe4n.ThreadId) (tcb' : TCB)
+    (hStep : endpointQueueRemoveDual endpointId isReceiveQ tid st = .ok ((), st'))
+    (hTcb' : st'.objects anyTid.toObjId = some (.tcb tcb')) :
+    ∃ tcb, st.objects anyTid.toObjId = some (.tcb tcb) ∧ tcb.ipcState = tcb'.ipcState := by
+  unfold endpointQueueRemoveDual at hStep; revert hStep
+  cases hObj : st.objects endpointId with
+  | none => simp
+  | some obj => cases obj with
+    | tcb _ | cnode _ | notification _ | vspaceRoot _ | untyped _ => simp
+    | endpoint ep =>
+      simp only []
+      cases hLookup : lookupTcb st tid with
+      | none => simp
+      | some tcbTid =>
+        simp only []
+        cases hPPrev : tcbTid.queuePPrev with
+        | none => simp
+        | some pprev =>
+          simp only []
+          generalize (if isReceiveQ then ep.receiveQ else ep.sendQ) = q
+          split
+          · simp
+          · cases pprev with
+            | endpointHead =>
+              simp only []
+              split
+              · simp
+              · cases hStore1 : storeObject endpointId _ st with
+                | error e => simp
+                | ok pair1 =>
+                simp only []; cases hNext : tcbTid.queueNext with
+                | none =>
+                  simp only []
+                  cases hStore2 : storeObject endpointId _ pair1.2 with
+                  | error e => simp
+                  | ok pair2 =>
+                  simp only []; cases hFinal : storeTcbQueueLinks pair2.2 tid none none none with
+                  | error e => simp
+                  | ok st4 =>
+                    simp only [Except.ok.injEq, Prod.mk.injEq]
+                    intro ⟨_, hEq⟩; subst hEq
+                    obtain ⟨tcb3, hTcb3, hIpc3⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ tid _ _ _ hFinal anyTid tcb' hTcb'
+                    by_cases hEqEp : anyTid.toObjId = endpointId
+                    · rw [hEqEp, storeObject_objects_eq _ _ endpointId _ hStore2] at hTcb3; cases hTcb3
+                    · rw [storeObject_objects_ne _ _ endpointId anyTid.toObjId _ hEqEp hStore2] at hTcb3
+                      by_cases hEqEp2 : anyTid.toObjId = endpointId
+                      · exact absurd hEqEp2 hEqEp
+                      · rw [storeObject_objects_ne _ _ endpointId anyTid.toObjId _ hEqEp2 hStore1] at hTcb3
+                        exact ⟨tcb3, hTcb3, hIpc3⟩
+                | some nextTid =>
+                  simp only []
+                  cases hLookupN : lookupTcb pair1.2 nextTid with
+                  | none => simp
+                  | some nextTcb =>
+                  simp only []; cases hLink : storeTcbQueueLinks pair1.2 nextTid _ _ nextTcb.queueNext with
+                  | error e => simp
+                  | ok st2 =>
+                  simp only []; cases hStore2 : storeObject endpointId _ st2 with
+                  | error e => simp
+                  | ok pair2 =>
+                  simp only []; cases hFinal : storeTcbQueueLinks pair2.2 tid none none none with
+                  | error e => simp
+                  | ok st4 =>
+                    simp only [Except.ok.injEq, Prod.mk.injEq]
+                    intro ⟨_, hEq⟩; subst hEq
+                    obtain ⟨tcb4, hTcb4, hIpc4⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ tid _ _ _ hFinal anyTid tcb' hTcb'
+                    by_cases hEqEp : anyTid.toObjId = endpointId
+                    · rw [hEqEp, storeObject_objects_eq _ _ endpointId _ hStore2] at hTcb4; cases hTcb4
+                    · rw [storeObject_objects_ne _ _ endpointId anyTid.toObjId _ hEqEp hStore2] at hTcb4
+                      obtain ⟨tcb2, hTcb2, hIpc2⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ nextTid _ _ _ hLink anyTid tcb4 hTcb4
+                      by_cases hEqEp2 : anyTid.toObjId = endpointId
+                      · exact absurd hEqEp2 hEqEp
+                      · rw [storeObject_objects_ne _ _ endpointId anyTid.toObjId _ hEqEp2 hStore1] at hTcb2
+                        exact ⟨tcb2, hTcb2, hIpc2.trans hIpc4⟩
+            | tcbNext prevTid =>
+              dsimp only
+              split
+              · simp
+              · cases hLookupP : lookupTcb st prevTid with
+                | none => simp
+                | some prevTcb =>
+                dsimp only [hLookupP]; split
+                · simp
+                · rename_i _ _ _ stAp heqAp
+                  split at heqAp
+                  · simp at heqAp
+                  · cases hLink0 : storeTcbQueueLinks st prevTid prevTcb.queuePrev prevTcb.queuePPrev tcbTid.queueNext with
+                    | error e => simp [hLink0] at heqAp
+                    | ok stPrev =>
+                    simp [hLink0] at heqAp; subst heqAp
+                    cases hNext : tcbTid.queueNext with
+                    | none =>
+                      dsimp only [hNext]
+                      cases hStore2 : storeObject endpointId _ stPrev with
+                      | error e => simp
+                      | ok pair2 =>
+                      dsimp only [hStore2]; cases hFinal : storeTcbQueueLinks pair2.2 tid none none none with
+                      | error e => simp
+                      | ok st4 =>
+                        simp only [Except.ok.injEq, Prod.mk.injEq]
+                        intro ⟨_, hEq⟩; subst hEq
+                        obtain ⟨tcb3, hTcb3, hIpc3⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ tid _ _ _ hFinal anyTid tcb' hTcb'
+                        by_cases hEqEp : anyTid.toObjId = endpointId
+                        · rw [hEqEp, storeObject_objects_eq _ _ endpointId _ hStore2] at hTcb3; cases hTcb3
+                        · rw [storeObject_objects_ne _ _ endpointId anyTid.toObjId _ hEqEp hStore2] at hTcb3
+                          obtain ⟨tcb1, hTcb1, hIpc1⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ prevTid _ _ _ hLink0 anyTid tcb3 hTcb3
+                          exact ⟨tcb1, hTcb1, hIpc1.trans hIpc3⟩
+                    | some nextTid =>
+                      dsimp only [hNext]
+                      cases hLookupN : lookupTcb stPrev nextTid with
+                      | none => simp
+                      | some nextTcb =>
+                      dsimp only [hLookupN]; cases hLink1 : storeTcbQueueLinks stPrev nextTid _ _ nextTcb.queueNext with
+                      | error e => simp
+                      | ok st2 =>
+                      dsimp only [hLink1]; cases hStore2 : storeObject endpointId _ st2 with
+                      | error e => simp
+                      | ok pair2 =>
+                      dsimp only [hStore2]; cases hFinal : storeTcbQueueLinks pair2.2 tid none none none with
+                      | error e => simp
+                      | ok st4 =>
+                        simp only [Except.ok.injEq, Prod.mk.injEq]
+                        intro ⟨_, hEq⟩; subst hEq
+                        obtain ⟨tcb4, hTcb4, hIpc4⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ tid _ _ _ hFinal anyTid tcb' hTcb'
+                        by_cases hEqEp : anyTid.toObjId = endpointId
+                        · rw [hEqEp, storeObject_objects_eq _ _ endpointId _ hStore2] at hTcb4; cases hTcb4
+                        · rw [storeObject_objects_ne _ _ endpointId anyTid.toObjId _ hEqEp hStore2] at hTcb4
+                          obtain ⟨tcb2, hTcb2, hIpc2⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ nextTid _ _ _ hLink1 anyTid tcb4 hTcb4
+                          obtain ⟨tcb1, hTcb1, hIpc1⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ prevTid _ _ _ hLink0 anyTid tcb2 hTcb2
+                          exact ⟨tcb1, hTcb1, hIpc1.trans (hIpc2.trans hIpc4)⟩
+
 /-- WS-F1/WS-E4/M-01: Send to endpoint using intrusive dual-queue semantics
 with IPC message transfer.
 

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -2579,6 +2579,22 @@ theorem endpointQueueRemoveDual_preserves_schedulerInvariantBundle
     rcases hCTV' with ⟨tcbC, hTcbC⟩
     exact endpointQueueRemoveDual_tcb_forward st st' endpointId isSendQ tid ctid.toObjId tcbC hStep hTcbC
 
+/-- WS-F1/TPI-D08: endpointQueueRemoveDual preserves ipcSchedulerContractPredicates.
+endpointQueueRemoveDual only modifies queue link fields via storeObject (endpoint)
+and storeTcbQueueLinks. The scheduler is unchanged and all TCB ipcStates are
+preserved, so the contract predicates are maintained via
+contracts_of_same_scheduler_ipcState. -/
+theorem endpointQueueRemoveDual_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (isSendQ : Bool) (tid : SeLe4n.ThreadId)
+    (hContract : ipcSchedulerContractPredicates st)
+    (hStep : endpointQueueRemoveDual endpointId isSendQ tid st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' :=
+  contracts_of_same_scheduler_ipcState st st'
+    (endpointQueueRemoveDual_scheduler_eq st st' endpointId isSendQ tid hStep)
+    (fun anyTid tcb' h => endpointQueueRemoveDual_tcb_ipcState_backward st st' endpointId isSendQ tid anyTid tcb' hStep h)
+    hContract
+
 -- ============================================================================
 -- WS-F1: endpointCall / endpointReplyRecv invariant preservation (F-11 remediation)
 --
@@ -3009,6 +3025,78 @@ theorem endpointReplyRecv_preserves_schedulerInvariantBundle
           simp only [hAwait, Except.ok.injEq] at hStep
           obtain ⟨_, hEq⟩ := Prod.mk.inj hStep; subst hEq
           exact endpointAwaitReceive_preserves_schedulerInvariantBundle _ _ endpointId receiver hInvMid hAwait
+
+/-- WS-F1/TPI-D09: endpointReplyRecv preserves ipcSchedulerContractPredicates.
+Chains storeTcbIpcStateAndMessage(.ready) + ensureRunnable contract preservation
+(same argument as endpointReply) with
+endpointAwaitReceive_preserves_ipcSchedulerContractPredicates. -/
+theorem endpointReplyRecv_preserves_ipcSchedulerContractPredicates
+    (st st' : SystemState) (endpointId : SeLe4n.ObjId)
+    (receiver replyTarget : SeLe4n.ThreadId) (msg : IpcMessage)
+    (hContract : ipcSchedulerContractPredicates st)
+    (hStep : endpointReplyRecv endpointId receiver replyTarget msg st = .ok ((), st')) :
+    ipcSchedulerContractPredicates st' := by
+  rcases hContract with ⟨hReady, hBlockSend, hBlockRecv⟩
+  unfold endpointReplyRecv at hStep
+  cases hLookup : lookupTcb st replyTarget with
+  | none => simp [hLookup] at hStep
+  | some tcb =>
+    simp only [hLookup] at hStep
+    cases hIpc : tcb.ipcState with
+    | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ =>
+      simp [hIpc] at hStep
+    | blockedOnReply _ =>
+      simp only [hIpc] at hStep
+      cases hMsg : storeTcbIpcStateAndMessage st replyTarget .ready (some msg) with
+      | error e => simp [hMsg] at hStep
+      | ok st1 =>
+        simp only [hMsg] at hStep
+        -- storeTcbIpcStateAndMessage + ensureRunnable preserves contracts
+        -- (same argument as endpointReply_preserves_ipcSchedulerContractPredicates)
+        have hSchedEq := storeTcbIpcStateAndMessage_scheduler_eq st st1 replyTarget .ready (some msg) hMsg
+        have hContractMid : ipcSchedulerContractPredicates (ensureRunnable st1 replyTarget) := by
+          refine ⟨?_, ?_, ?_⟩
+          · -- runnableThreadIpcReady
+            intro tid tcb' hTcb' hRun'
+            rw [ensureRunnable_preserves_objects] at hTcb'
+            by_cases hNe : tid.toObjId = replyTarget.toObjId
+            · exact storeTcbIpcStateAndMessage_ipcState_eq st st1 replyTarget .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+            · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne st st1 replyTarget .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+              have hNeTid : tid ≠ replyTarget := fun h => hNe (congrArg ThreadId.toObjId h)
+              rcases ensureRunnable_mem_reverse st1 replyTarget tid hRun' with hOld | hEq
+              · exact hReady tid tcb' hTcbPre (show tid ∈ st.scheduler.runnable by rwa [← hSchedEq])
+              · exact absurd hEq hNeTid
+          · -- blockedOnSendNotRunnable
+            intro tid tcb' eid hTcb' hIpcState'
+            rw [ensureRunnable_preserves_objects] at hTcb'
+            by_cases hNe : tid.toObjId = replyTarget.toObjId
+            · have := storeTcbIpcStateAndMessage_ipcState_eq st st1 replyTarget .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              rw [this] at hIpcState'; cases hIpcState'
+            · have hNeTid : tid ≠ replyTarget := fun h => hNe (congrArg ThreadId.toObjId h)
+              have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne st st1 replyTarget .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+              intro hRun'
+              rcases ensureRunnable_mem_reverse st1 replyTarget tid hRun' with hOld | hEq
+              · exact hBlockSend tid tcb' eid hTcbPre hIpcState' (show tid ∈ st.scheduler.runnable by rwa [← hSchedEq])
+              · exact absurd hEq hNeTid
+          · -- blockedOnReceiveNotRunnable
+            intro tid tcb' eid hTcb' hIpcState'
+            rw [ensureRunnable_preserves_objects] at hTcb'
+            by_cases hNe : tid.toObjId = replyTarget.toObjId
+            · have := storeTcbIpcStateAndMessage_ipcState_eq st st1 replyTarget .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              rw [this] at hIpcState'; cases hIpcState'
+            · have hNeTid : tid ≠ replyTarget := fun h => hNe (congrArg ThreadId.toObjId h)
+              have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne st st1 replyTarget .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+              intro hRun'
+              rcases ensureRunnable_mem_reverse st1 replyTarget tid hRun' with hOld | hEq
+              · exact hBlockRecv tid tcb' eid hTcbPre hIpcState' (show tid ∈ st.scheduler.runnable by rwa [← hSchedEq])
+              · exact absurd hEq hNeTid
+        -- endpointAwaitReceive preserves ipcSchedulerContractPredicates
+        cases hAwait : endpointAwaitReceive endpointId receiver (ensureRunnable st1 replyTarget) with
+        | error e => simp [hAwait] at hStep
+        | ok result =>
+          simp only [hAwait, Except.ok.injEq] at hStep
+          obtain ⟨_, hEq⟩ := Prod.mk.inj hStep; subst hEq
+          exact endpointAwaitReceive_preserves_ipcSchedulerContractPredicates _ _ endpointId receiver hContractMid hAwait
 
 /-- WS-F1/TPI-D09: endpointReply preserves ipcSchedulerContractPredicates.
 endpointReply only stores a TCB and calls ensureRunnable; the contract

--- a/SeLe4n/Kernel/Lifecycle/Invariant.lean
+++ b/SeLe4n/Kernel/Lifecycle/Invariant.lean
@@ -325,4 +325,86 @@ theorem retypeFromUntyped_preserves_lifecycleInvariantBundle
       st st' authority untypedId childId newObj allocSize hMeta hStep
   exact lifecycleInvariantBundle_of_metadata_consistent st' hMeta'
 
+/-- WS-F2: `retypeFromUntyped` preserves the untyped memory invariant.
+The source untyped's allocate operation preserves watermark validity,
+children-within-watermark, non-overlap, and unique IDs (given freshness of
+childId). Non-target untypeds are unchanged through both storeObject calls.
+If `newObj` is itself an untyped, it must be well-formed. -/
+theorem retypeFromUntyped_preserves_untypedMemoryInvariant
+    (st st' : SystemState)
+    (authority : CSpaceAddr)
+    (untypedId childId : SeLe4n.ObjId)
+    (newObj : KernelObject)
+    (allocSize : Nat)
+    (hInv : untypedMemoryInvariant st)
+    (_hNe : childId ≠ untypedId)
+    (hNewObjWF : ∀ ut_new, newObj = .untyped ut_new → ut_new.wellFormed)
+    (hFresh : ∀ ut, st.objects untypedId = some (.untyped ut) →
+        ∀ c ∈ ut.children, c.objId ≠ childId)
+    (hStep : retypeFromUntyped authority untypedId childId newObj allocSize st = .ok ((), st')) :
+    untypedMemoryInvariant st' := by
+  rcases hInv with ⟨hWM, hCB, hNO, hUI⟩
+  rcases retypeFromUntyped_ok_decompose st st' authority untypedId childId newObj allocSize hStep with
+    ⟨ut, ut', _cap, stLookup, stUt, offset, hObj, _hNotDev,
+     hLookup, _hAuth, hAlloc, hStoreUt, hStoreChild⟩
+  have hLookupSt : stLookup = st :=
+    cspaceLookupSlot_ok_state_eq st authority _ stLookup hLookup
+  rw [hLookupSt] at hStoreUt
+  -- Source untyped properties for ut
+  have hUtWM : ut.watermarkValid := hWM untypedId ut hObj
+  have hUtCB : ut.childrenWithinWatermark := hCB untypedId ut hObj
+  have hUtNO : ut.childrenNonOverlap := hNO untypedId ut hObj
+  have hUtUI : ut.childrenUniqueIds := hUI untypedId ut hObj
+  -- After allocate, ut' is well-formed
+  have hUt'WM := UntypedObject.allocate_preserves_watermarkValid ut ut' childId allocSize offset hUtWM hAlloc
+  have hUt'CB := UntypedObject.allocate_preserves_childrenWithinWatermark ut ut' childId allocSize offset hUtCB hAlloc
+  have hUt'NO := UntypedObject.allocate_preserves_childrenNonOverlap ut ut' childId allocSize offset hUtNO hUtCB hAlloc
+  have hUt'UI := UntypedObject.allocate_preserves_childrenUniqueIds ut ut' childId allocSize offset hUtUI (hFresh ut hObj) hAlloc
+  -- Helper: resolve post-state object at any oid through the two storeObject calls
+  have resolve : ∀ oid utPost,
+      st'.objects oid = some (.untyped utPost) →
+      (oid = childId ∧ newObj = .untyped utPost) ∨
+      (oid ≠ childId ∧ oid = untypedId ∧ ut' = utPost) ∨
+      (oid ≠ childId ∧ oid ≠ untypedId ∧ st.objects oid = some (.untyped utPost)) := by
+    intro oid utPost hObjPost
+    by_cases hEqChild : oid = childId
+    · left; constructor; exact hEqChild
+      rw [hEqChild] at hObjPost
+      have := storeObject_objects_eq stUt st' childId newObj hStoreChild
+      rw [this] at hObjPost; cases hObjPost; rfl
+    · right
+      rw [storeObject_objects_ne stUt st' childId oid newObj hEqChild hStoreChild] at hObjPost
+      by_cases hEqUt : oid = untypedId
+      · left; refine ⟨hEqChild, hEqUt, ?_⟩
+        rw [hEqUt] at hObjPost
+        have := storeObject_objects_eq st stUt untypedId (.untyped ut') hStoreUt
+        rw [this] at hObjPost; cases hObjPost; rfl
+      · right; exact ⟨hEqChild, hEqUt,
+          (storeObject_objects_ne st stUt untypedId oid (.untyped ut') hEqUt hStoreUt) ▸ hObjPost⟩
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · -- untypedWatermarkInvariant
+    intro oid utPost hObjPost
+    rcases resolve oid utPost hObjPost with ⟨_, hNewEq⟩ | ⟨_, _, hUtEq⟩ | ⟨_, _, hPre⟩
+    · exact (hNewObjWF utPost hNewEq).1
+    · exact hUtEq ▸ hUt'WM
+    · exact hWM oid utPost hPre
+  · -- untypedChildrenBoundsInvariant
+    intro oid utPost hObjPost
+    rcases resolve oid utPost hObjPost with ⟨_, hNewEq⟩ | ⟨_, _, hUtEq⟩ | ⟨_, _, hPre⟩
+    · exact (hNewObjWF utPost hNewEq).2.1
+    · exact hUtEq ▸ hUt'CB
+    · exact hCB oid utPost hPre
+  · -- untypedChildrenNonOverlapInvariant
+    intro oid utPost hObjPost
+    rcases resolve oid utPost hObjPost with ⟨_, hNewEq⟩ | ⟨_, _, hUtEq⟩ | ⟨_, _, hPre⟩
+    · exact (hNewObjWF utPost hNewEq).2.2.1
+    · exact hUtEq ▸ hUt'NO
+    · exact hNO oid utPost hPre
+  · -- untypedChildrenUniqueIdsInvariant
+    intro oid utPost hObjPost
+    rcases resolve oid utPost hObjPost with ⟨_, hNewEq⟩ | ⟨_, _, hUtEq⟩ | ⟨_, _, hPre⟩
+    · exact (hNewObjWF utPost hNewEq).2.2.2
+    · exact hUtEq ▸ hUt'UI
+    · exact hUI oid utPost hPre
+
 end SeLe4n.Kernel

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -349,6 +349,67 @@ theorem allocate_preserves_region (ut ut' : UntypedObject) (childId : SeLe4n.Obj
   have hU := (Prod.mk.inj hEq).1
   subst hU; exact ⟨rfl, rfl⟩
 
+/-- WS-F2: A successful allocation preserves childrenWithinWatermark.
+Existing children are within the old watermark (≤ new watermark), and the new
+child occupies [old_watermark, old_watermark + size] = [old_watermark, new_watermark]. -/
+theorem allocate_preserves_childrenWithinWatermark (ut ut' : UntypedObject)
+    (childId : SeLe4n.ObjId) (size offset : Nat)
+    (hBounds : ut.childrenWithinWatermark)
+    (hAlloc : ut.allocate childId size = some (ut', offset)) :
+    ut'.childrenWithinWatermark := by
+  rw [allocate_some_iff] at hAlloc
+  rcases hAlloc with ⟨_hCan, hEq⟩
+  have hU := (Prod.mk.inj hEq).1; subst hU
+  intro c hMem
+  simp at hMem ⊢
+  rcases hMem with rfl | hOld
+  · dsimp; omega
+  · have := hBounds c hOld; omega
+
+/-- WS-F2: A successful allocation preserves childrenNonOverlap, given that
+existing children are within the watermark. Since the new child starts at the
+old watermark and all existing children end at or before the old watermark,
+no overlap is possible. -/
+theorem allocate_preserves_childrenNonOverlap (ut ut' : UntypedObject)
+    (childId : SeLe4n.ObjId) (size offset : Nat)
+    (hNonOverlap : ut.childrenNonOverlap)
+    (hBounds : ut.childrenWithinWatermark)
+    (hAlloc : ut.allocate childId size = some (ut', offset)) :
+    ut'.childrenNonOverlap := by
+  rw [allocate_some_iff] at hAlloc
+  rcases hAlloc with ⟨_hCan, hEq⟩
+  have hU := (Prod.mk.inj hEq).1; subst hU
+  intro c₁ c₂ hMem₁ hMem₂ hNe
+  simp at hMem₁ hMem₂
+  rcases hMem₁ with rfl | hOld₁ <;> rcases hMem₂ with rfl | hOld₂
+  · exact absurd rfl hNe
+  · -- new child vs old child: old child ends ≤ watermark = new child offset
+    right; have := hBounds c₂ hOld₂; dsimp; omega
+  · -- old child vs new child: old child ends ≤ watermark = new child offset
+    left; have := hBounds c₁ hOld₁; dsimp; omega
+  · -- two old children: by pre-condition
+    exact hNonOverlap c₁ c₂ hOld₁ hOld₂ hNe
+
+/-- WS-F2: A successful allocation preserves childrenUniqueIds, given that
+the new child's ID does not collide with any existing child. -/
+theorem allocate_preserves_childrenUniqueIds (ut ut' : UntypedObject)
+    (childId : SeLe4n.ObjId) (size offset : Nat)
+    (hUnique : ut.childrenUniqueIds)
+    (hFresh : ∀ c ∈ ut.children, c.objId ≠ childId)
+    (hAlloc : ut.allocate childId size = some (ut', offset)) :
+    ut'.childrenUniqueIds := by
+  rw [allocate_some_iff] at hAlloc
+  rcases hAlloc with ⟨_hCan, hEq⟩
+  have hU := (Prod.mk.inj hEq).1; subst hU
+  intro c₁ c₂ hMem₁ hMem₂ hIdEq
+  simp at hMem₁ hMem₂
+  rcases hMem₁ with rfl | hOld₁ <;> rcases hMem₂ with rfl | hOld₂
+  · rfl
+  · -- new child has objId = childId, old child has objId ≠ childId
+    dsimp at hIdEq; exact absurd hIdEq.symm (hFresh c₂ hOld₂)
+  · dsimp at hIdEq; exact absurd hIdEq (hFresh c₁ hOld₁)
+  · exact hUnique c₁ c₂ hOld₁ hOld₂ hIdEq
+
 /-- `reset` restores watermark validity. -/
 theorem reset_watermarkValid (ut : UntypedObject) : ut.reset.watermarkValid := by
   simp [reset, watermarkValid]

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -369,6 +369,33 @@ run_check "INVARIANT" rg -n '^def endpointQueueRemoveDual' SeLe4n/Kernel/IPC/Dua
 run_check "INVARIANT" rg -n '^theorem endpointQueuePopHead_scheduler_eq' SeLe4n/Kernel/IPC/DualQueue.lean
 run_check "INVARIANT" rg -n '^theorem endpointQueueEnqueue_scheduler_eq' SeLe4n/Kernel/IPC/DualQueue.lean
 run_check "INVARIANT" rg -n '^theorem endpointQueueRemoveDual_scheduler_eq' SeLe4n/Kernel/IPC/DualQueue.lean
+run_check "INVARIANT" rg -n '^theorem endpointQueueRemoveDual_tcb_ipcState_backward' SeLe4n/Kernel/IPC/DualQueue.lean
+
+# WS-F1 dual-queue preservation theorem anchors (all three invariant families).
+run_check "INVARIANT" rg -n '^theorem endpointSendDual_preserves_ipcInvariant' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSendDual_preserves_schedulerInvariantBundle' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointSendDual_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceiveDual_preserves_ipcInvariant' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceiveDual_preserves_schedulerInvariantBundle' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReceiveDual_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointQueueRemoveDual_preserves_ipcInvariant' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointQueueRemoveDual_preserves_schedulerInvariantBundle' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointQueueRemoveDual_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointCall_preserves_ipcInvariant' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointCall_preserves_schedulerInvariantBundle' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointCall_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReply_preserves_ipcInvariant' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReply_preserves_schedulerInvariantBundle' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReply_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReplyRecv_preserves_ipcInvariant' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReplyRecv_preserves_schedulerInvariantBundle' SeLe4n/Kernel/IPC/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem endpointReplyRecv_preserves_ipcSchedulerContractPredicates' SeLe4n/Kernel/IPC/Invariant.lean
+
+# WS-F2 untyped memory invariant preservation anchors.
+run_check "INVARIANT" rg -n '^theorem retypeFromUntyped_preserves_untypedMemoryInvariant' SeLe4n/Kernel/Lifecycle/Invariant.lean
+run_check "INVARIANT" rg -n '^theorem allocate_preserves_childrenWithinWatermark' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^theorem allocate_preserves_childrenNonOverlap' SeLe4n/Model/Object.lean
+run_check "INVARIANT" rg -n '^theorem allocate_preserves_childrenUniqueIds' SeLe4n/Model/Object.lean
 
 # WS-D3 F-16 module docstring classification anchors must remain present.
 run_check "INVARIANT" rg -n '^/-!' SeLe4n/Kernel/Scheduler/Invariant.lean


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: WS-F1 (IPC handshake path invariant preservation), WS-F2 (untyped memory invariant preservation)
- Recommendation IDs closed: TPI-D08, TPI-D09, WS-F2
- Scope notes: Completes invariant preservation coverage for dual-queue operations and lifecycle operations

## Changes

### WS-F1: IPC Contract Preservation (TPI-D08, TPI-D09)

**DualQueue.lean:**
- Added `endpointQueueRemoveDual_tcb_ipcState_backward` theorem: Proves that TCB ipcState is preserved through `endpointQueueRemoveDual` by tracking state through `storeObject` and `storeTcbQueueLinks` calls. Handles all queue removal cases (head removal, middle removal with/without next).

**Invariant.lean:**
- Added `endpointQueueRemoveDual_preserves_ipcSchedulerContractPredicates` theorem: Chains scheduler equality with ipcState preservation to maintain contract predicates.
- Added `endpointReplyRecv_preserves_ipcSchedulerContractPredicates` theorem: Proves contract preservation through the `storeTcbIpcStateAndMessage(.ready) + ensureRunnable + endpointAwaitReceive` sequence, using the same pattern as `endpointReply`.

### WS-F2: Untyped Memory Invariant Preservation

**Lifecycle/Invariant.lean:**
- Added `retypeFromUntyped_preserves_untypedMemoryInvariant` theorem: Proves all four components of the untyped memory invariant are preserved:
  - Watermark validity: preserved by `allocate` operation
  - Children-within-watermark: new child at old watermark, existing children unchanged
  - Non-overlap: new child starts at old watermark, all existing children end at or before it
  - Unique IDs: new child ID is fresh (given by precondition)

**Model/Object.lean:**
- Added `allocate_preserves_childrenWithinWatermark` theorem: Existing children remain within old watermark (≤ new watermark); new child occupies [old_watermark, new_watermark].
- Added `allocate_preserves_childrenNonOverlap` theorem: No overlap possible since new child starts at old watermark and all existing children end at or before it.
- Added `allocate_preserves_childrenUniqueIds` theorem: Preserves uniqueness given fresh allocation ID.

### Test Anchors

Updated `scripts/test_tier3_invariant_surface.sh` with verification checks for:
- New backward transport theorem for dual-queue operations
- All three invariant family preservation theorems for WS-F1 operations (endpointSendDual, endpointReceiveDual, endpointQueueRemoveDual, endpointCall, endpointReply, endpointReplyRecv)
- WS-F2 untyped memory invariant preservation anchors

## Validation evidence

- [x] New theorems follow established proof patterns (backward transport, invariant preservation via state equality)
- [x] All proofs are constructive and complete (no `sorry`)
- [x] Test anchors added to `test_tier3_invariant_surface.sh` for CI verification
- [x] Theorems properly documented with workstream/recommendation IDs

## Documentation synchronization checklist

- [ ] Canonical source docs updated (deferred to separate doc sync PR)
- [ ] GitBook mirrors (deferred to separate doc sync PR)
- [ ] Generated navigation files (deferred to separate doc sync PR)
- [ ] Markdown-link automation (deferred to separate doc sync PR)
- [ ] Active slice/workstream status (deferred to separate doc sync PR)

## Risks / follow-ups

- Residual risks: None identified; proofs are complete and follow established patterns
- Deferred items: Documentation synchronization (README.md, SELE4N_SPEC.md

https://claude.ai/code/session_01NBd7PwpiPN4L9ZUimcHddY