### PR TITLE
Release v0.14.2: WS-H12e invariant reconciliation + docs sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 seLe4n is a production-oriented microkernel written in Lean 4 with machine-checked
 proofs, improving on seL4 architecture. Every kernel transition is an executable
 pure function with zero `sorry`/`axiom`. First hardware target: Raspberry Pi 5.
-Lean 4.28.0 toolchain, Lake build system, version 0.14.0.
+Lean 4.28.0 toolchain, Lake build system, version 0.14.2.
 
 ## Build and run
 
@@ -313,7 +313,7 @@ under `docs/` and `docs/gitbook/`.
 - **Active portfolio**: WS-G (kernel performance optimization) — WS-G1..G9 completed
 - **Active findings baseline**: `docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`
 - **Planning backbone**: `docs/audits/KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md`
-- **Completed**: WS-H12c (v0.14.0), WS-H12b (v0.13.9), WS-H12a (v0.13.8), WS-H11 (v0.13.7), WS-H10 (v0.13.6), WS-H9 (v0.13.4), WS-H8 (v0.13.2), WS-H6 (v0.13.1), WS-H5 (v0.12.19), WS-H4 (v0.12.18), WS-H3 (v0.12.17), WS-H2 (v0.12.16), WS-H1 (v0.12.16), WS-G1..G9 + refinement (v0.12.15), WS-F1..F4 (v0.12.2), WS-E1..E6 (v0.11.6), WS-D1..D4 (v0.11.0), WS-C1..C8 (v0.9.32), WS-B1..B11 (v0.9.0)
+- **Completed**: WS-H12e (v0.14.2), WS-H12d (v0.14.1), WS-H12c (v0.14.0), WS-H12b (v0.13.9), WS-H12a (v0.13.8), WS-H11 (v0.13.7), WS-H10 (v0.13.6), WS-H9 (v0.13.4), WS-H8 (v0.13.2), WS-H6 (v0.13.1), WS-H5 (v0.12.19), WS-H4 (v0.12.18), WS-H3 (v0.12.17), WS-H2 (v0.12.16), WS-H1 (v0.12.16), WS-G1..G9 + refinement (v0.12.15), WS-F1..F4 (v0.12.2), WS-E1..E6 (v0.11.6), WS-D1..D4 (v0.11.0), WS-C1..C8 (v0.9.32), WS-B1..B11 (v0.9.0)
 - **Hardware target**: Raspberry Pi 5 (ARM64)
 
 ## PR checklist

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ introducing substantial architectural improvements:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.14.0` |
+| **Version** | `0.14.2` |
 | **Lean toolchain** | `4.28.0` |
-| **Production Lean LoC** | 28,813 across 41 files |
-| **Test Lean LoC** | 2,265 across 3 test suites |
-| **Proved declarations** | 855 theorem/lemma declarations (zero sorry/axiom) |
+| **Production Lean LoC** | 30,348 across 41 files |
+| **Test Lean LoC** | 2,360 across 3 test suites |
+| **Proved declarations** | 920 theorem/lemma declarations (zero sorry/axiom) |
 | **Build jobs** | 86 |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Active findings** | [`AUDIT_CODEBASE_v0.12.2_v1.md`](docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](docs/audits/AUDIT_CODEBASE_v0.12.2_v2.md) |
 | **Active audit** | [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) — all 14 findings resolved |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](docs/audits/AUDIT_CODEBASE_v0.13.6.md) — comprehensive end-to-end audit, zero critical issues |
-| **Completed** | WS-H12c (v0.14.0), WS-H12b (v0.13.9), WS-H12a (v0.13.8), WS-H11 (v0.13.7), End-to-end audit (v0.13.6), WS-H10 (v0.13.6), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (v0.13.4), WS-H8 (v0.13.2), WS-H6 (v0.13.1), WS-H5 (v0.12.19), WS-H4 (v0.12.18), WS-H3 (v0.12.17), WS-H2 (v0.12.16), WS-H1 (v0.12.16), WS-G (v0.12.15), WS-F1..F4 (v0.12.2), WS-E (v0.11.6), WS-D (v0.11.0), WS-C (v0.9.32), WS-B (v0.9.0) |
+| **Completed** | WS-H12e (v0.14.2), WS-H12d (v0.14.1), WS-H12c (v0.14.0), WS-H12b (v0.13.9), WS-H12a (v0.13.8), WS-H11 (v0.13.7), End-to-end audit (v0.13.6), WS-H10 (v0.13.6), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (v0.13.4), WS-H8 (v0.13.2), WS-H6 (v0.13.1), WS-H5 (v0.12.19), WS-H4 (v0.12.18), WS-H3 (v0.12.17), WS-H2 (v0.12.16), WS-H1 (v0.12.16), WS-G (v0.12.15), WS-F1..F4 (v0.12.2), WS-E (v0.11.6), WS-D (v0.11.0), WS-C (v0.9.32), WS-B (v0.9.0) |
 | **Metrics source of truth** | `./scripts/report_current_state.py` (use before updating docs/gitbook) |
 
 All quantitative attributes above are generated from the codebase using

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -45,6 +45,8 @@ M7 (audit remediation).
 
 | Portfolio | Scope | Status |
 |-----------|-------|--------|
+| **WS-H12e** (v0.14.2) | Cross-subsystem invariant reconciliation: `coreIpcInvariantBundle` upgraded to `ipcInvariantFull`, `schedulerInvariantBundleFull` extended with `contextMatchesCurrent`, `ipcSchedulerCouplingInvariantBundle` extended with register-context and dequeue coherence, `proofLayerInvariantBundle` uses full scheduler bundle, all preservation proofs updated. Closes systemic invariant composition gaps from WS-H12a–d | Completed |
+| **WS-H12d** (v0.14.1) | IPC message payload bounds: `IpcMessage` registers/caps migrated to `Array` with `maxMessageRegisters`(120)/`maxExtraCaps`(3), bounds enforcement at all 4 send boundaries, `allPendingMessagesBounded` system invariant. Closes A-09 | Completed |
 | **WS-H12c** (v0.14.0) | Per-TCB register context with inline context switch: `registerContext` field on TCB, inline `saveOutgoingContext`/`restoreIncomingContext` in `schedule`, `contextMatchesCurrent` invariant with preservation proofs for scheduler and IPC operations, IF projection stripping. Closes H-03 | Completed |
 | **WS-H12b** (v0.13.9) | Dequeue-on-dispatch scheduler semantics: `queueCurrentConsistent` inverted to `current ∉ runnable` matching seL4's `switchToThread`/`tcbSchedDequeue`; schedule/handleYield/timerTick/switchDomain updated; `currentTimeSlicePositive` and `schedulerPriorityMatch` predicates; IPC coherence predicates; ~1800 lines of proofs re-proved. Closes H-04 | Completed |
 | **WS-H12a** (v0.13.8) | Legacy endpoint removal: `EndpointState` deleted, legacy IPC ops removed, ~60 dead theorems cleaned, `endpointReplyRecv` migrated to dual-queue. Closes A-08, M-01, A-25 | Completed |

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -13,17 +13,17 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 
 | Attribute | Value |
 |-----------|-------|
-| Version | `0.13.9` |
+| Version | `0.14.2` |
 | Lean toolchain | `4.28.0` |
-| Production LoC | 28,813 across 41 files |
-| Test LoC | 2,265 across 3 suites |
-| Proved declarations | 855 theorem/lemma declarations (zero sorry/axiom) |
+| Production LoC | 30,348 across 41 files |
+| Test LoC | 2,360 across 3 suites |
+| Proved declarations | 920 theorem/lemma declarations (zero sorry/axiom) |
 | Build jobs | 86 |
 | Active findings | [`AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md) |
 | Active audit | [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) (14 findings tracked to completion in WS-G) |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — comprehensive end-to-end audit, zero critical issues |
-| Recently completed | WS-H12c (v0.14.0, per-TCB register context with inline context switch), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), End-to-end audit (v0.13.6), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (NI coverage extension, v0.13.4), WS-H8 (enforcement-NI bridge, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path fix, v0.12.16), WS-G (kernel performance) |
-| Next workstream | WS-H12d–f, H13..H16 (remaining v0.12.15 audit remediation) |
+| Recently completed | WS-H12e (v0.14.2, cross-subsystem invariant reconciliation), WS-H12d (v0.14.1, IPC message payload bounds), WS-H12c (v0.14.0, per-TCB register context with inline context switch), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), End-to-end audit (v0.13.6), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (NI coverage extension, v0.13.4), WS-H8 (enforcement-NI bridge, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path fix, v0.12.16), WS-G (kernel performance) |
+| Next workstream | WS-H12f, H13..H16 (remaining v0.12.15 audit remediation) |
 | Metrics source of truth | `./scripts/report_current_state.py` |
 
 ## Milestone history
@@ -42,7 +42,40 @@ WS-H10 (security model foundations, v0.13.6) →
 End-to-end codebase audit (v0.13.6) →
 WS-H11 (VSpace & architecture enrichment, v0.13.7) →
 WS-H12a (legacy endpoint removal, v0.13.8) →
-WS-H12b (dequeue-on-dispatch scheduler semantics, v0.13.9).
+WS-H12b (dequeue-on-dispatch scheduler semantics, v0.13.9) →
+WS-H12c (per-TCB register context, v0.14.0) →
+WS-H12d (IPC message payload bounds, v0.14.1) →
+WS-H12e (cross-subsystem invariant reconciliation, v0.14.2).
+
+## Completed: WS-H12e Cross-Subsystem Invariant Reconciliation (v0.14.2)
+
+Reconciled all subsystem invariant compositions after WS-H12a–d changes.
+`coreIpcInvariantBundle` upgraded from `ipcInvariant` to `ipcInvariantFull`
+(3-conjunct: `ipcInvariant ∧ dualQueueSystemInvariant ∧ allPendingMessagesBounded`);
+`schedulerInvariantBundleFull` extended from 4 to 5 conjuncts (+ `contextMatchesCurrent`);
+`ipcSchedulerCouplingInvariantBundle` extended with `contextMatchesCurrent` and
+`currentThreadDequeueCoherent`; `proofLayerInvariantBundle` uses full scheduler bundle;
+8 frame lemmas + 3 compound preservation theorems + 7 composed `ipcInvariantFull`
+preservation theorems; all `*_preserves_schedulerInvariantBundleFull` theorems updated;
+default state proofs extended. Closes systemic invariant composition gaps from WS-H12a–d.
+
+## Completed: WS-H12d IPC Message Payload Bounds (v0.14.1)
+
+`IpcMessage` registers/caps migrated from `List` to `Array` with
+`maxMessageRegisters`(120)/`maxExtraCaps`(3). Bounds enforcement at all 4 send
+boundaries (`endpointSendDual`/`endpointCall`/`endpointReply`/`endpointReplyRecv`).
+4 `*_message_bounded` theorems. `allPendingMessagesBounded` system invariant
+integrated into `ipcInvariantFull` 3-conjunct bundle. `checkBounds_iff_bounded`
+decidability bridge. Information-flow enforcement updated with bounds-before-flow
+ordering. Closes A-09 (HIGH).
+
+## Completed: WS-H12c Per-TCB Register Context (v0.14.0)
+
+Per-TCB `registerContext` field on TCB with inline `saveOutgoingContext`/
+`restoreIncomingContext` in `schedule`. `contextMatchesCurrent` invariant with
+preservation proofs for all scheduler and IPC operations. Information-flow
+projection strips register context. `endpointInvariant` removed (vacuous since
+WS-H12a). Closes H-03 (HIGH).
 
 ## Completed: WS-H12b Dequeue-on-Dispatch Scheduler Semantics (v0.13.9)
 

--- a/docs/gitbook/22-next-slice-development-path.md
+++ b/docs/gitbook/22-next-slice-development-path.md
@@ -35,7 +35,7 @@ Four major portfolios are completed:
 - **WS-E, WS-D, WS-C, WS-B** (v0.9.0–v0.11.6): All earlier audit portfolios
   completed — test/CI hardening, proof quality, kernel design, model structure.
 
-## Immediate next: WS-H12d–f, H13..H16 and WS-F5..F8
+## Immediate next: WS-H12f, H13..H16 and WS-F5..F8
 
 ### Remaining WS-H workstreams — v0.12.15 audit remediation
 
@@ -47,7 +47,9 @@ The remaining WS-H workstreams address Phases 4–5 of the v0.12.15 audit plan:
 | **WS-H12a** | Legacy endpoint field & operation removal | Medium — **Completed** |
 | **WS-H12b** | Dequeue-on-dispatch scheduler semantics | Medium — **Completed** |
 | **WS-H12c** | Per-TCB register context with inline context switch (H-03) | Medium — **Completed** |
-| **WS-H12d–f** | Scheduler/IPC semantic alignment (message bounds, reconciliation) | Medium |
+| **WS-H12d** | IPC message payload bounds (A-09) | Medium — **Completed** |
+| **WS-H12e** | Cross-subsystem invariant reconciliation | Medium — **Completed** |
+| **WS-H12f** | Test harness update & documentation sync | Medium |
 | **WS-H13** | CSpace/service model enrichment (CDT refinement, service health) | Medium |
 | **WS-H14** | Type safety hardening (phantom types, API boundary contracts) | Low |
 | **WS-H15** | Platform hardening (RPi5 contract population, boot sequence) | Low |

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -5,12 +5,12 @@
 This GitBook is the long-form guide for seLe4n — a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.
 
 ## Current project state
-- **Version:** 0.13.9 (Lean 4.28.0).
-- **Codebase metrics:** 28,813 production LoC across 41 files; 2,265 test LoC across 3 suites; 855 theorem/lemma declarations (zero sorry/axiom); 86 build jobs.
+- **Version:** 0.14.2 (Lean 4.28.0).
+- **Codebase metrics:** 30,348 production LoC across 41 files; 2,360 test LoC across 3 suites; 920 theorem/lemma declarations (zero sorry/axiom); 86 build jobs.
 - **Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md).
 - **Active audit:** [`docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) (14 findings tracked to completion in WS-G).
-- **Recently completed:** WS-H12c (v0.14.0, per-TCB register context with inline context switch), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (NI coverage >80%, v0.13.4), WS-H8 (enforcement-NI bridge, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue structural invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI infrastructure, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path semantic fix, v0.12.16).
-- **Next workstream:** WS-H12d–f, H13..H16 (remaining v0.12.15 audit remediation) and WS-F5..F8 (remaining v0.12.2 audit remediation).
+- **Recently completed:** WS-H12e (v0.14.2, cross-subsystem invariant reconciliation), WS-H12d (v0.14.1, IPC message payload bounds), WS-H12c (v0.14.0, per-TCB register context with inline context switch), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (NI coverage >80%, v0.13.4), WS-H8 (enforcement-NI bridge, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue structural invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI infrastructure, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path semantic fix, v0.12.16).
+- **Next workstream:** WS-H12f, H13..H16 (remaining v0.12.15 audit remediation) and WS-F5..F8 (remaining v0.12.2 audit remediation).
 - **Prior completed:** WS-G (v0.12.15), WS-F1..F4 (v0.12.2), WS-E (v0.11.6), WS-D (v0.11.0), WS-C (v0.9.32), WS-B (v0.9.0).
 - **Hardware target:** Raspberry Pi 5 (ARM64).
 - **Metrics source of truth:** `./scripts/report_current_state.py` (sync README/spec/GitBook together in one PR).

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -1,12 +1,12 @@
 {
   "description": "This GitBook is the long-form guide for seLe4n \u2014 a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.",
   "current_state_bullets": [
-    "**Version:** 0.13.9 (Lean 4.28.0).",
-    "**Codebase metrics:** 28,813 production LoC across 41 files; 2,265 test LoC across 3 suites; 855 theorem/lemma declarations (zero sorry/axiom); 86 build jobs.",
+    "**Version:** 0.14.2 (Lean 4.28.0).",
+    "**Codebase metrics:** 30,348 production LoC across 41 files; 2,360 test LoC across 3 suites; 920 theorem/lemma declarations (zero sorry/axiom); 86 build jobs.",
     "**Active findings baseline:** [`docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md).",
     "**Active audit:** [`docs/audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](../audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) (14 findings tracked to completion in WS-G).",
-    "**Recently completed:** WS-H12c (v0.14.0, per-TCB register context with inline context switch), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (NI coverage >80%, v0.13.4), WS-H8 (enforcement-NI bridge, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue structural invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI infrastructure, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path semantic fix, v0.12.16).",
-    "**Next workstream:** WS-H12d\u2013f, H13..H16 (remaining v0.12.15 audit remediation) and WS-F5..F8 (remaining v0.12.2 audit remediation).",
+    "**Recently completed:** WS-H12e (v0.14.2, cross-subsystem invariant reconciliation), WS-H12d (v0.14.1, IPC message payload bounds), WS-H12c (v0.14.0, per-TCB register context with inline context switch), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (NI coverage >80%, v0.13.4), WS-H8 (enforcement-NI bridge, v0.13.2), WS-H6 (scheduler proof completion, v0.13.1), WS-H5 (IPC dual-queue structural invariant, v0.12.19), WS-H4 (capability invariant redesign, v0.12.18), WS-H3 (build/CI infrastructure, v0.12.17), WS-H2 (lifecycle safety guards, v0.12.16), WS-H1 (IPC call-path semantic fix, v0.12.16).",
+    "**Next workstream:** WS-H12f, H13..H16 (remaining v0.12.15 audit remediation) and WS-F5..F8 (remaining v0.12.2 audit remediation).",
     "**Prior completed:** WS-G (v0.12.15), WS-F1..F4 (v0.12.2), WS-E (v0.11.6), WS-D (v0.11.0), WS-C (v0.9.32), WS-B (v0.9.0).",
     "**Hardware target:** Raspberry Pi 5 (ARM64).",
     "**Metrics source of truth:** `./scripts/report_current_state.py` (sync README/spec/GitBook together in one PR).",

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -50,9 +50,9 @@ enforcement, and scheduling.
 |-----------|-------|
 | **Package version** | `0.14.2` (`lakefile.toml`) |
 | **Lean toolchain** | `4.28.0` (`lean-toolchain`) |
-| **Production LoC** | 28,813 across 41 Lean files |
-| **Test LoC** | 2,265 across 3 Lean test suites |
-| **Proved declarations** | 855 theorem/lemma declarations (zero sorry/axiom) |
+| **Production LoC** | 30,348 across 41 Lean files |
+| **Test LoC** | 2,360 across 3 Lean test suites |
+| **Proved declarations** | 920 theorem/lemma declarations (zero sorry/axiom) |
 | **Build jobs** | 86 |
 | **Target hardware** | Raspberry Pi 5 (ARM64) |
 | **Active findings** | [`AUDIT_CODEBASE_v0.12.2_v1.md`](../audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](../audits/AUDIT_CODEBASE_v0.12.2_v2.md) |


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-H12e (cross-subsystem invariant reconciliation, v0.14.2), WS-H12d (IPC message payload bounds, v0.14.1), WS-H12c (per-TCB register context, v0.14.0)
- **Recommendation IDs closed:** A-09 (HIGH, message bounds), H-03 (HIGH, register context)
- **Scope notes:** Documentation-only PR synchronizing completed workstream milestones and updated codebase metrics across all canonical and GitBook sources

## Changes

This PR updates all project documentation to reflect completion of three consecutive workstreams:

### WS-H12e (v0.14.2) — Cross-Subsystem Invariant Reconciliation
- `coreIpcInvariantBundle` upgraded from `ipcInvariant` to `ipcInvariantFull` (3-conjunct: `ipcInvariant ∧ dualQueueSystemInvariant ∧ allPendingMessagesBounded`)
- `schedulerInvariantBundleFull` extended from 4 to 5 conjuncts (+ `contextMatchesCurrent`)
- `ipcSchedulerCouplingInvariantBundle` extended with `contextMatchesCurrent` and `currentThreadDequeueCoherent`
- `proofLayerInvariantBundle` uses full scheduler bundle
- 8 frame lemmas + 3 compound preservation theorems + 7 composed `ipcInvariantFull` preservation theorems
- All `*_preserves_schedulerInvariantBundleFull` theorems updated; default state proofs extended
- Closes systemic invariant composition gaps from WS-H12a–d

### WS-H12d (v0.14.1) — IPC Message Payload Bounds
- `IpcMessage` registers/caps migrated from `List` to `Array` with `maxMessageRegisters`(120)/`maxExtraCaps`(3)
- Bounds enforcement at all 4 send boundaries (`endpointSendDual`/`endpointCall`/`endpointReply`/`endpointReplyRecv`)
- 4 `*_message_bounded` theorems; `allPendingMessagesBounded` system invariant integrated into `ipcInvariantFull`
- `checkBounds_iff_bounded` decidability bridge; information-flow enforcement updated with bounds-before-flow ordering
- Closes A-09 (HIGH)

### WS-H12c (v0.14.0) — Per-TCB Register Context
- Per-TCB `registerContext` field on TCB with inline `saveOutgoingContext`/`restoreIncomingContext` in `schedule`
- `contextMatchesCurrent` invariant with preservation proofs for all scheduler and IPC operations
- Information-flow projection strips register context; `endpointInvariant` removed (vacuous since WS-H12a)
- Closes H-03 (HIGH)

### Codebase metrics (v0.14.2)
- Production LoC: 30,348 (↑ 1,535 from v0.14.0)
- Test LoC: 2,360 (↑ 95 from v0.14.0)
- Proved declarations: 920 (↑ 65 from v0.14.0)
- Build jobs: 86 (unchanged)

## Documentation synchronization checklist

- [x] Canonical source docs updated first (`docs/spec/SELE4N_SPEC.md`, `CLAUDE.md`)
- [x] GitBook mirrors synchronized (`docs/gitbook/05-specification-and-roadmap.md`, `docs/gitbook/README.md`, `docs/gitbook/01-project-overview.md`, `docs/gitbook/22-next-slice-development-path.md`)
- [x] Generated navigation files refreshed (`docs/gitbook/navigation_manifest.json`)
- [x] README

https://claude.ai/code/session_01SmgTTj8wqV8NAyqHf8AGcg