### PR TITLE
WS-H6: Complete EDF scheduler proof with RunQueue well-formedness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## [0.13.3] - 2026-03-07
+
+### WS-H6: EDF Scheduler Proof Completion
+
+- **EDF bridge theorem completed (A-14/H-06 CRITICAL):** `chooseBestInBucket_edf_bridge` —
+  proves that `chooseBestInBucket` result is EDF-optimal among all domain-eligible
+  runnable threads at the same priority level. Handles both bucket-success and
+  full-scan-fallback paths using RunQueue well-formedness and priority-match
+  external predicates.
+- **RunQueue well-formedness predicate (H-06):** `RunQueue.wellFormed` — external
+  predicate capturing the implicit invariant maintained by insert/remove/rotate
+  API: forward (bucket→membership+threadPriority) and reverse
+  (membership→bucket) consistency.
+- **RunQueue well-formedness lemmas (H-06):** `maxPriorityBucket_subset`,
+  `maxPriorityBucket_threadPriority`, `mem_maxPriorityBucket_of_threadPriority`
+  — bridge lemmas connecting well-formedness to bucket-first EDF scheduling.
+- **Rotation preserves well-formedness (H-06):** `rotateToBack_preserves_wellFormed`
+  and 6 field-preservation lemmas (`rotateToBack_membership`,
+  `rotateToBack_threadPriority`, `rotateToBack_maxPriority`,
+  `rotateToBack_contains`, `rotateToBack_mem_iff`,
+  `rotateToBack_flat_subset`, `rotateToBack_flat_superset`) — proves that
+  `rotateToBack` preserves `wellFormed` and all RunQueue structural fields.
+- **External priority-match predicate (H-06):** `schedulerPriorityMatch` —
+  bridges RunQueue's internal `threadPriority` to authoritative TCB priority
+  in the object store.
+- **Full EDF preservation chain (H-06):**
+  `schedule_preserves_edfCurrentHasEarliestDeadline`,
+  `handleYield_preserves_edfCurrentHasEarliestDeadline`,
+  `timerTick_preserves_edfCurrentHasEarliestDeadline` — all sorry-free.
+- **Full bundle composition (H-06):**
+  `schedule_preserves_schedulerInvariantBundleFull`,
+  `handleYield_preserves_schedulerInvariantBundleFull`,
+  `timerTick_preserves_schedulerInvariantBundleFull`.
+- **Fold result membership lemma (H-06):**
+  `chooseBestRunnableBy_result_mem_aux` and `chooseBestRunnableBy_result_mem` —
+  proves that `chooseBestRunnableBy` result is drawn from the scanned list.
+- **Zero sorry/axiom.** `test_full.sh` passes (Tier 0-3).
+
 ## [0.13.2] - 2026-03-07
 
 ### WS-H8: Enforcement-NI Bridge & Missing Wrappers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 seLe4n is a production-oriented microkernel written in Lean 4 with machine-checked
 proofs, improving on seL4 architecture. Every kernel transition is an executable
 pure function with zero `sorry`/`axiom`. First hardware target: Raspberry Pi 5.
-Lean 4.28.0 toolchain, Lake build system, version 0.13.2.
+Lean 4.28.0 toolchain, Lake build system, version 0.13.3.
 
 ## Build and run
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ introducing substantial architectural improvements:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.13.2` |
+| **Version** | `0.13.3` |
 | **Lean toolchain** | `4.28.0` |
-| **Production Lean LoC** | 26,861 across 40 files |
+| **Production Lean LoC** | 27,580 across 40 files |
 | **Test Lean LoC** | 2,063 across 3 test suites |
-| **Proved declarations** | 779 theorem/lemma declarations (zero sorry/axiom) |
+| **Proved declarations** | 800 theorem/lemma declarations (zero sorry/axiom) |
 | **Build jobs** | 84 |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Active findings** | [`AUDIT_CODEBASE_v0.12.2_v1.md`](docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](docs/audits/AUDIT_CODEBASE_v0.12.2_v2.md) |

--- a/SeLe4n/Kernel/Scheduler/Invariant.lean
+++ b/SeLe4n/Kernel/Scheduler/Invariant.lean
@@ -157,4 +157,23 @@ theorem schedulerInvariantBundleFull_to_base {st : SystemState}
     (h : schedulerInvariantBundleFull st) : schedulerInvariantBundle st :=
   h.1
 
+-- ============================================================================
+-- WS-H6: RunQueue priority-match predicate
+-- ============================================================================
+
+/-- WS-H6: The RunQueue's recorded `threadPriority` mapping matches the actual
+TCB priority for every run-queue member.
+
+This is an external-consistency predicate bridging the RunQueue's internal
+`threadPriority` field to the authoritative TCB priority in the object store.
+Together with `RunQueue.wellFormed`, it enables the bucket-first scheduling
+proof: if a thread has the same priority as the selected candidate, it must
+reside in the same priority bucket. -/
+def schedulerPriorityMatch (st : SystemState) : Prop :=
+  ∀ tid, tid ∈ st.scheduler.runQueue →
+    match st.objects[tid.toObjId]? with
+    | some (.tcb tcb) =>
+        st.scheduler.runQueue.threadPriority[tid]? = some tcb.priority
+    | _ => True
+
 end SeLe4n.Kernel

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -1328,4 +1328,548 @@ theorem switchDomain_preserves_schedulerInvariantBundleFull
          switchDomain_preserves_timeSlicePositive st st' hTS hStep,
          switchDomain_preserves_edfCurrentHasEarliestDeadline st st' hEDF hStep⟩
 
-end SeLe4n.Kernel
+-- ============================================================================
+-- WS-H6 completion: EDF preservation for schedule, handleYield, timerTick
+-- ============================================================================
+
+/-- WS-H6: `setCurrentThread (some tid)` preserves EDF when the selected thread
+satisfies the EDF deadline ordering among same-domain/same-priority candidates.
+
+The proof uses the post-condition that `setCurrentThread` only changes
+`scheduler.current`, leaving `objects` and `runnable` unchanged. -/
+theorem setCurrentThread_some_preserves_edfCurrentHasEarliestDeadline
+    (st st' : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (tcbSel : TCB)
+    (hObj : st.objects[tid.toObjId]? = some (.tcb tcbSel))
+    (hEdfLocal : ∀ t, t ∈ st.scheduler.runnable →
+      match st.objects[t.toObjId]? with
+      | some (.tcb tcb) =>
+          tcb.domain = tcbSel.domain →
+          tcb.priority = tcbSel.priority →
+          tcbSel.deadline.toNat = 0 ∨
+            (tcb.deadline.toNat = 0 ∨ tcbSel.deadline.toNat ≤ tcb.deadline.toNat)
+      | _ => True)
+    (hStep : setCurrentThread (some tid) st = .ok ((), st')) :
+    edfCurrentHasEarliestDeadline st' := by
+  unfold setCurrentThread at hStep
+  cases hStep
+  unfold edfCurrentHasEarliestDeadline
+  simp only [hObj]
+  exact hEdfLocal
+
+/-- WS-H6: If `chooseBestRunnableBy` returns `some (resTid, resPrio, resDl)`, then
+`objects resTid.toObjId = some (.tcb tcb)` for some TCB with `tcb.priority = resPrio`
+and `tcb.deadline = resDl`. The result's fields always correspond to the actual TCB. -/
+private theorem chooseBestRunnableBy_result_fields
+    (objects : SeLe4n.ObjId → Option KernelObject)
+    (eligible : TCB → Bool)
+    (runnable : List SeLe4n.ThreadId)
+    (init : Option (SeLe4n.ThreadId × SeLe4n.Priority × SeLe4n.Deadline))
+    (resTid : SeLe4n.ThreadId) (resPrio : SeLe4n.Priority) (resDl : SeLe4n.Deadline)
+    (hOk : chooseBestRunnableBy objects eligible runnable init =
+      .ok (some (resTid, resPrio, resDl)))
+    (hInit : ∀ iTid iPrio iDl, init = some (iTid, iPrio, iDl) →
+      ∃ itcb, objects iTid.toObjId = some (.tcb itcb) ∧
+        itcb.priority = iPrio ∧ itcb.deadline = iDl) :
+    ∃ tcb, objects resTid.toObjId = some (.tcb tcb) ∧
+      tcb.priority = resPrio ∧ tcb.deadline = resDl := by
+  induction runnable generalizing init with
+  | nil =>
+      unfold chooseBestRunnableBy at hOk
+      simp at hOk
+      cases hOk
+      exact hInit resTid resPrio resDl rfl
+  | cons hd tl ih =>
+      unfold chooseBestRunnableBy at hOk
+      cases hHdObj : objects hd.toObjId with
+      | none => simp [hHdObj] at hOk
+      | some obj =>
+          cases obj with
+          | tcb hdTcb =>
+              simp only [hHdObj] at hOk
+              cases hElig : eligible hdTcb with
+              | false =>
+                  simp only [hElig] at hOk
+                  exact ih init hOk hInit
+              | true =>
+                  simp only [hElig, ↓reduceIte] at hOk
+                  cases init with
+                  | none =>
+                      exact ih (some (hd, hdTcb.priority, hdTcb.deadline)) hOk (by
+                        intro iTid iPrio iDl hEq
+                        simp at hEq; obtain ⟨rfl, rfl, rfl⟩ := hEq
+                        exact ⟨hdTcb, hHdObj, rfl, rfl⟩)
+                  | some triple =>
+                      obtain ⟨initTid, initPrio, initDl⟩ := triple
+                      dsimp only at hOk
+                      cases hBeat : isBetterCandidate initPrio initDl hdTcb.priority hdTcb.deadline with
+                      | true =>
+                          simp only [hBeat, ite_true] at hOk
+                          exact ih (some (hd, hdTcb.priority, hdTcb.deadline)) hOk (by
+                            intro iTid iPrio iDl hEq
+                            simp at hEq; obtain ⟨rfl, rfl, rfl⟩ := hEq
+                            exact ⟨hdTcb, hHdObj, rfl, rfl⟩)
+                      | false =>
+                          simp only [hBeat] at hOk
+                          exact ih (some (initTid, initPrio, initDl)) hOk hInit
+          | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ =>
+              simp [hHdObj] at hOk
+
+/-- WS-H6: If `chooseBestRunnableBy` with `init = none` returns a result, the
+result thread is a member of the scanned list.
+
+Proved via induction: the result is either the head of the list (when it becomes
+the first eligible candidate) or comes from the recursive tail scan. -/
+private theorem chooseBestRunnableBy_result_mem_aux
+    (objects : SeLe4n.ObjId → Option KernelObject)
+    (eligible : TCB → Bool)
+    (list : List SeLe4n.ThreadId)
+    (init : Option (SeLe4n.ThreadId × SeLe4n.Priority × SeLe4n.Deadline))
+    (resTid : SeLe4n.ThreadId) (resPrio : SeLe4n.Priority) (resDl : SeLe4n.Deadline)
+    (hOk : chooseBestRunnableBy objects eligible list init =
+      .ok (some (resTid, resPrio, resDl)))
+    (hAllTcb : ∀ t, t ∈ list → ∃ tcb, objects t.toObjId = some (.tcb tcb)) :
+    resTid ∈ list ∨ (∃ ip id, init = some (resTid, ip, id)) := by
+  induction list generalizing init with
+  | nil =>
+    unfold chooseBestRunnableBy at hOk
+    simp at hOk; cases hOk
+    exact Or.inr ⟨resPrio, resDl, rfl⟩
+  | cons hd tl ih =>
+    unfold chooseBestRunnableBy at hOk
+    have hAllTl : ∀ t, t ∈ tl → ∃ tcb, objects t.toObjId = some (.tcb tcb) :=
+      fun t ht => hAllTcb t (List.mem_cons.mpr (Or.inr ht))
+    cases hHdObj : objects hd.toObjId with
+    | none => simp [hHdObj] at hOk
+    | some obj =>
+      cases obj with
+      | tcb hdTcb =>
+        simp only [hHdObj] at hOk
+        cases hElig : eligible hdTcb with
+        | false =>
+          simp only [hElig] at hOk
+          have := ih init hOk hAllTl
+          exact this.elim (fun h => Or.inl (List.mem_cons.mpr (Or.inr h))) Or.inr
+        | true =>
+          simp only [hElig, ↓reduceIte] at hOk
+          cases init with
+          | none =>
+            have := ih (some (hd, hdTcb.priority, hdTcb.deadline)) hOk hAllTl
+            rcases this with hTl | ⟨ip, id, hInit⟩
+            · exact Or.inl (List.mem_cons.mpr (Or.inr hTl))
+            · simp at hInit; obtain ⟨rfl, _, _⟩ := hInit
+              exact Or.inl (List.mem_cons.mpr (Or.inl rfl))
+          | some triple =>
+            obtain ⟨initTid, initPrio, initDl⟩ := triple
+            dsimp only at hOk
+            cases hBeat : isBetterCandidate initPrio initDl hdTcb.priority hdTcb.deadline with
+            | true =>
+              simp only [hBeat, ite_true] at hOk
+              have := ih (some (hd, hdTcb.priority, hdTcb.deadline)) hOk hAllTl
+              rcases this with hTl | ⟨ip, id, hInit⟩
+              · exact Or.inl (List.mem_cons.mpr (Or.inr hTl))
+              · simp at hInit; obtain ⟨rfl, _, _⟩ := hInit
+                exact Or.inl (List.mem_cons.mpr (Or.inl rfl))
+            | false =>
+              simp only [hBeat] at hOk
+              have := ih (some (initTid, initPrio, initDl)) hOk hAllTl
+              exact this.elim (fun h => Or.inl (List.mem_cons.mpr (Or.inr h))) Or.inr
+      | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ =>
+        simp [hHdObj] at hOk
+
+private theorem chooseBestRunnableBy_result_mem
+    (objects : SeLe4n.ObjId → Option KernelObject)
+    (eligible : TCB → Bool)
+    (list : List SeLe4n.ThreadId)
+    (resTid : SeLe4n.ThreadId) (resPrio : SeLe4n.Priority) (resDl : SeLe4n.Deadline)
+    (hOk : chooseBestRunnableBy objects eligible list none =
+      .ok (some (resTid, resPrio, resDl)))
+    (hAllTcb : ∀ t, t ∈ list → ∃ tcb, objects t.toObjId = some (.tcb tcb)) :
+    resTid ∈ list := by
+  have := chooseBestRunnableBy_result_mem_aux objects eligible list none
+    resTid resPrio resDl hOk hAllTcb
+  rcases this with hMem | ⟨_, _, hNone⟩
+  · exact hMem
+  · exact absurd hNone (by simp)
+
+
+/-- WS-H6: Bridge from `chooseBestInBucket` to the EDF deadline ordering.
+
+Given RunQueue well-formedness and priority-match, the result of
+`chooseBestInBucket` is EDF-optimal among all domain-eligible runnable threads
+at the same priority level.
+
+The proof handles both paths of the bucket-first strategy:
+- **Bucket success**: RunQueue well-formedness guarantees all same-priority
+  threads reside in the same bucket, so per-bucket optimality implies global
+  optimality at the same priority level.
+- **Full-scan fallback**: optimality over `rq.toList` directly covers all
+  runnable threads. -/
+private theorem chooseBestInBucket_edf_bridge
+    (st : SystemState)
+    (tid : SeLe4n.ThreadId) (resPrio : SeLe4n.Priority) (resDl : SeLe4n.Deadline)
+    (tcbSel : TCB)
+    (hwf : RunQueue.wellFormed st.scheduler.runQueue)
+    (hpm : schedulerPriorityMatch st)
+    (hDomEq : tcbSel.domain = st.scheduler.activeDomain)
+    (hAllTcb : ∀ t, t ∈ st.scheduler.runnable →
+      ∃ tcb, st.objects[t.toObjId]? = some (.tcb tcb))
+    (hResult : chooseBestInBucket st.objects.get? st.scheduler.runQueue
+      st.scheduler.activeDomain = .ok (some (tid, resPrio, resDl)))
+    (hObj : st.objects[tid.toObjId]? = some (.tcb tcbSel)) :
+    ∀ t, t ∈ st.scheduler.runnable →
+      match st.objects[t.toObjId]? with
+      | some (.tcb tcb) =>
+          tcb.domain = tcbSel.domain →
+          tcb.priority = tcbSel.priority →
+          tcbSel.deadline.toNat = 0 ∨
+            (tcb.deadline.toNat = 0 ∨ tcbSel.deadline.toNat ≤ tcb.deadline.toNat)
+      | _ => True := by
+  -- Convert to objects.get?
+  have hAllTcbGet : ∀ u, u ∈ st.scheduler.runQueue.toList →
+      ∃ utcb, st.objects.get? u.toObjId = some (.tcb utcb) := by
+    intro u hMu
+    obtain ⟨utcb, hutcb⟩ := hAllTcb u (by simpa [SchedulerState.runnable] using hMu)
+    exact ⟨utcb, hutcb⟩
+  have hObjGet : st.objects.get? tid.toObjId = some (.tcb tcbSel) := hObj
+  -- Domain-eligibility helper
+  have eligOfDom : ∀ (tcb : TCB), tcb.domain = tcbSel.domain →
+      (fun tc : TCB => tc.domain == st.scheduler.activeDomain) tcb = true := by
+    intro tcb htDom; simp; rw [htDom, hDomEq]
+  -- Unfold chooseBestInBucket
+  unfold chooseBestInBucket at hResult
+  cases hBucket : chooseBestRunnableInDomain st.objects.get?
+      st.scheduler.runQueue.maxPriorityBucket st.scheduler.activeDomain none with
+  | error e => simp [hBucket] at hResult
+  | ok bestB =>
+    cases bestB with
+    | none =>
+      -- ── Full-scan fallback ──
+      simp only [hBucket] at hResult
+      cases hFull : chooseBestRunnableInDomain st.objects.get?
+          st.scheduler.runQueue.toList st.scheduler.activeDomain none with
+      | error e => simp [hFull] at hResult
+      | ok bestF =>
+        cases bestF with
+        | none => simp [hFull] at hResult
+        | some triple =>
+          simp only [hFull] at hResult
+          have hTripleEq : triple = (tid, resPrio, resDl) := by
+            simp at hResult; exact hResult
+          subst hTripleEq
+          have hFields := chooseBestRunnableBy_result_fields st.objects.get?
+            (fun tc => tc.domain == st.scheduler.activeDomain)
+            st.scheduler.runQueue.toList none tid resPrio resDl hFull
+            (by intro _ _ _ h; simp at h)
+          obtain ⟨resTcb, hResTcb, hResPrio, hResDl⟩ := hFields
+          rw [hObjGet] at hResTcb; cases hResTcb; subst hResPrio; subst hResDl
+          intro t hMem
+          cases hTObj : st.objects[t.toObjId]? with
+          | none => simp
+          | some tObj =>
+            cases tObj with
+            | tcb tcb =>
+              intro htDom htPrio
+              have hTObjGet : st.objects.get? t.toObjId = some (.tcb tcb) := hTObj
+              have hMemList : t ∈ st.scheduler.runQueue.toList := by
+                simpa [SchedulerState.runnable] using hMem
+              have hOpt := chooseBestRunnableBy_optimal st.objects.get?
+                (fun tc => tc.domain == st.scheduler.activeDomain)
+                st.scheduler.runQueue.toList tid tcbSel.priority tcbSel.deadline
+                hFull hAllTcbGet
+              have hNoBetter := hOpt t hMemList tcb hTObjGet (eligOfDom tcb htDom)
+              rw [htPrio] at hNoBetter
+              exact noBetter_implies_edf tcbSel.deadline tcb.deadline tcbSel.priority hNoBetter
+            | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ => simp
+    | some triple =>
+      -- ── Bucket success ──
+      simp only [hBucket] at hResult
+      have hTripleEq : triple = (tid, resPrio, resDl) := by
+        simp at hResult; exact hResult
+      subst hTripleEq
+      -- All bucket members have TCBs
+      have hBucketAllTcb : ∀ u, u ∈ st.scheduler.runQueue.maxPriorityBucket →
+          ∃ utcb, st.objects.get? u.toObjId = some (.tcb utcb) := by
+        intro u hU
+        have hURq := RunQueue.maxPriorityBucket_subset st.scheduler.runQueue hwf u hU
+        obtain ⟨utcb, hutcb⟩ := hAllTcb u (by
+          simpa [SchedulerState.runnable] using
+            RunQueue.membership_implies_flat st.scheduler.runQueue u hURq)
+        exact ⟨utcb, hutcb⟩
+      -- Result fields
+      have hFields := chooseBestRunnableBy_result_fields st.objects.get?
+        (fun tc => tc.domain == st.scheduler.activeDomain)
+        st.scheduler.runQueue.maxPriorityBucket none tid resPrio resDl hBucket
+        (by intro _ _ _ h; simp at h)
+      obtain ⟨resTcb, hResTcb, hResPrio, hResDl⟩ := hFields
+      rw [hObjGet] at hResTcb; cases hResTcb; subst hResPrio; subst hResDl
+      -- tid ∈ maxPriorityBucket
+      have hTidInBucket : tid ∈ st.scheduler.runQueue.maxPriorityBucket :=
+        chooseBestRunnableBy_result_mem st.objects.get?
+          (fun tc => tc.domain == st.scheduler.activeDomain)
+          st.scheduler.runQueue.maxPriorityBucket tid tcbSel.priority tcbSel.deadline
+          hBucket hBucketAllTcb
+      -- Extract max priority
+      obtain ⟨maxPrio, hMP, hTidTP⟩ :=
+        RunQueue.maxPriorityBucket_threadPriority st.scheduler.runQueue hwf tid hTidInBucket
+      have hTidMem := RunQueue.maxPriorityBucket_subset st.scheduler.runQueue hwf tid hTidInBucket
+      -- maxPrio = tcbSel.priority (via prioMatch)
+      have hPMTid := hpm tid hTidMem
+      simp only [hObj] at hPMTid
+      have hMaxEqPrio : maxPrio = tcbSel.priority := Option.some.inj (hTidTP.symm.trans hPMTid)
+      -- Main goal
+      intro t hMem
+      cases hTObj : st.objects[t.toObjId]? with
+      | none => simp
+      | some tObj =>
+        cases tObj with
+        | tcb tcb =>
+          intro htDom htPrio
+          -- t ∈ runQueue
+          have hTInRq : t ∈ st.scheduler.runQueue := by
+            rw [RunQueue.mem_iff_contains]
+            exact st.scheduler.runQueue.flat_wf t
+              (by simpa [SchedulerState.runnable] using hMem)
+          -- threadPriority[t]? = some maxPrio (via prioMatch + tcb.priority = maxPrio)
+          have hPMt := hpm t hTInRq; simp only [hTObj] at hPMt
+          have hTTP : st.scheduler.runQueue.threadPriority[t]? = some maxPrio :=
+            hPMt.trans (congrArg some (htPrio.trans hMaxEqPrio.symm))
+          -- t ∈ maxPriorityBucket (via wellFormed)
+          have hTInBucket :=
+            RunQueue.mem_maxPriorityBucket_of_threadPriority st.scheduler.runQueue hwf
+              t maxPrio hTInRq hTTP hMP
+          -- Bucket optimality → EDF
+          have hTObjGet : st.objects.get? t.toObjId = some (.tcb tcb) := hTObj
+          have hOpt := chooseBestRunnableBy_optimal st.objects.get?
+            (fun tc => tc.domain == st.scheduler.activeDomain)
+            st.scheduler.runQueue.maxPriorityBucket tid tcbSel.priority tcbSel.deadline
+            hBucket hBucketAllTcb
+          have hNoBetter := hOpt t hTInBucket tcb hTObjGet (eligOfDom tcb htDom)
+          rw [htPrio] at hNoBetter
+          exact noBetter_implies_edf tcbSel.deadline tcb.deadline tcbSel.priority hNoBetter
+        | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ => simp
+
+/-- WS-H6: `schedule` preserves `edfCurrentHasEarliestDeadline`.
+
+When schedule selects `none`, EDF is trivially `True`. When schedule selects
+`some tid`, the EDF property follows from `chooseBestInBucket_edf_bridge`.
+
+**Hypotheses**: RunQueue well-formedness and external priority-match. -/
+theorem schedule_preserves_edfCurrentHasEarliestDeadline
+    (st st' : SystemState)
+    (hwf : RunQueue.wellFormed st.scheduler.runQueue)
+    (hpm : schedulerPriorityMatch st)
+    (hAllTcb : ∀ t, t ∈ st.scheduler.runnable →
+      ∃ tcb, st.objects[t.toObjId]? = some (.tcb tcb))
+    (hStep : schedule st = .ok ((), st')) :
+    edfCurrentHasEarliestDeadline st' := by
+  unfold schedule at hStep
+  -- Unfold chooseThread to access chooseBestInBucket directly
+  simp only [chooseThread] at hStep
+  cases hCIB : chooseBestInBucket st.objects.get? st.scheduler.runQueue
+      st.scheduler.activeDomain with
+  | error e => simp [hCIB] at hStep
+  | ok cibRes =>
+    simp only [hCIB] at hStep
+    cases cibRes with
+    | none =>
+      -- chooseThread returned none → setCurrentThread none
+      exact setCurrentThread_none_preserves_edfCurrentHasEarliestDeadline st st' hStep
+    | some triple =>
+      obtain ⟨tid, resPrio, resDl⟩ := triple
+      -- chooseThread returned some tid
+      simp at hStep
+      cases hObj : st.objects[tid.toObjId]? with
+      | none => simp [hObj] at hStep
+      | some obj =>
+        cases obj with
+        | tcb tcbSel =>
+          simp only [hObj] at hStep
+          by_cases hSchedOk : st.scheduler.runQueue.contains tid = true ∧
+              tcbSel.domain = st.scheduler.activeDomain
+          · simp only [hSchedOk] at hStep
+            exact setCurrentThread_some_preserves_edfCurrentHasEarliestDeadline
+              st st' tid tcbSel hObj
+              (chooseBestInBucket_edf_bridge st tid resPrio resDl tcbSel
+                hwf hpm hSchedOk.2 hAllTcb hCIB hObj)
+              hStep
+          · exfalso; simp [hSchedOk] at hStep
+        | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ =>
+          simp [hObj] at hStep
+
+/-- WS-H6: `handleYield` preserves `edfCurrentHasEarliestDeadline`.
+
+`handleYield` rotates the current thread in its priority bucket and then
+calls `schedule`, which re-selects the best candidate from scratch.
+
+The EDF property is **re-established** (not merely preserved) by the
+`schedule` call. The rotation preserves RunQueue well-formedness and
+priority-match because it only reorders elements within a bucket without
+changing `threadPriority`, `membership`, or `objects`. -/
+theorem handleYield_preserves_edfCurrentHasEarliestDeadline
+    (st st' : SystemState)
+    (hwf : RunQueue.wellFormed st.scheduler.runQueue)
+    (hpm : schedulerPriorityMatch st)
+    (hAllTcb : ∀ t, t ∈ st.scheduler.runnable →
+      ∃ tcb, st.objects[t.toObjId]? = some (.tcb tcb))
+    (hStep : handleYield st = .ok ((), st')) :
+    edfCurrentHasEarliestDeadline st' := by
+  unfold handleYield at hStep
+  cases hCur : st.scheduler.current with
+  | none =>
+    -- no current thread → delegates directly to schedule
+    simp only [hCur] at hStep
+    exact schedule_preserves_edfCurrentHasEarliestDeadline st st' hwf hpm hAllTcb hStep
+  | some curTid =>
+    simp only [hCur] at hStep
+    -- handleYield checks membership, rotates, then calls schedule
+    by_cases hMemRQ : curTid ∈ st.scheduler.runQueue
+    · rw [if_pos hMemRQ] at hStep
+      -- hStep is definitionally equal to schedule of the rotated state
+      exact schedule_preserves_edfCurrentHasEarliestDeadline _ st'
+        (RunQueue.rotateToBack_preserves_wellFormed st.scheduler.runQueue hwf curTid)
+        (fun t hMem => by
+          simp only [RunQueue.rotateToBack_threadPriority]
+          exact hpm t ((RunQueue.rotateToBack_mem_iff _ _ _).mp hMem))
+        (fun t hMem => by
+          simp only [SchedulerState.runnable, RunQueue.toList] at hMem
+          exact hAllTcb t (by
+            simp only [SchedulerState.runnable, RunQueue.toList]
+            exact RunQueue.rotateToBack_flat_subset st.scheduler.runQueue curTid t hMem))
+        hStep
+    · have : ¬(st.scheduler.runQueue.contains curTid = true) := by
+        rwa [← RunQueue.mem_iff_contains]
+      simp [this] at hStep
+
+/-- WS-H6: `timerTick` preserves `edfCurrentHasEarliestDeadline`.
+
+- **No current thread**: scheduler unchanged, EDF trivially holds.
+- **Time-slice not expired**: only the TCB's `timeSlice` field is
+  decremented; `scheduler.current` and thread deadlines are unchanged,
+  so EDF is preserved.
+- **Time-slice expired**: TCB time-slice reset, queue rotation, and
+  `schedule` call re-establish EDF from scratch. -/
+theorem timerTick_preserves_edfCurrentHasEarliestDeadline
+    (st st' : SystemState)
+    (hwf : RunQueue.wellFormed st.scheduler.runQueue)
+    (hpm : schedulerPriorityMatch st)
+    (hEdf : edfCurrentHasEarliestDeadline st)
+    (hAllTcb : ∀ t, t ∈ st.scheduler.runnable →
+      ∃ tcb, st.objects[t.toObjId]? = some (.tcb tcb))
+    (hStep : timerTick st = .ok ((), st')) :
+    edfCurrentHasEarliestDeadline st' := by
+  unfold timerTick at hStep
+  cases hCur : st.scheduler.current with
+  | none =>
+    simp [hCur] at hStep; cases hStep
+    unfold edfCurrentHasEarliestDeadline; simp [hCur]
+  | some curTid =>
+    simp only [hCur] at hStep
+    cases hObj : st.objects[curTid.toObjId]? with
+    | none => simp [hObj] at hStep
+    | some obj =>
+      cases obj with
+      | tcb curTcb =>
+        simp only [hObj] at hStep
+        by_cases hExpire : curTcb.timeSlice ≤ 1
+        · -- Time-slice expired: reset, rotate, reschedule
+          rw [if_pos hExpire] at hStep
+          -- st.scheduler.runQueue is unchanged (only objects/machine changed)
+          -- The if-then checks membership, rotates, and calls schedule
+          by_cases hMemRQ : curTid ∈ st.scheduler.runQueue
+          · rw [if_pos (show curTid ∈ _ from hMemRQ)] at hStep
+            exact schedule_preserves_edfCurrentHasEarliestDeadline _ st'
+              (RunQueue.rotateToBack_preserves_wellFormed st.scheduler.runQueue hwf curTid)
+              (fun t hMem => by
+                simp only [RunQueue.rotateToBack_threadPriority, HashMap_getElem?_insert]
+                have hMem' := (RunQueue.rotateToBack_mem_iff _ _ _).mp hMem
+                by_cases hEq : curTid.toObjId == t.toObjId
+                · simp only [hEq, ite_true]
+                  have := hpm t hMem'
+                  rw [show t.toObjId = curTid.toObjId from (eq_of_beq hEq).symm, hObj] at this
+                  exact this
+                · simp only [hEq]; exact hpm t hMem')
+              (fun t hMem => by
+                simp only [SchedulerState.runnable, RunQueue.toList] at hMem
+                have hMemOrig : t ∈ st.scheduler.runnable := by
+                  simp only [SchedulerState.runnable, RunQueue.toList]
+                  exact RunQueue.rotateToBack_flat_subset st.scheduler.runQueue curTid t hMem
+                obtain ⟨tcbOrig, hTcbOrig⟩ := hAllTcb t hMemOrig
+                simp only [HashMap_getElem?_insert]
+                by_cases hEq : curTid.toObjId == t.toObjId
+                · simp only [hEq, ite_true]
+                  exact ⟨{ curTcb with timeSlice := defaultTimeSlice }, rfl⟩
+                · simp only [hEq]; exact ⟨tcbOrig, hTcbOrig⟩)
+              hStep
+          · rw [if_neg hMemRQ] at hStep; simp at hStep
+        · -- Time-slice not expired: only timeSlice changes
+          rw [if_neg hExpire] at hStep
+          simp only [Except.ok.injEq, Prod.mk.injEq, true_and] at hStep
+          subst hStep
+          -- Transfer from hEdf: objects only differ at curTid (timeSlice field)
+          unfold edfCurrentHasEarliestDeadline at hEdf ⊢
+          simp only [hCur] at hEdf ⊢
+          rw [hObj] at hEdf
+          -- Simplify curTid lookup via insert-self
+          simp only [HashMap_getElem?_insert, beq_self_eq_true, ite_true]
+          intro t hMem
+          specialize hEdf t hMem
+          by_cases hEq : curTid.toObjId == t.toObjId
+          · -- Same ObjId: both curTid and t map to modified curTcb
+            simp only [hEq, ite_true]
+            -- Same thread: deadline ≤ deadline is trivially true
+            intro _ _; exact Or.inr (Or.inr (Nat.le_refl _))
+          · -- Different ObjId: lookup unchanged
+            simp only [hEq]; exact hEdf
+      | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ =>
+        simp [hObj] at hStep
+
+-- ============================================================================
+-- WS-H6: Full scheduler invariant bundle composition theorems
+-- ============================================================================
+
+/-- WS-H6: `schedule` preserves the full scheduler invariant bundle. -/
+theorem schedule_preserves_schedulerInvariantBundleFull
+    (st st' : SystemState)
+    (hInv : schedulerInvariantBundleFull st)
+    (hwf : RunQueue.wellFormed st.scheduler.runQueue)
+    (hpm : schedulerPriorityMatch st)
+    (hAllTcb : ∀ t, t ∈ st.scheduler.runnable →
+      ∃ tcb, st.objects[t.toObjId]? = some (.tcb tcb))
+    (hStep : schedule st = .ok ((), st')) :
+    schedulerInvariantBundleFull st' := by
+  rcases hInv with ⟨hBase, hTS, hEDF⟩
+  exact ⟨schedule_preserves_schedulerInvariantBundle st st' hBase hStep,
+         schedule_preserves_timeSlicePositive st st' hTS hStep,
+         schedule_preserves_edfCurrentHasEarliestDeadline st st' hwf hpm hAllTcb hStep⟩
+
+/-- WS-H6: `handleYield` preserves the full scheduler invariant bundle. -/
+theorem handleYield_preserves_schedulerInvariantBundleFull
+    (st st' : SystemState)
+    (hInv : schedulerInvariantBundleFull st)
+    (hwf : RunQueue.wellFormed st.scheduler.runQueue)
+    (hpm : schedulerPriorityMatch st)
+    (hAllTcb : ∀ t, t ∈ st.scheduler.runnable →
+      ∃ tcb, st.objects[t.toObjId]? = some (.tcb tcb))
+    (hStep : handleYield st = .ok ((), st')) :
+    schedulerInvariantBundleFull st' := by
+  rcases hInv with ⟨hBase, hTS, hEDF⟩
+  exact ⟨handleYield_preserves_schedulerInvariantBundle st st' hBase hStep,
+         handleYield_preserves_timeSlicePositive st st' hTS hStep,
+         handleYield_preserves_edfCurrentHasEarliestDeadline st st' hwf hpm hAllTcb hStep⟩
+
+/-- WS-H6: `timerTick` preserves the full scheduler invariant bundle. -/
+theorem timerTick_preserves_schedulerInvariantBundleFull
+    (st st' : SystemState)
+    (hInv : schedulerInvariantBundleFull st)
+    (hwf : RunQueue.wellFormed st.scheduler.runQueue)
+    (hpm : schedulerPriorityMatch st)
+    (hAllTcb : ∀ t, t ∈ st.scheduler.runnable →
+      ∃ tcb, st.objects[t.toObjId]? = some (.tcb tcb))
+    (hStep : timerTick st = .ok ((), st')) :
+    schedulerInvariantBundleFull st' := by
+  rcases hInv with ⟨hBase, hTS, hEDF⟩
+  exact ⟨timerTick_preserves_schedulerInvariantBundle st st' ⟨hBase.1, hBase.2.1, hBase.2.2⟩ hStep,
+         timerTick_preserves_timeSlicePositive st st' hTS hStep,
+         timerTick_preserves_edfCurrentHasEarliestDeadline st st' hwf hpm hEDF hAllTcb hStep⟩

--- a/SeLe4n/Kernel/Scheduler/RunQueue.lean
+++ b/SeLe4n/Kernel/Scheduler/RunQueue.lean
@@ -359,5 +359,166 @@ theorem mem_toList_rotateToBack_ne (rq : RunQueue) (tid x : ThreadId)
       exact Or.inl (List.mem_erase_of_ne hne |>.mpr h)
   · exact Iff.rfl
 
+-- ============================================================================
+-- WS-H6: RunQueue well-formedness predicate
+-- ============================================================================
+
+/-- WS-H6: RunQueue well-formedness — priority-bucket structure is consistent
+with the membership set and thread-priority mapping.
+
+This captures the implicit structural invariant maintained by the
+insert/remove/rotate API (see RunQueue structure comment, lines 18-24).
+
+- **Forward**: every thread in a priority bucket is a run-queue member whose
+  recorded priority matches the bucket's priority.
+- **Reverse**: every run-queue member appears in its recorded-priority bucket. -/
+def wellFormed (rq : RunQueue) : Prop :=
+  (∀ prio tid, tid ∈ ((rq.byPriority[prio]?).getD []) →
+     rq.membership.contains tid = true ∧ rq.threadPriority[tid]? = some prio) ∧
+  (∀ tid, rq.membership.contains tid = true →
+     ∃ prio, rq.threadPriority[tid]? = some prio ∧
+       tid ∈ ((rq.byPriority[prio]?).getD []))
+
+/-- WS-H6: If a thread is in the max-priority bucket and the RunQueue is
+well-formed, then the thread is a member of the run queue. -/
+theorem maxPriorityBucket_subset (rq : RunQueue) (hwf : rq.wellFormed)
+    (t : ThreadId) (ht : t ∈ rq.maxPriorityBucket) : t ∈ rq := by
+  unfold maxPriorityBucket at ht
+  split at ht
+  · simp at ht
+  · rename_i prio _
+    unfold atPriority at ht
+    rw [mem_iff_contains]
+    exact (hwf.1 prio t ht).1
+
+/-- WS-H6: If a thread is in the max-priority bucket and the RunQueue is
+well-formed, then its recorded priority equals the max-priority value. -/
+theorem maxPriorityBucket_threadPriority (rq : RunQueue) (hwf : rq.wellFormed)
+    (t : ThreadId) (ht : t ∈ rq.maxPriorityBucket) :
+    ∃ prio, rq.maxPriority = some prio ∧ rq.threadPriority[t]? = some prio := by
+  unfold maxPriorityBucket at ht
+  split at ht
+  · simp at ht
+  · rename_i prio hMP
+    unfold atPriority at ht
+    exact ⟨prio, hMP, (hwf.1 prio t ht).2⟩
+
+/-- WS-H6: If a thread is a run-queue member whose recorded priority matches
+`maxPriority`, then the thread is in `maxPriorityBucket`. -/
+theorem mem_maxPriorityBucket_of_threadPriority (rq : RunQueue) (hwf : rq.wellFormed)
+    (t : ThreadId) (prio : Priority)
+    (hMem : t ∈ rq) (hTP : rq.threadPriority[t]? = some prio)
+    (hMP : rq.maxPriority = some prio) : t ∈ rq.maxPriorityBucket := by
+  show t ∈ (match rq.maxPriority with | none => [] | some p => rq.atPriority p)
+  rw [hMP]
+  show t ∈ rq.atPriority prio
+  unfold atPriority
+  obtain ⟨p, hpTP, hpBucket⟩ := hwf.2 t (mem_iff_contains.mp hMem)
+  have hEq : p = prio := Option.some.inj (hpTP.symm.trans hTP)
+  subst hEq
+  exact hpBucket
+
+-- ============================================================================
+-- WS-H6: rotateToBack field-preservation lemmas
+-- ============================================================================
+
+/-- `rotateToBack` does not change `membership`. -/
+theorem rotateToBack_membership (rq : RunQueue) (tid : ThreadId) :
+    (rq.rotateToBack tid).membership = rq.membership := by
+  unfold rotateToBack
+  split <;> rfl
+
+/-- `rotateToBack` does not change `threadPriority`. -/
+theorem rotateToBack_threadPriority (rq : RunQueue) (tid : ThreadId) :
+    (rq.rotateToBack tid).threadPriority = rq.threadPriority := by
+  unfold rotateToBack
+  split <;> rfl
+
+/-- `rotateToBack` does not change `maxPriority`. -/
+theorem rotateToBack_maxPriority (rq : RunQueue) (tid : ThreadId) :
+    (rq.rotateToBack tid).maxPriority = rq.maxPriority := by
+  unfold rotateToBack
+  split <;> rfl
+
+/-- `rotateToBack` does not change `contains`. -/
+theorem rotateToBack_contains (rq : RunQueue) (tid t : ThreadId) :
+    (rq.rotateToBack tid).contains t = rq.contains t := by
+  simp only [contains, rotateToBack_membership]
+
+/-- `rotateToBack` preserves membership (∈). -/
+theorem rotateToBack_mem_iff (rq : RunQueue) (tid t : ThreadId) :
+    t ∈ rq.rotateToBack tid ↔ t ∈ rq := by
+  simp only [mem_iff_contains, rotateToBack_contains]
+
+/-- Elements of the rotated flat list were in the original flat list. -/
+theorem rotateToBack_flat_subset (rq : RunQueue) (tid t : ThreadId) :
+    t ∈ (rq.rotateToBack tid).flat → t ∈ rq.flat := by
+  unfold rotateToBack
+  split
+  · intro h
+    simp only [List.mem_append, List.mem_singleton] at h
+    rcases h with h | rfl
+    · exact List.mem_of_mem_erase h
+    · exact rq.flat_wf_rev _ (by assumption)
+  · exact id
+
+/-- Original flat list elements appear in the rotated flat list. -/
+theorem rotateToBack_flat_superset (rq : RunQueue) (tid t : ThreadId) :
+    t ∈ rq.flat → t ∈ (rq.rotateToBack tid).flat := by
+  unfold rotateToBack
+  split
+  · intro h
+    simp only [List.mem_append, List.mem_singleton]
+    by_cases hEq : t = tid
+    · exact Or.inr hEq
+    · exact Or.inl ((List.mem_erase_of_ne hEq).2 h)
+  · exact id
+
+/-- `rotateToBack` preserves `wellFormed`. -/
+theorem rotateToBack_preserves_wellFormed (rq : RunQueue) (hwf : rq.wellFormed) (tid : ThreadId) :
+    (rq.rotateToBack tid).wellFormed := by
+  by_cases hc : rq.contains tid
+  · -- tid is in the run queue; rotation applies
+    have hTidMem : rq.membership.contains tid = true := hc
+    obtain ⟨tidPrio, hTidTP, hTidBucket⟩ := hwf.2 tid hTidMem
+    have hPrioVal : rq.threadPriority[tid]?.getD ⟨0⟩ = tidPrio := by
+      simp only [hTidTP, Option.getD]
+    -- Fully unfold the rotated wellFormed to access raw fields
+    unfold wellFormed
+    simp only [rotateToBack, hc, dite_true]
+    -- Now goal has: rq.membership, rq.threadPriority, rq.byPriority.insert ...
+    constructor
+    · -- Forward: bucket member → membership ∧ threadPriority
+      intro p t hMem
+      simp only [HashMap_getElem?_insert] at hMem
+      split at hMem
+      · -- prio == p: t is in the modified bucket
+        rename_i hPEq
+        simp only [Option.getD] at hMem
+        simp only [List.mem_append, List.mem_singleton] at hMem
+        rcases hMem with hFilter | rfl
+        · have hOrig := (List.mem_filter.mp hFilter).1
+          have hFwd := hwf.1 (rq.threadPriority[tid]?.getD ⟨0⟩) t hOrig
+          exact ⟨hFwd.1, by rw [(eq_of_beq hPEq).symm]; exact hFwd.2⟩
+        · exact ⟨hTidMem, by rw [(eq_of_beq hPEq).symm, hPrioVal]; exact hTidTP⟩
+      · -- prio ≠ p: bucket unchanged
+        exact hwf.1 p t hMem
+    · -- Reverse: membership → ∃ prio with bucket entry
+      intro t hMem
+      obtain ⟨p, hTP, hBucket⟩ := hwf.2 t hMem
+      refine ⟨p, hTP, ?_⟩
+      simp only [HashMap_getElem?_insert]
+      split
+      · -- prio == p
+        rename_i hPEq
+        simp only [Option.getD, List.mem_append, List.mem_singleton]
+        by_cases hTEq : t = tid
+        · exact Or.inr hTEq
+        · rw [← eq_of_beq hPEq] at hBucket
+          exact Or.inl (List.mem_filter.mpr ⟨hBucket, by simp [hTEq]⟩)
+      · exact hBucket
+  · -- tid not in run queue; rotateToBack is identity
+    simp only [rotateToBack, show ¬(rq.contains tid = true) from hc]; exact hwf
+
 end RunQueue
 end SeLe4n.Kernel

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "main",
-      "commit_sha": "0d278c6e7fd989b5c0c55e1c21ac176bf0e6b35e",
-      "tree_sha": "394d785b2869a30fc961f956c5064e7191ffc51e",
-      "committed_at_utc": "2026-03-07T02:29:45-05:00"
+      "branch": "claude/audit-optimize-codebase-3hUFg",
+      "commit_sha": "5e9b986e92eca4e156acd110c891c35645124a7a",
+      "tree_sha": "e42707c438195ec886fa0ee75f07e04e1d09047f",
+      "committed_at_utc": "2026-03-07T07:29:52+00:00"
     }
   },
   "source_sync": {
@@ -17,11 +17,11 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "c827361aedeae332d287f3aac710304df8113437670b03c8d579d2785535a192"
+    "source_digest": "db49512456c340cb8c989968fbe2978d20c63f527cf5485706cd6eadae22f880"
   },
   "summary": {
     "module_count": 43,
-    "declaration_count": 1542
+    "declaration_count": 1566
   },
   "modules": [
     {
@@ -6413,7 +6413,7 @@
     {
       "module": "SeLe4n.Kernel.Scheduler.Invariant",
       "path": "SeLe4n/Kernel/Scheduler/Invariant.lean",
-      "declaration_count": 15,
+      "declaration_count": 16,
       "declarations": [
         {
           "kind": "namespace",
@@ -6529,13 +6529,19 @@
             "schedulerInvariantBundle",
             "schedulerInvariantBundleFull"
           ]
+        },
+        {
+          "kind": "def",
+          "name": "schedulerPriorityMatch",
+          "line": 172,
+          "called": []
         }
       ]
     },
     {
       "module": "SeLe4n.Kernel.Scheduler.Operations",
       "path": "SeLe4n/Kernel/Scheduler/Operations.lean",
-      "declaration_count": 64,
+      "declaration_count": 75,
       "declarations": [
         {
           "kind": "namespace",
@@ -7101,13 +7107,124 @@
             "switchDomain_preserves_schedulerInvariantBundle",
             "switchDomain_preserves_timeSlicePositive"
           ]
+        },
+        {
+          "kind": "theorem",
+          "name": "setCurrentThread_some_preserves_edfCurrentHasEarliestDeadline",
+          "line": 1340,
+          "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "chooseBestRunnableBy_result_fields",
+          "line": 1364,
+          "called": [
+            "chooseBestRunnableBy",
+            "isBetterCandidate"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "chooseBestRunnableBy_result_mem_aux",
+          "line": 1424,
+          "called": [
+            "chooseBestRunnableBy",
+            "isBetterCandidate"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "chooseBestRunnableBy_result_mem",
+          "line": 1481,
+          "called": [
+            "chooseBestRunnableBy",
+            "chooseBestRunnableBy_result_mem_aux"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "chooseBestInBucket_edf_bridge",
+          "line": 1509,
+          "called": [
+            "chooseBestInBucket",
+            "chooseBestRunnableBy_optimal",
+            "chooseBestRunnableBy_result_fields",
+            "chooseBestRunnableBy_result_mem",
+            "chooseBestRunnableInDomain",
+            "noBetter_implies_edf"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "schedule_preserves_edfCurrentHasEarliestDeadline",
+          "line": 1659,
+          "called": [
+            "chooseBestInBucket",
+            "chooseBestInBucket_edf_bridge",
+            "chooseThread",
+            "schedule",
+            "setCurrentThread_none_preserves_edfCurrentHasEarliestDeadline",
+            "setCurrentThread_some_preserves_edfCurrentHasEarliestDeadline"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "handleYield_preserves_edfCurrentHasEarliestDeadline",
+          "line": 1710,
+          "called": [
+            "handleYield",
+            "schedule_preserves_edfCurrentHasEarliestDeadline"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "timerTick_preserves_edfCurrentHasEarliestDeadline",
+          "line": 1753,
+          "called": [
+            "defaultTimeSlice",
+            "schedule_preserves_edfCurrentHasEarliestDeadline",
+            "timerTick"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "schedule_preserves_schedulerInvariantBundleFull",
+          "line": 1833,
+          "called": [
+            "schedule",
+            "schedule_preserves_edfCurrentHasEarliestDeadline",
+            "schedule_preserves_schedulerInvariantBundle",
+            "schedule_preserves_timeSlicePositive"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "handleYield_preserves_schedulerInvariantBundleFull",
+          "line": 1848,
+          "called": [
+            "handleYield",
+            "handleYield_preserves_edfCurrentHasEarliestDeadline",
+            "handleYield_preserves_schedulerInvariantBundle",
+            "handleYield_preserves_timeSlicePositive"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "timerTick_preserves_schedulerInvariantBundleFull",
+          "line": 1863,
+          "called": [
+            "timerTick",
+            "timerTick_preserves_edfCurrentHasEarliestDeadline",
+            "timerTick_preserves_schedulerInvariantBundle",
+            "timerTick_preserves_timeSlicePositive"
+          ]
         }
       ]
     },
     {
       "module": "SeLe4n.Kernel.Scheduler.RunQueue",
       "path": "SeLe4n/Kernel/Scheduler/RunQueue.lean",
-      "declaration_count": 42,
+      "declaration_count": 54,
       "declarations": [
         {
           "kind": "namespace",
@@ -7473,6 +7590,119 @@
             "RunQueue",
             "rotateToBack",
             "toList"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "wellFormed",
+          "line": 375,
+          "called": [
+            "RunQueue"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "maxPriorityBucket_subset",
+          "line": 384,
+          "called": [
+            "RunQueue",
+            "atPriority",
+            "maxPriorityBucket",
+            "mem_iff_contains"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "maxPriorityBucket_threadPriority",
+          "line": 396,
+          "called": [
+            "RunQueue",
+            "atPriority",
+            "maxPriorityBucket"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "mem_maxPriorityBucket_of_threadPriority",
+          "line": 408,
+          "called": [
+            "RunQueue",
+            "atPriority"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_membership",
+          "line": 426,
+          "called": [
+            "RunQueue",
+            "rotateToBack"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_threadPriority",
+          "line": 432,
+          "called": [
+            "RunQueue",
+            "rotateToBack"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_maxPriority",
+          "line": 438,
+          "called": [
+            "RunQueue",
+            "rotateToBack"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_contains",
+          "line": 444,
+          "called": [
+            "RunQueue",
+            "contains",
+            "rotateToBack_membership"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_mem_iff",
+          "line": 449,
+          "called": [
+            "RunQueue",
+            "mem_iff_contains",
+            "rotateToBack_contains"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_flat_subset",
+          "line": 454,
+          "called": [
+            "RunQueue",
+            "rotateToBack"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_flat_superset",
+          "line": 466,
+          "called": [
+            "RunQueue",
+            "rotateToBack"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "rotateToBack_preserves_wellFormed",
+          "line": 478,
+          "called": [
+            "RunQueue",
+            "rotateToBack",
+            "wellFormed"
           ]
         }
       ]

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -20,7 +20,7 @@ kernel *is* the specification. This eliminates the verification gap between
 specification and implementation.
 
 Current state: 26,861 lines of production Lean across 40 modules, 2,063 lines across 3 Lean test suites,
-779 theorem/lemma declarations, zero unsound constructs, and a deterministic build surface of 84 jobs.
+800 theorem/lemma declarations, zero unsound constructs, and a deterministic build surface of 84 jobs.
 
 ## 3. Architectural improvements over seL4
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -13,11 +13,11 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 
 | Attribute | Value |
 |-----------|-------|
-| Version | `0.13.2` |
+| Version | `0.13.3` |
 | Lean toolchain | `4.28.0` |
 | Production LoC | 26,861 across 40 files |
 | Test LoC | 2,063 across 3 suites |
-| Proved declarations | 779 theorem/lemma declarations (zero sorry/axiom) |
+| Proved declarations | 800 theorem/lemma declarations (zero sorry/axiom) |
 | Build jobs | 84 |
 | Active findings | [`AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md) |
 | Active audit | [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) (14 findings tracked to completion in WS-G) |

--- a/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
+++ b/docs/gitbook/19-end-to-end-audit-and-quality-gates.md
@@ -16,10 +16,10 @@ and [`docs/audits/`](../audits/README.md).
 
 ## 2. Current quality state
 
-seLe4n v0.13.2 has:
+seLe4n v0.13.3 has:
 
 - **Zero sorry/axiom** in the production proof surface — fully machine-checked.
-- **779 theorem/lemma declarations** across 7 kernel subsystems.
+- **800 theorem/lemma declarations** across 7 kernel subsystems.
 - **O(1) hash-based data structures** for all kernel hot paths (WS-G, 14 findings closed).
 - **Tiered CI** with 4 validation tiers plus security scanning.
 - **Comprehensive negative-state testing** with per-mutation invariant checking.

--- a/docs/gitbook/22-next-slice-development-path.md
+++ b/docs/gitbook/22-next-slice-development-path.md
@@ -2,12 +2,12 @@
 
 ## Current state
 
-**Version:** 0.13.2 (Lean 4.28.0)
+**Version:** 0.13.3 (Lean 4.28.0)
 
 **Verified metrics snapshot (from `./scripts/report_current_state.py`):**
 - Production LoC: 26,861 across 40 files
 - Test LoC: 2,063 across 3 suites
-- Proved declarations: 779 theorem/lemma declarations (zero sorry/axiom)
+- Proved declarations: 800 theorem/lemma declarations (zero sorry/axiom)
 - Build jobs: 84
 
 Three major portfolios are completed:

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -5,8 +5,8 @@
 This GitBook is the long-form guide for seLe4n — a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.
 
 ## Current project state
-- **Version:** 0.13.2 (Lean 4.28.0).
-- **Codebase metrics:** 26,861 production LoC across 40 files; 2,063 test LoC across 3 suites; 779 theorem/lemma declarations (zero sorry/axiom); 84 build jobs.
+- **Version:** 0.13.3 (Lean 4.28.0).
+- **Codebase metrics:** 26,861 production LoC across 40 files; 2,063 test LoC across 3 suites; 800 theorem/lemma declarations (zero sorry/axiom); 84 build jobs.
 - **Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md).
 - **Active audit:** [`docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) (14 findings tracked to completion in WS-G).
 - **Recently completed:** WS-H8 (enforcement-NI bridge & missing wrappers, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue structural invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI infrastructure, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path semantic fix, v0.12.16).

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -1,8 +1,8 @@
 {
   "description": "This GitBook is the long-form guide for seLe4n \u2014 a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.",
   "current_state_bullets": [
-    "**Version:** 0.13.2 (Lean 4.28.0).",
-    "**Codebase metrics:** 26,861 production LoC across 40 files; 2,063 test LoC across 3 suites; 779 theorem/lemma declarations (zero sorry/axiom); 84 build jobs.",
+    "**Version:** 0.13.3 (Lean 4.28.0).",
+    "**Codebase metrics:** 26,861 production LoC across 40 files; 2,063 test LoC across 3 suites; 800 theorem/lemma declarations (zero sorry/axiom); 84 build jobs.",
     "**Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md).",
     "**Active audit:** [`docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) (14 findings tracked to completion in WS-G).",
     "**Recently completed:** WS-H8 (enforcement-NI bridge & missing wrappers, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue structural invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI infrastructure, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path semantic fix, v0.12.16).",

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -33,7 +33,7 @@ transition is an executable pure function. Every invariant is machine-checked â€
 The project keeps four concerns in one engineering loop:
 
 1. deterministic transition semantics (executable pure functions),
-2. machine-checked invariant preservation (779 theorem/lemma declarations),
+2. machine-checked invariant preservation (800 theorem/lemma declarations),
 3. architectural improvements over seL4 where the proof framework enables them,
 4. milestone-oriented delivery toward production on **Raspberry Pi 5** (ARM64).
 
@@ -52,13 +52,13 @@ enforcement, and scheduling.
 | **Lean toolchain** | `4.28.0` (`lean-toolchain`) |
 | **Production LoC** | 26,861 across 40 Lean files |
 | **Test LoC** | 2,063 across 3 Lean test suites |
-| **Proved declarations** | 779 theorem/lemma declarations (zero sorry/axiom) |
+| **Proved declarations** | 800 theorem/lemma declarations (zero sorry/axiom) |
 | **Build jobs** | 84 |
 | **Target hardware** | Raspberry Pi 5 (ARM64) |
 | **Active findings** | [`AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md) |
 | **Active audit** | [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) (14 findings tracked to completion in WS-G) |
 | **Next workstream** | WS-F5..F8 (remaining v0.12.2 audit remediation) |
-| **Recently completed** | WS-H6 (v0.12.20, scheduler proof-surface completion), WS-H5 (v0.12.19, IPC dual-queue structural invariant), WS-H4 (v0.12.18, capability invariant redesign), WS-H3 (v0.12.17, build/CI infrastructure), WS-H2 (v0.12.16, lifecycle safety), WS-H1 (v0.12.16, IPC call-path semantic fix), WS-G (v0.12.15, kernel performance) |
+| **Recently completed** | WS-H8 (v0.13.2, enforcement-NI bridge & missing wrappers), WS-H6 (v0.13.1, scheduler proof-surface completion), WS-H5 (v0.12.19, IPC dual-queue structural invariant), WS-H4 (v0.12.18, capability invariant redesign), WS-H3 (v0.12.17, build/CI infrastructure), WS-H2 (v0.12.16, lifecycle safety), WS-H1 (v0.12.16, IPC call-path semantic fix), WS-G (v0.12.15, kernel performance) |
 | **Prior completed** | WS-F1..F4 (v0.12.2), WS-E (v0.11.6), WS-D (v0.11.0), WS-C (v0.9.32), WS-B (v0.9.0) |
 | **Metrics source of truth** | `./scripts/report_current_state.py` |
 | **Codebase map feed** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`; includes `source_sync.source_digest` with branch/commit metadata preserved under `repository.head`; each declaration entry includes additive `called` references for internal declaration invocations; docs-sync checks compare the stable subset)) |
@@ -89,7 +89,8 @@ semantic and proof foundations of the previous one.
 
 | Portfolio | Scope | Workstreams |
 |-----------|-------|-------------|
-| **WS-H6** (v0.12.20) | Scheduler proof-surface completion: RunQueue reverse bridge (`flat_wf_rev`, `membership_implies_flat`, `mem_toList_iff_mem`) and scheduler candidate-selection lemmas (`isBetterCandidate_transitive`, `bucketFirst_fullScan_equivalence`); schedule membership validation now uses O(1) runQueue membership checks | WS-H6 completed |
+| **WS-H8** (v0.13.2) | Enforcement-NI bridge & missing wrappers: enforcement soundness meta-theorems, 4 new enforcement wrappers (`notificationSignalChecked`, `cspaceCopyChecked`, `cspaceMoveChecked`, `endpointReceiveDualChecked`), NI bridge theorems, projection hardening (domain timing metadata), `enforcementBoundaryExtended` (8 policy-gated ops); 26 new theorems | WS-H8 completed |
+| **WS-H6** (v0.13.1) | Scheduler proof-surface completion: RunQueue reverse bridge (`flat_wf_rev`, `membership_implies_flat`, `mem_toList_iff_mem`) and scheduler candidate-selection lemmas (`isBetterCandidate_transitive`, `bucketFirst_fullScan_equivalence`); schedule membership validation now uses O(1) runQueue membership checks | WS-H6 completed |
 | **WS-H5** (v0.12.19) | IPC dual-queue structural invariant: `intrusiveQueueWellFormed`, `dualQueueSystemInvariant`, `tcbQueueLinkIntegrity`; 13 preservation theorems for all dual-queue operations; closes C-04/A-22 (CRITICAL), A-23 (HIGH), A-24 (HIGH) | WS-H5 completed |
 | **WS-H4** (v0.12.18) | Capability invariant redesign: `capabilityInvariantBundle` extended from 4-tuple to 7-tuple with `cspaceSlotCountBounded`, `cdtCompleteness`, `cdtAcyclicity`; all 25+ preservation theorems re-proved against non-trivial predicates | WS-H4 completed |
 | **WS-H3** (v0.12.17) | Build/CI infrastructure fixes: `run_check` return value fix (H-12), `test_docs_sync.sh` CI integration (M-19), Tier 3 `rg` availability guard with `grep -P` fallback (M-20) | WS-H3 completed |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "seLe4n"
-version = "0.13.2"
+version = "0.13.3"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-H6 (EDF Scheduler Proof Completion)
- **Recommendation IDs closed:** A-14/H-06 CRITICAL
- **Scope notes:** Completes the EDF preservation proof chain for `schedule`, `handleYield`, and `timerTick` operations by introducing RunQueue well-formedness predicate and bridging theorems.

## Changes

### Core EDF Preservation Theorems (Operations.lean)

**New theorems (11 total):**

1. **`setCurrentThread_some_preserves_edfCurrentHasEarliestDeadline`** — Proves that `setCurrentThread (some tid)` preserves EDF when the selected thread satisfies deadline ordering among same-domain/same-priority candidates.

2. **`chooseBestRunnableBy_result_fields`** (private) — Establishes that `chooseBestRunnableBy` result fields (priority, deadline) correspond to the actual TCB in the object store.

3. **`chooseBestRunnableBy_result_mem_aux`** (private) — Proves via induction that the result thread is a member of the scanned list.

4. **`chooseBestRunnableBy_result_mem`** (private) — Wrapper for the auxiliary membership lemma.

5. **`chooseBestInBucket_edf_bridge`** (private) — **CRITICAL:** Bridges `chooseBestInBucket` to EDF deadline ordering. Proves that the result is EDF-optimal among all domain-eligible runnable threads at the same priority level. Handles both bucket-success and full-scan-fallback paths using RunQueue well-formedness and priority-match predicates.

6. **`schedule_preserves_edfCurrentHasEarliestDeadline`** — Proves `schedule` preserves EDF by delegating to `chooseBestInBucket_edf_bridge`.

7. **`handleYield_preserves_edfCurrentHasEarliestDeadline`** — Proves `handleYield` (which rotates the current thread and reschedules) re-establishes EDF via `schedule`.

8. **`timerTick_preserves_edfCurrentHasEarliestDeadline`** — Proves `timerTick` preserves EDF in the no-expiry case and re-establishes it when time-slice expires.

9. **`schedule_preserves_schedulerInvariantBundleFull`** — Composes EDF, base invariant, and time-slice preservation for `schedule`.

10. **`handleYield_preserves_schedulerInvariantBundleFull`** — Composes all three preservation properties for `handleYield`.

11. **`timerTick_preserves_schedulerInvariantBundleFull`** — Composes all three preservation properties for `timerTick`.

### RunQueue Well-Formedness (RunQueue.lean)

**New definitions and theorems (13 total):**

1. **`RunQueue.wellFormed`** — External predicate capturing the implicit invariant maintained by insert/remove/rotate API:
   - **Forward:** every thread in a priority bucket is a run-queue member whose recorded priority matches the bucket's priority.
   - **Reverse:** every run-queue member appears in its recorded-priority bucket.

2. **`maxPriorityBucket_subset`** — If a thread is in the max-priority bucket and the RunQueue is well-formed, then the thread is a member of the run queue.

3. **`maxPriorityBucket_threadPriority`** — If a thread is in the max-priority bucket and the RunQueue is well-formed, then its recorded priority equals the max-priority value.

4. **`mem_maxPriorityBucket_of_threadPriority`** — If a thread is a run-queue member whose recorded priority matches `maxPriority`, then the thread is in `maxPriorityBucket`.

5. **`rotateToBack_membership`** — `rotateToBack

https://claude.ai/code/session_01PKk6ABhkbEW5Sp61iJnVMq