### PR TITLE
ci: harden ARM64 cache restore reliability

### DIFF
--- a/.github/workflows/platform_security_baseline.yml
+++ b/.github/workflows/platform_security_baseline.yml
@@ -29,14 +29,17 @@ jobs:
 
       - name: Restore Lean and Lake caches
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        env:
+          # ARM runners frequently time out while restoring very large .lake/build archives.
+          # Extend per-segment timeout to reduce transient "The operation was canceled" cache failures.
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: '30'
         with:
           path: |
             ~/.elan
             .lake/packages
-            .lake/build
-          key: ${{ runner.os }}-${{ runner.arch }}-lean-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml', 'scripts/setup_lean_env.sh') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-lean-nobuild-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml', 'scripts/setup_lean_env.sh') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-lean-
+            ${{ runner.os }}-${{ runner.arch }}-lean-nobuild-
 
       - name: Setup Lean toolchain
         run: ./scripts/setup_lean_env.sh


### PR DESCRIPTION
### Motivation
- ARM64 fast-gate CI runs were intermittently failing during cache restore with `Error: The operation was canceled.` because very large `.lake/build` archives were timing out or aborting on ARM runners.

### Description
- Adjusted the `architecture-arm64-fast` job in `/.github/workflows/platform_security_baseline.yml` to stop restoring `.lake/build` from the cache, added `SEGMENT_DOWNLOAD_TIMEOUT_MINS: '30'` to the cache step to reduce transient per-segment cancellations, and rotated the ARM cache key namespace to `lean-nobuild-*` to avoid reusing legacy oversized archives.

### Testing
- Ran `./scripts/test_smoke.sh` locally which exercises hygiene, build, tier-2 trace and negative-state checks and docs sync, and the entire smoke suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0dfdd4b4832b8b11781ec49e9a39)