### PR TITLE
WS-H12/H-03: Implement per-TCB register context save/restore

### DIFF
--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1991,6 +1991,7 @@ theorem endpointReply_preserves_capabilityInvariantBundle
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hAttRule, _hLifecycle, hBounded, hComp, hAcyclic⟩
   unfold endpointReply at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st target with
   | none => simp [hLookup] at hStep
   | some tcb =>

--- a/SeLe4n/Kernel/IPC/DualQueue.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue.lean
@@ -1522,7 +1522,9 @@ receiver, modeling seL4 badge delivery through endpoint capabilities. -/
 def endpointSendDual (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
     (msg : IpcMessage) : Kernel Unit :=
   fun st =>
-    match st.objects[endpointId]? with
+    -- WS-H12/A-09: Validate message payload bounds before any state mutation
+    if !msg.wellFormed then .error .invalidArgument
+    else match st.objects[endpointId]? with
     | some (.endpoint ep) =>
         match ep.receiveQ.head with
         | some _ =>
@@ -1622,7 +1624,9 @@ when a receiver later dequeues, the caller transitions to `blockedOnReply` inste
 def endpointCall (endpointId : SeLe4n.ObjId) (caller : SeLe4n.ThreadId)
     (msg : IpcMessage) : Kernel Unit :=
   fun st =>
-    match st.objects[endpointId]? with
+    -- WS-H12/A-09: Validate message payload bounds before any state mutation
+    if !msg.wellFormed then .error .invalidArgument
+    else match st.objects[endpointId]? with
     | some (.endpoint ep) =>
         match ep.receiveQ.head with
         | some _ =>
@@ -1661,7 +1665,9 @@ confused-deputy attacks where unauthorized threads reply to blocked callers. -/
 def endpointReply (replier : SeLe4n.ThreadId) (target : SeLe4n.ThreadId)
     (msg : IpcMessage) : Kernel Unit :=
   fun st =>
-    match lookupTcb st target with
+    -- WS-H12/A-09: Validate message payload bounds before any state mutation
+    if !msg.wellFormed then .error .invalidArgument
+    else match lookupTcb st target with
     | none => .error .objectNotFound
     | some tcb =>
         match tcb.ipcState with
@@ -1689,7 +1695,9 @@ def endpointReplyRecv
     (replyTarget : SeLe4n.ThreadId)
     (msg : IpcMessage) : Kernel Unit :=
   fun st =>
-    match lookupTcb st replyTarget with
+    -- WS-H12/A-09: Validate message payload bounds before any state mutation
+    if !msg.wellFormed then .error .invalidArgument
+    else match lookupTcb st replyTarget with
     | none => .error .objectNotFound
     | some tcb =>
         match tcb.ipcState with

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -1708,6 +1708,19 @@ theorem notificationWait_result_wellFormed_wait
   · rfl
 
 -- ============================================================================
+-- WS-H12/A-09: Helper for eliminating message bounds check in proofs
+-- ============================================================================
+
+/-- WS-H12/A-09: When a function guarded by `if !msg.wellFormed then .error .invalidArgument else f`
+succeeds with `.ok`, the bounds check must have passed. This eliminates the `if` branch in proofs. -/
+theorem ipcBoundsCheck_ok {α : Type} {msg : IpcMessage} {f : Except KernelError α} {r : α}
+    (h : (if !msg.wellFormed then .error .invalidArgument else f) = .ok r) :
+    f = .ok r := by
+  split at h
+  · simp at h
+  · exact h
+
+-- ============================================================================
 -- WS-E4/M-12: Preservation theorems for endpointReply
 -- ============================================================================
 
@@ -1722,6 +1735,7 @@ theorem endpointReply_preserves_schedulerInvariantBundle
     (hStep : endpointReply replier target msg st = .ok ((), st')) :
     schedulerInvariantBundle st' := by
   unfold endpointReply at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st target with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -1823,6 +1837,7 @@ theorem endpointReply_preserves_ipcInvariant
     (hStep : endpointReply replier target msg st = .ok ((), st')) :
     ipcInvariant st' := by
   unfold endpointReply at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st target with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -2172,6 +2187,7 @@ theorem endpointSendDual_preserves_ipcInvariant
     (hStep : endpointSendDual endpointId sender msg st = .ok ((), st')) :
     ipcInvariant st' := by
   unfold endpointSendDual at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj => cases obj with
@@ -2221,6 +2237,7 @@ theorem endpointSendDual_preserves_schedulerInvariantBundle
     schedulerInvariantBundle st' := by
   rcases hInv with ⟨hQCC, hRQU, hCTV⟩
   unfold endpointSendDual at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj => cases obj with
@@ -2323,6 +2340,7 @@ theorem endpointSendDual_preserves_ipcSchedulerContractPredicates
     ipcSchedulerContractPredicates st' := by
   rcases hContract with ⟨hReady, hBlockSend, hBlockRecv, hBlockCall, hBlockReply⟩
   unfold endpointSendDual at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj => cases obj with
@@ -3265,6 +3283,7 @@ theorem endpointCall_preserves_ipcInvariant
     (hStep : endpointCall endpointId caller msg st = .ok ((), st')) :
     ipcInvariant st' := by
   unfold endpointCall at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj => cases obj with
@@ -3323,6 +3342,7 @@ theorem endpointCall_preserves_schedulerInvariantBundle
     schedulerInvariantBundle st' := by
   rcases hInv with ⟨hQCC, hRQU, hCTV⟩
   unfold endpointCall at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj => cases obj with
@@ -3450,6 +3470,7 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
     ipcSchedulerContractPredicates st' := by
   rcases hContract with ⟨hReady, hBlockSend, hBlockRecv, hBlockCall, hBlockReply⟩
   unfold endpointCall at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj => cases obj with
@@ -3641,6 +3662,7 @@ theorem endpointCall_blocked_stays_blocked
     (hStep : endpointCall endpointId caller msg st = .ok ((), st')) :
     caller ∉ st'.scheduler.runnable := by
   unfold endpointCall at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj => cases obj with
@@ -3688,6 +3710,7 @@ theorem endpointReplyRecv_preserves_ipcInvariant
     (hStep : endpointReplyRecv endpointId receiver replyTarget msg st = .ok ((), st')) :
     ipcInvariant st' := by
   unfold endpointReplyRecv at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st replyTarget with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -3753,6 +3776,7 @@ theorem endpointReplyRecv_preserves_schedulerInvariantBundle
     (hStep : endpointReplyRecv endpointId receiver replyTarget msg st = .ok ((), st')) :
     schedulerInvariantBundle st' := by
   unfold endpointReplyRecv at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st replyTarget with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -3866,6 +3890,7 @@ theorem endpointReplyRecv_preserves_ipcSchedulerContractPredicates
     ipcSchedulerContractPredicates st' := by
   rcases hContract with ⟨hReady, hBlockSend, hBlockRecv, hBlockCall, hBlockReply⟩
   unfold endpointReplyRecv at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st replyTarget with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -4045,6 +4070,7 @@ theorem endpointReply_preserves_ipcSchedulerContractPredicates
     ipcSchedulerContractPredicates st' := by
   rcases hContract with ⟨hReady, hBlockSend, hBlockRecv, hBlockCall, hBlockReply⟩
   unfold endpointReply at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st target with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -5341,6 +5367,7 @@ theorem endpointReply_preserves_dualQueueSystemInvariant
     (hInv : dualQueueSystemInvariant st) :
     dualQueueSystemInvariant st' := by
   unfold endpointReply at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st target with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -5444,6 +5471,7 @@ theorem endpointReplyRecv_preserves_dualQueueSystemInvariant
     (hInv : dualQueueSystemInvariant st) :
     dualQueueSystemInvariant st' := by
   unfold endpointReplyRecv at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st replyTgt with
   | none => simp [hLookup] at hStep
   | some tcb =>
@@ -6384,6 +6412,7 @@ theorem endpointSendDual_preserves_dualQueueSystemInvariant
           ep'.receiveQ.tail ≠ some tailTid)) :
     dualQueueSystemInvariant st' := by
   unfold endpointSendDual at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj =>
@@ -6553,6 +6582,7 @@ theorem endpointCall_preserves_dualQueueSystemInvariant
           ep'.receiveQ.tail ≠ some tailTid)) :
     dualQueueSystemInvariant st' := by
   unfold endpointCall at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hObj : st.objects[endpointId]? with
   | none => simp [hObj] at hStep
   | some obj =>

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -1450,6 +1450,21 @@ private theorem setCurrentThread_preserves_projection
       | none => rfl
       | some t' => simp [hTidHigh t' hTid]
 
+/-- WS-H12/H-03: Context switch preserves state projection when both the current
+(outgoing) thread and all runnable threads are non-observable.
+
+saveContext only changes `registerContext` of the outgoing TCB (non-observable →
+projectObjects returns none for that ObjId). restoreContext only changes
+`machine.regs` (projectMachineRegs returns none when current is non-observable).
+Scheduler state is unchanged. -/
+private theorem contextSwitchState_preserves_projection
+    (ctx : LabelingContext) (observer : IfObserver)
+    (st : SystemState) (tid : SeLe4n.ThreadId)
+    (hCurrentHigh : ∀ t, st.scheduler.current = some t → threadObservable ctx observer t = false)
+    (hAllRunnable : ∀ tid, tid ∈ st.scheduler.runnable → threadObservable ctx observer tid = false) :
+    projectState ctx observer (contextSwitchState st tid) = projectState ctx observer st := by
+  sorry
+
 /-- WS-H9: schedule when all schedulable threads are non-observable preserves projection.
 schedule = chooseThread (read-only) >> setCurrentThread. Since chooseThread picks from
 the runQueue and all runnable threads are non-observable, the result is non-observable. -/
@@ -1482,11 +1497,22 @@ private theorem schedule_preserves_projection
           simp only [hObj] at hStep
           split at hStep
           · next hCond =>
-            exact setCurrentThread_preserves_projection ctx observer (some tid) st st'
+            -- WS-H12/H-03: hStep now goes through contextSwitchState
+            -- contextSwitchState preserves scheduler (runnable, current) and non-observable projection
+            have hCtxSched := contextSwitchState_preserves_scheduler st tid
+            have hCurrentHighCtx : ∀ t, (contextSwitchState st tid).scheduler.current = some t →
+                threadObservable ctx observer t = false := by
+              intro t hCur; rw [hCtxSched] at hCur; exact hCurrentHigh t hCur
+            have hCtxProj : projectState ctx observer (contextSwitchState st tid) = projectState ctx observer st := by
+              exact contextSwitchState_preserves_projection ctx observer st tid hCurrentHigh hAllRunnable
+            rw [← hCtxProj]
+            exact setCurrentThread_preserves_projection ctx observer (some tid) (contextSwitchState st tid) st'
               (fun t h => by
                 cases h
-                exact hAllRunnable tid ((RunQueue.mem_toList_iff_mem _ tid).mpr hCond.1))
-              hCurrentHigh hStep
+                have : tid ∈ st.scheduler.runnable := by
+                  exact (RunQueue.mem_toList_iff_mem _ tid).mpr hCond.1
+                exact hAllRunnable tid this)
+              hCurrentHighCtx hStep
           · simp at hStep
         | _ => simp [hObj] at hStep
 
@@ -1936,6 +1962,7 @@ private theorem endpointReply_preserves_projection
     (hStep : endpointReply replier target msg st = .ok ((), st')) :
     projectState ctx observer st' = projectState ctx observer st := by
   unfold endpointReply at hStep
+  have hStep := ipcBoundsCheck_ok hStep
   cases hLookup : lookupTcb st target with
   | none => simp [hLookup] at hStep
   | some tcb =>

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -1460,10 +1460,44 @@ Scheduler state is unchanged. -/
 private theorem contextSwitchState_preserves_projection
     (ctx : LabelingContext) (observer : IfObserver)
     (st : SystemState) (tid : SeLe4n.ThreadId)
-    (hCurrentHigh : ∀ t, st.scheduler.current = some t → threadObservable ctx observer t = false)
-    (hAllRunnable : ∀ tid, tid ∈ st.scheduler.runnable → threadObservable ctx observer tid = false) :
+    (hCurrentHigh : ∀ t, st.scheduler.current = some t → threadObservable ctx observer t = false) :
     projectState ctx observer (contextSwitchState st tid) = projectState ctx observer st := by
-  sorry
+  simp only [projectState]; congr 1
+  · -- objects: saveContext only changes outTid.toObjId (non-observable via coherence)
+    funext oid; simp only [projectObjects]
+    by_cases hObs : objectObservable ctx observer oid
+    · simp only [hObs, ite_true]
+      congr 1
+      exact contextSwitchState_preserves_objects_at st tid oid (fun outTid hCur => by
+        have hThreadHigh := hCurrentHigh outTid hCur
+        have hObjHigh : objectObservable ctx observer outTid.toObjId = false := by
+          rw [← threadObservable_eq_objectObservable]; exact hThreadHigh
+        exact fun h => by rw [h] at hObs; simp [hObs] at hObjHigh)
+    · simp [hObs]
+  · -- runnable: scheduler unchanged
+    simp only [projectRunnable, contextSwitchState_preserves_scheduler]
+  · -- current: scheduler unchanged
+    simp only [projectCurrent, contextSwitchState_preserves_scheduler]
+  · -- services: unchanged by context switch
+    funext sid; simp only [projectServiceStatus]
+    congr 1; simp only [lookupService, contextSwitchState_preserves_services]
+  · -- activeDomain: scheduler unchanged
+    simp only [projectActiveDomain, contextSwitchState_preserves_scheduler]
+  · -- irqHandlers: unchanged by context switch
+    funext irq; simp only [projectIrqHandlers, contextSwitchState_preserves_irqHandlers]
+  · -- objectIndex: unchanged by context switch
+    simp only [projectObjectIndex, contextSwitchState_preserves_objectIndex]
+  · -- domainTimeRemaining: scheduler unchanged
+    simp only [projectDomainTimeRemaining, contextSwitchState_preserves_scheduler]
+  · -- domainSchedule: scheduler unchanged
+    simp only [projectDomainSchedule, contextSwitchState_preserves_scheduler]
+  · -- domainScheduleIndex: scheduler unchanged
+    simp only [projectDomainScheduleIndex, contextSwitchState_preserves_scheduler]
+  · -- machineRegs: projectMachineRegs returns none when current is non-observable
+    simp only [projectMachineRegs, contextSwitchState_preserves_scheduler]
+    cases hCur : st.scheduler.current with
+    | none => rfl
+    | some t => simp [hCurrentHigh t hCur]
 
 /-- WS-H9: schedule when all schedulable threads are non-observable preserves projection.
 schedule = chooseThread (read-only) >> setCurrentThread. Since chooseThread picks from
@@ -1504,7 +1538,7 @@ private theorem schedule_preserves_projection
                 threadObservable ctx observer t = false := by
               intro t hCur; rw [hCtxSched] at hCur; exact hCurrentHigh t hCur
             have hCtxProj : projectState ctx observer (contextSwitchState st tid) = projectState ctx observer st := by
-              exact contextSwitchState_preserves_projection ctx observer st tid hCurrentHigh hAllRunnable
+              exact contextSwitchState_preserves_projection ctx observer st tid hCurrentHigh
             rw [← hCtxProj]
             exact setCurrentThread_preserves_projection ctx observer (some tid) (contextSwitchState st tid) st'
               (fun t h => by

--- a/SeLe4n/Kernel/InformationFlow/Policy.lean
+++ b/SeLe4n/Kernel/InformationFlow/Policy.lean
@@ -63,6 +63,12 @@ structure LabelingContext where
   threadLabelOf : SeLe4n.ThreadId → SecurityLabel
   endpointLabelOf : SeLe4n.ObjId → SecurityLabel
   serviceLabelOf : ServiceId → SecurityLabel
+  /-- Thread label coherence: a thread's security label equals the label of its
+      backing TCB object. Required for context-switch projection preservation
+      (H-03): saveContext modifies the TCB at `tid.toObjId`, and projection
+      invisibility requires `objectObservable` to agree with `threadObservable`. -/
+  threadObjectCoherent : ∀ tid : SeLe4n.ThreadId,
+    threadLabelOf tid = objectLabelOf tid.toObjId
 
 /-- Minimal default labeling: everything is publicly observable and untrusted. -/
 def defaultLabelingContext : LabelingContext :=
@@ -71,6 +77,7 @@ def defaultLabelingContext : LabelingContext :=
     threadLabelOf := fun _ => SecurityLabel.publicLabel
     endpointLabelOf := fun _ => SecurityLabel.publicLabel
     serviceLabelOf := fun _ => SecurityLabel.publicLabel
+    threadObjectCoherent := fun _ => rfl
   }
 
 theorem confidentialityFlowsTo_refl (c : Confidentiality) :

--- a/SeLe4n/Kernel/InformationFlow/Projection.lean
+++ b/SeLe4n/Kernel/InformationFlow/Projection.lean
@@ -79,6 +79,13 @@ def objectObservable (ctx : LabelingContext) (observer : IfObserver) (oid : SeLe
 def threadObservable (ctx : LabelingContext) (observer : IfObserver) (tid : SeLe4n.ThreadId) : Bool :=
   securityFlowsTo (ctx.threadLabelOf tid) observer.clearance
 
+/-- Thread–object observability coherence: `threadObservable` and `objectObservable`
+agree for a thread's backing TCB object, via `LabelingContext.threadObjectCoherent`. -/
+theorem threadObservable_eq_objectObservable (ctx : LabelingContext) (observer : IfObserver)
+    (tid : SeLe4n.ThreadId) :
+    threadObservable ctx observer tid = objectObservable ctx observer tid.toObjId := by
+  simp only [threadObservable, objectObservable, ctx.threadObjectCoherent]
+
 /-- Service projection keeps only status because service identity is carried by `ServiceId`. -/
 def serviceObservable (ctx : LabelingContext) (observer : IfObserver) (sid : ServiceId) : Bool :=
   securityFlowsTo (ctx.serviceLabelOf sid) observer.clearance

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -203,6 +203,34 @@ def chooseThread : Kernel (Option SeLe4n.ThreadId) :=
     | .ok none => .ok (none, st)
     | .ok (some (tid, _, _)) => .ok (some tid, st)
 
+/-- WS-H12/H-03: Save machine registers into the outgoing thread's TCB register context.
+Returns the updated state with the outgoing thread's `registerContext` set to the
+current machine register file. -/
+def saveContext (st : SystemState) (outTid : SeLe4n.ThreadId) : SystemState :=
+  match st.objects[outTid.toObjId]? with
+  | some (.tcb tcb) =>
+      let tcb' := { tcb with registerContext := st.machine.regs }
+      { st with objects := st.objects.insert outTid.toObjId (.tcb tcb') }
+  | _ => st
+
+/-- WS-H12/H-03: Restore machine registers from the incoming thread's TCB register context.
+Returns the updated state with the machine register file set to the incoming
+thread's saved `registerContext`. -/
+def restoreContext (st : SystemState) (inTid : SeLe4n.ThreadId) : SystemState :=
+  match st.objects[inTid.toObjId]? with
+  | some (.tcb tcb) =>
+      { st with machine := { st.machine with regs := tcb.registerContext } }
+  | _ => st
+
+/-- WS-H12/H-03: Context save/restore step factored from `schedule`.
+Computes the state after saving outgoing context and restoring incoming context.
+The key property is that this preserves the scheduler state. -/
+def contextSwitchState (st : SystemState) (tid : SeLe4n.ThreadId) : SystemState :=
+  let stSaved := match st.scheduler.current with
+    | some outTid => saveContext st outTid
+    | none => st
+  restoreContext stSaved tid
+
 /-- Scheduler step for the bootstrap model.
 
 Failure modes are explicit:
@@ -212,7 +240,12 @@ Failure modes are explicit:
 **Performance note:** Membership validation uses O(1) HashSet-backed
 `tid ∈ st'.scheduler.runQueue`. WS-H6 also provides a bidirectional bridge
 (`RunQueue.mem_toList_iff_mem`) for any proof obligations phrased over
-`st'.scheduler.runnable` (`rq.toList`). -/
+`st'.scheduler.runnable` (`rq.toList`).
+
+WS-H12/H-03: Context save/restore is performed inline during dispatch:
+- Save the outgoing thread's registers into its TCB (`saveContext`)
+- Restore the incoming thread's registers from its TCB (`restoreContext`)
+This models the per-TCB register save area used by seL4 for context switches. -/
 def schedule : Kernel Unit :=
   fun st =>
     match chooseThread st with
@@ -222,7 +255,9 @@ def schedule : Kernel Unit :=
         match st'.objects[tid.toObjId]? with
         | some (.tcb tcb) =>
             if tid ∈ st'.scheduler.runQueue ∧ tcb.domain = st'.scheduler.activeDomain then
-              setCurrentThread (some tid) st'
+              -- WS-H12/H-03: Inline context save/restore
+              let stCtx := contextSwitchState st' tid
+              setCurrentThread (some tid) stCtx
             else
               .error .schedulerInvariantViolation
         | _ => .error .schedulerInvariantViolation
@@ -335,6 +370,202 @@ def scheduleDomain : Kernel Unit :=
       .ok ((), { st with scheduler := sched' })
 
 -- ============================================================================
+-- WS-H12/H-03: Context save/restore preservation lemmas
+-- ============================================================================
+
+theorem saveContext_preserves_scheduler (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (saveContext st tid).scheduler = st.scheduler := by
+  unfold saveContext
+  cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj =>
+      cases obj with
+      | tcb _ => rfl
+      | _ => rfl
+
+theorem restoreContext_preserves_scheduler (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (restoreContext st tid).scheduler = st.scheduler := by
+  unfold restoreContext
+  cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj =>
+      cases obj with
+      | tcb _ => rfl
+      | _ => rfl
+
+theorem saveContext_preserves_objects_keys (st : SystemState) (tid : SeLe4n.ThreadId)
+    (k : ObjId) (hk : k ≠ tid.toObjId) :
+    (saveContext st tid).objects[k]? = st.objects[k]? := by
+  unfold saveContext
+  cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj =>
+      cases obj with
+      | tcb _ => simp [HashMap_getElem?_insert, Ne.symm hk]
+      | _ => rfl
+
+theorem contextSwitchState_preserves_scheduler (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (contextSwitchState st tid).scheduler = st.scheduler := by
+  unfold contextSwitchState
+  cases st.scheduler.current with
+  | none => exact restoreContext_preserves_scheduler st tid
+  | some outTid =>
+      rw [restoreContext_preserves_scheduler, saveContext_preserves_scheduler]
+
+theorem restoreContext_preserves_objects (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (restoreContext st tid).objects = st.objects := by
+  unfold restoreContext
+  cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj => cases obj <;> rfl
+
+theorem contextSwitchState_preserves_objects_at (st : SystemState)
+    (tid : SeLe4n.ThreadId) (k : ObjId)
+    (hk : ∀ outTid, st.scheduler.current = some outTid → k ≠ outTid.toObjId) :
+    (contextSwitchState st tid).objects[k]? = st.objects[k]? := by
+  unfold contextSwitchState
+  cases hCur : st.scheduler.current with
+  | none =>
+      show (restoreContext st tid).objects[k]? = st.objects[k]?
+      rw [restoreContext_preserves_objects]
+  | some outTid =>
+      show (restoreContext (saveContext st outTid) tid).objects[k]? = st.objects[k]?
+      rw [restoreContext_preserves_objects]
+      exact saveContext_preserves_objects_keys st outTid k (hk outTid hCur)
+
+/-- WS-H12/H-03: If a TCB exists in `st.objects` for the incoming thread,
+a TCB still exists at that position after context switch, with the same domain. -/
+theorem contextSwitchState_preserves_tcb (st : SystemState)
+    (tid : SeLe4n.ThreadId) (tcb : TCB)
+    (hObj : st.objects[tid.toObjId]? = some (.tcb tcb)) :
+    ∃ tcb' : TCB, (contextSwitchState st tid).objects[tid.toObjId]? = some (.tcb tcb')
+      ∧ tcb'.domain = tcb.domain
+      ∧ tcb'.priority = tcb.priority
+      ∧ tcb'.deadline = tcb.deadline
+      ∧ tcb'.timeSlice = tcb.timeSlice := by
+  unfold contextSwitchState
+  cases hCur : st.scheduler.current with
+  | none =>
+      show ∃ tcb', (restoreContext st tid).objects[tid.toObjId]? = some (.tcb tcb') ∧ _
+      rw [restoreContext_preserves_objects]; exact ⟨tcb, hObj, rfl, rfl, rfl, rfl⟩
+  | some outTid =>
+      show ∃ tcb', (restoreContext (saveContext st outTid) tid).objects[tid.toObjId]? = some (.tcb tcb') ∧ _
+      rw [restoreContext_preserves_objects]
+      unfold saveContext
+      cases hS : st.objects[outTid.toObjId]? with
+      | none => exact ⟨tcb, hObj, rfl, rfl, rfl, rfl⟩
+      | some obj =>
+          cases obj with
+          | tcb tcbOut =>
+              by_cases hEq : tid.toObjId = outTid.toObjId
+              · -- tid is the outgoing thread — saveContext updates registerContext only
+                have hBEq : (outTid.toObjId == tid.toObjId) = true := by simp [hEq]
+                simp only [HashMap_getElem?_insert, hBEq, ite_true]
+                -- tcbOut and tcb are the same TCB
+                have hSame : tcbOut = tcb := by
+                  have h := hObj; rw [hEq] at h; simp only [hS, Option.some.injEq, KernelObject.tcb.injEq] at h; exact h
+                exact ⟨{ tcbOut with registerContext := st.machine.regs }, rfl, by rw [hSame], by rw [hSame], by rw [hSame], by rw [hSame]⟩
+              · simp only [HashMap_getElem?_insert, show ¬(outTid.toObjId == tid.toObjId) = true from by simp; exact Ne.symm hEq, ite_false]
+                exact ⟨tcb, hObj, rfl, rfl, rfl, rfl⟩
+          | _ => exact ⟨tcb, hObj, rfl, rfl, rfl, rfl⟩
+
+/-- Convenience wrapper: TCB existence after context switch. -/
+theorem contextSwitchState_preserves_tcb_exists (st : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (hObj : ∃ tcb : TCB, st.objects[tid.toObjId]? = some (.tcb tcb)) :
+    ∃ tcb : TCB, (contextSwitchState st tid).objects[tid.toObjId]? = some (.tcb tcb) := by
+  obtain ⟨tcb, hTcb⟩ := hObj
+  obtain ⟨tcb', hTcb', _, _, _, _⟩ := contextSwitchState_preserves_tcb st tid tcb hTcb
+  exact ⟨tcb', hTcb'⟩
+
+/-- WS-H12/H-03: Context switch preserves timeSlice for all TCBs.
+saveContext only updates registerContext; restoreContext only changes machine.regs. -/
+theorem contextSwitchState_preserves_timeSlicePositive (st : SystemState)
+    (tid : SeLe4n.ThreadId)
+    (hInv : timeSlicePositive st) :
+    timeSlicePositive (contextSwitchState st tid) := by
+  intro t hMem
+  have hCtxSched := contextSwitchState_preserves_scheduler st tid
+  have hMemOrig : t ∈ st.scheduler.runnable := by
+    simp [SchedulerState.runnable] at hMem ⊢
+    rwa [hCtxSched] at hMem
+  have hOrig := hInv t hMemOrig
+  unfold contextSwitchState
+  cases hCur : st.scheduler.current with
+  | none =>
+      show match (restoreContext st tid).objects[t.toObjId]? with | some (.tcb tcb) => _ | _ => _
+      rw [restoreContext_preserves_objects]
+      exact hOrig
+  | some outTid =>
+      show match (restoreContext (saveContext st outTid) tid).objects[t.toObjId]? with | some (.tcb tcb) => _ | _ => _
+      rw [restoreContext_preserves_objects]
+      unfold saveContext
+      cases hS : st.objects[outTid.toObjId]? with
+      | none => exact hOrig
+      | some obj =>
+          cases obj with
+          | tcb tcbOut =>
+              by_cases hEq : t.toObjId = outTid.toObjId
+              · have hBEq : (outTid.toObjId == t.toObjId) = true := by simp [hEq]
+                simp only [HashMap_getElem?_insert, hBEq, ite_true]
+                rw [hEq, hS] at hOrig
+                exact hOrig
+              · simp only [HashMap_getElem?_insert, show ¬(outTid.toObjId == t.toObjId) = true from by simp; exact Ne.symm hEq, ite_false]
+                exact hOrig
+          | _ => exact hOrig
+
+/-- WS-H12/H-03: Context switch preserves EDF-local property.
+The EDF comparison only uses `domain`, `priority`, and `deadline` fields — all
+of which are unchanged by saveContext (registerContext only) and restoreContext
+(machine.regs only). -/
+theorem contextSwitchState_preserves_edf_local (st : SystemState) (inTid : SeLe4n.ThreadId)
+    (tcbSel : TCB)
+    (hLocal : ∀ t, t ∈ st.scheduler.runnable →
+      match st.objects[t.toObjId]? with
+      | some (.tcb tcb) =>
+          tcb.domain = tcbSel.domain →
+          tcb.priority = tcbSel.priority →
+          tcbSel.deadline.toNat = 0 ∨
+            (tcb.deadline.toNat = 0 ∨ tcbSel.deadline.toNat ≤ tcb.deadline.toNat)
+      | _ => True) :
+    ∀ t, t ∈ (contextSwitchState st inTid).scheduler.runnable →
+      match (contextSwitchState st inTid).objects[t.toObjId]? with
+      | some (.tcb tcb) =>
+          tcb.domain = tcbSel.domain →
+          tcb.priority = tcbSel.priority →
+          tcbSel.deadline.toNat = 0 ∨
+            (tcb.deadline.toNat = 0 ∨ tcbSel.deadline.toNat ≤ tcb.deadline.toNat)
+      | _ => True := by
+  intro t hMem
+  have hCtxSched := contextSwitchState_preserves_scheduler st inTid
+  have hMemOrig : t ∈ st.scheduler.runnable := by
+    simp [SchedulerState.runnable] at hMem ⊢; rwa [hCtxSched] at hMem
+  have hOrig := hLocal t hMemOrig
+  unfold contextSwitchState
+  cases hCur : st.scheduler.current with
+  | none =>
+      show match (restoreContext st inTid).objects[t.toObjId]? with | some (.tcb tcb) => _ | _ => _
+      rw [restoreContext_preserves_objects]; exact hOrig
+  | some outTid =>
+      show match (restoreContext (saveContext st outTid) inTid).objects[t.toObjId]? with | some (.tcb tcb) => _ | _ => _
+      rw [restoreContext_preserves_objects]
+      unfold saveContext
+      cases hS : st.objects[outTid.toObjId]? with
+      | none => exact hOrig
+      | some obj =>
+          cases obj with
+          | tcb tcbOut =>
+              by_cases hEq : t.toObjId = outTid.toObjId
+              · -- t is the outgoing thread — domain/priority/deadline preserved
+                have hBEq : (outTid.toObjId == t.toObjId) = true := by simp [hEq]
+                simp only [HashMap_getElem?_insert, hBEq, ite_true]
+                rw [hEq, hS] at hOrig
+                exact hOrig
+              · simp only [HashMap_getElem?_insert, show ¬(outTid.toObjId == t.toObjId) = true from by simp; exact Ne.symm hEq, ite_false]
+                exact hOrig
+          | _ => exact hOrig
+
+-- ============================================================================
 -- Preservation theorems
 -- ============================================================================
 
@@ -349,7 +580,7 @@ theorem schedule_eq_chooseThread_then_setCurrent :
               match st'.objects[tid.toObjId]? with
               | some (.tcb tcb) =>
                   if tid ∈ st'.scheduler.runQueue ∧ tcb.domain = st'.scheduler.activeDomain then
-                    setCurrentThread (some tid) st'
+                    setCurrentThread (some tid) (contextSwitchState st' tid)
                   else
                     .error .schedulerInvariantViolation
               | _ => .error .schedulerInvariantViolation) := by
@@ -452,12 +683,15 @@ theorem schedule_preserves_wellFormed
                   cases obj with
                   | tcb tcb =>
                       by_cases hSchedOk : tid ∈ stChoose.scheduler.runQueue ∧ tcb.domain = stChoose.scheduler.activeDomain
-                      · simp [hChoose, hObj, hSchedOk] at hStep
-                        have hSet : setCurrentThread (some tid) stChoose = .ok ((), st') := by
-                          simpa [hChoose, hObj, hSchedOk] using hStep
+                      · have hCtxSched : (contextSwitchState stChoose tid).scheduler = stChoose.scheduler :=
+                          contextSwitchState_preserves_scheduler stChoose tid
                         have hMemRunnable : tid ∈ stChoose.scheduler.runnable := by
                           simpa [SchedulerState.runnable] using (RunQueue.mem_toList_iff_mem stChoose.scheduler.runQueue tid).2 hSchedOk.1
-                        exact setCurrentThread_preserves_wellFormed stChoose st' tid hMemRunnable hSet
+                        have hMemCtx : tid ∈ (contextSwitchState stChoose tid).scheduler.runnable := by
+                          rw [hCtxSched]; exact hMemRunnable
+                        have hSet : setCurrentThread (some tid) (contextSwitchState stChoose tid) = .ok ((), st') := by
+                          simpa [hChoose, hObj, hSchedOk] using hStep
+                        exact setCurrentThread_preserves_wellFormed (contextSwitchState stChoose tid) st' tid hMemCtx hSet
                       · have hSchedOk' : ¬(stChoose.scheduler.runQueue.contains tid = true ∧ tcb.domain = stChoose.scheduler.activeDomain) := by
                           simpa [RunQueue.mem_iff_contains] using hSchedOk
                         simp [hChoose, hObj, hSchedOk'] at hStep
@@ -535,7 +769,11 @@ theorem schedule_preserves_runQueueUnique
                   cases obj with
                   | tcb tcb =>
                       by_cases hSchedOk : tid ∈ stChoose.scheduler.runQueue ∧ tcb.domain = stChoose.scheduler.activeDomain
-                      · exact setCurrentThread_preserves_runQueueUnique stChoose st' (some tid) hUniqueChoose (by
+                      · have hCtxSched : (contextSwitchState stChoose tid).scheduler = stChoose.scheduler :=
+                          contextSwitchState_preserves_scheduler stChoose tid
+                        have hUniqueCtx : runQueueUnique (contextSwitchState stChoose tid).scheduler := by
+                          rw [hCtxSched]; exact hUniqueChoose
+                        exact setCurrentThread_preserves_runQueueUnique (contextSwitchState stChoose tid) st' (some tid) hUniqueCtx (by
                           simpa [hChoose, hObj, hSchedOk] using hStep)
                       · have hSchedOk' : ¬(stChoose.scheduler.runQueue.contains tid = true ∧ tcb.domain = stChoose.scheduler.activeDomain) := by
                           simpa [RunQueue.mem_iff_contains] using hSchedOk
@@ -569,8 +807,9 @@ theorem schedule_preserves_currentThreadValid
                   cases obj with
                   | tcb tcb =>
                       by_cases hSchedOk : tid ∈ stChoose.scheduler.runQueue ∧ tcb.domain = stChoose.scheduler.activeDomain
-                      · exact setCurrentThread_some_preserves_currentThreadValid stChoose st' tid
-                          ⟨tcb, hObj⟩
+                      · have hCtxTcb := contextSwitchState_preserves_tcb_exists stChoose tid ⟨tcb, hObj⟩
+                        exact setCurrentThread_some_preserves_currentThreadValid (contextSwitchState stChoose tid) st' tid
+                          hCtxTcb
                           (by simpa [hChoose, hObj, hSchedOk] using hStep)
                       · have hSchedOk' : ¬(stChoose.scheduler.runQueue.contains tid = true ∧ tcb.domain = stChoose.scheduler.activeDomain) := by
                           simpa [RunQueue.mem_iff_contains] using hSchedOk
@@ -646,10 +885,13 @@ theorem schedule_preserves_currentThreadInActiveDomain
                   cases obj with
                   | tcb tcb =>
                       by_cases hSchedOk : tid ∈ stChoose.scheduler.runQueue ∧ tcb.domain = stChoose.scheduler.activeDomain
-                      · have hSet : setCurrentThread (some tid) stChoose = .ok ((), st') := by
+                      · have hSet : setCurrentThread (some tid) (contextSwitchState stChoose tid) = .ok ((), st') := by
                           simpa [hChoose, hObj, hSchedOk] using hStep
+                        simp [setCurrentThread] at hSet
                         cases hSet
-                        simp [currentThreadInActiveDomain, hObj, hSchedOk.2]
+                        have hCtxSched := contextSwitchState_preserves_scheduler stChoose tid
+                        obtain ⟨tcb', hTcb', hDom, _, _, _⟩ := contextSwitchState_preserves_tcb stChoose tid tcb hObj
+                        simp [currentThreadInActiveDomain, hTcb', hCtxSched, hDom, hSchedOk.2]
                       · have hSchedOk' : ¬(stChoose.scheduler.runQueue.contains tid = true ∧ tcb.domain = stChoose.scheduler.activeDomain) := by
                           simpa [RunQueue.mem_iff_contains] using hSchedOk
                         simp [hChoose, hObj, hSchedOk'] at hStep
@@ -1154,7 +1396,9 @@ theorem schedule_preserves_timeSlicePositive
                   | tcb tcb =>
                       by_cases hOk : tid ∈ stChoose.scheduler.runQueue ∧
                           tcb.domain = stChoose.scheduler.activeDomain
-                      · exact setCurrentThread_preserves_timeSlicePositive stChoose st' (some tid) hInvC
+                      · have hInvCtx : timeSlicePositive (contextSwitchState stChoose tid) :=
+                          contextSwitchState_preserves_timeSlicePositive stChoose tid hInvC
+                        exact setCurrentThread_preserves_timeSlicePositive (contextSwitchState stChoose tid) st' (some tid) hInvCtx
                           (by simpa [hChoose, hObj, hOk] using hStep)
                       · have hOk' : ¬(stChoose.scheduler.runQueue.contains tid = true ∧
                             tcb.domain = stChoose.scheduler.activeDomain) := by
@@ -1689,11 +1933,23 @@ theorem schedule_preserves_edfCurrentHasEarliestDeadline
           by_cases hSchedOk : st.scheduler.runQueue.contains tid = true ∧
               tcbSel.domain = st.scheduler.activeDomain
           · simp only [hSchedOk] at hStep
+            have hEdfOrig := chooseBestInBucket_edf_bridge st tid resPrio resDl tcbSel
+              hwf hpm hSchedOk.2 hAllTcb hCIB hObj
+            obtain ⟨tcbSel', hObjCtx, hDomSel, hPrioSel, hDlSel, _⟩ :=
+              contextSwitchState_preserves_tcb st tid tcbSel hObj
+            -- Bridge EDF local property: replace tcbSel fields with tcbSel' fields
+            have hEdfCtx : ∀ t, t ∈ (contextSwitchState st tid).scheduler.runnable →
+                match (contextSwitchState st tid).objects[t.toObjId]? with
+                | some (.tcb tcb) =>
+                    tcb.domain = tcbSel'.domain →
+                    tcb.priority = tcbSel'.priority →
+                    tcbSel'.deadline.toNat = 0 ∨
+                      (tcb.deadline.toNat = 0 ∨ tcbSel'.deadline.toNat ≤ tcb.deadline.toNat)
+                | _ => True := by
+              rw [hDomSel, hPrioSel, hDlSel]
+              exact contextSwitchState_preserves_edf_local st tid tcbSel hEdfOrig
             exact setCurrentThread_some_preserves_edfCurrentHasEarliestDeadline
-              st st' tid tcbSel hObj
-              (chooseBestInBucket_edf_bridge st tid resPrio resDl tcbSel
-                hwf hpm hSchedOk.2 hAllTcb hCIB hObj)
-              hStep
+              (contextSwitchState st tid) st' tid tcbSel' hObjCtx hEdfCtx hStep
           · exfalso; simp [hSchedOk] at hStep
         | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ =>
           simp [hObj] at hStep

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -419,6 +419,60 @@ theorem restoreContext_preserves_objects (st : SystemState) (tid : SeLe4n.Thread
   | none => rfl
   | some obj => cases obj <;> rfl
 
+theorem saveContext_preserves_services (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (saveContext st tid).services = st.services := by
+  unfold saveContext; cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj => cases obj <;> rfl
+
+theorem restoreContext_preserves_services (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (restoreContext st tid).services = st.services := by
+  unfold restoreContext; cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj => cases obj <;> rfl
+
+theorem saveContext_preserves_irqHandlers (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (saveContext st tid).irqHandlers = st.irqHandlers := by
+  unfold saveContext; cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj => cases obj <;> rfl
+
+theorem restoreContext_preserves_irqHandlers (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (restoreContext st tid).irqHandlers = st.irqHandlers := by
+  unfold restoreContext; cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj => cases obj <;> rfl
+
+theorem saveContext_preserves_objectIndex (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (saveContext st tid).objectIndex = st.objectIndex := by
+  unfold saveContext; cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj => cases obj <;> rfl
+
+theorem restoreContext_preserves_objectIndex (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (restoreContext st tid).objectIndex = st.objectIndex := by
+  unfold restoreContext; cases st.objects[tid.toObjId]? with
+  | none => rfl
+  | some obj => cases obj <;> rfl
+
+theorem contextSwitchState_preserves_services (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (contextSwitchState st tid).services = st.services := by
+  unfold contextSwitchState; cases st.scheduler.current with
+  | none => exact restoreContext_preserves_services st tid
+  | some outTid => rw [restoreContext_preserves_services, saveContext_preserves_services]
+
+theorem contextSwitchState_preserves_irqHandlers (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (contextSwitchState st tid).irqHandlers = st.irqHandlers := by
+  unfold contextSwitchState; cases st.scheduler.current with
+  | none => exact restoreContext_preserves_irqHandlers st tid
+  | some outTid => rw [restoreContext_preserves_irqHandlers, saveContext_preserves_irqHandlers]
+
+theorem contextSwitchState_preserves_objectIndex (st : SystemState) (tid : SeLe4n.ThreadId) :
+    (contextSwitchState st tid).objectIndex = st.objectIndex := by
+  unfold contextSwitchState; cases st.scheduler.current with
+  | none => exact restoreContext_preserves_objectIndex st tid
+  | some outTid => rw [restoreContext_preserves_objectIndex, saveContext_preserves_objectIndex]
+
 theorem contextSwitchState_preserves_objects_at (st : SystemState)
     (tid : SeLe4n.ThreadId) (k : ObjId)
     (hk : ∀ outTid, st.scheduler.current = some outTid → k ≠ outTid.toObjId) :

--- a/SeLe4n/Machine.lean
+++ b/SeLe4n/Machine.lean
@@ -28,14 +28,21 @@ The `RuntimeBoundaryContract.memoryAccessAllowed` predicate already provides
 the extension point for this transition. -/
 abbrev Memory := PAddr → UInt8
 
-/-- Pure register file state used by scheduler/context-switch modeling. -/
+/-- WS-H12/H-03: Number of general-purpose registers in the ARM64 model (x0-x30). -/
+def numGPR : Nat := 31
+
+/-- Pure register file state used by scheduler/context-switch modeling.
+
+WS-H12/H-03: `gpr` changed from function type to `Array` with fixed size `numGPR`
+to support `DecidableEq` for `TCB` (needed for per-TCB register context). -/
 structure RegisterFile where
   pc : RegValue
   sp : RegValue
-  gpr : RegName → RegValue
+  gpr : Array RegValue := Array.replicate numGPR 0
+  deriving Repr, DecidableEq
 
 instance : Inhabited RegisterFile where
-  default := { pc := 0, sp := 0, gpr := fun _ => 0 }
+  default := { pc := 0, sp := 0, gpr := Array.replicate numGPR 0 }
 
 /-- Top-level abstract machine state manipulated by kernel transitions. -/
 structure MachineState where
@@ -47,10 +54,11 @@ instance : Inhabited MachineState where
   default := { regs := default, memory := fun _ => 0, timer := 0 }
 
 def readReg (rf : RegisterFile) (r : RegName) : RegValue :=
-  rf.gpr r
+  if h : r < rf.gpr.size then rf.gpr[r] else 0
 
 def writeReg (rf : RegisterFile) (r : RegName) (v : RegValue) : RegisterFile :=
-  { rf with gpr := fun r' => if r' = r then v else rf.gpr r' }
+  if h : r < rf.gpr.size then { rf with gpr := rf.gpr.set r v }
+  else rf
 
 def readMem (ms : MachineState) (addr : PAddr) : UInt8 :=
   ms.memory addr
@@ -68,14 +76,26 @@ def tick (ms : MachineState) : MachineState :=
 -- Register read-after-write and frame lemmas (WS-E4 preparation)
 -- ============================================================================
 
-theorem readReg_writeReg_eq (rf : RegisterFile) (r : RegName) (v : RegValue) :
+theorem readReg_writeReg_eq (rf : RegisterFile) (r : RegName) (v : RegValue)
+    (hBound : r < rf.gpr.size) :
     readReg (writeReg rf r v) r = v := by
-  simp [readReg, writeReg]
+  simp only [readReg, writeReg, hBound, dite_true, Array.size_set]
+  exact Array.getElem_set_self ..
 
 theorem readReg_writeReg_ne (rf : RegisterFile) (r r' : RegName) (v : RegValue)
     (hNe : r' ≠ r) :
     readReg (writeReg rf r v) r' = readReg rf r' := by
-  simp [readReg, writeReg, hNe]
+  simp only [readReg, writeReg]
+  split
+  · rename_i hr
+    simp only [Array.size_set] at *
+    split
+    · rename_i hr'
+      rw [Array.getElem_set_ne]
+      exact fun h => hNe h.symm
+    · rename_i hr'
+      simp [hr'] at *
+  · rfl
 
 theorem readMem_writeMem_eq (ms : MachineState) (addr : PAddr) (value : UInt8) :
     readMem (writeMem ms addr value) addr = value := by
@@ -87,10 +107,12 @@ theorem readMem_writeMem_ne (ms : MachineState) (addr addr' : PAddr) (value : UI
   simp [readMem, writeMem, hNe]
 
 theorem writeReg_preserves_pc (rf : RegisterFile) (r : RegName) (v : RegValue) :
-    (writeReg rf r v).pc = rf.pc := rfl
+    (writeReg rf r v).pc = rf.pc := by
+  simp [writeReg]; split <;> rfl
 
 theorem writeReg_preserves_sp (rf : RegisterFile) (r : RegName) (v : RegValue) :
-    (writeReg rf r v).sp = rf.sp := rfl
+    (writeReg rf r v).sp = rf.sp := by
+  simp [writeReg]; split <;> rfl
 
 theorem writeMem_preserves_regs (ms : MachineState) (addr : PAddr) (value : UInt8) :
     (writeMem ms addr value).regs = ms.regs := rfl

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -1,4 +1,5 @@
 import SeLe4n.Prelude
+import SeLe4n.Machine
 
 namespace SeLe4n.Model
 
@@ -55,18 +56,34 @@ def hasRight (cap : Capability) (right : AccessRight) : Bool :=
 
 end Capability
 
+/-- WS-H12/A-09: Maximum number of message registers in an IPC payload.
+Matches seL4 MCS standard configuration (120 message registers). -/
+def maxMessageRegisters : Nat := 120
+
+/-- WS-H12/A-09: Maximum number of extra capability slots in an IPC payload.
+Matches seL4 standard configuration (3 extra caps). -/
+def maxExtraCaps : Nat := 3
+
 /-- WS-E4/M-02: Structured IPC message payload for endpoint transfers.
 
-Models seL4 message registers plus optional capability transfer and sender badge. -/
+Models seL4 message registers plus optional capability transfer and sender badge.
+
+WS-H12/A-09: Changed from unbounded `List` to bounded `Array` with
+`maxMessageRegisters` and `maxExtraCaps` limits matching seL4 MCS configuration. -/
 structure IpcMessage where
-  registers : List Nat
-  caps : List Capability := []
+  registers : Array Nat := #[]
+  caps : Array Capability := #[]
   badge : Option SeLe4n.Badge := none
   deriving Repr, DecidableEq
 
 namespace IpcMessage
 
-def empty : IpcMessage := { registers := [], caps := [], badge := none }
+def empty : IpcMessage := { registers := #[], caps := #[], badge := none }
+
+/-- WS-H12/A-09: An IPC message is well-formed when its payload sizes
+do not exceed the seL4-aligned limits. -/
+def wellFormed (msg : IpcMessage) : Bool :=
+  msg.registers.size ≤ maxMessageRegisters && msg.caps.size ≤ maxExtraCaps
 
 end IpcMessage
 
@@ -126,6 +143,10 @@ structure TCB where
       Stored in the sender's TCB while blocked; transferred to the receiver
       on handshake/dequeue. `none` = no pending message. -/
   pendingMessage : Option IpcMessage := none
+  /-- WS-H12/H-03: Per-thread register save area for context switching.
+      Stores the full ARM64 general-purpose register set (x0-x30, sp, pc, pstate).
+      Saved on dispatch-out, restored on dispatch-in by `schedule`. -/
+  registerContext : SeLe4n.RegisterFile := default
   deriving Repr, DecidableEq
 
 inductive EndpointState where

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -31,6 +31,7 @@ inductive KernelError where
   | childIdSelfOverwrite    -- WS-H2/H-06: childId = untypedId in retypeFromUntyped
   | childIdCollision        -- WS-H2/A-26: childId collides with existing object or untyped child
   | addressOutOfBounds      -- WS-H11/A-05: physical address exceeds machine address width
+  | invalidArgument         -- WS-H12/A-09: generic invalid argument (e.g., IPC message exceeds payload bounds)
   deriving Repr, DecidableEq
 
 /-- M-05/WS-E6: One entry in the round-robin domain schedule table.

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -587,7 +587,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
   let epId : SeLe4n.ObjId := demoEndpoint
   let senderId : SeLe4n.ThreadId := 1
   let receiverId : SeLe4n.ThreadId := 12
-  let testMsg : IpcMessage := { registers := [42, 7], caps := [], badge := some ⟨123⟩ }
+  let testMsg : IpcMessage := { registers := #[42, 7], caps := #[], badge := some ⟨123⟩ }
   -- Fresh endpoint for dual-queue test
   let ep0 : KernelObject := .endpoint {
     state := .idle, queue := [], waitingReceiver := none,
@@ -611,7 +611,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
             | none => none
           let msgRegs := match recvMsg with
             | some m => m.registers
-            | none => []
+            | none => #[]
           IO.println s!"message transfer registers: {reprStr msgRegs}"
           let msgBadge := match recvMsg with
             | some m => m.badge
@@ -632,7 +632,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"F1-02 receive-first error: {reprStr err}"
   | .ok (_, stWait) =>
       -- Sender sends with message (receiver queued → rendezvous)
-      let rendezvousMsg : IpcMessage := { registers := [99], caps := [], badge := none }
+      let rendezvousMsg : IpcMessage := { registers := #[99], caps := #[], badge := none }
       match SeLe4n.Kernel.endpointSendDual epId senderId rendezvousMsg stWait with
       | .error err => IO.println s!"F1-02 send error: {reprStr err}"
       | .ok (_, stRend) =>
@@ -641,7 +641,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
             | none => none
           let rendRegs := match rendMsg with
             | some m => m.registers
-            | none => []
+            | none => #[]
           IO.println s!"rendezvous delivery registers: {reprStr rendRegs}"
   -- F1-03: Call + Reply roundtrip with message payload
   let ep2 : KernelObject := .endpoint {
@@ -653,7 +653,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
   | .error err => IO.println s!"F1-03 receive error: {reprStr err}"
   | .ok (_, stWait2) =>
       -- Caller calls with message
-      let callMsg : IpcMessage := { registers := [10, 20, 30], caps := [], badge := some ⟨456⟩ }
+      let callMsg : IpcMessage := { registers := #[10, 20, 30], caps := #[], badge := some ⟨456⟩ }
       match SeLe4n.Kernel.endpointCall epId senderId callMsg stWait2 with
       | .error err => IO.println s!"F1-03 call error: {reprStr err}"
       | .ok (_, stCalled) =>
@@ -666,7 +666,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
             | none => false
           IO.println s!"call/reply caller blocked: {callerBlocked}"
           -- WS-H1/M-02: Reply with response message — receiverId is the authorized replier
-          let replyMsg : IpcMessage := { registers := [100, 200], caps := [], badge := none }
+          let replyMsg : IpcMessage := { registers := #[100, 200], caps := #[], badge := none }
           match SeLe4n.Kernel.endpointReply receiverId senderId replyMsg stCalled with
           | .error err => IO.println s!"F1-03 reply error: {reprStr err}"
           | .ok (_, stReplied) =>
@@ -675,7 +675,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
                 | none => none
               let replyRegs := match replyResult with
                 | some m => m.registers
-                | none => []
+                | none => #[]
               IO.println s!"call/reply response registers: {reprStr replyRegs}"
   -- WS-H1: Call blocking-path — caller enqueues as blockedOnCall, receiver dequeues,
   -- caller transitions to blockedOnReply (not .ready), then explicit Reply unblocks.
@@ -686,7 +686,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
   let serverId : SeLe4n.ThreadId := receiverId  -- reuse thread 12
   let stH1 : SystemState := { st1 with objects := st1.objects.insert epId ep3 }
   -- No receiver queued → caller enqueues on sendQ with blockedOnCall
-  let h1CallMsg : IpcMessage := { registers := [77], caps := [], badge := none }
+  let h1CallMsg : IpcMessage := { registers := #[77], caps := #[], badge := none }
   match SeLe4n.Kernel.endpointCall epId callerId h1CallMsg stH1 with
   | .error err => IO.println s!"H1-01 call error: {reprStr err}"
   | .ok (_, stBlocked) =>
@@ -715,7 +715,7 @@ private def runIpcMessageTransferTrace (st1 : SystemState) : IO Unit := do
           IO.println s!"H1 caller blockedOnReply after dequeue: {isBlockedOnReply}"
           IO.println s!"H1 caller not ready after dequeue: {callerNotReady}"
           -- Explicit Reply from the authorized server unblocks the caller
-          let h1ReplyMsg : IpcMessage := { registers := [88], caps := [], badge := none }
+          let h1ReplyMsg : IpcMessage := { registers := #[88], caps := #[], badge := none }
           match SeLe4n.Kernel.endpointReply serverId callerId h1ReplyMsg stDequeued with
           | .error err => IO.println s!"H1-03 reply error: {reprStr err}"
           | .ok (_, stReplied) =>

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -61,12 +61,12 @@ E4-C02    | high     | cspaceCopy target matches: true
 E4-M01    | high     | dual-queue sender blocked on sendQ non-empty: true
 E4-M12    | high     | endpointReply unblocked target: true
 F1-01a    | critical | message sender has pending: true
-F1-01b    | critical | message transfer registers: [42, 7]
+F1-01b    | critical | message transfer registers: #[42, 7]
 F1-01c    | critical | message transfer badge: some { val := 123 }
 F1-01d    | high     | message sender cleared after transfer: true
-F1-02     | critical | rendezvous delivery registers: [99]
+F1-02     | critical | rendezvous delivery registers: #[99]
 F1-03a    | high     | call/reply caller blocked: true
-F1-03b    | critical | call/reply response registers: [100, 200]
+F1-03b    | critical | call/reply response registers: #[100, 200]
 H1-01     | critical | H1 caller blockedOnCall: true
 H1-02     | critical | H1 caller blockedOnReply after dequeue: true
 H1-03     | critical | H1 caller not ready after dequeue: true


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: WS-H12 (Context switching and register management)
- Recommendation IDs closed: WS-H12/H-03, WS-H12/A-09
- Scope notes: Implements per-thread register save areas for context switching, matching seL4's TCB-based register context model

## Changes

### Core Context Switch Implementation

**Kernel/Scheduler/Operations.lean:**
- Added `saveContext`: Saves machine registers into outgoing thread's TCB `registerContext` field
- Added `restoreContext`: Restores machine registers from incoming thread's TCB `registerContext` field
- Added `contextSwitchState`: Factors context save/restore, preserving scheduler state
- Modified `schedule` to inline context save/restore during thread dispatch
- Added 20+ preservation theorems proving context switch operations preserve scheduler state, object keys, and critical invariants (`timeSlicePositive`, EDF ordering)

**Machine.lean:**
- Changed `RegisterFile.gpr` from function type to fixed-size `Array RegValue` (31 GPRs for ARM64)
- Added `numGPR` constant (31) and `DecidableEq` derivation for `RegisterFile`
- Updated `readReg`/`writeReg` to use array bounds checking
- Updated register read-after-write lemmas with bounds preconditions

**Model/Object.lean:**
- Added `registerContext: RegisterFile` field to `TCB` structure
- Added `maxMessageRegisters` (120) and `maxExtraCaps` (3) constants for IPC payload bounds
- Changed `IpcMessage.registers` and `IpcMessage.caps` from `List` to bounded `Array`
- Added `IpcMessage.wellFormed` predicate for payload validation

### Information Flow & Invariant Preservation

**Kernel/InformationFlow/Invariant.lean:**
- Added `contextSwitchState_preserves_projection` theorem: proves context switch preserves state projection when current thread is non-observable
- Updated `schedule_preserves_projection` to account for inline context switching

**Kernel/InformationFlow/Policy.lean:**
- Added `threadObjectCoherent` requirement to `LabelingContext`: thread security label must equal its backing TCB object's label

**Kernel/InformationFlow/Projection.lean:**
- Added `threadObservable_eq_objectObservable` theorem: proves thread and object observability agree via coherence

**Kernel/IPC/Invariant.lean:**
- Added `ipcBoundsCheck_ok` helper theorem for eliminating message bounds checks in proofs
- Updated `endpointReply`, `endpointSendDual`, `endpointCall` preservation theorems to use bounds check helper

**Kernel/IPC/DualQueue.lean:**
- Added message bounds validation (`if !msg.wellFormed then .error .invalidArgument`) to `endpointSendDual`, `endpointCall`, `endpointReply`

### Proof Updates

**Kernel/Scheduler/Operations.lean (preservation theorems):**
- Updated `schedule_preserves_wellFormed`, `schedule_preserves_runQueueUnique`, `schedule_preserves_currentThreadValid`, `schedule_preserves_currentThreadInActiveDomain`, `schedule_preserves_timeSlicePositive`, `schedule_preserves_edfCurrentHasEarliestDeadline` to thread context switch state through proofs

**Kernel/Capability/Invariant.lean:**
- Updated `endpointReply_preserves_capabilityInvariantBundle` with bounds check helper

### Test Updates

**Testing/MainTraceHarness.lean:**
- Updated IPC message construction to use `Array` syntax (`#[...]` instead of `[...]`)

**tests/fixtures/main_trace_smoke.expected:**
- Updated expected output to reflect `Array` representation in trace output

## Validation evidence

- Existing test suite passes with new context switch implementation
- Preservation theorems prove scheduler state invariance across context switches
- Information flow theorems prove projection preservation for non-

https://claude.ai/code/session_01BnW69XYt7PbCS8nCojCM2z