### PR TITLE
Avoid CI hang: run Tier 2 negative suites with `lean --run`

### DIFF
--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -3,12 +3,12 @@
   "repository": {
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
-    "branch": "main",
-    "commit_sha": "f71afd3415fd3fcb7244c320c8e5d1ee7bfd0973",
-    "tree_sha": "964c78e0241f9043f2b14b695e67d1e30e3f3056",
-    "cache_key": "f71afd3415fd3fcb7244c320c8e5d1ee7bfd0973:964c78e0241f9043f2b14b695e67d1e30e3f3056"
+    "branch": "work",
+    "commit_sha": "8dcbe67f41576a7b8f39c43b1ff31207f9a60f16",
+    "tree_sha": "2287b43d1833d212af0a4ed83e7ed1a06fed6a38",
+    "cache_key": "8dcbe67f41576a7b8f39c43b1ff31207f9a60f16:2287b43d1833d212af0a4ed83e7ed1a06fed6a38"
   },
-  "committed_at_utc": "2026-03-04T20:21:02-05:00",
+  "committed_at_utc": "2026-03-05T01:21:10+00:00",
   "summary": {
     "module_count": 43,
     "declaration_count": 1363

--- a/scripts/test_tier2_negative.sh
+++ b/scripts/test_tier2_negative.sh
@@ -10,7 +10,9 @@ cd "${REPO_ROOT}"
 
 ensure_lake_available
 
-run_check "TRACE" lake exe negative_state_suite
-run_check "TRACE" lake exe information_flow_suite
+# Run suites through the Lean interpreter to avoid pathological C compilation
+# times for very large test modules (notably NegativeStateSuite).
+run_check "TRACE" lake env lean --run tests/NegativeStateSuite.lean
+run_check "TRACE" lake env lean --run tests/InformationFlowSuite.lean
 
 finalize_report


### PR DESCRIPTION
### Motivation
- Tier 2 negative checks were intermittently hanging during `lake exe negative_state_suite` due to pathological native C compilation times for the very large `NegativeStateSuite` module, causing CI instability and timeouts.
- The goal is to restore deterministic CI/test execution by avoiding the expensive native compilation stage while preserving test semantics.

### Description
- Updated `scripts/test_tier2_negative.sh` to run the negative suites via the Lean interpreter using `lake env lean --run tests/NegativeStateSuite.lean` and `lake env lean --run tests/InformationFlowSuite.lean` with a short comment explaining the reason for the change.
- Regenerated `docs/codebase_map.json` so the docs-sync check remains consistent with the repository snapshot.
- Kept the change scoped to test execution and generated docs; no kernel transitions, theorems, or invariant surfaces were modified.

### Testing
- Ran `source ~/.elan/env && ./scripts/test_smoke.sh` and verified the smoke suite completed successfully with the tier 2 negative checks passing.
- Executed `source ~/.elan/env && timeout 180 lake env lean --run tests/NegativeStateSuite.lean` and `... tests/InformationFlowSuite.lean`, both of which ran and passed under the interpreter.
- Ran `./scripts/generate_codebase_map.py --pretty --output docs/codebase_map.json` and the subsequent docs-sync validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a900324628832b99e3f4cbccbc69f6)