### PR TITLE
Audit coverage: endpointReplyRecv, cspaceMutate, CDT childMap, and Machine config

### DIFF
--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -133,16 +133,6 @@ private def chooseBestInBucket
     -- fall back to full-list scan.
     chooseBestRunnableInDomain objects rq.toList activeDomain none
 
-/-- M-05/WS-E6: Filter runnable threads to those in the specified domain. -/
-def filterByDomain
-    (objects : SeLe4n.ObjId → Option KernelObject)
-    (runnable : List SeLe4n.ThreadId)
-    (domain : SeLe4n.DomainId) : List SeLe4n.ThreadId :=
-  runnable.filter fun tid =>
-    match objects tid.toObjId with
-    | some (.tcb tcb) => tcb.domain == domain
-    | _ => false
-
 /-- M-03/M-05 WS-E6/WS-G4: Choose the highest-priority runnable thread from the
 active domain using deterministic selection: priority > EDF deadline > FIFO.
 
@@ -163,7 +153,13 @@ def chooseThread : Kernel (Option SeLe4n.ThreadId) :=
 
 Failure modes are explicit:
 - malformed runnable entries (non-TCB object IDs) surface as `schedulerInvariantViolation`,
-- selecting a thread not present in runnable also surfaces as `schedulerInvariantViolation`. -/
+- selecting a thread not present in runnable also surfaces as `schedulerInvariantViolation`.
+
+**Performance note:** The membership check `tid ∈ st'.scheduler.runnable` resolves to
+`List.Mem tid rq.flat` (O(n)). An O(1) alternative via `tid ∈ st'.scheduler.runQueue`
+(HashSet-backed) is semantically equivalent under the RunQueue structural invariant
+`flat_wf` but would require adding a reverse invariant `flat_wf_rev` and updating
+~15 preservation theorem proofs. Deferred to a future workstream. -/
 def schedule : Kernel Unit :=
   fun st =>
     match chooseThread st with

--- a/SeLe4n/Machine.lean
+++ b/SeLe4n/Machine.lean
@@ -228,6 +228,11 @@ private def noOverlapAux : List MemoryRegion → Bool
   | [] => true
   | r :: rs => rs.all (fun r' => !r.overlaps r') && noOverlapAux rs
 
+/-- Check whether a natural number is a positive power of two (1, 2, 4, 8, ...).
+    Uses bitwise characterization: `n > 0 ∧ n &&& (n - 1) == 0`. -/
+@[inline] private def isPowerOfTwo (n : Nat) : Bool :=
+  n > 0 && (n &&& (n - 1)) == 0
+
 /-- A machine configuration is well-formed when:
     1. All regions have nonzero size.
     2. No two regions overlap.
@@ -236,7 +241,7 @@ private def noOverlapAux : List MemoryRegion → Bool
 def wellFormed (cfg : MachineConfig) : Bool :=
   cfg.memoryMap.all (·.size > 0)
   && noOverlapAux cfg.memoryMap
-  && cfg.pageSize > 0
+  && isPowerOfTwo cfg.pageSize
   && cfg.registerWidth > 0
   && cfg.virtualAddressWidth > 0
   && cfg.physicalAddressWidth > 0

--- a/SeLe4n/Testing/InvariantChecks.lean
+++ b/SeLe4n/Testing/InvariantChecks.lean
@@ -192,6 +192,25 @@ private def notificationWaiterConsistentChecks (objectIds : List SeLe4n.ObjId) (
           (s!"notification waiter consistent: oid={oid} tid={tid.toNat}", ok) :: inner) acc
     | _ => acc) []
 
+/-- Audit: Runtime check for CDT `childMapConsistent` — verifies that the
+`childMap` HashMap mirrors the parent→child edges in the `edges` list.
+Checks both directions: every childMap entry has a corresponding edge,
+and every edge has a corresponding childMap entry. -/
+private def cdtChildMapConsistentCheck (st : SystemState) : List (String × Bool) :=
+  let cdt := st.cdt
+  -- Forward: every childMap entry has a corresponding edge
+  let forwardChecks := cdt.childMap.toList.foldr (fun (parent, children) acc =>
+    children.foldr (fun child inner =>
+      let ok := cdt.edges.any fun e => e.parent == parent && e.child == child
+      (s!"cdt childMap→edges: parent={reprStr parent} child={reprStr child}", ok) :: inner) acc) []
+  -- Backward: every edge has a corresponding childMap entry
+  let backwardChecks := cdt.edges.map fun e =>
+    let ok := match cdt.childMap.get? e.parent with
+      | some children => children.any (· == e.child)
+      | none => false
+    (s!"cdt edges→childMap: parent={reprStr e.parent} child={reprStr e.child}", ok)
+  forwardChecks ++ backwardChecks
+
 def stateInvariantChecksFor (objectIds : List SeLe4n.ObjId) (st : SystemState)
     (serviceIds : List ServiceId := []) : List (String × Bool) :=
   let schedulerChecks : List (String × Bool) :=
@@ -228,6 +247,7 @@ def stateInvariantChecksFor (objectIds : List SeLe4n.ObjId) (st : SystemState)
     ++ asidTableConsistencyChecks objectIds st
     ++ untypedWatermarkChecks objectIds st
     ++ notificationWaiterConsistentChecks objectIds st
+    ++ cdtChildMapConsistentCheck st
 
 /--
 Fallback invariant check surface for callers without an explicit object-id inventory.

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -30,7 +30,7 @@ def svcRestart : ServiceId := 104
 def svcRestartBroken : ServiceId := 105
 
 def bootstrapInvariantObjectIds : List SeLe4n.ObjId :=
-  [1, 10, 11, 12, 20, demoEndpoint, demoNotification, demoUntyped, 200]
+  [1, 10, 11, 12, 20, demoEndpoint, demoNotification, demoUntyped]
 
 def bootstrapServiceIds : List ServiceId :=
   [svcDb, svcApi, svcDenied, svcBroken, svcRestart, svcRestartBroken]

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -887,7 +887,90 @@ private def runNegativeChecks : IO Unit := do
 
   IO.println "WS-F2 untyped memory negative checks passed"
 
+/-- Audit coverage: endpointReplyRecv and cspaceMutate tests.
+    Split into a separate function to avoid maxRecDepth limits in the main do block. -/
+private def runAuditCoverageChecks : IO Unit := do
+  -- ── Audit: endpointReplyRecv coverage ────────────────────────────────
+  -- NEG-REPLYRECV-01: replyRecv with non-existent reply target
+  expectError "endpointReplyRecv non-existent reply target"
+    (SeLe4n.Kernel.endpointReplyRecv endpointId (SeLe4n.ThreadId.ofNat 6) (SeLe4n.ThreadId.ofNat 999)
+      .empty baseState)
+    .objectNotFound
+
+  -- NEG-REPLYRECV-02: replyRecv when reply target is not in blockedOnReply state
+  expectError "endpointReplyRecv target not blocked on reply"
+    (SeLe4n.Kernel.endpointReplyRecv endpointId (SeLe4n.ThreadId.ofNat 6) (SeLe4n.ThreadId.ofNat 7)
+      .empty baseState)
+    .replyCapInvalid
+
+  -- POS-REPLYRECV: Set up a valid blockedOnReply scenario via endpointCall, then replyRecv
+  -- First, enqueue receiver in the dual-queue receiveQ (not legacy waitingReceiver)
+  let (_, stCallSetup1) ← expectOkState "replyRecv setup: receiver blocks on receive"
+    (SeLe4n.Kernel.endpointReceiveDual endpointId (SeLe4n.ThreadId.ofNat 8) baseState)
+  -- Caller calls endpoint (handshakes with queued receiver, caller blocks for reply)
+  let (_, stCallSetup2) ← expectOkState "replyRecv setup: caller calls endpoint"
+    (SeLe4n.Kernel.endpointCall endpointId (SeLe4n.ThreadId.ofNat 7) .empty stCallSetup1)
+  -- Verify caller is now blocked on reply
+  match (stCallSetup2.objects[(SeLe4n.ThreadId.ofNat 7).toObjId]? : Option KernelObject) with
+  | some (KernelObject.tcb callerTcb) =>
+      if callerTcb.ipcState = .blockedOnReply endpointId then
+        IO.println "positive check passed [replyRecv setup: caller blockedOnReply]"
+      else
+        throw <| IO.userError s!"replyRecv setup: expected caller blockedOnReply, got {reprStr callerTcb.ipcState}"
+  | _ => throw <| IO.userError "replyRecv setup: expected caller TCB"
+  -- Now execute replyRecv: receiver replies to caller and waits on endpoint
+  let (_, stReplyRecv) ← expectOkState "replyRecv success"
+    (SeLe4n.Kernel.endpointReplyRecv endpointId (SeLe4n.ThreadId.ofNat 8) (SeLe4n.ThreadId.ofNat 7)
+      .empty stCallSetup2)
+  -- Verify caller is unblocked (ready)
+  match (stReplyRecv.objects[(SeLe4n.ThreadId.ofNat 7).toObjId]? : Option KernelObject) with
+  | some (KernelObject.tcb unblocked) =>
+      if unblocked.ipcState = .ready then
+        IO.println "positive check passed [replyRecv: caller unblocked after reply]"
+      else
+        throw <| IO.userError s!"replyRecv: expected caller ready, got {reprStr unblocked.ipcState}"
+  | _ => throw <| IO.userError "replyRecv: expected caller TCB after reply"
+  IO.println "endpointReplyRecv coverage checks passed"
+
+  -- ── Audit: cspaceMutate coverage ─────────────────────────────────────
+  -- NEG-MUTATE-01: mutate on non-existent CNode
+  expectError "cspaceMutate non-existent CNode"
+    (SeLe4n.Kernel.cspaceMutate { cnode := 999, slot := 0 } [.read] none baseState)
+    .objectNotFound
+
+  -- NEG-MUTATE-02: mutate with rights not a subset (escalation attempt)
+  expectError "cspaceMutate rights escalation denied"
+    (SeLe4n.Kernel.cspaceMutate slot0 [.read, .write, .grant] none baseState)
+    .invalidCapability
+
+  -- POS-MUTATE: attenuate rights successfully
+  let (_, stMutated) ← expectOkState "cspaceMutate attenuate to read-only"
+    (SeLe4n.Kernel.cspaceMutate slot0 [.read] none baseState)
+  -- Verify rights were attenuated
+  match SeLe4n.Kernel.cspaceLookupSlot slot0 stMutated with
+  | .ok (cap, _) =>
+      if cap.rights = [.read] then
+        IO.println "positive check passed [cspaceMutate: rights attenuated to read-only]"
+      else
+        throw <| IO.userError s!"cspaceMutate: expected [read], got {reprStr cap.rights}"
+  | .error err =>
+      throw <| IO.userError s!"cspaceMutate: lookup after mutate failed: {reprStr err}"
+
+  -- POS-MUTATE-BADGE: mutate with badge override
+  let (_, stBadgeMutate) ← expectOkState "cspaceMutate with badge override"
+    (SeLe4n.Kernel.cspaceMutate slot0 [.read] (some (SeLe4n.Badge.ofNat 77)) baseState)
+  match SeLe4n.Kernel.cspaceLookupSlot slot0 stBadgeMutate with
+  | .ok (cap, _) =>
+      if cap.badge = some 77 then
+        IO.println "positive check passed [cspaceMutate: badge override applied]"
+      else
+        throw <| IO.userError s!"cspaceMutate: expected badge 77, got {reprStr cap.badge}"
+  | .error err =>
+      throw <| IO.userError s!"cspaceMutate: lookup after badge mutate failed: {reprStr err}"
+  IO.println "cspaceMutate coverage checks passed"
+
 end SeLe4n.Testing
 
-def main : IO Unit :=
+def main : IO Unit := do
   SeLe4n.Testing.runNegativeChecks
+  SeLe4n.Testing.runAuditCoverageChecks


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: Comprehensive Audit 2026
- Recommendation IDs closed: Audit coverage gaps for endpointReplyRecv, cspaceMutate, CDT childMap consistency, and Machine configuration validation
- Scope notes: Adds test coverage for kernel IPC and capability space operations, runtime invariant checks for CDT consistency, stricter machine config validation, and refactors scheduler code for clarity.

## Changes

### Test Coverage (NegativeStateSuite.lean)
- **New function `runAuditCoverageChecks`**: Extracted into separate function to avoid maxRecDepth limits in main do block
  - **endpointReplyRecv coverage**: NEG-REPLYRECV-01 (non-existent reply target), NEG-REPLYRECV-02 (target not blocked on reply), POS-REPLYRECV (valid reply scenario via endpointCall → endpointReplyRecv → unblock)
  - **cspaceMutate coverage**: NEG-MUTATE-01 (non-existent CNode), NEG-MUTATE-02 (rights escalation denial), POS-MUTATE (rights attenuation), POS-MUTATE-BADGE (badge override)
- Updated `main` to call both `runNegativeChecks` and `runAuditCoverageChecks`

### Invariant Checks (InvariantChecks.lean)
- **New function `cdtChildMapConsistentCheck`**: Runtime audit of CDT (Capability Derivation Tree) consistency
  - Verifies bidirectional consistency: every `childMap` entry has corresponding edge, and every edge has corresponding `childMap` entry
  - Integrated into `stateInvariantChecksFor`

### Machine Configuration (Machine.lean)
- **New helper `isPowerOfTwo`**: Validates that a natural number is a positive power of two using bitwise characterization (`n > 0 ∧ n &&& (n - 1) == 0`)
- **Stricter `wellFormed` validation**: Changed `cfg.pageSize > 0` to `isPowerOfTwo cfg.pageSize` to enforce architectural requirement that page sizes must be powers of two

### Scheduler Refactoring (Scheduler/Operations.lean)
- **Removed `filterByDomain` function**: Unused helper that filtered runnable threads by domain
- **Enhanced `schedule` documentation**: Added performance note explaining O(n) membership check in runnable list and deferred O(1) HashSet alternative to future workstream (requires ~15 preservation theorem updates)

### Test Data (MainTraceHarness.lean)
- **Removed object ID 200** from `bootstrapInvariantObjectIds`: Cleanup of test fixture to match actual bootstrap state

## Validation evidence

- Existing test suite passes with new audit coverage checks
- New invariant check integrates with existing state validation framework
- Machine config validation strengthened without breaking existing configurations
- Scheduler documentation clarifies performance trade-offs for future optimization

## Documentation synchronization checklist

- [ ] Canonical source docs updated (if applicable)
- [ ] GitBook mirrors synchronized (if applicable)
- [ ] Generated navigation files refreshed (if applicable)
- [ ] Markdown-link automation passed (if applicable)
- [ ] Active slice/workstream status synchronized (if applicable)

## Risks / follow-ups

- Residual risks: None identified
- Deferred items + owning workstream:
  - O(1) scheduler membership check optimization deferred to future workstream (requires ~15 preservation theorem proofs)
  - Reverse invariant `flat_wf_rev` for RunQueue HashSet backing deferred to same workstream

https://claude.ai/code/session_01U7nRuWQbg744rgjbv8fnxq