### PR TITLE
Fix invariant-surface CI anchors for interpreter-based negative-suite runner

### DIFF
--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -98,7 +98,7 @@ run_check "INVARIANT" rg -n '^def projectState' SeLe4n/Kernel/InformationFlow/Pr
 run_check "INVARIANT" rg -n '^def lowEquivalent' SeLe4n/Kernel/InformationFlow/Projection.lean
 run_check "INVARIANT" rg -n '^theorem lowEquivalent_trans' SeLe4n/Kernel/InformationFlow/Projection.lean
 run_check "INVARIANT" rg -n '^private def runInformationFlowChecks' tests/InformationFlowSuite.lean
-run_check "INVARIANT" rg -n '^run_check "TRACE" lake exe information_flow_suite' scripts/test_tier2_negative.sh
+run_check "INVARIANT" rg -n '^run_check "TRACE" lake env lean --run tests/InformationFlowSuite\.lean' scripts/test_tier2_negative.sh
 run_check "INVARIANT" rg -n '^ELAN_INSTALLER_SHA256=' scripts/setup_lean_env.sh
 run_check "INVARIANT" rg -n '^compute_sha256\(\)' scripts/setup_lean_env.sh
 # shellcheck disable=SC2016
@@ -107,7 +107,7 @@ run_check "INVARIANT" rg -n '^compute_sha256\(\)' scripts/setup_lean_env.sh
 run_check "INVARIANT" rg -n '^structure BootstrapBuilder' SeLe4n/Testing/StateBuilder.lean
 run_check "INVARIANT" rg -n '^def build \(builder : BootstrapBuilder\)' SeLe4n/Testing/StateBuilder.lean
 run_check "INVARIANT" rg -n '^private def runNegativeChecks' tests/NegativeStateSuite.lean
-run_check "INVARIANT" rg -n '^run_check "TRACE" lake exe negative_state_suite' scripts/test_tier2_negative.sh
+run_check "INVARIANT" rg -n '^run_check "TRACE" lake env lean --run tests/NegativeStateSuite\.lean' scripts/test_tier2_negative.sh
 run_check "INVARIANT" rg -n 'trace_sequence_probe_manifest\.csv' scripts/test_tier4_nightly_candidates.sh
 run_check "INVARIANT" rg -n '^def runMainTrace' SeLe4n/Testing/MainTraceHarness.lean
 run_check "INVARIANT" rg -n '^def bootstrapState' SeLe4n/Testing/MainTraceHarness.lean


### PR DESCRIPTION
### Motivation
- The Tier 3 invariant-surface checks asserted `lake exe ...` anchors while the Tier 2 negative suites now run under the interpreter with `lake env lean --run ...`, causing a spurious Tier 3 CI failure. 

### Description
- Updated `scripts/test_tier3_invariant_surface.sh` to replace the stale anchor patterns with the interpreter-based commands, specifically changing the Information Flow and Negative State suite anchors to `^run_check "TRACE" lake env lean --run tests/InformationFlowSuite\.lean` and `^run_check "TRACE" lake env lean --run tests/NegativeStateSuite\.lean` respectively. 

### Testing
- Ran the repository validation and CI gates including `./scripts/test_smoke.sh`, `./scripts/test_tier3_invariant_surface.sh`, and `./scripts/test_full.sh`, and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0a9a4584832bae1a94fe832aeffe)