### PR TITLE
WS-H6: add RunQueue reverse membership invariant bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,15 @@ See [Path to Real Hardware](docs/gitbook/10-path-to-real-hardware-mobile-first.m
 | **WS-H3** | v0.12.17 | Build/CI infrastructure fixes: `run_check` return value fix (H-12), docs sync CI integration (M-19), Tier 3 `rg` guard (M-20) | H3 |
 | **WS-H2** | v0.12.16 | Lifecycle safety guards: childId collision/self-overwrite guards, TCB scheduler cleanup, CNode CDT detach, atomic retype | H2 |
 | **WS-H1** | v0.12.16 | IPC call-path semantic fix: `blockedOnCall` state, reply-target scoping, 5-conjunct `ipcSchedulerContractPredicates` | H1 |
+
 | **WS-G** | v0.12.6–v0.12.15 | Kernel performance: all hot paths migrated to O(1) hash-based structures, 14 audit findings resolved | G1–G9 + refinement |
 | **WS-F1..F4** | v0.12.2–v0.12.5 | Critical audit remediation: IPC message transfer (14 theorems), untyped memory (watermark tracking), info-flow completeness (15 NI theorems), proof gap closure | F1–F4 |
 | **WS-E** | v0.11.0–v0.11.6 | Test/CI hardening, proof quality, kernel hardening, capability/IPC, info-flow enforcement, completeness | E1–E6 |
 | **WS-D** | v0.11.0 | Test validity, info-flow enforcement, proof gaps, kernel design | D1–D4 |
 | **WS-C** | v0.9.32 | Model structure, documentation, maintainability | C1–C8 |
 | **WS-B** | v0.9.0 | Comprehensive audit (2026-02) | B1–B11 |
+
+**WS-H6 progress note (v0.12.20-dev):** `RunQueue` now carries bidirectional structural consistency (`flat_wf` and `flat_wf_rev`), with theorem `membership_implies_flat` closing the M-04 reverse bridge (`tid ∈ membership → tid ∈ flat`).
 
 Prior audits (v0.8.0–v0.9.32), milestone closeouts, and legacy GitBook chapters
 are archived in [`docs/dev_history/`](docs/dev_history/README.md).

--- a/SeLe4n/Kernel/Scheduler/RunQueue.lean
+++ b/SeLe4n/Kernel/Scheduler/RunQueue.lean
@@ -11,6 +11,10 @@ structure RunQueue where
   /-- WS-G4: Structural invariant — every flat-list entry is in the HashSet.
       Needed to bridge `∈ rq.flat` (flat list) and `∈ rq` (HashSet) in proofs. -/
   flat_wf : ∀ tid, tid ∈ flat → membership.contains tid = true
+  /-- WS-H6/M-04: Reverse structural invariant — every HashSet member appears in
+      the flat list. Together with `flat_wf`, this yields full bidirectional
+      consistency between O(1) membership and list-based scheduling scans. -/
+  flat_wf_rev : ∀ tid, membership.contains tid = true → tid ∈ flat
   /- WS-G4: Implicit invariant (maintained structurally by `insert`/`remove` API):
      Every thread in `membership` has a corresponding entry in `threadPriority`,
      and vice versa. This is NOT enforced as a proof obligation in the structure
@@ -23,6 +27,9 @@ namespace RunQueue
   byPriority := {}; membership := {}; threadPriority := {}
   flat := []; size := 0; maxPriority := none
   flat_wf := fun _ h => nomatch h
+  flat_wf_rev := by
+    intro tid h
+    simp [Std.HashSet.contains_empty] at h
 instance : Inhabited RunQueue where default := empty
 instance : EmptyCollection RunQueue where emptyCollection := empty
 instance : Repr RunQueue where reprPrec rq _ := repr rq.flat
@@ -58,7 +65,17 @@ def insert (rq : RunQueue) (tid : ThreadId) (prio : Priority) : RunQueue :=
         rcases hx with h | rfl
         · have := rq.flat_wf x h
           simp [Std.HashSet.contains_insert, this]
-        · simp [Std.HashSet.contains_insert] }
+        · simp [Std.HashSet.contains_insert]
+      flat_wf_rev := by
+        intro x hx
+        have : x ∈ rq.membership ∨ x = tid := by
+          have htmp : tid = x ∨ x ∈ rq.membership := by
+            simpa [Std.HashSet.contains_insert, beq_iff_eq, Bool.or_eq_true] using hx
+          exact htmp.elim (fun h => Or.inr h.symm) Or.inl
+        rcases this with hOld | hEq
+        · exact List.mem_append.mpr (Or.inl (rq.flat_wf_rev x hOld))
+        · subst hEq
+          exact List.mem_append.mpr (Or.inr (List.mem_singleton_self x)) }
 
 def remove (rq : RunQueue) (tid : ThreadId) : RunQueue :=
   let prio := rq.threadPriority[tid]?
@@ -84,7 +101,20 @@ def remove (rq : RunQueue) (tid : ThreadId) : RunQueue :=
       have ⟨hFlat, hNe⟩ := List.mem_filter.mp hx
       have hXNeTid : x ≠ tid := by simpa using hNe
       have hMem := rq.flat_wf x hFlat
-      simp [Std.HashSet.contains_erase, hMem, Ne.symm hXNeTid] }
+      simp [Std.HashSet.contains_erase, hMem, Ne.symm hXNeTid]
+    flat_wf_rev := by
+      intro x hx
+      have hxNe : x ≠ tid := by
+        intro hEq
+        subst hEq
+        simp [Std.HashSet.contains_erase] at hx
+      have hxMem : x ∈ rq.membership := by
+        have hFalse : (x == tid) = false := by simp [hxNe]
+        have htmp : ¬ tid = x ∧ x ∈ rq.membership := by
+          simpa [Std.HashSet.contains_erase, hFalse, Bool.and_eq_true] using hx
+        exact htmp.2
+      have hxFlat : x ∈ rq.flat := rq.flat_wf_rev x hxMem
+      exact List.mem_filter.mpr ⟨hxFlat, by simp [hxNe]⟩ }
 
 def rotateHead (rq : RunQueue) (tid : ThreadId) (prio : Priority) : RunQueue :=
   if hc : rq.contains tid then
@@ -103,7 +133,13 @@ def rotateHead (rq : RunQueue) (tid : ThreadId) (prio : Priority) : RunQueue :=
                     simp only [List.mem_append, List.mem_singleton] at hx
                     rcases hx with h | rfl
                     · exact rq.flat_wf x (List.mem_of_mem_erase h)
-                    · exact hc }
+                    · exact hc
+                  flat_wf_rev := by
+                    intro x hx
+                    have hOld : x ∈ rq.flat := rq.flat_wf_rev x hx
+                    by_cases hEq : x = tid
+                    · subst hEq; exact List.mem_append.mpr (Or.inr (List.mem_singleton_self x))
+                    · exact List.mem_append.mpr (Or.inl ((List.mem_erase_of_ne hEq).2 hOld)) }
             else rq
   else rq
 
@@ -120,7 +156,13 @@ def rotateToBack (rq : RunQueue) (tid : ThreadId) : RunQueue :=
           simp only [List.mem_append, List.mem_singleton] at hx
           rcases hx with h | rfl
           · exact rq.flat_wf x (List.mem_of_mem_erase h)
-          · exact hc }
+          · exact hc
+        flat_wf_rev := by
+          intro x hx
+          have hOld : x ∈ rq.flat := rq.flat_wf_rev x hx
+          by_cases hEq : x = tid
+          · subst hEq; exact List.mem_append.mpr (Or.inr (List.mem_singleton_self x))
+          · exact List.mem_append.mpr (Or.inl ((List.mem_erase_of_ne hEq).2 hOld)) }
   else rq
 
 @[inline] def toList (rq : RunQueue) : List ThreadId := rq.flat
@@ -204,6 +246,11 @@ theorem not_mem_toList_of_not_mem (rq : RunQueue) (tid : ThreadId)
   intro hFlat
   have := rq.flat_wf tid hFlat
   exact h (by rw [mem_iff_contains]; exact this)
+
+/-- WS-H6/M-04: Reverse bridge from O(1) membership to flat-list membership. -/
+theorem membership_implies_flat (rq : RunQueue) (tid : ThreadId)
+    (h : tid ∈ rq) : tid ∈ rq.toList := by
+  exact rq.flat_wf_rev tid (by simpa [mem_iff_contains] using h)
 
 @[simp] theorem toList_empty : (empty : RunQueue).toList = [] := rfl
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,6 +57,7 @@ for the full execution plan.
 - **WS-H3:** completed (v0.12.17). Build/CI infrastructure fixes — `run_check` return value fix (H-12), `test_docs_sync.sh` CI integration (M-19), Tier 3 `rg` availability guard with `grep -P` fallback (M-20). See [`docs/audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md).
 - **WS-H2:** completed (v0.12.16). Lifecycle safety guards — childId collision/self-overwrite guards, TCB scheduler cleanup on retype, CNode CDT detach, atomic retype. See [`docs/audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md).
 - **WS-H1:** completed (v0.12.16). IPC call-path semantic fix — `blockedOnCall` variant, reply-target scoping, 5-conjunct `ipcSchedulerContractPredicates`. See [`docs/audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md).
+- **WS-H6:** in progress (v0.12.20-dev). Scheduler proof completion slice landed for M-04: `RunQueue.flat_wf_rev` and theorem `membership_implies_flat` establish bidirectional membership↔flat consistency for O(1) membership migration proofs.
 - **WS-G1..G9:** all completed (v0.12.6–v0.12.15). See [`docs/audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md`](audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md).
 - **WS-F1..F4:** completed. See [`docs/audits/AUDIT_v0.12.2_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.12.2_WORKSTREAM_PLAN.md).
 - **WS-E1..E6:** all completed (historical archive).

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -22,7 +22,7 @@ Component level:
 
 Data structure:
 
-- `RunQueue` (`Scheduler/RunQueue.lean`, WS-G4) — priority-bucketed run queue with `flat_wf` structural invariant bridging `Std.HashSet` membership and `flat : List ThreadId`. `chooseBestInBucket` bucket-first scheduling: O(k) max-priority bucket scan with full-list fallback. `remove` computes filtered bucket once for both `byPriority` and `maxPriority` (v0.12.15 refinement). Implicit `membership` ↔ `threadPriority` consistency maintained by insert/remove API (runtime-verified by `runQueueThreadPriorityConsistentB`).
+- `RunQueue` (`Scheduler/RunQueue.lean`, WS-G4/WS-H6) — priority-bucketed run queue with bidirectional structural invariants `flat_wf` and `flat_wf_rev`, plus theorem `membership_implies_flat` to bridge O(1) `Std.HashSet` membership back to `flat : List ThreadId`. `chooseBestInBucket` bucket-first scheduling: O(k) max-priority bucket scan with full-list fallback. `remove` computes filtered bucket once for both `byPriority` and `maxPriority` (v0.12.15 refinement). Implicit `membership` ↔ `threadPriority` consistency maintained by insert/remove API (runtime-verified by `runQueueThreadPriorityConsistentB`).
 - 13 bridge lemmas: `mem_insert`, `mem_remove`, `mem_rotateHead`, `mem_rotateToBack`, `not_mem_empty`, `toList_insert_not_mem`, `toList_filter_insert_neg`, `toList_filter_remove_neg`, `not_mem_toList_of_not_mem`, `not_mem_remove_toList`, `mem_toList_rotateToBack_self`, `toList_rotateToBack_nodup`, `mem_toList_rotateToBack_ne`.
 
 Bundle level:

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -148,7 +148,7 @@ Authoritative detail:
 
 ### 5.2 Completed — Scheduler Optimization
 
-- **WS-G4:** ~~Run queue restructure~~ **COMPLETED** — `RunQueue` structure with `Std.HashMap Priority (List ThreadId)` + `Std.HashSet ThreadId` + `flat_wf` structural invariant; `SchedulerState.runQueue` replaces flat `runnable : List ThreadId`; O(1) `insert`/`remove`/`contains`/`rotateHead`/`rotateToBack`; `chooseBestInBucket` bucket-first scheduling reduces best-candidate selection from O(t) to O(k); `withRunnableQueue`/`runnableHead`/`runnableTail` eliminated; 13 bridge lemmas; 30+ IPC invariant proofs migrated; info-flow projection re-proved; closes F-P02, F-P07, F-P12 (v0.12.9)
+- **WS-G4:** ~~Run queue restructure~~ **COMPLETED** — `RunQueue` structure with `Std.HashMap Priority (List ThreadId)` + `Std.HashSet ThreadId` + bidirectional structural invariants (`flat_wf`, `flat_wf_rev`); `SchedulerState.runQueue` replaces flat `runnable : List ThreadId`; O(1) `insert`/`remove`/`contains`/`rotateHead`/`rotateToBack`; `chooseBestInBucket` bucket-first scheduling reduces best-candidate selection from O(t) to O(k); `withRunnableQueue`/`runnableHead`/`runnableTail` eliminated; bridge theorem `membership_implies_flat` closes the reverse consistency direction; 30+ IPC invariant proofs migrated; info-flow projection re-proved; closes F-P02, F-P07, F-P12 (v0.12.9, reverse bridge refined in WS-H6).
 
 ### 5.3 Completed — CNode Optimization
 


### PR DESCRIPTION
### Motivation
- Close the M-04 reverse-direction gap for RunQueue structural consistency so O(1) membership checks can be bridged back to the list-based scan surface used in many scheduler proofs. 
- Provide the minimal WS-H6 slice needed by higher-level scheduler proofs (membership→flat) without changing scheduling semantics or introducing proof escapes.

### Description
- Add `flat_wf_rev : ∀ tid, membership.contains tid = true → tid ∈ flat` to `RunQueue` and maintain it in `empty`, `insert`, `remove`, `rotateHead`, and `rotateToBack` in `SeLe4n/Kernel/Scheduler/RunQueue.lean`.
- Add the bridge theorem `membership_implies_flat` (exposes `flat_wf_rev` as `tid ∈ rq → tid ∈ rq.toList`).
- Update list- and docs-mirroring files to record the WS-H6 progress: `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, and `docs/gitbook/12-proof-and-invariant-map.md`.

### Testing
- Ran `lake build` which completed successfully (no new errors or `sorry`).
- Ran `./scripts/test_fast.sh` which passed locally (hygiene + build checks passed).
- Ran `./scripts/test_smoke.sh` which passed locally (trace/fixture check passed).
- An invocation of the Tier-2 negative suite (`negative_state_suite`) timed out once in this interactive environment during an extended run; core build and fast/smoke tiers passed and CI / full test runners should be used to validate the full Tier-2/Tier-3 runs end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88d51fbb0832baedbc1e7fd9d7ea1)