### PR TITLE
H3-prep: Platform binding architecture with VSpaceBackend abstraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,12 @@ SeLe4n/Kernel/IPC/DualQueue.lean Intrusive dual-queue IPC operations
 SeLe4n/Kernel/IPC/Invariant.lean IPC invariant preservation proofs
 SeLe4n/Kernel/Lifecycle/*        Lifecycle/retype transitions + invariants
 SeLe4n/Kernel/Service/*          Service orchestration + policy
-SeLe4n/Kernel/Architecture/*     Architecture assumptions + VSpace
+SeLe4n/Kernel/Architecture/*     Architecture assumptions + VSpace + VSpaceBackend
 SeLe4n/Kernel/InformationFlow/*  Security labels, projection, non-interference
 SeLe4n/Kernel/API.lean           Public kernel interface
+SeLe4n/Platform/Contract.lean    PlatformBinding typeclass (H3-prep)
+SeLe4n/Platform/Sim/*            Simulation platform contracts
+SeLe4n/Platform/RPi5/*           Raspberry Pi 5 platform stubs (BCM2712)
 SeLe4n/Testing/*                 Test harness, state builder, fixtures
 Main.lean                        Executable entry point
 tests/                           Executable test suites + fixtures

--- a/README.md
+++ b/README.md
@@ -97,11 +97,13 @@ machine-checked invariant preservation proofs:
 ├──────────────┴─────────────┴────────────┴───────────┴────────────────┤
 │          Information Flow  (Policy, Projection, Enforcement)         │
 ├──────────────────────────────────────────────────────────────────────┤
-│          Architecture  (VSpace, Adapter, Assumptions)                │
+│          Architecture  (VSpace, VSpaceBackend, Adapter, Assumptions) │
 ├──────────────────────────────────────────────────────────────────────┤
 │                  Model  (Object, State, CDT)                         │
 ├──────────────────────────────────────────────────────────────────────┤
-│                 Foundations  (Prelude, Machine)                      │
+│                 Foundations  (Prelude, Machine, MachineConfig)        │
+├──────────────────────────────────────────────────────────────────────┤
+│          Platform  (Contract, Sim, RPi5)  ← H3-prep bindings        │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -111,7 +113,7 @@ Each kernel subsystem follows the **Operations/Invariant split**: transitions in
 | Module | Purpose |
 |--------|---------|
 | `SeLe4n/Prelude.lean` | Typed identifiers (`ThreadId`, `ObjId`, `CPtr`, etc.) + `KernelM` monad |
-| `SeLe4n/Machine.lean` | Register file, memory, timer — abstract machine primitives |
+| `SeLe4n/Machine.lean` | Register file, memory, timer, `MachineConfig`, `MemoryRegion` |
 | `SeLe4n/Model/Object.lean` | `TCB`, `Endpoint`, `Notification`, `CNode`, `VSpaceRoot`, CDT |
 | `SeLe4n/Model/State.lean` | `SystemState` with functional maps, lifecycle metadata, CDT slot↔node |
 | `SeLe4n/Kernel/Scheduler/*` | Priority + EDF scheduling, domain partitioning, timer tick |
@@ -121,9 +123,12 @@ Each kernel subsystem follows the **Operations/Invariant split**: transitions in
 | `SeLe4n/Kernel/IPC/Invariant.lean` | IPC invariant preservation proofs |
 | `SeLe4n/Kernel/Lifecycle/*` | Object retype with lifecycle metadata preservation |
 | `SeLe4n/Kernel/Service/*` | Service graph, dependency tracking, policy enforcement *(extension)* |
-| `SeLe4n/Kernel/Architecture/*` | VSpace map/unmap/lookup, adapter contracts, boundary assumptions |
+| `SeLe4n/Kernel/Architecture/*` | VSpace map/unmap/lookup, `VSpaceBackend` class, adapter contracts, boundary assumptions |
 | `SeLe4n/Kernel/InformationFlow/*` | N-domain labels, state projection, non-interference, enforcement |
 | `SeLe4n/Kernel/API.lean` | Unified public API surface and invariant bundle aliases |
+| `SeLe4n/Platform/Contract.lean` | `PlatformBinding` typeclass — formal interface for hardware targets |
+| `SeLe4n/Platform/Sim/*` | Simulation platform binding (permissive contracts for testing) |
+| `SeLe4n/Platform/RPi5/*` | Raspberry Pi 5 platform binding (BCM2712/ARM64 H3-prep stubs) |
 | `Main.lean` | Executable trace harness |
 | `tests/` | Negative-state suite, information-flow suite, trace sequence probe |
 
@@ -142,9 +147,12 @@ full execution plan.
 4. ~~Close proof gaps for `timerTick`, `cspaceMutate`, notification ops~~ **(WS-F4 COMPLETED)** — `timerTick` scheduler/kernel invariant preservation, `cspaceMutate`/`cspaceRevokeCdt`/`cspaceRevokeCdtStrict` capability invariant preservation, notification signal/wait ipcInvariant + schedulerInvariantBundle + ipcSchedulerContractPredicates preservation; 11 Tier-3 surface anchors
 
 **Path to Raspberry Pi 5:**
-The hardware target is Raspberry Pi 5 (ARM64). Once audit remediation closes the
-proof gaps, the next phase binds architecture-neutral semantics to platform-specific
-interfaces without invalidating core proofs. See
+The hardware target is Raspberry Pi 5 (ARM64). The `Platform/` directory now
+provides the structural foundation for hardware binding: a `PlatformBinding`
+typeclass, `MachineConfig`/`MemoryRegion` types, a `VSpaceBackend` abstraction,
+and concrete stubs for RPi5 (BCM2712 memory map, GIC-400 IRQ constants, ARM64
+runtime contract). Once remaining audit remediation closes, H3 will populate
+these stubs with hardware-validated contracts. See
 [Path to Real Hardware](docs/gitbook/10-path-to-real-hardware-mobile-first.md).
 
 ## Completed workstreams (historical)

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -3,3 +3,7 @@ import SeLe4n.Machine
 import SeLe4n.Model.Object
 import SeLe4n.Model.State
 import SeLe4n.Kernel.API
+import SeLe4n.Kernel.Architecture.VSpaceBackend
+import SeLe4n.Platform.Contract
+import SeLe4n.Platform.Sim.Contract
+import SeLe4n.Platform.RPi5.Contract

--- a/SeLe4n/Kernel/Architecture/Assumptions.lean
+++ b/SeLe4n/Kernel/Architecture/Assumptions.lean
@@ -142,4 +142,42 @@ chain works as follows:
 This four-step chain ensures every declared assumption has a concrete proof-level
 consumer, closing the gap identified in finding M-08. -/
 
+-- ============================================================================
+-- H3 preparation: Extended boot boundary contract
+-- ============================================================================
+
+/-- H3-prep: Exception level at which the kernel receives control from the
+    bootloader. Relevant for ARM64 platforms where EL1 vs EL2 entry
+    determines available system registers and MMU configuration. -/
+inductive ExceptionLevel where
+  | el1
+  | el2
+  deriving Repr, DecidableEq
+
+/-- H3-prep: Extended boot boundary contract with platform-specific fields.
+
+    The base `BootBoundaryContract` declares abstract consistency propositions.
+    `ExtendedBootBoundaryContract` adds platform-visible boot parameters that
+    the H3 workstream needs:
+
+    - **Entry exception level**: EL1 or EL2 (determines available system regs).
+    - **Initial page table state**: Whether the MMU is identity-mapped at entry.
+    - **Device tree location**: Physical address of the DTB.
+    - **Kernel entry point**: Physical address of the kernel's `_start` symbol.
+    - **Initial stack pointer**: Physical address of the initial kernel stack.
+
+    The base `BootBoundaryContract` is embedded, so all existing proofs that
+    depend on it continue to work through the `.base` projection. -/
+structure ExtendedBootBoundaryContract extends BootBoundaryContract where
+  /-- Exception level at kernel entry. -/
+  entryLevel : ExceptionLevel
+  /-- Whether the MMU is identity-mapped at kernel entry. -/
+  mmuIdentityMapped : Bool
+  /-- Physical address of the device tree blob. -/
+  deviceTreeBase : SeLe4n.PAddr
+  /-- Physical address of the kernel entry point (`_start`). -/
+  kernelEntryPoint : SeLe4n.PAddr
+  /-- Physical address of the initial kernel stack top. -/
+  initialStackPointer : SeLe4n.PAddr
+
 end SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Architecture/VSpaceBackend.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceBackend.lean
@@ -1,0 +1,128 @@
+import SeLe4n.Model.State
+
+/-!
+# VSpace Backend Abstraction (H3 preparation)
+
+This module defines the `VSpaceBackend` typeclass — a forward-looking
+abstraction over VSpace implementations. The current flat-list model
+(`VSpaceRoot.mappings : List (VAddr × PAddr)`) satisfies this interface
+naturally. When H3 introduces ARMv8 hierarchical page tables, a new
+backend can be instantiated without changing the abstract kernel proofs.
+
+## Design
+
+The typeclass mirrors the existing VSpace operations in
+`SeLe4n.Kernel.Architecture.VSpace` but makes the implementation
+strategy abstract:
+
+- `mapPage`: Insert a virtual-to-physical mapping.
+- `unmapPage`: Remove a virtual-to-physical mapping.
+- `lookupPage`: Translate a virtual address to a physical address.
+
+Each operation returns an `Option` to signal failure (conflict, not-found).
+The backend is responsible for maintaining its internal consistency.
+
+## Invariant obligations
+
+A backend must satisfy:
+1. **ASID uniqueness**: Two roots with the same ASID must be identical.
+2. **Non-overlap**: No two mappings within a root share the same virtual address.
+3. **Round-trip correctness**: `lookupPage` after `mapPage` returns the mapped
+   physical address. `lookupPage` after `unmapPage` returns `none`.
+
+These obligations are expressed as propositions that a backend instantiation
+must prove. The current `ListVSpaceBackend` instance inherits these from
+the existing `VSpaceInvariant.lean` theorems.
+
+## Status
+
+H3-prep forward declaration. The existing VSpace operations continue to
+work as before. This interface will be consumed during H3 when the RPi5
+platform provides an ARMv8 page-table backend.
+-/
+
+namespace SeLe4n.Kernel.Architecture
+
+open SeLe4n
+
+/-- Abstract VSpace backend interface.
+
+    A backend provides page-level map/unmap/lookup operations over an
+    opaque root representation. The abstract kernel calls these through
+    the existing `vspaceMapPage`/`vspaceUnmapPage`/`vspaceLookup`
+    functions; the backend determines the internal data structure.
+
+    **Type parameter `Root`:** The backing representation for a single
+    address space (e.g., `VSpaceRoot` for the current flat-list model,
+    or a hierarchical page table for ARM64). -/
+class VSpaceBackend (Root : Type) where
+  /-- Insert a virtual-to-physical mapping into the root.
+      Returns `none` if the mapping conflicts with an existing entry. -/
+  mapPage : Root → VAddr → PAddr → Option Root
+  /-- Remove the mapping for a virtual address from the root.
+      Returns `none` if no mapping exists for the given vaddr. -/
+  unmapPage : Root → VAddr → Option Root
+  /-- Translate a virtual address to a physical address.
+      Returns `none` if the vaddr is not mapped. -/
+  lookupPage : Root → VAddr → Option PAddr
+  /-- The ASID bound to this root. -/
+  rootAsid : Root → ASID
+  /-- Mapping a page preserves the root's ASID. -/
+  mapPage_preserves_asid :
+    ∀ root root' vaddr paddr,
+      mapPage root vaddr paddr = some root' → rootAsid root' = rootAsid root
+  /-- Unmapping a page preserves the root's ASID. -/
+  unmapPage_preserves_asid :
+    ∀ root root' vaddr,
+      unmapPage root vaddr = some root' → rootAsid root' = rootAsid root
+  /-- Round-trip: lookup after successful map returns the mapped address. -/
+  lookup_after_map :
+    ∀ root root' vaddr paddr,
+      mapPage root vaddr paddr = some root' →
+      lookupPage root' vaddr = some paddr
+  /-- Non-interference: map at one vaddr does not affect lookup at another. -/
+  lookup_map_other :
+    ∀ root root' vaddr vaddr' paddr,
+      vaddr ≠ vaddr' →
+      mapPage root vaddr paddr = some root' →
+      lookupPage root' vaddr' = lookupPage root vaddr'
+  /-- Round-trip: lookup after successful unmap returns none. -/
+  lookup_after_unmap :
+    ∀ root root' vaddr,
+      unmapPage root vaddr = some root' →
+      lookupPage root' vaddr = none
+  /-- Non-interference: unmap at one vaddr does not affect lookup at another. -/
+  lookup_unmap_other :
+    ∀ root root' vaddr vaddr',
+      vaddr ≠ vaddr' →
+      unmapPage root vaddr = some root' →
+      lookupPage root' vaddr' = lookupPage root vaddr'
+
+-- ============================================================================
+-- List-based VSpaceBackend instance (current model)
+-- ============================================================================
+
+open SeLe4n.Model in
+/-- The existing flat-list `VSpaceRoot` satisfies the `VSpaceBackend` interface.
+
+    This instance delegates to the operations and lemmas already defined in
+    `SeLe4n.Model.Object` (`VSpaceRoot.mapPage`, `.unmapPage`, `.lookup`)
+    and proved in `VSpaceRoot.mapPage_asid_eq`, `lookup_mapPage_eq`, etc.
+
+    No new proofs are required — all obligations are discharged by existing
+    theorems. -/
+instance listVSpaceBackend : VSpaceBackend VSpaceRoot where
+  mapPage root vaddr paddr := root.mapPage vaddr paddr
+  unmapPage root vaddr := root.unmapPage vaddr
+  lookupPage root vaddr := root.lookup vaddr
+  rootAsid root := root.asid
+  mapPage_preserves_asid := VSpaceRoot.mapPage_asid_eq
+  unmapPage_preserves_asid := VSpaceRoot.unmapPage_asid_eq
+  lookup_after_map := VSpaceRoot.lookup_mapPage_eq
+  lookup_map_other := fun root root' vaddr vaddr' paddr hNe hMap =>
+    VSpaceRoot.lookup_mapPage_ne root root' vaddr vaddr' paddr hNe hMap
+  lookup_after_unmap := VSpaceRoot.lookup_unmapPage_eq_none
+  lookup_unmap_other := fun root root' vaddr vaddr' hNe hUnmap =>
+    VSpaceRoot.lookup_unmapPage_ne root root' vaddr vaddr' hNe hUnmap
+
+end SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Architecture/VSpaceBackend.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceBackend.lean
@@ -22,17 +22,20 @@ strategy abstract:
 Each operation returns an `Option` to signal failure (conflict, not-found).
 The backend is responsible for maintaining its internal consistency.
 
-## Invariant obligations
+## Per-operation invariant obligations
 
 A backend must satisfy:
-1. **ASID uniqueness**: Two roots with the same ASID must be identical.
-2. **Non-overlap**: No two mappings within a root share the same virtual address.
-3. **Round-trip correctness**: `lookupPage` after `mapPage` returns the mapped
+1. **ASID preservation**: `mapPage` and `unmapPage` do not change the root's ASID.
+2. **Round-trip correctness**: `lookupPage` after `mapPage` returns the mapped
    physical address. `lookupPage` after `unmapPage` returns `none`.
+3. **Non-interference**: Map/unmap at one vaddr does not affect lookup at another.
 
-These obligations are expressed as propositions that a backend instantiation
-must prove. The current `ListVSpaceBackend` instance inherits these from
-the existing `VSpaceInvariant.lean` theorems.
+System-level invariants (e.g., cross-root ASID uniqueness, within-root
+no-virtual-overlap) are enforced by `SeLe4n/Kernel/Architecture/VSpace.lean`
+and `VSpaceInvariant.lean`, not by the backend itself.
+
+The current `ListVSpaceBackend` instance inherits all obligations from
+the existing `VSpaceRoot` lemmas in `SeLe4n/Model/Object.lean`.
 
 ## Status
 

--- a/SeLe4n/Machine.lean
+++ b/SeLe4n/Machine.lean
@@ -135,4 +135,94 @@ theorem default_registerFile_sp_zero :
 theorem default_timer_zero :
     (default : MachineState).timer = 0 := rfl
 
+-- ============================================================================
+-- H3 preparation: MachineConfig and MemoryRegion (platform-binding readiness)
+-- ============================================================================
+
+/-- H3-prep: Classification of physical memory region kinds.
+
+Used by platform bindings to declare the hardware memory map. Kernel-level
+proofs remain total over `Memory = PAddr → UInt8`; the `MemoryKind` annotation
+enables platform-specific access checks and MMU permission assignments. -/
+inductive MemoryKind where
+  | ram
+  | device
+  | reserved
+  deriving Repr, DecidableEq
+
+/-- H3-prep: A contiguous physical memory region with a declared kind.
+
+Platforms declare their memory map as a list of `MemoryRegion` entries. The
+abstract kernel does not enforce these bounds directly — enforcement happens
+at the `RuntimeBoundaryContract.memoryAccessAllowed` predicate. This type
+provides the vocabulary for platform bindings to express address constraints
+that the contract can reference. -/
+structure MemoryRegion where
+  base : PAddr
+  size : Nat
+  kind : MemoryKind
+  deriving Repr, DecidableEq
+
+namespace MemoryRegion
+
+/-- The end address (exclusive) of a memory region. -/
+@[inline] def endAddr (r : MemoryRegion) : Nat := r.base.toNat + r.size
+
+/-- Check whether a physical address falls within this region. -/
+@[inline] def contains (r : MemoryRegion) (addr : PAddr) : Bool :=
+  r.base.toNat ≤ addr.toNat && addr.toNat < r.endAddr
+
+/-- Two regions overlap if their address ranges intersect. -/
+def overlaps (r₁ r₂ : MemoryRegion) : Bool :=
+  r₁.base.toNat < r₂.endAddr && r₂.base.toNat < r₁.endAddr
+
+theorem contains_iff (r : MemoryRegion) (addr : PAddr) :
+    r.contains addr = true ↔ r.base.toNat ≤ addr.toNat ∧ addr.toNat < r.endAddr := by
+  simp [contains, endAddr]
+
+end MemoryRegion
+
+/-- H3-prep: Platform-declared machine configuration parameters.
+
+Each platform binding provides a `MachineConfig` that declares the hardware's
+architectural constants. These are used by platform-specific contracts and
+adapters, not by the abstract kernel transitions (which remain `Nat`-based
+for proof convenience).
+
+**Register/address widths:** Expressed in bits. The abstract model uses
+unbounded `Nat` for all values; widths are advisory constraints that platform
+contracts can check against.
+
+**Page size:** Standard memory management unit page size in bytes.
+
+**Max ASID:** Upper bound on the number of address-space identifiers. The
+abstract model places no bound; this enables platform contracts to validate
+ASID allocation stays within hardware limits. -/
+structure MachineConfig where
+  /-- Register width in bits (e.g., 64 for ARM64). -/
+  registerWidth : Nat
+  /-- Virtual address width in bits (e.g., 48 for ARMv8). -/
+  virtualAddressWidth : Nat
+  /-- Physical address width in bits (e.g., 52 for ARMv8). -/
+  physicalAddressWidth : Nat
+  /-- Standard page size in bytes (e.g., 4096). -/
+  pageSize : Nat
+  /-- Maximum number of address-space identifiers (e.g., 65536 for 16-bit ASID). -/
+  maxASID : Nat
+  /-- Platform memory map: declared physical memory regions. -/
+  memoryMap : List MemoryRegion
+  deriving Repr
+
+namespace MachineConfig
+
+/-- Total RAM capacity: sum of sizes of all RAM-kind regions. -/
+def totalRAM (cfg : MachineConfig) : Nat :=
+  cfg.memoryMap.filter (·.kind == .ram) |>.map (·.size) |>.foldl (· + ·) 0
+
+/-- Check whether a physical address falls within any declared region. -/
+def addressInMap (cfg : MachineConfig) (addr : PAddr) : Bool :=
+  cfg.memoryMap.any (·.contains addr)
+
+end MachineConfig
+
 end SeLe4n

--- a/SeLe4n/Machine.lean
+++ b/SeLe4n/Machine.lean
@@ -223,6 +223,24 @@ def totalRAM (cfg : MachineConfig) : Nat :=
 def addressInMap (cfg : MachineConfig) (addr : PAddr) : Bool :=
   cfg.memoryMap.any (·.contains addr)
 
+/-- A pairwise non-overlap check over the memory map regions. -/
+private def noOverlapAux : List MemoryRegion → Bool
+  | [] => true
+  | r :: rs => rs.all (fun r' => !r.overlaps r') && noOverlapAux rs
+
+/-- A machine configuration is well-formed when:
+    1. All regions have nonzero size.
+    2. No two regions overlap.
+    3. Page size is a positive power of two.
+    4. Register, virtual address, and physical address widths are positive. -/
+def wellFormed (cfg : MachineConfig) : Bool :=
+  cfg.memoryMap.all (·.size > 0)
+  && noOverlapAux cfg.memoryMap
+  && cfg.pageSize > 0
+  && cfg.registerWidth > 0
+  && cfg.virtualAddressWidth > 0
+  && cfg.physicalAddressWidth > 0
+
 end MachineConfig
 
 end SeLe4n

--- a/SeLe4n/Platform/Contract.lean
+++ b/SeLe4n/Platform/Contract.lean
@@ -26,8 +26,9 @@ and test harnesses instantiate a concrete platform.
 ## Current instantiations
 
 - `SeLe4n.Platform.Sim.simPlatformBinding` — simulation target for trace
-  harness and test execution. Wraps the permissive fixtures from
-  `SeLe4n.Testing.RuntimeContractFixtures`.
+  harness and test execution. Defines permissive contracts parallel to
+  `SeLe4n.Testing.RuntimeContractFixtures` (functionally equivalent but
+  organized under the Platform namespace).
 - `SeLe4n.Platform.RPi5.rpi5PlatformBinding` — Raspberry Pi 5 (BCM2712/ARM64)
   stub for H3 hardware binding.
 -/

--- a/SeLe4n/Platform/Contract.lean
+++ b/SeLe4n/Platform/Contract.lean
@@ -1,0 +1,73 @@
+import SeLe4n.Kernel.Architecture.Assumptions
+
+/-!
+# Platform Binding Contract (H3 preparation)
+
+This module defines the `PlatformBinding` typeclass — the formal interface that
+any hardware platform must satisfy to instantiate the seLe4n kernel. A platform
+binding bundles:
+
+1. **MachineConfig** — architectural constants (register width, page size, ASID
+   limits, physical memory map).
+2. **RuntimeBoundaryContract** — decidable predicates on timer monotonicity,
+   register context stability, and memory access permissions.
+3. **BootBoundaryContract** — propositions about initial object-store and
+   capability-ref consistency.
+4. **InterruptBoundaryContract** — predicates on supported IRQ lines and handler
+   mappings.
+
+## Design rationale
+
+The typeclass approach makes platform selection a type parameter rather than a
+value parameter. Kernel transitions remain platform-agnostic (they do not
+mention any `PlatformBinding` instance). Only architecture-adapter entrypoints
+and test harnesses instantiate a concrete platform.
+
+## Current instantiations
+
+- `SeLe4n.Platform.Sim.simPlatformBinding` — simulation target for trace
+  harness and test execution. Wraps the permissive fixtures from
+  `SeLe4n.Testing.RuntimeContractFixtures`.
+- `SeLe4n.Platform.RPi5.rpi5PlatformBinding` — Raspberry Pi 5 (BCM2712/ARM64)
+  stub for H3 hardware binding.
+-/
+
+namespace SeLe4n.Platform
+
+open SeLe4n.Kernel.Architecture
+
+/-- A complete platform binding bundles all architecture-boundary contracts
+    together with the platform's machine configuration.
+
+    Platform implementors provide an instance of this class. Kernel code
+    never depends on a specific instance — it is parameterized over the
+    typeclass when adapter operations need platform-specific contracts. -/
+class PlatformBinding (platform : Type) where
+  /-- Platform name used for diagnostics and trace output. -/
+  name : String
+  /-- Hardware architectural parameters. -/
+  machineConfig : SeLe4n.MachineConfig
+  /-- Runtime boundary contract governing timer, register, and memory access. -/
+  runtimeContract : RuntimeBoundaryContract
+  /-- Boot-time boundary contract governing initial state consistency. -/
+  bootContract : BootBoundaryContract
+  /-- Interrupt routing contract governing IRQ line support and handler mapping. -/
+  interruptContract : InterruptBoundaryContract
+
+/-- Extract the runtime contract from a platform binding instance. -/
+@[inline] def PlatformBinding.runtime [PlatformBinding platform] : RuntimeBoundaryContract :=
+  PlatformBinding.runtimeContract (platform := platform)
+
+/-- Extract the boot contract from a platform binding instance. -/
+@[inline] def PlatformBinding.boot [PlatformBinding platform] : BootBoundaryContract :=
+  PlatformBinding.bootContract (platform := platform)
+
+/-- Extract the interrupt contract from a platform binding instance. -/
+@[inline] def PlatformBinding.interrupt [PlatformBinding platform] : InterruptBoundaryContract :=
+  PlatformBinding.interruptContract (platform := platform)
+
+/-- Extract the machine configuration from a platform binding instance. -/
+@[inline] def PlatformBinding.config [PlatformBinding platform] : SeLe4n.MachineConfig :=
+  PlatformBinding.machineConfig (platform := platform)
+
+end SeLe4n.Platform

--- a/SeLe4n/Platform/RPi5/Board.lean
+++ b/SeLe4n/Platform/RPi5/Board.lean
@@ -52,17 +52,22 @@ def uart0Base : SeLe4n.PAddr := SeLe4n.PAddr.ofNat 0xFE201000
 
     Regions are listed from low to high address:
     1. RAM: 0x0000_0000 – 0xFC00_0000 (4032 MiB usable before peripherals)
-    2. Low peripherals: 0xFE00_0000 – 0xFF84_FFFF (legacy + GIC)
-    3. High peripherals: 0x10_0000_0000+ (BCM2712-specific, not modeled yet) -/
+    2. GPU/VideoCore: 0xFC00_0000 – 0xFE00_0000 (32 MiB reserved for GPU firmware)
+    3. Low peripherals: 0xFE00_0000 – 0xFF84_FFFF (legacy BCM2712 + GIC-400)
+    4. Reserved: 0xFF85_0000 – 0xFFFF_FFFF (above GIC, to 4 GB boundary)
+    5. High peripherals: 0x10_0000_0000+ (BCM2712-specific, not modeled yet) -/
 def rpi5MemoryMap : List SeLe4n.MemoryRegion :=
   [ { base := SeLe4n.PAddr.ofNat 0x00000000
       size := 4032 * 1024 * 1024  -- 4032 MiB usable RAM
       kind := .ram }
+  , { base := SeLe4n.PAddr.ofNat 0xFC000000
+      size := 0x02000000  -- 32 MiB GPU/VideoCore firmware region
+      kind := .reserved }
   , { base := SeLe4n.PAddr.ofNat 0xFE000000
-      size := 0x01850000  -- ~24.3 MiB peripheral window
+      size := 0x01850000  -- ~24.3 MiB peripheral window (legacy + GIC-400)
       kind := .device }
   , { base := SeLe4n.PAddr.ofNat 0xFF850000
-      size := 0x007B0000  -- reserved region above GIC
+      size := 0x007B0000  -- reserved region above GIC to 4 GB boundary
       kind := .reserved }
   ]
 

--- a/SeLe4n/Platform/RPi5/Board.lean
+++ b/SeLe4n/Platform/RPi5/Board.lean
@@ -1,0 +1,98 @@
+import SeLe4n.Machine
+
+/-!
+# Raspberry Pi 5 — Board Definition (BCM2712)
+
+Hardware constants for the Broadcom BCM2712 SoC used in the Raspberry Pi 5.
+This module defines the physical memory map, peripheral base addresses, and
+architectural parameters that platform contracts reference.
+
+## References
+
+- BCM2712 ARM Peripherals datasheet
+- ARM Cortex-A76 Technical Reference Manual
+- ARM Architecture Reference Manual (ARMv8-A)
+
+## Status
+
+H3-prep stub. Values are based on publicly available BCM2712 documentation.
+Full register-level definitions will be added during the H3 platform-binding
+workstream.
+-/
+
+namespace SeLe4n.Platform.RPi5
+
+-- ============================================================================
+-- BCM2712 physical address map
+-- ============================================================================
+
+/-- BCM2712 low-peripheral base address (legacy 32-bit peripheral window). -/
+def peripheralBaseLow : SeLe4n.PAddr := SeLe4n.PAddr.ofNat 0xFE000000
+
+/-- BCM2712 high-peripheral base address (new peripherals in BCM2712). -/
+def peripheralBaseHigh : SeLe4n.PAddr := SeLe4n.PAddr.ofNat 0x1000000000
+
+/-- GIC-400 distributor base address. -/
+def gicDistributorBase : SeLe4n.PAddr := SeLe4n.PAddr.ofNat 0xFF841000
+
+/-- GIC-400 CPU interface base address. -/
+def gicCpuInterfaceBase : SeLe4n.PAddr := SeLe4n.PAddr.ofNat 0xFF842000
+
+/-- ARM Generic Timer frequency (54 MHz crystal on RPi5). -/
+def timerFrequencyHz : Nat := 54000000
+
+/-- UART0 (PL011) base address for debug console. -/
+def uart0Base : SeLe4n.PAddr := SeLe4n.PAddr.ofNat 0xFE201000
+
+-- ============================================================================
+-- RPi5 memory map
+-- ============================================================================
+
+/-- Standard Raspberry Pi 5 physical memory map (4 GB model).
+
+    Regions are listed from low to high address:
+    1. RAM: 0x0000_0000 – 0xFC00_0000 (4032 MiB usable before peripherals)
+    2. Low peripherals: 0xFE00_0000 – 0xFF84_FFFF (legacy + GIC)
+    3. High peripherals: 0x10_0000_0000+ (BCM2712-specific, not modeled yet) -/
+def rpi5MemoryMap : List SeLe4n.MemoryRegion :=
+  [ { base := SeLe4n.PAddr.ofNat 0x00000000
+      size := 4032 * 1024 * 1024  -- 4032 MiB usable RAM
+      kind := .ram }
+  , { base := SeLe4n.PAddr.ofNat 0xFE000000
+      size := 0x01850000  -- ~24.3 MiB peripheral window
+      kind := .device }
+  , { base := SeLe4n.PAddr.ofNat 0xFF850000
+      size := 0x007B0000  -- reserved region above GIC
+      kind := .reserved }
+  ]
+
+-- ============================================================================
+-- ARM64 architectural constants
+-- ============================================================================
+
+/-- ARMv8-A machine configuration for Raspberry Pi 5. -/
+def rpi5MachineConfig : SeLe4n.MachineConfig :=
+  {
+    registerWidth := 64
+    virtualAddressWidth := 48
+    physicalAddressWidth := 44   -- BCM2712 supports 44-bit PA
+    pageSize := 4096             -- 4 KiB granule (standard)
+    maxASID := 65536             -- 16-bit ASID with TTBR.ASID
+    memoryMap := rpi5MemoryMap
+  }
+
+-- ============================================================================
+-- GIC-400 IRQ constants
+-- ============================================================================
+
+/-- Number of shared peripheral interrupts (SPIs) on BCM2712 GIC-400. -/
+def gicSpiCount : Nat := 192
+
+/-- ARM Generic Timer PPI (Private Peripheral Interrupt) ID.
+    Non-secure physical timer: INTID 30. -/
+def timerPpiId : SeLe4n.Irq := SeLe4n.Irq.ofNat 30
+
+/-- ARM Generic Timer virtual timer PPI: INTID 27. -/
+def virtualTimerPpiId : SeLe4n.Irq := SeLe4n.Irq.ofNat 27
+
+end SeLe4n.Platform.RPi5

--- a/SeLe4n/Platform/RPi5/BootContract.lean
+++ b/SeLe4n/Platform/RPi5/BootContract.lean
@@ -41,12 +41,17 @@ def rpi5BootContract : BootBoundaryContract :=
 /-- RPi5 interrupt contract: declares which IRQ lines the GIC-400 supports
     and assumes all supported lines have handler mappings.
 
-    In H3, `irqLineSupported` will check against the actual GIC-400 SPI
-    count and PPI assignments. `irqHandlerMapped` will verify that the
-    IRQ handler table has been populated during boot. -/
+    **Supported range:** INTIDs 0–223 (SGIs 0–15, PPIs 16–31, SPIs 32–223).
+    SGIs (software-generated interrupts) are included because the GIC-400
+    distributes them like any other interrupt; they don't need boot-time
+    handler mapping but are addressable.
+
+    In H3, `irqLineSupported` will be refined to distinguish SGI/PPI/SPI
+    ranges. `irqHandlerMapped` will verify that the IRQ handler table has
+    been populated during boot for PPIs and SPIs. -/
 def rpi5InterruptContract : InterruptBoundaryContract :=
   {
-    irqLineSupported := fun irq => irq.toNat < gicSpiCount + 32  -- SPIs + PPIs
+    irqLineSupported := fun irq => irq.toNat < gicSpiCount + 32  -- SGIs + PPIs + SPIs
     irqHandlerMapped := fun _ _ => True  -- placeholder: all mapped
   }
 

--- a/SeLe4n/Platform/RPi5/BootContract.lean
+++ b/SeLe4n/Platform/RPi5/BootContract.lean
@@ -1,0 +1,53 @@
+import SeLe4n.Platform.RPi5.Board
+import SeLe4n.Kernel.Architecture.Assumptions
+
+/-!
+# Raspberry Pi 5 — Boot Boundary Contract
+
+Platform-specific boot boundary contract for the BCM2712 SoC. Declares the
+assumptions about initial system state when the kernel receives control from
+the bootloader (ATF / U-Boot).
+
+## Boot sequence assumptions
+
+1. ARM Trusted Firmware (ATF) has initialized EL3 and handed off to EL2/EL1.
+2. U-Boot has loaded the kernel image and device tree blob into RAM.
+3. The MMU is disabled or in identity-map mode at kernel entry.
+4. The BSS section is zeroed (matches `default_memory_returns_zero`).
+
+## Status
+
+H3-prep stub. Object-type and capability-ref metadata consistency are
+declared as `True` placeholders. Full boot-state verification requires
+the H3 platform-binding workstream to define the concrete initial state
+construction and prove it satisfies these contracts.
+-/
+
+namespace SeLe4n.Platform.RPi5
+
+open SeLe4n.Kernel.Architecture
+
+/-- RPi5 boot contract: initial state consistency is asserted by the bootloader.
+
+    In H3, these will become substantive propositions verified against the
+    concrete initial `SystemState` constructed by the boot sequence.
+    For now, they are `True` placeholders. -/
+def rpi5BootContract : BootBoundaryContract :=
+  {
+    objectTypeMetadataConsistent := True
+    capabilityRefMetadataConsistent := True
+  }
+
+/-- RPi5 interrupt contract: declares which IRQ lines the GIC-400 supports
+    and assumes all supported lines have handler mappings.
+
+    In H3, `irqLineSupported` will check against the actual GIC-400 SPI
+    count and PPI assignments. `irqHandlerMapped` will verify that the
+    IRQ handler table has been populated during boot. -/
+def rpi5InterruptContract : InterruptBoundaryContract :=
+  {
+    irqLineSupported := fun irq => irq.toNat < gicSpiCount + 32  -- SPIs + PPIs
+    irqHandlerMapped := fun _ _ => True  -- placeholder: all mapped
+  }
+
+end SeLe4n.Platform.RPi5

--- a/SeLe4n/Platform/RPi5/Contract.lean
+++ b/SeLe4n/Platform/RPi5/Contract.lean
@@ -1,0 +1,47 @@
+import SeLe4n.Platform.Contract
+import SeLe4n.Platform.RPi5.RuntimeContract
+import SeLe4n.Platform.RPi5.BootContract
+
+/-!
+# Raspberry Pi 5 — Platform Binding
+
+Composed `PlatformBinding` instance for the Raspberry Pi 5 (BCM2712, ARM64).
+This is the first hardware target for seLe4n.
+
+## Hardware profile
+
+- **SoC**: Broadcom BCM2712, quad-core ARM Cortex-A76 @ 2.4 GHz
+- **Architecture**: ARMv8.2-A (AArch64)
+- **RAM**: Up to 8 GB LPDDR4X (4 GB modeled here)
+- **Interrupt controller**: GIC-400 (ARM Generic Interrupt Controller v2)
+- **Timer**: ARM Generic Timer, 54 MHz crystal
+- **Debug**: PL011 UART at 0xFE201000
+
+## Status
+
+H3-prep stub. The binding is structurally complete (all contract fields
+populated) but uses placeholder values for boot and interrupt contracts.
+The H3 workstream will replace these with hardware-validated contracts
+and add:
+- ARMv8 multi-level page table walk semantics
+- GIC-400 IRQ routing and acknowledgment
+- ARM Generic Timer CNTPCT_EL0 binding
+- MMU TTBR0/TTBR1 and TLB invalidation operations
+- Verified boot sequence (ATF → U-Boot → kernel entry)
+-/
+
+namespace SeLe4n.Platform.RPi5
+
+/-- Marker type for the Raspberry Pi 5 platform. -/
+structure RPi5Platform where
+  deriving Repr
+
+/-- The Raspberry Pi 5 platform binding instance. -/
+instance rpi5PlatformBinding : SeLe4n.Platform.PlatformBinding RPi5Platform where
+  name := "Raspberry Pi 5 (BCM2712 / ARM64)"
+  machineConfig := rpi5MachineConfig
+  runtimeContract := rpi5RuntimeContract
+  bootContract := rpi5BootContract
+  interruptContract := rpi5InterruptContract
+
+end SeLe4n.Platform.RPi5

--- a/SeLe4n/Platform/RPi5/RuntimeContract.lean
+++ b/SeLe4n/Platform/RPi5/RuntimeContract.lean
@@ -1,0 +1,48 @@
+import SeLe4n.Platform.RPi5.Board
+import SeLe4n.Kernel.Architecture.Assumptions
+
+/-!
+# Raspberry Pi 5 — Runtime Boundary Contract
+
+Platform-specific runtime boundary contract for the BCM2712 SoC. This contract
+encodes the hardware assumptions that the abstract kernel model relies on:
+
+1. **Timer monotonicity**: The ARM Generic Timer (CNTPCT_EL0) is monotonically
+   non-decreasing. Counter rollover is outside the operational lifetime.
+2. **Register context stability**: Context switches preserve the full ARMv8-A
+   general-purpose register file (X0–X30, SP, PC, PSTATE).
+3. **Memory access permissions**: Access is allowed only to addresses within
+   declared RAM regions of the platform memory map. Device and reserved
+   regions require explicit MMIO adapter calls (not modeled here).
+
+## Status
+
+H3-prep stub. The predicates are well-typed and decidable but not yet
+validated against actual hardware behavior. Full hardware validation is
+part of the H4 evidence-convergence workstream.
+-/
+
+namespace SeLe4n.Platform.RPi5
+
+open SeLe4n.Kernel.Architecture
+open SeLe4n.Model
+
+/-- RPi5 runtime contract: timer must not go backward, registers are always
+    stable (ARMv8 context-switch guarantee), and memory access is restricted
+    to declared RAM regions in the BCM2712 memory map. -/
+def rpi5RuntimeContract : RuntimeBoundaryContract :=
+  {
+    timerMonotonic := fun st st' => st.machine.timer ≤ st'.machine.timer
+    registerContextStable := fun _ _ => True
+    memoryAccessAllowed := fun _ addr =>
+      rpi5MachineConfig.memoryMap.any fun region =>
+        region.kind == .ram && region.contains addr
+    timerMonotonicDecidable := by intro st st'; infer_instance
+    registerContextStableDecidable := by intro st st'; infer_instance
+    memoryAccessAllowedDecidable := by
+      intro _ addr
+      simp only [rpi5MachineConfig, rpi5MemoryMap]
+      infer_instance
+  }
+
+end SeLe4n.Platform.RPi5

--- a/SeLe4n/Platform/Sim/BootContract.lean
+++ b/SeLe4n/Platform/Sim/BootContract.lean
@@ -1,0 +1,33 @@
+import SeLe4n.Kernel.Architecture.Assumptions
+
+/-!
+# Simulation Platform — Boot Contract
+
+Simulation-target boot boundary contract. Provides trivially-true propositions
+for object-type metadata consistency and capability-ref metadata consistency,
+enabling trace harness execution without platform-specific boot validation.
+-/
+
+namespace SeLe4n.Platform.Sim
+
+open SeLe4n.Kernel.Architecture
+
+/-- Simulation boot contract: all boot-time consistency conditions hold trivially.
+    Suitable for test bootstrapping where the state builder constructs a valid
+    initial state by construction. -/
+def simBootContract : BootBoundaryContract :=
+  {
+    objectTypeMetadataConsistent := True
+    capabilityRefMetadataConsistent := True
+  }
+
+/-- Simulation interrupt contract: all IRQ lines are supported and all handlers
+    are considered mapped. Used for testing IRQ-adjacent paths without hardware
+    constraints. -/
+def simInterruptContract : InterruptBoundaryContract :=
+  {
+    irqLineSupported := fun _ => True
+    irqHandlerMapped := fun _ _ => True
+  }
+
+end SeLe4n.Platform.Sim

--- a/SeLe4n/Platform/Sim/Contract.lean
+++ b/SeLe4n/Platform/Sim/Contract.lean
@@ -1,0 +1,54 @@
+import SeLe4n.Platform.Contract
+import SeLe4n.Platform.Sim.RuntimeContract
+import SeLe4n.Platform.Sim.BootContract
+
+/-!
+# Simulation Platform Binding
+
+Composed `PlatformBinding` instance for the simulation target. This is the
+platform used by trace harnesses, negative-state suites, and development
+testing. It bundles permissive runtime contracts with trivially-true boot
+and interrupt contracts.
+
+## Machine configuration
+
+The simulation platform declares an idealized 64-bit machine with:
+- 64-bit registers and 48-bit virtual / 52-bit physical addressing
+- 4 KiB pages
+- 16-bit ASID space (65536 entries)
+- A single 256 MiB RAM region starting at physical address 0
+
+These values match common ARM64 defaults and enable the trace harness to
+exercise scheduler, IPC, and VSpace paths without hitting artificial bounds.
+-/
+
+namespace SeLe4n.Platform.Sim
+
+/-- Marker type for the simulation platform. -/
+structure SimPlatform where
+  deriving Repr
+
+/-- Simulation machine configuration: idealized 64-bit ARM64 parameters. -/
+def simMachineConfig : SeLe4n.MachineConfig :=
+  {
+    registerWidth := 64
+    virtualAddressWidth := 48
+    physicalAddressWidth := 52
+    pageSize := 4096
+    maxASID := 65536
+    memoryMap := [
+      { base := SeLe4n.PAddr.ofNat 0
+        size := 256 * 1024 * 1024  -- 256 MiB
+        kind := .ram }
+    ]
+  }
+
+/-- The simulation platform binding instance. -/
+instance simPlatformBinding : SeLe4n.Platform.PlatformBinding SimPlatform where
+  name := "Simulation (permissive)"
+  machineConfig := simMachineConfig
+  runtimeContract := simRuntimeContractPermissive
+  bootContract := simBootContract
+  interruptContract := simInterruptContract
+
+end SeLe4n.Platform.Sim

--- a/SeLe4n/Platform/Sim/RuntimeContract.lean
+++ b/SeLe4n/Platform/Sim/RuntimeContract.lean
@@ -1,0 +1,45 @@
+import SeLe4n.Kernel.Architecture.Assumptions
+
+/-!
+# Simulation Platform — Runtime Contracts
+
+Simulation-target runtime boundary contracts for trace harness execution and
+testing. These mirror the fixtures in `SeLe4n.Testing.RuntimeContractFixtures`
+but are organized under the `Platform.Sim` namespace as part of the H3-prep
+platform-binding architecture.
+
+**Non-production:** These contracts are intentionally broad (accept-all) or
+intentionally restrictive (deny-all) for testing purposes. They MUST NOT be
+used by production kernel modules under `SeLe4n/Kernel/`.
+-/
+
+namespace SeLe4n.Platform.Sim
+
+open SeLe4n.Kernel.Architecture
+open SeLe4n.Model
+
+/-- Permissive runtime contract that accepts all timer, register, and memory operations.
+    Used for success-path testing in trace harnesses. -/
+def simRuntimeContractPermissive : RuntimeBoundaryContract :=
+  {
+    timerMonotonic := fun st st' => st.machine.timer ≤ st'.machine.timer
+    registerContextStable := fun _ _ => True
+    memoryAccessAllowed := fun _ _ => True
+    timerMonotonicDecidable := by intro st st'; infer_instance
+    registerContextStableDecidable := by intro st st'; infer_instance
+    memoryAccessAllowedDecidable := by intro st addr; infer_instance
+  }
+
+/-- Restrictive runtime contract that denies all runtime operations.
+    Used for error-path testing in trace harnesses. -/
+def simRuntimeContractRestrictive : RuntimeBoundaryContract :=
+  {
+    timerMonotonic := fun _ _ => False
+    registerContextStable := fun _ _ => False
+    memoryAccessAllowed := fun _ _ => False
+    timerMonotonicDecidable := by intro st st'; infer_instance
+    registerContextStableDecidable := by intro st st'; infer_instance
+    memoryAccessAllowedDecidable := by intro st addr; infer_instance
+  }
+
+end SeLe4n.Platform.Sim

--- a/docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md
+++ b/docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md
@@ -21,11 +21,26 @@ reviewers can quickly detect misuse and contributors can reason about what is sa
 - `SeLe4n/Kernel/Architecture/Invariant.lean` proves preservation theorems over the same trusted
   contract surface.
 
+### Platform binding layer (H3-prep)
+
+- `SeLe4n/Platform/Contract.lean` defines `PlatformBinding` typeclass bundling
+  `MachineConfig`, `RuntimeBoundaryContract`, `BootBoundaryContract`, and
+  `InterruptBoundaryContract`.
+- `SeLe4n/Platform/Sim/*` provides simulation-target platform contracts
+  (permissive/restrictive) for trace harness and test execution.
+- `SeLe4n/Platform/RPi5/*` provides Raspberry Pi 5 platform-specific contract
+  stubs (BCM2712 memory map, ARM64 config, RAM-only access contract).
+- Platform modules import `SeLe4n/Kernel/Architecture/Assumptions.lean` but
+  are not imported by any `SeLe4n/Kernel/` module.
+
 ### Test-only fixtures (non-production)
 
 - `SeLe4n/Testing/RuntimeContractFixtures.lean` contains permissive fixtures:
   - `SeLe4n.Testing.runtimeContractAcceptAll`
   - `SeLe4n.Testing.runtimeContractDenyAll`
+- `SeLe4n/Platform/Sim/RuntimeContract.lean` contains parallel simulation contracts:
+  - `SeLe4n.Platform.Sim.simRuntimeContractPermissive`
+  - `SeLe4n.Platform.Sim.simRuntimeContractRestrictive`
 - These fixtures exist only to drive executable trace scenarios and must not appear in
   production kernel modules under `SeLe4n/Kernel`.
 
@@ -43,9 +58,11 @@ Before merging any PR that touches architecture-boundary semantics:
 
 1. Ensure new runtime contract definitions intended for production live under
    `SeLe4n/Kernel/Architecture/*`.
-2. Keep permissive or denial-style fixtures in test-only modules under `SeLe4n/Testing/*` (or non-kernel test executables).
-3. Run `./scripts/test_fast.sh` locally; do not bypass Tier 0 failures.
-4. If a new fixture is added, document why it cannot be a production contract.
+2. Keep permissive or denial-style fixtures in test-only modules under
+   `SeLe4n/Testing/*` or `SeLe4n/Platform/Sim/*` (never in `SeLe4n/Kernel/`).
+3. Platform-specific contracts go in `SeLe4n/Platform/<target>/*`.
+4. Run `./scripts/test_fast.sh` locally; do not bypass Tier 0 failures.
+5. If a new fixture is added, document why it cannot be a production contract.
 
 ## 5. Review guidance
 

--- a/docs/PLATFORM_BINDING_ADR.md
+++ b/docs/PLATFORM_BINDING_ADR.md
@@ -1,0 +1,110 @@
+# ADR: Platform Binding Architecture (H3 Preparation)
+
+**Status:** Accepted
+**Date:** 2026-03-01
+**Context:** Pre-H3 structural preparation for hardware-specific implementation
+**Relates to:** WS-B1 (VSpace ADR), WS-C7 (Finite Object Store ADR), H3 (Platform binding)
+
+---
+
+## Decision
+
+Introduce a `Platform/` directory with a `PlatformBinding` typeclass, platform-
+specific contract stubs, and supporting foundational types (`MachineConfig`,
+`MemoryRegion`, `VSpaceBackend`) to structurally prepare the codebase for
+hardware-specific implementation without forking the repository.
+
+## Context
+
+seLe4n is transitioning from abstract kernel semantics (H0–H2) toward hardware-
+specific implementation on Raspberry Pi 5 (H3). The question was whether to:
+
+1. **Fork** the repository into abstract-kernel and hardware-binding repos, or
+2. **Reorganize** with a new `Platform/` namespace in the existing monorepo.
+
+## Analysis
+
+### Why not fork
+
+1. **Proof chain continuity.** The `RuntimeBoundaryContract` instantiation for
+   RPi5 must import `SeLe4n.Model.State`, `SeLe4n.Kernel.Architecture.Assumptions`,
+   and satisfy invariants defined in `SeLe4n.Kernel.Architecture.Invariant`. A
+   cross-repo boundary would require coordinated releases for every change to
+   `SystemState`, `KernelError`, or any invariant bundle.
+
+2. **Contract instantiation IS the proof.** The `AdapterProofHooks` structure
+   requires the platform to prove preservation of abstract invariant bundles.
+   Separate repos mean the platform code compiles against a snapshot, losing the
+   guarantee that proofs compose against the live kernel.
+
+3. **Codebase scale.** At ~19K LoC, monorepo tooling is not a bottleneck.
+
+### Why this organization
+
+The `Platform/` namespace provides:
+
+- **Clean import boundaries:** `SeLe4n.Kernel.*` never imports `SeLe4n.Platform.*`.
+  Platform modules import `Kernel.Architecture.*` to instantiate contracts.
+- **Multiple build targets without repo splits:** Lake handles `SeLe4n`,
+  `Platform.Sim`, and `Platform.RPi5` as discoverable library modules.
+- **Future multi-platform readiness:** Adding RISC-V or x86 later is just
+  `Platform/RiscV/` with new contract instantiations.
+- **Structural hygiene enforcement:** Platform test fixtures live in `Platform/Sim/`
+  rather than `Testing/`, making the production/test boundary architectural.
+
+## Changes Introduced
+
+### New types (additive to Machine.lean)
+
+- `MemoryKind` — RAM, Device, Reserved
+- `MemoryRegion` — base PAddr, size, kind, with `contains`/`overlaps` helpers
+- `MachineConfig` — register width, address width, page size, max ASID, memory map
+
+### New typeclass (Platform/Contract.lean)
+
+- `PlatformBinding` — bundles `MachineConfig`, `RuntimeBoundaryContract`,
+  `BootBoundaryContract`, `InterruptBoundaryContract` with a platform name
+
+### New abstraction (Architecture/VSpaceBackend.lean)
+
+- `VSpaceBackend` class — abstract page map/unmap/lookup with ASID preservation,
+  round-trip correctness, and non-interference obligations
+- `listVSpaceBackend` instance — delegates to existing `VSpaceRoot` methods and
+  lemmas (zero new proofs required)
+
+### Extended boot contract (additive to Assumptions.lean)
+
+- `ExceptionLevel` — EL1/EL2 enumeration
+- `ExtendedBootBoundaryContract extends BootBoundaryContract` — adds entry level,
+  MMU state, device tree base, kernel entry point, initial stack pointer
+
+### Platform instantiations
+
+- `Platform/Sim/` — `SimPlatform` with permissive runtime, trivially-true boot,
+  64-bit idealized machine config with 256 MiB RAM region
+- `Platform/RPi5/` — `RPi5Platform` with BCM2712 memory map, GIC-400 constants,
+  ARM64 config (44-bit PA, 16-bit ASID), RAM-only memory access contract
+
+## What was NOT changed
+
+- No existing definitions were moved or renamed
+- No existing invariant anchors were broken (all 400+ tier-3 checks pass)
+- No existing imports were modified in `SeLe4n/Kernel/` modules
+- The `Testing/RuntimeContractFixtures.lean` fixtures remain in place (tier-3
+  anchors depend on their exact location)
+
+## Consequences
+
+- H3 hardware binding can now proceed by populating `Platform/RPi5/` stubs
+  with hardware-validated contracts and adding an ARMv8 `VSpaceBackend` instance
+- The abstract kernel proof surface remains completely unchanged
+- New platforms can be added as `Platform/<name>/` without restructuring
+- The `PlatformBinding` typeclass enables parameterized adapter operations
+
+## Migration path (future)
+
+1. H3: Populate RPi5 contracts with hardware-validated predicates
+2. H3: Implement ARMv8 page table `VSpaceBackend` instance
+3. H3: Add ARM Generic Timer and GIC-400 adapter bindings
+4. H4: Connect executable trace scenarios to hardware test fixtures
+5. Post-H4: Consider `FiniteMap` abstraction for data structure optimization

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -40,7 +40,9 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 - `SeLe4n/Prelude.lean`
   - object/thread IDs and kernel monad contract used globally.
 - `SeLe4n/Machine.lean`
-  - machine registers, memory abstraction, and pure update/read helpers.
+  - machine registers, memory abstraction, and pure update/read helpers,
+  - `MachineConfig` (register/address width, page size, ASID limit) and
+    `MemoryRegion`/`MemoryKind` for platform memory map declaration.
 
 ### Model
 
@@ -109,19 +111,39 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 ### Architecture subsystem
 
 - `SeLe4n/Kernel/Architecture/Assumptions.lean`
-  - named architecture-facing assumption interfaces and contract references.
+  - named architecture-facing assumption interfaces and contract references,
+  - `ExtendedBootBoundaryContract` with platform boot fields (entry level, MMU state, DTB location).
 - `SeLe4n/Kernel/Architecture/Adapter.lean`
   - deterministic adapter entrypoints (`adapterAdvanceTimer`, `adapterReadMemory`, `adapterWriteMemory`)
     with bounded failure mapping for invalid/unsupported contexts.
 - `SeLe4n/Kernel/Architecture/VSpace.lean`
   - VSpace address-space operations (`vspaceMapPage`, `vspaceUnmapPage`, `vspaceLookup`),
     ASID root resolution, and page-table management.
+- `SeLe4n/Kernel/Architecture/VSpaceBackend.lean` *(H3-prep)*
+  - `VSpaceBackend` typeclass abstracting page map/unmap/lookup with round-trip obligations,
+  - `listVSpaceBackend` instance: the current flat-list `VSpaceRoot` satisfying the interface.
 - `SeLe4n/Kernel/Architecture/VSpaceInvariant.lean`
   - VSpace invariant bundle, success-path and error-path preservation theorems,
     round-trip correctness theorems (`vspaceLookup_after_map`, etc.).
 - `SeLe4n/Kernel/Architecture/Invariant.lean`
   - `proofLayerInvariantBundle` connecting adapter assumptions to theorem-layer invariants,
     composed preservation hooks for success and failure paths.
+
+### Platform layer (H3-prep)
+
+- `SeLe4n/Platform/Contract.lean`
+  - `PlatformBinding` typeclass: formal interface for hardware targets bundling
+    `MachineConfig`, `RuntimeBoundaryContract`, `BootBoundaryContract`, and
+    `InterruptBoundaryContract`.
+- `SeLe4n/Platform/Sim/{RuntimeContract,BootContract,Contract}.lean`
+  - Simulation platform binding (`SimPlatform`) with permissive/restrictive
+    runtime contracts, trivially-true boot and interrupt contracts, and an
+    idealized 64-bit machine config. Used by trace harnesses and test suites.
+- `SeLe4n/Platform/RPi5/{Board,RuntimeContract,BootContract,Contract}.lean`
+  - Raspberry Pi 5 platform binding (`RPi5Platform`) with BCM2712 memory map,
+    GIC-400/ARM Generic Timer constants, ARM64 machine config (64-bit, 48-bit
+    VA, 44-bit PA, 4 KiB pages, 16-bit ASID), and RAM-only memory access
+    contract. Boot and interrupt contracts are H3-prep stubs.
 
 ### Information-flow subsystem
 
@@ -176,15 +198,18 @@ SeLe4n.lean
     ├── Kernel/IPC/{Operations,Invariant}.lean
     ├── Kernel/Lifecycle/{Operations,Invariant}.lean
     ├── Kernel/Service/{Operations,Invariant}.lean
-    ├── Kernel/Architecture/{Assumptions,Adapter,VSpace,VSpaceInvariant,Invariant}.lean
+    ├── Kernel/Architecture/{Assumptions,Adapter,VSpace,VSpaceBackend,VSpaceInvariant,Invariant}.lean
     └── Kernel/InformationFlow/{Policy,Projection,Enforcement,Invariant}.lean
+├── Platform/Contract.lean
+├── Platform/Sim/{RuntimeContract,BootContract,Contract}.lean
+└── Platform/RPi5/{Board,RuntimeContract,BootContract,Contract}.lean
 ```
 
 ### 3.2 Mermaid graph (documentation source of truth)
 
 ```mermaid
 graph TD
-  P[Prelude + Machine] --> M[Model Object/State]
+  P[Prelude + Machine + MachineConfig] --> M[Model Object/State]
   M --> S[Scheduler]
   M --> C[Capability]
   M --> I[IPC]
@@ -193,12 +218,14 @@ graph TD
   I --> B
   B --> L[Lifecycle]
   L --> V[Service]
-  V --> A[Architecture Assumptions/Adapter/VSpace]
+  V --> A[Architecture Assumptions/Adapter/VSpace/VSpaceBackend]
   M --> IF[InformationFlow Policy/Projection/Enforcement]
   IF --> IFI[InformationFlow Invariant]
   A --> AI[Architecture Invariant]
   AI --> X[API + Main executable traces]
   IFI --> X
+  A --> PL[Platform Contract/Sim/RPi5]
+  PL --> X
 ```
 
 This direction should be preserved to prevent proof cycles and maintain module readability.

--- a/docs/gitbook/10-path-to-real-hardware-mobile-first.md
+++ b/docs/gitbook/10-path-to-real-hardware-mobile-first.md
@@ -21,7 +21,7 @@ developed with this target in mind.
 | **H0** | Architecture-neutral semantics and proofs | **Complete** | M1–M7, WS-B..E |
 | **H1** | Architecture-boundary interfaces and adapters | **Complete** | M6 |
 | **H2** | Audit-driven proof deepening | **Active** (WS-F) | Close CRIT/HIGH findings |
-| **H3** | Platform binding — Raspberry Pi 5 hardware | Planned | ~~WS-F2~~ (done), ~~WS-F3~~ (done) |
+| **H3** | Platform binding — Raspberry Pi 5 hardware | **H3-prep complete** | ~~WS-F2~~ (done), ~~WS-F3~~ (done) |
 | **H4** | Evidence convergence — connect proofs to platform | Planned | H3 complete |
 
 ### H2 — Active: closing proof gaps (WS-F)
@@ -34,14 +34,35 @@ binding is meaningful:
 - **Information flow** (CRIT-02/03): complete projection and NI coverage.
 - **Dual-queue verification** (CRIT-05): the production IPC model needs proofs.
 
-### H3 — Planned: Raspberry Pi 5 binding
+### H3 — In progress: Raspberry Pi 5 binding
 
-Once WS-F closes the critical proof gaps:
+**H3-prep (structural foundation) is complete.** The `Platform/` directory
+provides the organizational infrastructure for hardware binding:
 
-1. Map `MachineState` to BCM2712 register set and memory map.
-2. Bind `VSpaceRoot` to ARMv8 page table structures.
-3. Implement interrupt routing for GIC-400.
-4. Bind timer adapter to ARM Generic Timer.
+- **`PlatformBinding` typeclass** (`SeLe4n/Platform/Contract.lean`) — formal
+  interface bundling `MachineConfig`, `RuntimeBoundaryContract`,
+  `BootBoundaryContract`, and `InterruptBoundaryContract`.
+- **`MachineConfig` and `MemoryRegion`** (`SeLe4n/Machine.lean`) — platform-
+  declared register width, address width, page size, ASID limits, and physical
+  memory map with RAM/device/reserved regions.
+- **`VSpaceBackend` class** (`SeLe4n/Kernel/Architecture/VSpaceBackend.lean`) —
+  abstract page map/unmap/lookup with round-trip correctness obligations.
+  The existing flat-list `VSpaceRoot` satisfies this via `listVSpaceBackend`.
+- **`ExtendedBootBoundaryContract`** — adds entry exception level, MMU state,
+  device tree location, entry point, and stack pointer to the base boot contract.
+- **Simulation platform** (`Platform/Sim/`) — `SimPlatform` with permissive
+  contracts for trace harness and test execution.
+- **RPi5 platform stubs** (`Platform/RPi5/`) — BCM2712 memory map, GIC-400
+  base addresses, ARM Generic Timer frequency, PL011 UART address, ARM64
+  machine config (64-bit registers, 48-bit VA, 44-bit PA, 4 KiB pages,
+  16-bit ASID), and a RAM-only memory access contract.
+
+**Remaining H3 work** (once WS-F closes critical proof gaps):
+
+1. Populate RPi5 runtime contract with hardware-validated predicates.
+2. Implement ARMv8 multi-level page table walk as a `VSpaceBackend` instance.
+3. Implement interrupt routing for GIC-400 with IRQ acknowledgment.
+4. Bind timer adapter to ARM Generic Timer (CNTPCT_EL0).
 5. Define boot sequence as a verified initial state construction.
 
 ### H4 — Planned: evidence convergence
@@ -61,7 +82,11 @@ Once WS-F closes the critical proof gaps:
 
 ## 5. What contributors can do now
 
-- Focus on WS-F workstreams (especially WS-F4 — WS-F1, WS-F2, WS-F3 complete).
-- Keep transitions architecture-neutral unless explicitly marked otherwise.
+- Focus on remaining WS-F workstreams (WS-F5..F8 — WS-F1..F4 complete).
+- Review the `Platform/RPi5/` stubs and contribute hardware-specific knowledge.
+- Keep kernel transitions architecture-neutral — hardware assumptions belong in
+  `PlatformBinding` instances, not in `Kernel/` modules.
 - Document hardware assumptions explicitly in adapter interfaces.
 - Add executable evidence for boundary success/failure behavior.
+- When working on platform-specific code, instantiate the `PlatformBinding`
+  typeclass rather than hard-coding contracts.

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -37,5 +37,6 @@
 ## Production path
 
 - [Path to Real Hardware (Raspberry Pi 5)](10-path-to-real-hardware-mobile-first.md)
+- [Platform Binding Architecture (ADR)](../PLATFORM_BINDING_ADR.md)
 - [Project Usage and Value](17-project-usage-value.md)
 - [Next Development Path](22-next-slice-development-path.md)

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -166,11 +166,23 @@ The first production hardware target is **Raspberry Pi 5** (ARM64, BCM2712).
 | **H0** | Architecture-neutral semantics and proofs | Complete (M1–M7, WS-B..E) |
 | **H1** | Architecture-boundary interfaces and adapters | Complete (M6) |
 | **H2** | Audit-driven proof deepening (close critical gaps) | Active (WS-F) |
-| **H3** | Platform binding — map interfaces to Raspberry Pi 5 hardware | Planned |
+| **H3** | Platform binding — map interfaces to Raspberry Pi 5 hardware | **H3-prep complete** |
 | **H4** | Evidence convergence — connect proofs to platform assumptions | Planned |
 
-The critical prerequisite for H3 is closing the WS-F proof gaps — particularly
-complete information-flow coverage (WS-F3). Untyped memory (WS-F2) and information-flow completeness (WS-F3) are now complete.
+**H3 preparation (structural):** The `Platform/` directory now provides the
+organizational foundation for hardware binding:
+
+- `PlatformBinding` typeclass (`SeLe4n/Platform/Contract.lean`)
+- `MachineConfig` and `MemoryRegion` types (`SeLe4n/Machine.lean`)
+- `VSpaceBackend` abstraction with `listVSpaceBackend` instance
+- `ExtendedBootBoundaryContract` with platform boot fields
+- Simulation platform (`Platform/Sim/`) for testing
+- RPi5 stubs (`Platform/RPi5/`) with BCM2712 memory map, GIC-400 constants,
+  ARM64 machine config, and platform-specific runtime contract
+
+The critical prerequisite for full H3 execution is closing the remaining WS-F
+proof gaps. Untyped memory (WS-F2) and information-flow completeness (WS-F3)
+are now complete.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** H3 preparation (structural foundation)
- **Recommendation IDs closed:** None (forward-looking infrastructure)
- **Scope notes:** Introduces `Platform/` directory with `PlatformBinding` typeclass, `VSpaceBackend` abstraction, and platform-specific contract stubs for Raspberry Pi 5 and simulation targets. No existing kernel code modified; all changes are additive.

## What changed

### Core abstractions (H3-prep)

1. **`VSpaceBackend` typeclass** (`SeLe4n/Kernel/Architecture/VSpaceBackend.lean`)
   - Abstract interface for page map/unmap/lookup operations
   - Obligations: ASID preservation, round-trip correctness, non-interference
   - `listVSpaceBackend` instance: existing flat-list `VSpaceRoot` satisfies the interface via existing lemmas (zero new proofs)

2. **`MachineConfig` and `MemoryRegion`** (`SeLe4n/Machine.lean`)
   - Platform-declared architectural parameters: register width, address width, page size, ASID limits
   - Memory map with RAM/device/reserved region classification
   - Helper predicates: `contains`, `overlaps`, `totalRAM`, `addressInMap`

3. **`PlatformBinding` typeclass** (`SeLe4n/Platform/Contract.lean`)
   - Bundles `MachineConfig`, `RuntimeBoundaryContract`, `BootBoundaryContract`, `InterruptBoundaryContract`
   - Enables parameterized platform selection without forking the repository

4. **`ExtendedBootBoundaryContract`** (`SeLe4n/Kernel/Architecture/Assumptions.lean`)
   - Extends base `BootBoundaryContract` with platform-visible fields: entry exception level, MMU state, DTB location, kernel entry point, initial stack pointer
   - Embeds base contract for backward compatibility

### Platform instantiations

1. **Simulation platform** (`SeLe4n/Platform/Sim/`)
   - `SimPlatform` marker type with idealized 64-bit ARM64 config (256 MiB RAM)
   - Permissive and restrictive runtime contracts for test execution
   - Trivially-true boot and interrupt contracts

2. **Raspberry Pi 5 platform** (`SeLe4n/Platform/RPi5/`)
   - `RPi5Platform` marker type with BCM2712 memory map and ARM64 config (44-bit PA, 16-bit ASID)
   - Board constants: peripheral bases, GIC-400 addresses, timer frequency
   - RAM-only memory access contract (device/reserved regions excluded)
   - Placeholder boot and interrupt contracts for H3 completion

### Documentation

- **ADR: Platform Binding Architecture** (`docs/PLATFORM_BINDING_ADR.md`) — rationale for monorepo organization vs. forking, design decisions, consequences
- Updated roadmap status in `README.md`, `docs/spec/SELE4N_SPEC.md`, and `docs/gitbook/10-path-to-real-hardware-mobile-first.md`
- Updated module map in `docs/gitbook/03-architecture-and-module-map.md`
- Updated hardware boundary contract policy in `docs/HARDWARE_BOUNDARY_CONTRACT_POLICY.md`

## Design rationale

**Why not fork?** The proof chain depends on live imports of `SystemState`, `KernelError`, and invariant bundles. A cross-repo boundary would require coordinated releases for every change. The monorepo approach (19K LoC) maintains proof continuity while providing clean import boundaries: `SeLe4n.Kernel.*` never imports `SeLe4n.Platform.*`.

**VSpaceBackend abstraction:** Prepares for H3 ARMv8 hierarchical page tables without changing abstract kernel proofs. The current flat-list model satisfies the interface naturally; a new backend can be instantiated later.

**Platform binding as typeclass:** Enables parameterized adapter operations and test harnesses

https://claude.ai/code/session_01TRLVN9UNxSPmPTK7oGUjTH