### PR TITLE
WS-H7 Part A: Make HashMap BEq order-independent for VSpaceRoot and CNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ See [Path to Real Hardware](docs/gitbook/10-path-to-real-hardware-mobile-first.m
 | Portfolio | Version | Scope | Workstreams |
 |-----------|---------|-------|-------------|
 | **WS-H6** | v0.12.20 | Scheduler proof-surface completion: reverse RunQueue invariant `flat_wf_rev`, bridge lemmas `membership_implies_flat`/`mem_toList_iff_mem`, candidate-order theorem `isBetterCandidate_transitive`, and `bucketFirst_fullScan_equivalence`; scheduler membership validation now uses O(1) runQueue membership | H6 |
+| **WS-H7 (Part A)** | v0.12.21 | HashMap equality hardening: `BEq VSpaceRoot` and `BEq CNode` now use size + fold-based containment checks (order-independent) instead of `toList` iteration order | H7-A07 |
 | **WS-H5** | v0.12.19 | IPC dual-queue structural invariant: `intrusiveQueueWellFormed`, `dualQueueSystemInvariant`, `tcbQueueLinkIntegrity`; 13 preservation theorems for all dual-queue operations. Closes C-04/A-22 (CRITICAL), A-23 (HIGH), A-24 (HIGH) | H5 |
 | **WS-H4** | v0.12.18 | Capability invariant redesign: `capabilityInvariantBundle` 7-tuple with `cspaceSlotCountBounded`, `cdtCompleteness`, `cdtAcyclicity` | H4 |
 | **WS-H3** | v0.12.17 | Build/CI infrastructure fixes: `run_check` return value fix (H-12), docs sync CI integration (M-19), Tier 3 `rg` guard (M-20) | H3 |

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -628,7 +628,7 @@ instance : BEq VSpaceRoot where
   beq a b :=
     a.asid == b.asid &&
     a.mappings.size == b.mappings.size &&
-    a.mappings.toList.all (fun (k, v) => b.mappings[k]? == some v)
+    a.mappings.fold (init := true) (fun acc k v => acc && (b.mappings[k]? == some v))
 
 namespace CNode
 
@@ -843,7 +843,7 @@ instance : BEq CNode where
   beq a b :=
     a.guard == b.guard && a.radix == b.radix &&
     a.slots.size == b.slots.size &&
-    a.slots.toList.all (fun (k, v) => b.slots[k]? == some v)
+    a.slots.fold (init := true) (fun acc k v => acc && (b.slots[k]? == some v))
 
 -- ============================================================================
 -- WS-E4/C-03: Capability Derivation Tree (CDT) model

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -176,3 +176,4 @@ A change is done when all are true:
 - [ ] Invariant/theorem updates are paired with implementation changes.
 - [ ] Required validation commands were run.
 - [ ] Documentation was synchronized.
+- [ ] For WS-H7/A-07 updates, verify `BEq VSpaceRoot` and `BEq CNode` avoid `HashMap.toList` order dependence (use size + fold checks).

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -241,7 +241,7 @@ VSpace invariant bundle preservation is now proven for both success and error pa
 
 Data structure (WS-G6 / F-P05):
 
-- `VSpaceRoot.mappings : Std.HashMap VAddr PAddr` — O(1) amortized lookup/insert/erase replacing O(m) list scan. HashMap key uniqueness makes `noVirtualOverlap` trivially true via the universal `noVirtualOverlap_trivial` theorem (subsumes `noVirtualOverlap_empty`, `mapPage_noVirtualOverlap`, `unmapPage_noVirtualOverlap`). `BEq VSpaceRoot` instance for entry-wise comparison. `hashMapVSpaceBackend` replaces `listVSpaceBackend`.
+- `VSpaceRoot.mappings : Std.HashMap VAddr PAddr` — O(1) amortized lookup/insert/erase replacing O(m) list scan. HashMap key uniqueness makes `noVirtualOverlap` trivially true via the universal `noVirtualOverlap_trivial` theorem (subsumes `noVirtualOverlap_empty`, `mapPage_noVirtualOverlap`, `unmapPage_noVirtualOverlap`). `BEq VSpaceRoot` instance uses size + fold containment (order-independent HashMap equality). `hashMapVSpaceBackend` replaces `listVSpaceBackend`.
 
 VSpace invariant bundle structure (3-conjunct, WS-G3):
 - `vspaceAsidRootsUnique` — no two VSpaceRoot objects share the same ASID

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -298,6 +298,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 6. fixture-backed executable evidence (`Main.lean` + trace fixture),
 7. tiered validation command behavior (`test_fast`/`smoke`/`full`/`nightly`),
 8. top-level import hygiene: `SeLe4n/Kernel/API.lean` is the canonical aggregate API surface.
+9. HashMap-backed equality for `VSpaceRoot` and `CNode` is order-independent (size + fold containment), preventing false inequality from bucket iteration order.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Close audit finding A-07 by removing `BEq` dependence on `Std.HashMap.toList` iteration order so semantically-equal HashMaps cannot compare unequal.
- Prevent brittle proof/logic failures downstream that rely on stable semantic equality for `VSpaceRoot` and `CNode` values.

### Description
- Replace order-dependent comparisons `a.mappings.toList.all ...` / `a.slots.toList.all ...` with size checks plus `Std.HashMap.fold` containment checks in the `BEq` instances for `VSpaceRoot` and `CNode` (i.e., `size` + forward containment via `fold`).
- Update project documentation to reflect the equality hardening in `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/12-proof-and-invariant-map.md`.
- Kept the equality change local to `SeLe4n/Model/Object.lean` and did not alter observable runtime semantics; documentation explains the rationale and verification guidance.

### Testing
- Built the project with the provided environment setup and build pipeline via `./scripts/setup_lean_env.sh --build` / `lake build`, which completed successfully.
- Ran the lightweight validation suites: `./scripts/test_fast.sh` and `./scripts/test_smoke.sh`, both of which passed without introducing `sorry`/`axiom` or build failures.
- Verified that the Lean files typecheck and that the changed `BEq` definitions compile as part of the full `lake build` run that completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8adb1910c832b84da5d714c75889b)