### PR TITLE
Fix comment typo: "shellcheck" → "Shell-checker"

### DIFF
--- a/scripts/setup_lean_env.sh
+++ b/scripts/setup_lean_env.sh
@@ -136,7 +136,7 @@ install_missing_packages() {
   local missing_apt=()
   local missing_any=0
 
-  # shellcheck and ripgrep are only needed for test/lint — skip during build-only setup.
+  # Shell-checker and ripgrep are only needed for test/lint — skip during build-only setup.
   if [ "${SKIP_TEST_DEPS}" -eq 0 ]; then
     if ! command -v shellcheck >/dev/null 2>&1; then
       missing_apt+=("shellcheck")


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: N/A
- Recommendation IDs closed: N/A
- Scope notes: Minor documentation fix in setup script comment

## Changes

Fixed a typo in the comment for the `install_missing_packages()` function in `scripts/setup_lean_env.sh`. Changed "shellcheck" to "Shell-checker" for consistency with proper noun capitalization conventions.

## Validation evidence

- [x] No functional code changes; comment-only modification
- [x] No test execution required for this trivial fix

## Documentation synchronization checklist

- [x] N/A — This is a comment fix in a shell script, not documentation

## Risks / follow-ups

- Residual risks: None
- Deferred items: None

https://claude.ai/code/session_01Cak8J5coGYmparKLc9AxwD