### PR TITLE
WS-G5: Migrate CNode slots to HashMap for O(1) operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.12.10] - 2026-03-01
+
+### WS-G5: CNode Slot HashMap (completed)
+
+- **CNode slot HashMap migration:** `CNode.slots` changed from `List (Slot × Capability)` to `Std.HashMap Slot Capability`. All capability lookups (`CNode.lookup`), inserts (`CNode.insert`), and deletes (`CNode.remove`) now O(1) amortized instead of O(m) linear scan.
+- **`slotsUnique` invariant trivially true:** HashMap enforces key uniqueness by construction. `CNode.slotsUnique` redefined as `True`, and all three preservation theorems (`insert_slotsUnique`, `remove_slotsUnique`, `revokeTargetLocal_slotsUnique`) now prove `trivial`.
+- **Bridge lemmas:** `HashMap_filter_preserves_key` (single-filter key preservation for `revokeTargetLocal`) and `HashMap_filter_filter_getElem?` (double-filter idempotency for projection) in `Prelude.lean`. Both avoid `Std.HashMap`'s `Option.pfilter` dependent types by working at the membership level.
+- **Projection idempotency reformulated:** `projectKernelObject_idempotent` in `Projection.lean` reformulated from structural equality to slot-level lookup equality, because `Std.HashMap.filter` reverses internal `AssocList` bucket ordering making `(m.filter f).filter f ≠ m.filter f` structurally.
+- **BEq instances for runtime tests:** Manual `BEq CNode` (entry-wise HashMap comparison) and `BEq KernelObject` instances replace the lost `DecidableEq KernelObject` derivation.
+- **CSpace invariant proofs migrated:** `cspaceRevoke_local_target_reduction` rewritten with HashMap-level reasoning (`mem_filter`, `getKey_beq`, `getElem_filter`). `cspaceLookupSound_of_cspaceSlotUnique` simplified (HashMap lookup is direct). `revokedRefs` computations use `cn.slots.toList.filter`.
+- **Test infrastructure updated:** `InvariantChecks.lean` uses `cn.slots.toList.foldr`. `MainTraceHarness.lean` and all test suites use `Std.HashMap.ofList` for CNode construction. `InformationFlowSuite.lean` uses `cn.slots.toList.any` and `cn.slots.size`.
+- **Full proof migration:** zero sorry/axiom across all 10 modified files. `test_full.sh` passes (Tier 0-3).
+- Closes finding F-P03 (CNode slot linear scan).
+
 ## [0.12.9] - 2026-03-01
 
 ### WS-G4: Run Queue Restructure (completed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - **Bridge lemmas:** `HashMap_filter_preserves_key` (single-filter key preservation for `revokeTargetLocal`) and `HashMap_filter_filter_getElem?` (double-filter idempotency for projection) in `Prelude.lean`. Both avoid `Std.HashMap`'s `Option.pfilter` dependent types by working at the membership level.
 - **Projection idempotency reformulated:** `projectKernelObject_idempotent` in `Projection.lean` reformulated from structural equality to slot-level lookup equality, because `Std.HashMap.filter` reverses internal `AssocList` bucket ordering making `(m.filter f).filter f ≠ m.filter f` structurally.
 - **BEq instances for runtime tests:** Manual `BEq CNode` (entry-wise HashMap comparison) and `BEq KernelObject` instances replace the lost `DecidableEq KernelObject` derivation.
-- **CSpace invariant proofs migrated:** `cspaceRevoke_local_target_reduction` rewritten with HashMap-level reasoning (`mem_filter`, `getKey_beq`, `getElem_filter`). `cspaceLookupSound_of_cspaceSlotUnique` simplified (HashMap lookup is direct). `revokedRefs` computations use `cn.slots.toList.filter`.
-- **Test infrastructure updated:** `InvariantChecks.lean` uses `cn.slots.toList.foldr`. `MainTraceHarness.lean` and all test suites use `Std.HashMap.ofList` for CNode construction. `InformationFlowSuite.lean` uses `cn.slots.toList.any` and `cn.slots.size`.
+- **CSpace invariant proofs migrated:** `cspaceRevoke_local_target_reduction` rewritten with HashMap-level reasoning (`mem_filter`, `getKey_beq`, `getElem_filter`). `cspaceLookupSound_of_cspaceSlotUnique` simplified (HashMap lookup is direct). `revokedRefs` computed via `HashMap.fold` in a single O(m) pass (no intermediate `.toList` allocation).
+- **Test infrastructure updated:** `InvariantChecks.lean` uses `cn.slots.toList.foldr`. `MainTraceHarness.lean` and all test suites use `Std.HashMap.ofList` for CNode construction. `InformationFlowSuite.lean` uses `cn.slots.contains` for O(1) key-existence checks and `cn.slots.size` for slot counts.
 - **Full proof migration:** zero sorry/axiom across all 10 modified files. `test_full.sh` passes (Tier 0-3).
 - Closes finding F-P03 (CNode slot linear scan).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 seLe4n is a production-oriented microkernel written in Lean 4 with machine-checked
 proofs, improving on seL4 architecture. Every kernel transition is an executable
 pure function with zero `sorry`/`axiom`. First hardware target: Raspberry Pi 5.
-Lean 4.28.0 toolchain, Lake build system, version 0.12.9.
+Lean 4.28.0 toolchain, Lake build system, version 0.12.10.
 
 ## Build and run
 
@@ -285,10 +285,10 @@ under `docs/` and `docs/gitbook/`.
 
 ## Active workstream context
 
-- **Active portfolio**: WS-G (kernel performance optimization) — WS-G1..G4 completed
+- **Active portfolio**: WS-G (kernel performance optimization) — WS-G1..G5 completed
 - **Active findings baseline**: `docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`
 - **Planning backbone**: `docs/audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md`
-- **Completed**: WS-G1..G4 (v0.12.9), WS-F1..F4 (v0.12.2), WS-E1..E6 (v0.11.6), WS-D1..D4 (v0.11.0), WS-C1..C8 (v0.9.32), WS-B1..B11 (v0.9.0)
+- **Completed**: WS-G1..G5 (v0.12.10), WS-F1..F4 (v0.12.2), WS-E1..E6 (v0.11.6), WS-D1..D4 (v0.11.0), WS-C1..C8 (v0.9.32), WS-B1..B11 (v0.9.0)
 - **Hardware target**: Raspberry Pi 5 (ARM64)
 
 ## PR checklist

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.12.9-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.12.10-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -46,13 +46,13 @@ improving on specific architectural aspects:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.12.9` |
+| **Version** | `0.12.10` |
 | **Lean toolchain** | `4.28.0` |
 | **Production Lean LoC** | 16,485 across 34 files |
 | **Proved theorems** | 400+ (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (ARM64) |
 | **Active findings** | [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) |
-| **Active workstream** | WS-G (kernel performance optimization) — WS-G1..G4 completed |
+| **Active workstream** | WS-G (kernel performance optimization) — WS-G1..G5 completed |
 | **Prior completed** | WS-F (v0.12.2), WS-E (v0.11.6), WS-D (v0.11.0), WS-C (v0.9.32), WS-B (v0.9.0) |
 
 ## Quick start

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -86,17 +86,16 @@ def cspaceSlotUnique (st : SystemState) : Prop :=
     st.objects[cnodeId]? = some (KernelObject.cnode cn) →
     cn.slotsUnique
 
-/-- Lookup completeness: every capability entry in a CNode's slot list is retrievable
-via `lookupSlotCap`.
+/-- Lookup completeness: every capability stored in a CNode's slot HashMap is
+retrievable via `lookupSlotCap`.
 
-WS-E2 / C-01 reformulation: this is non-trivial because `CNode.lookup` uses
-`List.find?`, which returns only the first match for a given slot index. If duplicate
-slot indices existed (violating `cspaceSlotUnique`), later entries would be
-unretrievable. This property holds if and only if `cspaceSlotUnique` holds. -/
+WS-G5: With HashMap-backed slots, lookup completeness is direct — `CNode.lookup`
+delegates to `HashMap.getElem?`, which is the canonical accessor. The property
+is trivially true by the identity `CNode.lookup slot = cn.slots[slot]?`. -/
 def cspaceLookupSound (st : SystemState) : Prop :=
   ∀ (cnodeId : SeLe4n.ObjId) (cn : CNode) (slot : SeLe4n.Slot) (cap : Capability),
     st.objects[cnodeId]? = some (KernelObject.cnode cn) →
-    (slot, cap) ∈ cn.slots →
+    cn.lookup slot = some cap →
     SystemState.lookupSlotCap st { cnode := cnodeId, slot := slot } = some cap
 
 /-- Attenuation rule component used by the M2 capability invariant bundle. -/
@@ -195,8 +194,8 @@ theorem cspaceRevoke_local_target_reduction
       | cnode cn =>
 
           let revokedRefs : List SlotRef :=
-            (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
-              (fun entry => { cnode := addr.cnode, slot := entry.fst })
+            (cn.slots.toList.filter (fun entry => entry.1 ≠ addr.slot ∧ entry.2.target = parent.target)).map
+              (fun entry => { cnode := addr.cnode, slot := entry.1 })
           let revokedObj := KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)
           let storedState : SystemState :=
             { st with
@@ -224,34 +223,33 @@ theorem cspaceRevoke_local_target_reduction
             have hEq := SystemState.lookupSlotCap_eq_of_objects_eq st' storedState
               { cnode := addr.cnode, slot := slot } hObjEq
             simpa [hEq] using hLookup
-          simp [storedState, revokedObj, SystemState.lookupSlotCap, SystemState.lookupCNode,
-            CNode.lookup, CNode.revokeTargetLocal] at hLookupStored
-          rcases hLookupStored with ⟨slot', hFind⟩
-          have hPred :
-              ((decide (slot' = addr.slot) || !decide (cap.target = parent.target)) &&
-                decide (slot' = slot)) = true := by
-            have hPredRaw := List.find?_some
-              (p := fun entry : SeLe4n.Slot × Capability =>
-                (decide (entry.fst = addr.slot) || !decide (entry.snd.target = parent.target)) &&
-                  decide (entry.fst = slot))
-              (a := (slot', cap)) hFind
-            simpa using hPredRaw
-          have hSplit :
-              (decide (slot' = addr.slot) || !decide (cap.target = parent.target)) = true ∧
-              decide (slot' = slot) = true := by
-            simpa [Bool.and_eq_true] using hPred
-          have hEqSlot : slot' = slot := by
-            simpa using hSplit.2
-          have hOrProp : slot' = addr.slot ∨ cap.target ≠ parent.target := by
-            simpa using hSplit.1
+          -- WS-G5: With HashMap-backed slots, CNode.lookup delegates to getElem?.
+          -- Extract that the filtered HashMap lookup succeeds at `slot`.
+          have hFilterLookup : (cn.revokeTargetLocal addr.slot parent.target).lookup slot = some cap := by
+            simp [storedState, revokedObj, SystemState.lookupSlotCap, SystemState.lookupCNode,
+              CNode.lookup] at hLookupStored
+            exact hLookupStored
+          -- revokeTargetLocal filters with: fun s c => s == addr.slot || !(c.target == parent.target)
+          have hMemFilter : slot ∈ cn.slots.filter (fun s c => s == addr.slot || !(c.target == parent.target)) := by
+            rw [CNode.revokeTargetLocal, CNode.lookup] at hFilterLookup
+            exact Std.HashMap.mem_iff_isSome_getElem?.mpr (by simp [hFilterLookup])
+          -- By mem_filter, the filter predicate holds for the stored key and value.
+          have ⟨hMemOrig, hPredTrue⟩ := Std.HashMap.mem_filter.mp hMemFilter
+          -- Normalize: getKey slot ≈ slot, and the stored value cn.slots[slot] = cap
+          have hKeyEq : cn.slots.getKey slot hMemOrig = slot := eq_of_beq (Std.HashMap.getKey_beq hMemOrig)
+          have hValEq : cn.slots[slot] = cap := by
+            have h1 := @Std.HashMap.getElem_filter _ _ _ _ cn.slots _ _ _ slot hMemFilter
+            have h2 := Std.HashMap.getElem?_eq_some_getElem hMemFilter
+            rw [h1] at h2
+            rw [CNode.revokeTargetLocal, CNode.lookup] at hFilterLookup
+            rw [hFilterLookup] at h2
+            exact (Option.some.inj h2).symm
+          rw [hKeyEq, hValEq] at hPredTrue
+          -- hPredTrue : (slot == addr.slot || !(cap.target == parent.target)) = true
           by_cases hSlot : slot = addr.slot
           · exact hSlot
-          · have hNotTarget : cap.target ≠ parent.target := by
-              rcases hOrProp with hSrc | hNe
-              · exfalso
-                exact hSlot (hEqSlot.symm.trans hSrc)
-              · exact hNe
-            exact False.elim (hNotTarget hTarget)
+          · exfalso
+            simp [hSlot, hTarget] at hPredTrue
 
 theorem cspaceLookupSlot_preserves_state
     (st st' : SystemState)
@@ -351,8 +349,8 @@ theorem cspaceRevoke_preserves_source
           | cnode cn =>
 
               let revokedRefs : List SlotRef :=
-                (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
-                  (fun entry => { cnode := addr.cnode, slot := entry.fst })
+                (cn.slots.toList.filter (fun entry => entry.1 ≠ addr.slot ∧ entry.2.target = parent.target)).map
+                  (fun entry => { cnode := addr.cnode, slot := entry.1 })
               let revokedObj := KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)
               let storedState : SystemState :=
                 { st with
@@ -649,16 +647,15 @@ theorem badge_merge_idempotent
 
 /-- Derive `cspaceLookupSound` from `cspaceSlotUnique` for any state.
 
-This bridge theorem connects the two reformulated invariant components: lookup
-completeness follows from slot-index uniqueness because `CNode.mem_lookup_of_slotsUnique`
-requires uniqueness to guarantee that `find?` returns the expected entry. -/
+WS-G5: With HashMap-backed slots, `CNode.lookup` delegates directly to
+`HashMap.getElem?`, making lookup completeness trivial by definition.
+The bridge from `slotsUnique` to `lookupSound` is now immediate. -/
 theorem cspaceLookupSound_of_cspaceSlotUnique
-    (st : SystemState) (hUniq : cspaceSlotUnique st) :
+    (st : SystemState) (_hUniq : cspaceSlotUnique st) :
     cspaceLookupSound st := by
-  intro cnodeId cn slot cap hObj hMem
-  have hU := hUniq cnodeId cn hObj
-  simp [SystemState.lookupSlotCap, SystemState.lookupCNode, hObj]
-  exact CNode.mem_lookup_of_slotsUnique cn slot cap hU hMem
+  intro cnodeId cn slot cap hObj hLookup
+  simp [SystemState.lookupSlotCap, SystemState.lookupCNode, hObj, CNode.lookup]
+  exact hLookup
 
 /-- WS-E2 / H-01: Transfer `cspaceSlotUnique` across a non-CNode `storeObject`.
 

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -193,9 +193,12 @@ theorem cspaceRevoke_local_target_reduction
       | untyped _ => simp [hObj] at hStep
       | cnode cn =>
 
+                    -- WS-G5: revokedRefs via HashMap.fold — single O(m) pass.
           let revokedRefs : List SlotRef :=
-            (cn.slots.toList.filter (fun entry => entry.1 ≠ addr.slot ∧ entry.2.target = parent.target)).map
-              (fun entry => { cnode := addr.cnode, slot := entry.1 })
+            cn.slots.fold (fun acc s c =>
+              if s != addr.slot && c.target == parent.target then
+                { cnode := addr.cnode, slot := s } :: acc
+              else acc) []
           let revokedObj := KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)
           let storedState : SystemState :=
             { st with
@@ -348,9 +351,12 @@ theorem cspaceRevoke_preserves_source
           | untyped _ => simp [hLookup, hObj] at hStep
           | cnode cn =>
 
+              -- WS-G5: revokedRefs via HashMap.fold — single O(m) pass.
               let revokedRefs : List SlotRef :=
-                (cn.slots.toList.filter (fun entry => entry.1 ≠ addr.slot ∧ entry.2.target = parent.target)).map
-                  (fun entry => { cnode := addr.cnode, slot := entry.1 })
+                cn.slots.fold (fun acc s c =>
+                  if s != addr.slot && c.target == parent.target then
+                    { cnode := addr.cnode, slot := s } :: acc
+                  else acc) []
               let revokedObj := KernelObject.cnode (cn.revokeTargetLocal addr.slot parent.target)
               let storedState : SystemState :=
                 { st with

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -285,9 +285,12 @@ def cspaceRevoke (addr : CSpaceAddr) : Kernel Unit :=
         match st'.objects[addr.cnode]? with
         | some (.cnode cn) =>
             let cn' := cn.revokeTargetLocal addr.slot parent.target
+            -- WS-G5: HashMap.fold collects revoked SlotRefs in a single O(m) pass.
             let revokedRefs : List SlotRef :=
-              (cn.slots.toList.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
-                (fun entry => { cnode := addr.cnode, slot := entry.fst })
+              cn.slots.fold (fun acc s c =>
+                if s != addr.slot && c.target == parent.target then
+                  { cnode := addr.cnode, slot := s } :: acc
+                else acc) []
             match storeObject addr.cnode (.cnode cn') st' with
             | .error e => .error e
             | .ok (_, st'') => clearCapabilityRefs revokedRefs st''

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -286,7 +286,7 @@ def cspaceRevoke (addr : CSpaceAddr) : Kernel Unit :=
         | some (.cnode cn) =>
             let cn' := cn.revokeTargetLocal addr.slot parent.target
             let revokedRefs : List SlotRef :=
-              (cn.slots.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
+              (cn.slots.toList.filter (fun entry => entry.fst ≠ addr.slot ∧ entry.snd.target = parent.target)).map
                 (fun entry => { cnode := addr.cnode, slot := entry.fst })
             match storeObject addr.cnode (.cnode cn') st' with
             | .error e => .error e

--- a/SeLe4n/Kernel/InformationFlow/Projection.lean
+++ b/SeLe4n/Kernel/InformationFlow/Projection.lean
@@ -74,25 +74,36 @@ def capTargetObservable (ctx : LabelingContext) (observer : IfObserver) (target 
 
 /-- WS-F3/F-22: Filter a KernelObject to redact high-domain information.
 For CNode objects, removes capability slots whose targets are not observable
-by the given observer. All other object types pass through unchanged. -/
+by the given observer. All other object types pass through unchanged.
+
+WS-G5: Uses `HashMap.filter` for O(m) filtering on HashMap-backed CNode slots. -/
 def projectKernelObject (ctx : LabelingContext) (observer : IfObserver) (obj : KernelObject) : KernelObject :=
   match obj with
   | .cnode cn =>
-      .cnode { cn with slots := cn.slots.filter (fun (_, cap) =>
+      .cnode { cn with slots := cn.slots.filter (fun _ cap =>
         capTargetObservable ctx observer cap.target) }
   | other => other
 
-/-- WS-F3/F-22: `projectKernelObject` is idempotent — filtering twice yields the
-same result as filtering once. -/
+/-- WS-F3/F-22: `projectKernelObject` is idempotent — filtering twice yields
+observationally equivalent results to filtering once.
+
+WS-G5: With HashMap-backed CNode slots, idempotency is stated at the slot
+lookup level rather than structural equality, because `Std.HashMap.filter`
+in Lean 4.28.0 reverses internal `AssocList` bucket ordering, making
+`(m.filter f).filter f ≠ m.filter f` structurally despite identical entries.
+For all non-CNode variants, structural equality holds directly. -/
 theorem projectKernelObject_idempotent
-    (ctx : LabelingContext) (observer : IfObserver) (obj : KernelObject) :
-    projectKernelObject ctx observer (projectKernelObject ctx observer obj) =
-      projectKernelObject ctx observer obj := by
+    (ctx : LabelingContext) (observer : IfObserver) (obj : KernelObject)
+    (slot : SeLe4n.Slot) :
+    match projectKernelObject ctx observer (projectKernelObject ctx observer obj),
+          projectKernelObject ctx observer obj with
+    | .cnode cn1, .cnode cn2 => cn1.lookup slot = cn2.lookup slot
+    | _, _ => True := by
   cases obj with
   | cnode cn =>
-    simp only [projectKernelObject]
-    simp only [List.filter_filter, Bool.and_self]
-  | _ => rfl
+    simp only [projectKernelObject, CNode.lookup]
+    exact SeLe4n.HashMap_filter_filter_getElem? cn.slots _ slot
+  | _ => trivial
 
 /-- WS-F3/F-22: `projectKernelObject` preserves object type. -/
 theorem projectKernelObject_objectType

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -166,11 +166,16 @@ structure Notification where
   pendingBadge : Option SeLe4n.Badge := none
   deriving Repr, DecidableEq
 
+/-- WS-G5/F-P03: CNode capability space node.
+`slots` is backed by `Std.HashMap Slot Capability` for O(1) amortized
+lookup, insert, and delete — replacing the O(m) list-based representation.
+HashMap key uniqueness is structural, eliminating the need for an explicit
+`slotsUnique` invariant. -/
 structure CNode where
   guard : Nat
   radix : Nat
-  slots : List (SeLe4n.Slot × Capability)
-  deriving Repr, DecidableEq
+  slots : Std.HashMap SeLe4n.Slot Capability
+  deriving Repr
 
 /-- WS-F2: Child allocation record within an untyped memory region.
 Each child records the object identity, its byte offset within the parent
@@ -627,7 +632,7 @@ inductive ResolveError where
   deriving Repr, DecidableEq
 
 def empty : CNode :=
-  { guard := 0, radix := 0, slots := [] }
+  { guard := 0, radix := 0, slots := {} }
 
 /-- Number of addressable slots represented by this CNode radix width. -/
 def slotCount (node : CNode) : Nat :=
@@ -652,31 +657,44 @@ def resolveSlot (node : CNode) (cptr : SeLe4n.CPtr) (depth : Nat) : Except Resol
     else
       .error .guardMismatch
 
+/-- WS-G5/F-P03: O(1) amortized slot lookup via `HashMap.find?`. -/
 def lookup (node : CNode) (slot : SeLe4n.Slot) : Option Capability :=
-  (node.slots.find? (fun entry => entry.fst = slot)).map Prod.snd
+  node.slots[slot]?
 
+/-- WS-G5/F-P03: O(1) amortized slot insert via `HashMap.insert`.
+HashMap key uniqueness ensures the old entry for `slot` is replaced. -/
 def insert (node : CNode) (slot : SeLe4n.Slot) (cap : Capability) : CNode :=
-  let slots := (slot, cap) :: node.slots.filter (fun entry => entry.fst ≠ slot)
-  { node with slots }
+  { node with slots := node.slots.insert slot cap }
 
+/-- WS-G5/F-P03: O(1) amortized slot removal via `HashMap.erase`. -/
 def remove (node : CNode) (slot : SeLe4n.Slot) : CNode :=
-  { node with slots := node.slots.filter (fun entry => entry.fst ≠ slot) }
+  { node with slots := node.slots.erase slot }
 
 /-- Local revoke helper for the current modeled slice.
 
 This keeps the authority-bearing source slot while deleting sibling slots in the same CNode that
 name the same capability target. Full cross-CNode revoke requires an explicit derivation graph and
-is intentionally deferred. -/
+is intentionally deferred.
+
+WS-G5/F-P03: Inherently O(m) (filter-by-target), uses `HashMap.filter`. -/
 def revokeTargetLocal (node : CNode) (sourceSlot : SeLe4n.Slot) (target : CapTarget) : CNode :=
   {
     node with
-      slots := node.slots.filter (fun entry => entry.fst = sourceSlot ∨ entry.snd.target ≠ target)
+      slots := node.slots.filter fun s c => s == sourceSlot || !(c.target == target)
   }
 
+/-- WS-G5: After removing a slot, lookup returns `none`.
+Maps directly to `HashMap.getElem?_erase_self`. -/
 theorem lookup_remove_eq_none (node : CNode) (slot : SeLe4n.Slot) :
     (node.remove slot).lookup slot = none := by
-  unfold remove lookup
-  simp
+  simp [remove, lookup]
+
+/-- WS-G5: If `lookup` returns `some`, the slot key is present in the HashMap.
+Replaces the list-era membership theorem with HashMap semantics. -/
+theorem lookup_mem_of_some (node : CNode) (slot : SeLe4n.Slot) (cap : Capability)
+    (h : node.lookup slot = some cap) : slot ∈ node.slots := by
+  simp [lookup] at h
+  exact Std.HashMap.mem_iff_isSome_getElem?.mpr (by simp [h])
 
 theorem resolveSlot_depthMismatch
     (node : CNode)
@@ -687,116 +705,104 @@ theorem resolveSlot_depthMismatch
   unfold resolveSlot
   simp [hDepth]
 
+/-- WS-G5: Source slot is preserved by `revokeTargetLocal` because the filter
+predicate always includes entries where `s = sourceSlot`. -/
 theorem lookup_revokeTargetLocal_source_eq_lookup
     (node : CNode)
     (sourceSlot : SeLe4n.Slot)
     (target : CapTarget) :
     (node.revokeTargetLocal sourceSlot target).lookup sourceSlot = node.lookup sourceSlot := by
-  unfold revokeTargetLocal lookup
-  have hPred :
-      (fun entry : SeLe4n.Slot × Capability =>
-        (decide (entry.fst = sourceSlot) || !decide (entry.snd.target = target)) &&
-          decide (entry.fst = sourceSlot)) =
-      (fun entry : SeLe4n.Slot × Capability => decide (entry.fst = sourceSlot)) := by
-    funext entry
-    by_cases hEq : entry.fst = sourceSlot <;> simp [hEq]
-  simp [hPred]
+  simp only [revokeTargetLocal, lookup]
+  exact SeLe4n.HashMap_filter_preserves_key node.slots _ sourceSlot
+    (fun k' _ hBeq => by simp [eq_of_beq hBeq])
 
 -- ============================================================================
--- WS-E2 / C-01: Non-trivial CNode slot-index uniqueness infrastructure
+-- WS-G5/WS-E2/C-01: CNode slot-index uniqueness infrastructure
 -- ============================================================================
 
-/-- CNode slot-index uniqueness: each slot index maps to at most one capability
-in the slot list. This is a non-trivial structural invariant maintained by CNode
-operations (insert removes duplicates before prepending, remove/revoke only filter).
+/-- CNode slot-index uniqueness: each slot index maps to at most one capability.
 
-WS-E2 / C-01 remediation: replaces the prior tautological definition that merely
-proved a pure function returns the same output for the same input. -/
-def slotsUnique (cn : CNode) : Prop :=
-  ∀ slot cap₁ cap₂,
-    (slot, cap₁) ∈ cn.slots →
-    (slot, cap₂) ∈ cn.slots →
-    cap₁ = cap₂
+WS-G5: With HashMap-backed slots, key uniqueness is structural — HashMap enforces
+that each key maps to exactly one value. This invariant is trivially satisfied
+for all CNodes by construction. The definition is retained for backward
+compatibility with the invariant surface (Capability/Invariant.lean). -/
+def slotsUnique (_cn : CNode) : Prop :=
+  True
 
-theorem empty_slotsUnique : CNode.empty.slotsUnique := by
-  intro slot cap₁ cap₂ h₁
-  simp [CNode.empty] at h₁
+/-- WS-G5: Trivially true — HashMap enforces key uniqueness by construction. -/
+theorem empty_slotsUnique : CNode.empty.slotsUnique :=
+  trivial
 
-/-- `insert` preserves slot-key uniqueness: the old entry for `slot` is filtered out
-before prepending the new one, so no duplicate keys are introduced. -/
+/-- WS-G5: Trivially true — HashMap.insert enforces key uniqueness by construction. -/
 theorem insert_slotsUnique
     (cn : CNode) (slot : SeLe4n.Slot) (cap : Capability)
-    (hUniq : cn.slotsUnique) :
-    (cn.insert slot cap).slotsUnique := by
-  intro s c₁ c₂ h₁ h₂
-  simp only [insert, List.mem_cons, List.mem_filter] at h₁ h₂
-  rcases h₁ with h₁eq | ⟨h₁m, h₁p⟩
-  · obtain ⟨rfl, rfl⟩ := Prod.mk.inj h₁eq
-    rcases h₂ with h₂eq | ⟨h₂m, h₂p⟩
-    · exact (Prod.mk.inj h₂eq).2.symm
-    · exfalso; simp at h₂p
-  · rcases h₂ with h₂eq | ⟨h₂m, h₂p⟩
-    · obtain ⟨rfl, rfl⟩ := Prod.mk.inj h₂eq
-      exfalso; simp at h₁p
-    · exact hUniq s c₁ c₂ h₁m h₂m
+    (_hUniq : cn.slotsUnique) :
+    (cn.insert slot cap).slotsUnique :=
+  trivial
 
-/-- `remove` preserves slot-key uniqueness: filtering can only reduce the slot list. -/
+/-- WS-G5: Trivially true — HashMap.erase preserves key uniqueness. -/
 theorem remove_slotsUnique
     (cn : CNode) (slot : SeLe4n.Slot)
-    (hUniq : cn.slotsUnique) :
-    (cn.remove slot).slotsUnique := by
-  intro s c₁ c₂ h₁ h₂
-  simp only [remove, List.mem_filter] at h₁ h₂
-  exact hUniq s c₁ c₂ h₁.1 h₂.1
+    (_hUniq : cn.slotsUnique) :
+    (cn.remove slot).slotsUnique :=
+  trivial
 
-/-- `revokeTargetLocal` preserves slot-key uniqueness: it is a filter operation
-that can only reduce the slot list. -/
+/-- WS-G5: Trivially true — HashMap.filter preserves key uniqueness. -/
 theorem revokeTargetLocal_slotsUnique
     (cn : CNode) (sourceSlot : SeLe4n.Slot) (target : CapTarget)
-    (hUniq : cn.slotsUnique) :
-    (cn.revokeTargetLocal sourceSlot target).slotsUnique := by
-  intro s c₁ c₂ h₁ h₂
-  simp only [revokeTargetLocal, List.mem_filter] at h₁ h₂
-  exact hUniq s c₁ c₂ h₁.1 h₂.1
+    (_hUniq : cn.slotsUnique) :
+    (cn.revokeTargetLocal sourceSlot target).slotsUnique :=
+  trivial
 
-/-- Soundness of `lookup`: a successful lookup witnesses membership in the slot list. -/
-theorem lookup_mem_of_some
-    (cn : CNode) (slot : SeLe4n.Slot) (cap : Capability)
-    (hLookup : cn.lookup slot = some cap) :
-    (slot, cap) ∈ cn.slots := by
-  unfold lookup at hLookup
-  cases hFind : cn.slots.find? (fun entry => decide (entry.fst = slot)) with
-  | none => simp [hFind] at hLookup
-  | some entry =>
-    simp [hFind] at hLookup
-    have hSlot : entry.fst = slot := by simpa using List.find?_some hFind
-    have hMem := List.mem_of_find?_eq_some hFind
-    rw [← hLookup, ← hSlot]
-    exact (Prod.eta entry) ▸ hMem
+/-- WS-G5: If a slot is present in the HashMap, lookup returns its value.
+With HashMap-backed slots, `slotsUnique` is trivially satisfied (structural
+invariant of HashMap), so the uniqueness hypothesis is unused. -/
+theorem mem_lookup_of_slotsUnique (node : CNode) (_hUniq : node.slotsUnique)
+    (slot : SeLe4n.Slot) (hMem : slot ∈ node.slots) :
+    node.lookup slot = some node.slots[slot] :=
+  Std.HashMap.getElem?_eq_some_getElem hMem
 
-/-- Completeness of `lookup` under slot-index uniqueness: every slot list member is
-retrievable. This is non-trivial — it fails when duplicate slot indices exist,
-because `find?` returns only the first match. (WS-E2 / C-01) -/
-theorem mem_lookup_of_slotsUnique
-    (cn : CNode) (slot : SeLe4n.Slot) (cap : Capability)
-    (hUniq : cn.slotsUnique)
-    (hMem : (slot, cap) ∈ cn.slots) :
-    cn.lookup slot = some cap := by
-  unfold lookup
-  cases hFind : cn.slots.find? (fun entry => decide (entry.fst = slot)) with
-  | none =>
-    exfalso
-    have := (List.find?_eq_none.mp hFind) ⟨slot, cap⟩ hMem
-    simp at this
-  | some entry =>
-    simp
-    have hSlot : entry.fst = slot := by simpa using List.find?_some hFind
-    have hEntryMem := List.mem_of_find?_eq_some hFind
-    have hRewrite : (slot, entry.snd) ∈ cn.slots := by
-      rw [← hSlot]; exact (Prod.eta entry) ▸ hEntryMem
-    exact hUniq slot entry.snd cap hRewrite hMem
+/-- WS-G5: Lookup roundtrip after insert — inserting at `slot` makes lookup
+return the inserted capability. Maps directly to `HashMap.getElem?_insert_self`. -/
+theorem lookup_insert_eq
+    (cn : CNode) (slot : SeLe4n.Slot) (cap : Capability) :
+    (cn.insert slot cap).lookup slot = some cap := by
+  simp [insert, lookup]
+
+/-- WS-G5: Insert at a different slot does not affect lookup.
+Maps directly to `HashMap.getElem?_insert`. -/
+theorem lookup_insert_ne
+    (cn : CNode) (slot slot' : SeLe4n.Slot) (cap : Capability)
+    (hNe : slot ≠ slot') :
+    (cn.insert slot cap).lookup slot' = cn.lookup slot' := by
+  simp only [insert, lookup]
+  rw [Std.HashMap.getElem?_insert]
+  have : ¬((slot == slot') = true) := by
+    intro h; exact hNe (eq_of_beq h)
+  simp [this]
+
+/-- WS-G5: Remove at a different slot does not affect lookup.
+Maps directly to `HashMap.getElem?_erase`. -/
+theorem lookup_remove_ne
+    (cn : CNode) (slot slot' : SeLe4n.Slot)
+    (hNe : slot ≠ slot') :
+    (cn.remove slot).lookup slot' = cn.lookup slot' := by
+  simp only [remove, lookup]
+  rw [Std.HashMap.getElem?_erase]
+  have : ¬((slot == slot') = true) := by
+    intro h; exact hNe (eq_of_beq h)
+  simp [this]
 
 end CNode
+
+/-- WS-G5: `BEq` instance for `CNode` using entry-wise comparison on the
+HashMap-backed slots. Two CNodes are equal iff their guard, radix, and all
+slot entries agree (same size + every key maps to the same value). -/
+instance : BEq CNode where
+  beq a b :=
+    a.guard == b.guard && a.radix == b.radix &&
+    a.slots.size == b.slots.size &&
+    a.slots.toList.all (fun (k, v) => b.slots[k]? == some v)
 
 -- ============================================================================
 -- WS-E4/C-03: Capability Derivation Tree (CDT) model
@@ -928,6 +934,10 @@ def projectObservedEdges
 
 end CapDerivationTree
 
+/-- WS-G5: `DecidableEq` removed from `KernelObject` because `CNode.slots` is now
+`Std.HashMap Slot Capability` which does not have a `DecidableEq` instance.
+`Repr` is retained for trace output. `BEq` is provided manually via entry-wise
+HashMap comparison for runtime test assertions. -/
 inductive KernelObject where
   | tcb (t : TCB)
   | endpoint (e : Endpoint)
@@ -935,7 +945,19 @@ inductive KernelObject where
   | cnode (c : CNode)
   | vspaceRoot (v : VSpaceRoot)
   | untyped (u : UntypedObject)
-  deriving Repr, DecidableEq
+  deriving Repr
+
+/-- WS-G5: Manual `BEq` for `KernelObject` dispatching to constituent `BEq`
+instances. CNode comparison uses the entry-wise `BEq CNode` instance above. -/
+instance : BEq KernelObject where
+  beq
+    | .tcb a, .tcb b => a == b
+    | .endpoint a, .endpoint b => a == b
+    | .notification a, .notification b => a == b
+    | .cnode a, .cnode b => a == b
+    | .vspaceRoot a, .vspaceRoot b => a == b
+    | .untyped a, .untyped b => a == b
+    | _, _ => false
 
 inductive KernelObjectType where
   | tcb

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -608,10 +608,11 @@ def ownerOfSlot (ref : SlotRef) : CSpaceOwner :=
 def ownsSlot (st : SystemState) (owner : CSpaceOwner) (ref : SlotRef) : Prop :=
   owner = ownerOfSlot ref ∧ ∃ cap, lookupSlotCap st ref = some cap
 
-/-- Enumerate all concrete capability entries held by one modeled owner CNode. -/
+/-- Enumerate all concrete capability entries held by one modeled owner CNode.
+WS-G5: Projects HashMap-backed slots to `List` for enumeration compatibility. -/
 def ownedSlots (st : SystemState) (owner : CSpaceOwner) : List (SeLe4n.Slot × Capability) :=
   match lookupCNode st owner with
-  | some cn => cn.slots
+  | some cn => cn.slots.toList
   | none => []
 
 /-- Lifecycle metadata view of object identity typing. -/

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -590,6 +590,62 @@ theorem HashMap_getElem?_eq_get? {α β : Type} [BEq α] [Hashable α]
 theorem HashMap_get?_eq_getElem? {α β : Type} [BEq α] [Hashable α]
     (m : Std.HashMap α β) (k : α) : m.get? k = m[k]? := rfl
 
+/-- WS-G5: Bridge lemma for `HashMap.filter` key preservation.
+When the filter predicate `f` is guaranteed to return `true` for key `k`
+(and any BEq-equivalent key), `filter` does not remove `k`'s entry.
+
+This bridges over the dependent `Option.pfilter` that `Std.HashMap.getElem?_filter`
+produces, which is difficult to work with directly due to the membership proof
+in `getKey`. -/
+theorem HashMap_filter_preserves_key
+    {α β : Type _} [BEq α] [Hashable α] [EquivBEq α] [LawfulHashable α]
+    (m : Std.HashMap α β) (f : α → β → Bool) (k : α)
+    (hTrue : ∀ (k' : α) (v : β), (k' == k) = true → f k' v = true) :
+    (m.filter f)[k]? = m[k]? := by
+  simp only [Std.HashMap.getElem?_filter]
+  suffices h : ∀ (o : Option β) (p : (a : β) → o = some a → Bool),
+      (∀ a (h : o = some a), p a h = true) → o.pfilter p = o by
+    apply h
+    intro a ha
+    have hMem : k ∈ m := Std.HashMap.mem_iff_isSome_getElem?.mpr (by simp [ha])
+    exact hTrue _ _ (Std.HashMap.getKey_beq hMem)
+  intro o p hp
+  cases o with
+  | none => rfl
+  | some v => simp [hp]
+
+/-- WS-G5: Lookup-level filter idempotency for HashMap.
+For a predicate that ignores the key (depends only on the value),
+double-filtering is lookup-equivalent to single-filtering.
+
+This avoids the need for structural `HashMap.filter_filter` (which is
+unavailable in Lean 4.28.0's Std library due to `AssocList.filter`
+internal bucket-ordering differences). -/
+theorem HashMap_filter_filter_getElem?
+    {α β : Type _} [BEq α] [Hashable α] [EquivBEq α] [LawfulHashable α]
+    (m : Std.HashMap α β) (f : α → β → Bool) (k : α) :
+    ((m.filter f).filter f)[k]? = (m.filter f)[k]? := by
+  by_cases hMem : k ∈ m.filter f
+  · -- k is in m.filter f; the value there already satisfies f,
+    -- so the second filter preserves the same entry.
+    have ⟨_, hF⟩ := Std.HashMap.mem_filter.mp hMem
+    have hMemFF : k ∈ (m.filter f).filter f := by
+      rw [Std.HashMap.mem_filter]
+      refine ⟨hMem, ?_⟩
+      rw [Std.HashMap.getKey_filter]
+      rw [Std.HashMap.getElem_filter]
+      exact hF
+    have h1 := Std.HashMap.getElem?_eq_some_getElem hMemFF
+    have h2 := Std.HashMap.getElem?_eq_some_getElem hMem
+    have h3 : ((m.filter f).filter f)[k] = (m.filter f)[k] :=
+      Std.HashMap.getElem_filter
+    rw [h1, h2, h3]
+  · -- k ∉ m.filter f ⇒ k ∉ (m.filter f).filter f ⇒ both sides are none
+    have hNotMemFF : k ∉ (m.filter f).filter f :=
+      fun h => hMem (Std.HashMap.mem_of_mem_filter h)
+    rw [Std.HashMap.getElem?_eq_none hNotMemFF,
+        Std.HashMap.getElem?_eq_none hMem]
+
 /-- WS-G2: Bridge lemma for `HashSet.contains` on empty. -/
 theorem HashSet_contains_empty {α : Type} [BEq α] [Hashable α]
     {a : α} : (∅ : Std.HashSet α).contains a = false :=

--- a/SeLe4n/Testing/InvariantChecks.lean
+++ b/SeLe4n/Testing/InvariantChecks.lean
@@ -91,7 +91,7 @@ private def cspaceSlotCoherencyChecks (objectIds : List SeLe4n.ObjId) (st : Syst
   objectIds.foldr (fun oid acc =>
     match (st.objects[oid]? : Option KernelObject) with
     | some (.cnode cn) =>
-        cn.slots.foldr (fun (slot, cap) inner =>
+        cn.slots.toList.foldr (fun (slot, cap) inner =>
           let ok := match cap.target with
             | .object targetId => (st.objects[targetId]?).isSome
             | .cnodeSlot cnId _ => (st.objects[cnId]?).isSome
@@ -107,7 +107,7 @@ private def capabilityRightsStructuralChecks (objectIds : List SeLe4n.ObjId) (st
   objectIds.foldr (fun oid acc =>
     match (st.objects[oid]? : Option KernelObject) with
     | some (.cnode cn) =>
-        cn.slots.foldr (fun (slot, cap) inner =>
+        cn.slots.toList.foldr (fun (slot, cap) inner =>
           let ok := match cap.badge with
             | some _ => !cap.rights.isEmpty
             | none => true

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -49,7 +49,7 @@ def bootstrapState : SystemState :=
     |>.withObject 10 (.cnode {
       guard := 0
       radix := 0
-      slots :=
+      slots := Std.HashMap.ofList
         [ (0, {
             target := .object 1
             rights := [.read, .write, .grant]
@@ -220,7 +220,7 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
   let deepRadixCNode : CNode := {
     guard := 3
     radix := 12
-    slots := [
+    slots := Std.HashMap.ofList [
       (1, { target := .object 1, rights := [.read], badge := none }),
       (1024, { target := .object 12, rights := [.read, .write], badge := none })
     ]
@@ -715,7 +715,7 @@ private def runUntypedMemoryTrace (st1 : SystemState) : IO Unit := do
           watermark := 0, children := [], isDevice := true })
         |>.insert 10 (.cnode {
           guard := 0, radix := 0,
-          slots := [
+          slots := Std.HashMap.ofList [
             (0, { target := .object 1, rights := [.read, .write, .grant], badge := none }),
             (5, { target := .object 12, rights := [.read, .write], badge := none }),
             (6, { target := .object demoUntyped, rights := [.read, .write], badge := none }),
@@ -783,7 +783,7 @@ private def buildParameterizedTopology
   let cnodeSlots : List (SeLe4n.Slot × Capability) :=
     (List.range threadCount).map fun i =>
       (⟨i⟩, { target := .object ⟨1000 + i⟩, rights := [.read, .write], badge := none })
-  let cnodeObj : KernelObject := .cnode { guard := 0, radix := radix, slots := cnodeSlots }
+  let cnodeObj : KernelObject := .cnode { guard := 0, radix := radix, slots := Std.HashMap.ofList cnodeSlots }
   let vspaceRoots : List (SeLe4n.ObjId × KernelObject) :=
     (List.range asidCount).map fun i =>
       let oid : SeLe4n.ObjId := ⟨3000 + i⟩

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -34,7 +34,7 @@ The following categories of theorems exist in the proof surface. Claims about pr
 | **Substantive preservation** | Proves that a *successful* operation preserves an invariant over *changed* state. | High |
 | **Error-case preservation** | Proves that a *failed* operation preserves an invariant by returning unchanged state. Trivially true. | Low (technically correct but not security evidence) |
 | **Compositional preservation** | Derives post-state invariant from pre-state through operation-specific transfer lemmas (`cspaceSlotUnique_of_storeObject_*`, `CNode.insert_slotsUnique`, etc.). (WS-E2 H-01 resolved: all preservation proofs refactored to this pattern.) | High |
-| **Structural invariant** | Proves a genuine structural property requiring a witness (e.g., `capabilityInvariantBundle_of_slotUnique` requires `CNode.slotsUnique` evidence). (WS-E2 C-01 resolved: former tautological proofs reformulated.) | High |
+| **Structural invariant** | Proves a genuine structural property requiring a witness (e.g., `capabilityInvariantBundle_of_slotUnique` requires `CNode.slotsUnique` evidence). (WS-E2 C-01 resolved: former tautological proofs reformulated. WS-G5: `slotsUnique` now trivially true — HashMap key uniqueness is structural.) | High |
 | **End-to-end chain** | Proves a multi-step semantic property across subsystem boundaries (e.g., `badge_notification_routing_consistent` — badge propagation from mint through notification signal/wait). (WS-E2 H-03 resolved.) | High |
 | **Non-interference** | Proves that a high-domain operation preserves low-equivalence for unrelated observers. | Critical for security assurance |
 
@@ -42,7 +42,7 @@ The following categories of theorems exist in the proof surface. Claims about pr
 
 | Finding | Prior category | Resolution |
 |---|---|---|
-| C-01 (Tautological proofs) | Tautological (assurance: None) | Reformulated to **Structural invariant**: `cspaceSlotUnique` now encodes CNode slot-index uniqueness via `CNode.slotsUnique`; `cspaceLookupSound` proves lookup completeness; bridge theorem `cspaceLookupSound_of_cspaceSlotUnique` connects them; `capabilityInvariantBundle_of_slotUnique` replaces tautological `capabilityInvariantBundle_holds`. |
+| C-01 (Tautological proofs) | Tautological (assurance: None) | Reformulated to **Structural invariant**: `cspaceSlotUnique` now encodes CNode slot-index uniqueness via `CNode.slotsUnique`; `cspaceLookupSound` proves lookup completeness; bridge theorem `cspaceLookupSound_of_cspaceSlotUnique` connects them; `capabilityInvariantBundle_of_slotUnique` replaces tautological `capabilityInvariantBundle_holds`. (WS-G5: `slotsUnique` trivially true with `Std.HashMap` key uniqueness.) |
 | H-01 (Non-compositional proofs) | Non-compositional preservation (assurance: Medium) | Refactored to **Compositional preservation**: all preservation proofs derive post-state from pre-state via transfer lemmas. CNode operations use `CNode.insert_slotsUnique`, `CNode.remove_slotsUnique`, `CNode.revokeTargetLocal_slotsUnique`. |
 | H-03 (Badge safety gap) | Gap (no theorem) | Closed with **End-to-end chain**: `mintDerivedCap_badge_propagated` -> `cspaceMint_child_badge_preserved` -> `notificationSignal_badge_stored_fresh` -> `notificationWait_recovers_pending_badge` -> `badge_notification_routing_consistent`; plus `badge_merge_idempotent`. |
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,7 +7,7 @@ production-oriented microkernel written in Lean 4 with machine-checked proofs.
 
 It is aligned to the **current active slice**:
 
-- **active:** WS-G portfolio (kernel performance optimization — WS-G1..G4 completed),
+- **active:** WS-G portfolio (kernel performance optimization — WS-G1..G5 completed),
 - **findings baseline:** [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md),
 - **completed predecessor:** WS-F portfolio (v0.12.2 audit remediation — WS-F1..F4 completed), WS-E (v0.11.6),
 - **hardware target:** Raspberry Pi 5 (ARM64).
@@ -46,7 +46,7 @@ for the full execution plan.
 | **WS-G2** | Object store HashMap | Critical | F-P01, F-P10, F-P13 | **Completed** |
 | **WS-G3** | ASID resolution table | Critical | F-P06 | **Completed** |
 | **WS-G4** | Run queue restructure | Critical | F-P02, F-P07, F-P12 | **Completed** |
-| **WS-G5** | CNode slot HashMap | High | F-P03 | Planning |
+| **WS-G5** | CNode slot HashMap | High | F-P03 | **Completed** |
 | **WS-G6** | VSpace mapping HashMap | High | F-P05 | Planning |
 | **WS-G7** | IPC queue + notification | High | F-P04, F-P11 | Planning |
 | **WS-G8** | Graph traversal optimization | High | F-P08, F-P14 | Planning |

--- a/docs/audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md
+++ b/docs/audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md
@@ -400,8 +400,11 @@ Two bridge lemmas added to Prelude.lean: `HashMap_filter_preserves_key` for
 projection filter idempotency (reformulated at slot-lookup level because
 `AssocList.filter` reverses bucket ordering). `projectKernelObject_idempotent`
 reformulated from structural to slot-level equality. Manual `BEq CNode` and
-`BEq KernelObject` instances replace lost `DecidableEq` derivation. All 10 files
-modified, zero sorry/axiom, `test_full.sh` passes Tier 0-3. Closes F-P03.
+`BEq KernelObject` instances replace lost `DecidableEq` derivation.
+`revokedRefs` computation in `cspaceRevoke` uses `HashMap.fold` for a single O(m)
+pass (no intermediate `.toList` allocation). Test slot-existence checks use
+`HashMap.contains` for O(1). All 10 files modified, zero sorry/axiom,
+`test_full.sh` passes Tier 0-3. Closes F-P03.
 
 ---
 

--- a/docs/audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md
+++ b/docs/audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md
@@ -340,7 +340,7 @@ subsystem rewrites, significant theorem re-proof).
 
 ---
 
-### WS-G5: CNode Slot HashMap (F-P03) — HIGH
+### WS-G5: CNode Slot HashMap (F-P03) — COMPLETED
 
 **Objective:** Replace list-based CNode slots with `Std.HashMap Slot Capability`,
 reducing every capability lookup, insert, and delete from O(m) to O(1) amortized.
@@ -390,6 +390,18 @@ recommended (HashMap object store ensures CNode retrieval is O(1)).
 
 **Estimated effort:** Medium (contained to CNode subsystem; well-defined
 theorem migration).
+
+**Completion notes (v0.12.10):**
+Completed in v0.12.10. `CNode.slots` migrated from `List (Slot × Capability)` to
+`Std.HashMap Slot Capability`. All CNode operations (`lookup`, `insert`, `remove`)
+are O(1) amortized. `slotsUnique` invariant trivially true (HashMap key uniqueness).
+Two bridge lemmas added to Prelude.lean: `HashMap_filter_preserves_key` for
+`revokeTargetLocal` source-slot preservation, and `HashMap_filter_filter_getElem?` for
+projection filter idempotency (reformulated at slot-lookup level because
+`AssocList.filter` reverses bucket ordering). `projectKernelObject_idempotent`
+reformulated from structural to slot-level equality. Manual `BEq CNode` and
+`BEq KernelObject` instances replace lost `DecidableEq` derivation. All 10 files
+modified, zero sorry/axiom, `test_full.sh` passes Tier 0-3. Closes F-P03.
 
 ---
 
@@ -699,8 +711,8 @@ P3:  [WS-G5]──[WS-G6]──[WS-G7]──[WS-G8]──[WS-G9]
 | WS-G1 | Prerequisite | (infrastructure) | **Completed** | Low |
 | WS-G2 | Critical | F-P01, F-P10, F-P13 | **Completed** | Medium-High |
 | WS-G3 | Critical | F-P06 | **Completed** | Low |
-| WS-G4 | Critical | F-P02, F-P07, F-P12 | Planning | High |
-| WS-G5 | High | F-P03 | Planning | Medium |
+| WS-G4 | Critical | F-P02, F-P07, F-P12 | **Completed** | High |
+| WS-G5 | High | F-P03 | **Completed** | Medium |
 | WS-G6 | High | F-P05 | Planning | Medium |
 | WS-G7 | High | F-P04, F-P11 | Planning | Low-Medium |
 | WS-G8 | High | F-P08, F-P14 | Planning | Medium |

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -53,7 +53,7 @@ M7 (audit remediation).
   - **WS-G2** (Object store HashMap): **COMPLETED** (v0.12.7) — `Std.HashMap ObjId KernelObject`.
   - **WS-G3** (ASID resolution table): **COMPLETED** (v0.12.8) — `Std.HashMap ASID ObjId`.
   - **WS-G4** (Run queue restructure): **COMPLETED** (v0.12.9) — priority-bucketed `RunQueue`.
-  - **WS-G5** (CNode slot HashMap): **COMPLETED** (v0.12.10) — `Std.HashMap Slot Capability` for O(1) capability operations.
+  - **WS-G5** (CNode slot HashMap): **COMPLETED** (v0.12.10) — `Std.HashMap Slot Capability` for O(1) capability operations; `cspaceRevoke` `revokedRefs` via `HashMap.fold` (single O(m) pass).
   - WS-G6..G9: planning.
 - **WS-F** (v0.12.2 audit remediation): closing proof gaps identified by two independent audits.
   - **WS-F1** (IPC message transfer + dual-queue verification): **COMPLETED** — `IpcMessage` wired into all dual-queue and compound IPC operations; 14 invariant preservation theorems; 7 trace anchors with actual data transfer.

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -48,6 +48,13 @@ M7 (audit remediation).
 
 ### Active work
 
+- **WS-G** (kernel performance optimization): HashMap-based data structure migration for O(1) operations.
+  - **WS-G1** (Hashable infrastructure): **COMPLETED** (v0.12.6) — `Hashable` for all 13 typed identifiers.
+  - **WS-G2** (Object store HashMap): **COMPLETED** (v0.12.7) — `Std.HashMap ObjId KernelObject`.
+  - **WS-G3** (ASID resolution table): **COMPLETED** (v0.12.8) — `Std.HashMap ASID ObjId`.
+  - **WS-G4** (Run queue restructure): **COMPLETED** (v0.12.9) — priority-bucketed `RunQueue`.
+  - **WS-G5** (CNode slot HashMap): **COMPLETED** (v0.12.10) — `Std.HashMap Slot Capability` for O(1) capability operations.
+  - WS-G6..G9: planning.
 - **WS-F** (v0.12.2 audit remediation): closing proof gaps identified by two independent audits.
   - **WS-F1** (IPC message transfer + dual-queue verification): **COMPLETED** — `IpcMessage` wired into all dual-queue and compound IPC operations; 14 invariant preservation theorems; 7 trace anchors with actual data transfer.
   - **WS-F2** (Untyped memory model): **COMPLETED** — `UntypedObject` with region/watermark, `retypeFromUntyped` with allocSize validation, device restriction, 10+ theorems, 6 negative tests, 8 trace anchors.

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -52,7 +52,7 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
   - capability rights/targets,
   - TCB structure + IPC state + intrusive queue link hooks (`queuePrev`/`queuePPrev`/`queueNext`),
   - endpoint protocol fields,
-  - CNode slot store and local revoke helper,
+  - CNode `Std.HashMap Slot Capability` slot store and local revoke helper (WS-G5),
   - `KernelObject` discriminated union.
 
 - `SeLe4n/Model/State.lean`

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -35,7 +35,7 @@ Completed:
 2. **WS-G2**: ~~Object store & ObjectIndex HashMap~~ **COMPLETED** (v0.12.7)
 3. **WS-G3**: ~~ASID Resolution Table~~ **COMPLETED** (v0.12.8)
 4. **WS-G4**: ~~Run queue restructure~~ **COMPLETED** (v0.12.9)
-5. **WS-G5**: ~~CNode slot HashMap~~ **COMPLETED** (v0.12.10)
+5. **WS-G5**: ~~CNode slot HashMap~~ **COMPLETED** (v0.12.10) — `Std.HashMap Slot Capability`; `HashMap.fold` for `cspaceRevoke` `revokedRefs`
 
 Prior portfolio **WS-F** (v0.12.2 audit remediation): WS-F1..F4 all **COMPLETED**.
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -13,11 +13,11 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 
 | Attribute | Value |
 |-----------|-------|
-| Version | `0.12.8` |
+| Version | `0.12.10` |
 | Lean toolchain | `4.28.0` |
 | Production LoC | 16,485 across 34 files |
 | Proved theorems | 400+ (zero sorry/axiom) |
-| Active portfolio | WS-G (kernel performance optimization) — WS-G1..G3 completed |
+| Active portfolio | WS-G (kernel performance optimization) — WS-G1..G5 completed |
 
 ## Milestone history
 
@@ -34,10 +34,8 @@ Completed:
 1. **WS-G1**: ~~Typed identifier Hashable instances~~ **COMPLETED** (v0.12.6)
 2. **WS-G2**: ~~Object store & ObjectIndex HashMap~~ **COMPLETED** (v0.12.7)
 3. **WS-G3**: ~~ASID Resolution Table~~ **COMPLETED** (v0.12.8)
-
-Planned:
-4. **WS-G4**: Run queue restructure
-5. **WS-G5**: CNode slot HashMap
+4. **WS-G4**: ~~Run queue restructure~~ **COMPLETED** (v0.12.9)
+5. **WS-G5**: ~~CNode slot HashMap~~ **COMPLETED** (v0.12.10)
 
 Prior portfolio **WS-F** (v0.12.2 audit remediation): WS-F1..F4 all **COMPLETED**.
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -24,7 +24,8 @@ This chapter maps where semantics, proofs, and execution evidence live in the cu
 - `SeLe4n/Machine.lean`
   - machine-level state helpers.
 - `SeLe4n/Model/Object.lean`
-  - object-level representations (including TCB intrusive queue link fields).
+  - object-level representations (including TCB intrusive queue link fields);
+    CNode `Std.HashMap Slot Capability` slot store with O(1) operations (WS-G5).
 - `SeLe4n/Model/State.lean`
   - global system-state composition and update helpers (including
     `SchedulerState.runQueue : RunQueue` priority-bucketed run queue, WS-G4).

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -41,7 +41,7 @@ Preservation shape:
 
 Component level:
 
-- `cspaceSlotUnique` — structural CNode slot-index uniqueness (reformulated in WS-E2; non-tautological, requires `CNode.slotsUnique`),
+- `cspaceSlotUnique` — structural CNode slot-index uniqueness (reformulated in WS-E2; WS-G5: trivially true with `Std.HashMap` key uniqueness),
 - `cspaceLookupSound` — lookup completeness grounded in slot membership (reformulated in WS-E2; non-tautological),
 - `cspaceAttenuationRule` — minted capabilities attenuate rights,
 - `lifecycleAuthorityMonotonicity` — authority only decreases through lifecycle operations.
@@ -485,7 +485,7 @@ backward-preservation and frame lemmas.
 
 - `capTargetObservable` — observability gate for `.object`, `.cnodeSlot`, `.replyCap` targets,
 - `projectKernelObject` — redacts high-domain capability slot contents from CNodes,
-- `projectKernelObject_idempotent` — safety: double-filtering is idempotent,
+- `projectKernelObject_idempotent` — safety: double-filtering is idempotent (WS-G5: reformulated to slot-level lookup equality for `Std.HashMap` compatibility),
 - `projectKernelObject_objectType` — safety: filtering preserves object type.
 
 **Enforcement-NI bridges** (`Invariant.lean`):

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -139,7 +139,7 @@ Authoritative detail:
 
 ### 5.3 Completed — CNode Optimization
 
-- **WS-G5:** ~~CNode slot HashMap~~ **COMPLETED** — `CNode.slots : Std.HashMap Slot Capability` replacing `List (Slot × Capability)`; `lookup`/`insert`/`remove` all O(1) amortized; `slotsUnique` trivially true (HashMap key uniqueness); 2 bridge lemmas (`HashMap_filter_preserves_key`, `HashMap_filter_filter_getElem?`); `projectKernelObject_idempotent` reformulated to slot-level lookup equality; manual `BEq CNode`/`BEq KernelObject` instances; 10 files modified; closes F-P03 (v0.12.10)
+- **WS-G5:** ~~CNode slot HashMap~~ **COMPLETED** — `CNode.slots : Std.HashMap Slot Capability` replacing `List (Slot × Capability)`; `lookup`/`insert`/`remove` all O(1) amortized; `slotsUnique` trivially true (HashMap key uniqueness); 2 bridge lemmas (`HashMap_filter_preserves_key`, `HashMap_filter_filter_getElem?`); `projectKernelObject_idempotent` reformulated to slot-level lookup equality; `cspaceRevoke` `revokedRefs` via `HashMap.fold` (single O(m) pass); manual `BEq CNode`/`BEq KernelObject` instances; 10 files modified; closes F-P03 (v0.12.10)
 
 ### 5.4 Planned — Further Optimization
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -54,7 +54,7 @@ enforcement, and scheduling.
 | **Proved theorems** | 400+ (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (ARM64) |
 | **Active findings** | [`AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md), [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) |
-| **Active portfolio** | WS-G (kernel performance optimization) — WS-G1..G4 completed |
+| **Active portfolio** | WS-G (kernel performance optimization) — WS-G1..G5 completed |
 | **Prior completed** | WS-F (v0.12.2), WS-E (v0.11.6), WS-D (v0.11.0), WS-C (v0.9.32), WS-B (v0.9.0) |
 
 ---
@@ -137,11 +137,15 @@ Authoritative detail:
 
 - **WS-G4:** ~~Run queue restructure~~ **COMPLETED** — `RunQueue` structure with `Std.HashMap Priority (List ThreadId)` + `Std.HashSet ThreadId` + `flat_wf` structural invariant; `SchedulerState.runQueue` replaces flat `runnable : List ThreadId`; O(1) `insert`/`remove`/`contains`/`rotateHead`/`rotateToBack`; `chooseBestInBucket` bucket-first scheduling reduces best-candidate selection from O(t) to O(k); `withRunnableQueue`/`runnableHead`/`runnableTail` eliminated; 13 bridge lemmas; 30+ IPC invariant proofs migrated; info-flow projection re-proved; closes F-P02, F-P07, F-P12 (v0.12.9)
 
-### 5.3 Planned — Further Optimization
+### 5.3 Completed — CNode Optimization
 
-- **WS-G5:** CNode slot HashMap (F-P03)
+- **WS-G5:** ~~CNode slot HashMap~~ **COMPLETED** — `CNode.slots : Std.HashMap Slot Capability` replacing `List (Slot × Capability)`; `lookup`/`insert`/`remove` all O(1) amortized; `slotsUnique` trivially true (HashMap key uniqueness); 2 bridge lemmas (`HashMap_filter_preserves_key`, `HashMap_filter_filter_getElem?`); `projectKernelObject_idempotent` reformulated to slot-level lookup equality; manual `BEq CNode`/`BEq KernelObject` instances; 10 files modified; closes F-P03 (v0.12.10)
 
-### 5.4 Prior Portfolio: WS-F (completed, v0.12.2)
+### 5.4 Planned — Further Optimization
+
+(No further data-structure workstreams are in active development. WS-G6..G9 remain planned.)
+
+### 5.5 Prior Portfolio: WS-F (completed, v0.12.2)
 
 The WS-F portfolio addressed findings from two independent v0.12.2 codebase audits.
 Combined: 6 CRITICAL, 6 HIGH, 12 MEDIUM, 9 LOW findings.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.12.9"
+version = "0.12.10"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/tests/InformationFlowSuite.lean
+++ b/tests/InformationFlowSuite.lean
@@ -115,14 +115,14 @@ private def runInformationFlowChecks : IO Unit := do
 
   -- Verify the two states ARE actually different (so this isn't a tautological comparison)
   expect "altState differs from sampleState (secret object changed)"
-    (sampleState.objects[(2 : SeLe4n.ObjId)]? ≠ altState.objects[(2 : SeLe4n.ObjId)]?)
+    (!(sampleState.objects[(2 : SeLe4n.ObjId)]? == altState.objects[(2 : SeLe4n.ObjId)]?))
 
   expect "altState differs from sampleState (current thread changed)"
     (sampleState.scheduler.current ≠ altState.scheduler.current)
 
   -- Verify public projections of distinct states are equal (non-trivial low-equivalence)
   expect "distinct states: public object projection matches for public observer"
-    (publicProjectionSample.objects 1 = publicProjectionAlt.objects 1)
+    (publicProjectionSample.objects 1 == publicProjectionAlt.objects 1)
 
   expect "distinct states: secret objects both hidden for public observer"
     ((publicProjectionSample.objects 2).isNone && (publicProjectionAlt.objects 2).isNone)
@@ -141,7 +141,7 @@ private def runInformationFlowChecks : IO Unit := do
   let knownOids : List SeLe4n.ObjId := [1, 2]
   let knownSids : List ServiceId := [1, 2]
   let objectsMatch := knownOids.all (fun oid =>
-    publicProjectionSample.objects oid = publicProjectionAlt.objects oid)
+    publicProjectionSample.objects oid == publicProjectionAlt.objects oid)
   let servicesMatch := knownSids.all (fun sid =>
     publicProjectionSample.services sid = publicProjectionAlt.services sid)
   let fullLowEq := objectsMatch
@@ -258,8 +258,8 @@ private def runInformationFlowChecks : IO Unit := do
   -- cspaceMintChecked: same-domain mint should be allowed
   let mintState :=
     (BootstrapBuilder.empty
-      |>.withObject 100 (.cnode { guard := 0, radix := 8, slots := [(0, { target := .object 200, rights := [.read, .write], badge := none })] })
-      |>.withObject 101 (.cnode { guard := 0, radix := 8, slots := [] })
+      |>.withObject 100 (.cnode { guard := 0, radix := 8, slots := (Std.HashMap.ofList [(0, { target := .object 200, rights := [.read, .write], badge := none })]) })
+      |>.withObject 101 (.cnode { guard := 0, radix := 8, slots := (Std.HashMap.ofList []) })
       |>.build)
 
   let sameDomainMintCtx : SeLe4n.Kernel.LabelingContext :=
@@ -499,11 +499,11 @@ private def runInformationFlowChecks : IO Unit := do
     (BootstrapBuilder.empty
       |>.withObject 1 (.endpoint { state := .idle, queue := [], waitingReceiver := none })  -- public target
       |>.withObject 2 (.notification { state := .idle, waitingThreads := [], pendingBadge := none })  -- secret target
-      |>.withObject 50 (.cnode { guard := 0, radix := 8, slots :=
-          [ (0, { target := .object 1, rights := [.read], badge := none })      -- cap to public obj
-          , (1, { target := .object 2, rights := [.read, .write], badge := none })  -- cap to secret obj
-          , (2, { target := .replyCap 1, rights := [.read], badge := none })    -- reply cap to public thread
-          ] })
+      |>.withObject 50 (.cnode { guard := 0, radix := 8, slots := (Std.HashMap.ofList
+          [ (0, { target := .object 1, rights := [.read], badge := none })
+          , (1, { target := .object 2, rights := [.read, .write], badge := none })
+          , (2, { target := .replyCap 1, rights := [.read], badge := none })
+          ]) })
       |>.build)
 
   -- oid 50 (the CNode) is public so both observers can see it
@@ -521,16 +521,16 @@ private def runInformationFlowChecks : IO Unit := do
   | some (.cnode cn) =>
     -- Slot 0 (target: public obj 1) should be present
     expect "WS-F3/F-22: public observer sees cap slot targeting public object"
-      (cn.slots.any (fun (s, _) => s = 0))
+      (cn.slots.toList.any (fun (s, _) => s = 0))
     -- Slot 1 (target: secret obj 2) should be filtered out
     expect "WS-F3/F-22: public observer cannot see cap slot targeting secret object"
-      (!cn.slots.any (fun (s, _) => s = 1))
+      (!cn.slots.toList.any (fun (s, _) => s = 1))
     -- Slot 2 (target: replyCap to public thread 1) should be present
     expect "WS-F3/F-22: public observer sees reply cap to public thread"
-      (cn.slots.any (fun (s, _) => s = 2))
+      (cn.slots.toList.any (fun (s, _) => s = 2))
     -- Verify slot count
     expect "WS-F3/F-22: public observer sees exactly 2 of 3 slots"
-      (cn.slots.length = 2)
+      (cn.slots.size = 2)
   | _ =>
     throw <| IO.userError "WS-F3/F-22: public observer should see CNode object at oid 50"
 
@@ -538,7 +538,7 @@ private def runInformationFlowChecks : IO Unit := do
   match cnodeAdminProj.objects 50 with
   | some (.cnode cn) =>
     expect "WS-F3/F-22: admin observer sees all 3 cap slots"
-      (cn.slots.length = 3)
+      (cn.slots.size = 3)
   | _ =>
     throw <| IO.userError "WS-F3/F-22: admin observer should see CNode object at oid 50"
 
@@ -555,21 +555,21 @@ private def runInformationFlowChecks : IO Unit := do
     (BootstrapBuilder.empty
       |>.withObject 1 (.endpoint { state := .idle, queue := [], waitingReceiver := none })  -- public target
       |>.withObject 2 (.notification { state := .idle, waitingThreads := [], pendingBadge := none })  -- secret target
-      |>.withObject 60 (.cnode { guard := 0, radix := 8, slots :=
-          [ (0, { target := .cnodeSlot 1 0, rights := [.read], badge := none })    -- cnodeSlot to public CNode
-          , (1, { target := .cnodeSlot 2 0, rights := [.read], badge := none })    -- cnodeSlot to secret CNode
-          ] })
+      |>.withObject 60 (.cnode { guard := 0, radix := 8, slots := (Std.HashMap.ofList
+          [ (0, { target := .cnodeSlot 1 0, rights := [.read], badge := none })
+          , (1, { target := .cnodeSlot 2 0, rights := [.read], badge := none })
+          ]) })
       |>.build)
 
   let cnodeSlotProj := SeLe4n.Kernel.projectState cnodeLabeling reviewer cnodeSlotState
   match cnodeSlotProj.objects 60 with
   | some (.cnode cn) =>
     expect "WS-F3/F-22: cnodeSlot target to public CNode is visible"
-      (cn.slots.any (fun (s, _) => s = 0))
+      (cn.slots.toList.any (fun (s, _) => s = 0))
     expect "WS-F3/F-22: cnodeSlot target to secret CNode is filtered"
-      (!cn.slots.any (fun (s, _) => s = 1))
+      (!cn.slots.toList.any (fun (s, _) => s = 1))
     expect "WS-F3/F-22: cnodeSlot variant: exactly 1 of 2 slots visible"
-      (cn.slots.length = 1)
+      (cn.slots.size = 1)
   | _ =>
     throw <| IO.userError "WS-F3/F-22: CNode at oid 60 should be visible for cnodeSlot test"
 

--- a/tests/InformationFlowSuite.lean
+++ b/tests/InformationFlowSuite.lean
@@ -521,13 +521,13 @@ private def runInformationFlowChecks : IO Unit := do
   | some (.cnode cn) =>
     -- Slot 0 (target: public obj 1) should be present
     expect "WS-F3/F-22: public observer sees cap slot targeting public object"
-      (cn.slots.toList.any (fun (s, _) => s = 0))
+      (cn.slots.contains 0)
     -- Slot 1 (target: secret obj 2) should be filtered out
     expect "WS-F3/F-22: public observer cannot see cap slot targeting secret object"
-      (!cn.slots.toList.any (fun (s, _) => s = 1))
+      (!cn.slots.contains 1)
     -- Slot 2 (target: replyCap to public thread 1) should be present
     expect "WS-F3/F-22: public observer sees reply cap to public thread"
-      (cn.slots.toList.any (fun (s, _) => s = 2))
+      (cn.slots.contains 2)
     -- Verify slot count
     expect "WS-F3/F-22: public observer sees exactly 2 of 3 slots"
       (cn.slots.size = 2)
@@ -565,9 +565,9 @@ private def runInformationFlowChecks : IO Unit := do
   match cnodeSlotProj.objects 60 with
   | some (.cnode cn) =>
     expect "WS-F3/F-22: cnodeSlot target to public CNode is visible"
-      (cn.slots.toList.any (fun (s, _) => s = 0))
+      (cn.slots.contains 0)
     expect "WS-F3/F-22: cnodeSlot target to secret CNode is filtered"
-      (!cn.slots.toList.any (fun (s, _) => s = 1))
+      (!cn.slots.contains 1)
     expect "WS-F3/F-22: cnodeSlot variant: exactly 1 of 2 slots visible"
       (cn.slots.size = 1)
   | _ =>

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -28,7 +28,7 @@ private def baseState : SystemState :=
     |>.withObject cnodeId (.cnode {
       guard := 0
       radix := 0
-      slots := [
+      slots := Std.HashMap.ofList [
         (0, {
           target := .object endpointId
           rights := [.read, .write]
@@ -40,7 +40,7 @@ private def baseState : SystemState :=
     |>.withObject guardedCnodeId (.cnode {
       guard := 1
       radix := 2
-      slots := [
+      slots := Std.HashMap.ofList [
         (1, {
           target := .object endpointId
           rights := [.read]
@@ -195,7 +195,7 @@ private def f2UntypedState : SystemState :=
     |>.withObject f2UntypedAuthCnode (.cnode {
       guard := 0
       radix := 0
-      slots := [
+      slots := Std.HashMap.ofList [
         (0, {
           target := .object f2UntypedObjId
           rights := [.read, .write, .grant]
@@ -222,7 +222,7 @@ private def f2DeviceState : SystemState :=
     |>.withObject f2UntypedAuthCnode (.cnode {
       guard := 0
       radix := 0
-      slots := [
+      slots := Std.HashMap.ofList [
         (0, {
           target := .object f2DeviceUntypedId
           rights := [.read, .write, .grant]
@@ -306,7 +306,7 @@ private def runNegativeChecks : IO Unit := do
       objects := baseState.objects.insert cnodeId (.cnode {
             guard := 0
             radix := 0
-            slots := [
+            slots := Std.HashMap.ofList [
               (strictRootSlot.slot, {
                 target := .object endpointId
                 rights := [.read, .write]


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-G5 (CNode Slot HashMap) — **COMPLETED**
- **Recommendation IDs closed:** F-P03
- **Scope notes:** Complete migration of `CNode.slots` from `List (Slot × Capability)` to `Std.HashMap Slot Capability`, reducing all capability lookup, insert, and delete operations from O(m) to O(1) amortized. Includes theorem re-proof, invariant simplification, and bridge lemmas for HashMap-specific semantics.

## Key Changes

### Core Data Structure Migration
- **`CNode.slots`**: Changed from `List (SeLe4n.Slot × Capability)` to `Std.HashMap SeLe4n.Slot Capability`
- **`CNode` derivation**: Removed `DecidableEq` (HashMap lacks this instance); retained `Repr`; added manual `BEq CNode` instance for runtime test assertions
- **`KernelObject` derivation**: Removed `DecidableEq`; added manual `BEq KernelObject` instance dispatching to constituent types

### Operation Complexity Improvements
- **`CNode.lookup`**: O(m) list scan → O(1) amortized HashMap lookup via `HashMap.getElem?`
- **`CNode.insert`**: O(m) filter + prepend → O(1) amortized HashMap insert
- **`CNode.remove`**: O(m) filter → O(1) amortized HashMap erase
- **`CNode.revokeTargetLocal`**: Inherently O(m) (filter-by-target); now uses `HashMap.filter`

### Invariant Simplification
- **`CNode.slotsUnique`**: Redefined from a non-trivial membership predicate to `True` — HashMap enforces key uniqueness by construction
- **Preservation theorems** (`insert_slotsUnique`, `remove_slotsUnique`, `revokeTargetLocal_slotsUnique`): All now prove `trivial`
- **Bridge theorem** `cspaceLookupSound_of_cspaceSlotUnique`: Simplified — lookup completeness is now immediate by definition

### New Bridge Lemmas (Prelude.lean)
1. **`HashMap_filter_preserves_key`**: Proves that filtering a HashMap preserves a key's entry when the filter predicate is guaranteed true for that key. Used to establish that `revokeTargetLocal` preserves the source slot.
2. **`HashMap_filter_filter_getElem?`**: Proves double-filtering is lookup-equivalent to single-filtering. Necessary because `Std.HashMap.filter` reverses internal `AssocList` bucket ordering, making structural equality fail despite identical entries.

### Theorem Re-proof
- **`lookup_remove_eq_none`**: Simplified from list-based reasoning to `simp [remove, lookup]`
- **`lookup_mem_of_some`**: Reformulated to use `HashMap.mem_iff_isSome_getElem?`
- **`mem_lookup_of_slotsUnique`**: Simplified — now delegates directly to `HashMap.getElem?_eq_some_getElem`
- **New theorems**: `lookup_insert_eq`, `lookup_insert_ne`, `lookup_remove_ne` for roundtrip properties
- **`projectKernelObject_idempotent`**: Reformulated from structural equality to slot-level lookup equality (due to HashMap bucket-ordering reversal)

### Test Suite Updates
- Updated `InformationFlowSuite.lean`, `NegativeStateSuite.lean`, `MainTraceHarness.lean` to construct CNode slots via `Std.HashMap.ofList` instead of list literals
- Updated slot enumeration in `InvariantChecks.lean` and `Invariant.lean` to use `.toList` for HashMap iteration

### Documentation
- Updated `KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md` to mark WS-G5 as COMPLETED with detailed completion notes

https://claude.ai/code/session_019AGe5zBixQVbaSvwQs5gXz