### PR TITLE
Claude/audit pr 386 v e fv v

### DIFF
--- a/SeLe4n/Kernel/Capability/Invariant/Authority.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Authority.lean
@@ -5,7 +5,7 @@ namespace SeLe4n.Kernel
 open SeLe4n.Model
 
 /-- Delete transition authority reduction clause. -/
-theorem cspaceDeleteSlot_authority_reduction
+private theorem cspaceDeleteSlot_authority_reduction
     (st st' : SystemState)
     (addr : CSpaceAddr)
     (hStep : cspaceDeleteSlot addr st = .ok ((), st')) :
@@ -129,7 +129,7 @@ theorem cspaceLookupSlot_preserves_state
       simp [hLookup] at hStep
       exact hStep.2.symm
 
-theorem cspaceInsertSlot_lookup_eq
+private theorem cspaceInsertSlot_lookup_eq
     (st st' : SystemState)
     (addr : CSpaceAddr)
     (cap : Capability)
@@ -247,7 +247,7 @@ theorem cspaceRevoke_preserves_source
               refine ⟨parent, ?_⟩
               exact (cspaceLookupSlot_ok_iff_lookupSlotCap st' addr parent).2 hCapFinal
 
-theorem mintDerivedCap_attenuates
+private theorem mintDerivedCap_attenuates
     (parent child : Capability)
     (rights : List AccessRight)
     (badge : Option SeLe4n.Badge)

--- a/SeLe4n/Kernel/IPC/Invariant/Defs.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Defs.lean
@@ -1,10 +1,7 @@
-import SeLe4n.Kernel.Scheduler.Invariant
 import SeLe4n.Kernel.Scheduler.Operations
 import SeLe4n.Kernel.IPC.DualQueue
 
 namespace SeLe4n.Kernel
-
-open SeLe4n.Model
 
 open SeLe4n.Model
 

--- a/SeLe4n/Kernel/IPC/Invariant/Structural.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Structural.lean
@@ -108,7 +108,7 @@ theorem endpointQueuePopHead_link_safe (q : IntrusiveQueue) (st : SystemState)
 -- ---- Frame lemmas: ensureRunnable / removeRunnable ----
 
 /-- WS-H5: ensureRunnable preserves intrusiveQueueWellFormed. -/
-theorem ensureRunnable_preserves_intrusiveQueueWellFormed
+private theorem ensureRunnable_preserves_intrusiveQueueWellFormed
     (st : SystemState) (tid : SeLe4n.ThreadId)
     (q : IntrusiveQueue) (hWf : intrusiveQueueWellFormed q st) :
     intrusiveQueueWellFormed q (ensureRunnable st tid) := by
@@ -118,7 +118,7 @@ theorem ensureRunnable_preserves_intrusiveQueueWellFormed
     fun tl h => let ⟨t, ht, hn⟩ := hTail tl h; ⟨t, by rwa [ensureRunnable_preserves_objects], hn⟩⟩
 
 /-- WS-H5: removeRunnable preserves intrusiveQueueWellFormed. -/
-theorem removeRunnable_preserves_intrusiveQueueWellFormed
+private theorem removeRunnable_preserves_intrusiveQueueWellFormed
     (st : SystemState) (tid : SeLe4n.ThreadId)
     (q : IntrusiveQueue) (hWf : intrusiveQueueWellFormed q st) :
     intrusiveQueueWellFormed q (removeRunnable st tid) := by
@@ -128,7 +128,7 @@ theorem removeRunnable_preserves_intrusiveQueueWellFormed
     fun tl h => let ⟨t, ht, hn⟩ := hTail tl h; ⟨t, by rwa [removeRunnable_preserves_objects], hn⟩⟩
 
 /-- WS-H5: ensureRunnable preserves tcbQueueLinkIntegrity. -/
-theorem ensureRunnable_preserves_tcbQueueLinkIntegrity
+private theorem ensureRunnable_preserves_tcbQueueLinkIntegrity
     (st : SystemState) (tid : SeLe4n.ThreadId) (h : tcbQueueLinkIntegrity st) :
     tcbQueueLinkIntegrity (ensureRunnable st tid) := by
   constructor
@@ -140,7 +140,7 @@ theorem ensureRunnable_preserves_tcbQueueLinkIntegrity
     exact ⟨tA, by rw [ensureRunnable_preserves_objects]; exact hA, hN⟩
 
 /-- WS-H5: removeRunnable preserves tcbQueueLinkIntegrity. -/
-theorem removeRunnable_preserves_tcbQueueLinkIntegrity
+private theorem removeRunnable_preserves_tcbQueueLinkIntegrity
     (st : SystemState) (tid : SeLe4n.ThreadId) (h : tcbQueueLinkIntegrity st) :
     tcbQueueLinkIntegrity (removeRunnable st tid) := by
   constructor
@@ -152,7 +152,7 @@ theorem removeRunnable_preserves_tcbQueueLinkIntegrity
     exact ⟨tA, by rw [removeRunnable_preserves_objects]; exact hA, hN⟩
 
 /-- WS-H5: ensureRunnable preserves dualQueueEndpointWellFormed. -/
-theorem ensureRunnable_preserves_dualQueueEndpointWellFormed
+private theorem ensureRunnable_preserves_dualQueueEndpointWellFormed
     (st : SystemState) (tid : SeLe4n.ThreadId) (epId : SeLe4n.ObjId)
     (hWf : dualQueueEndpointWellFormed epId st) :
     dualQueueEndpointWellFormed epId (ensureRunnable st tid) := by
@@ -167,7 +167,7 @@ theorem ensureRunnable_preserves_dualQueueEndpointWellFormed
                ensureRunnable_preserves_intrusiveQueueWellFormed st tid ep.receiveQ hWf.2⟩
 
 /-- WS-H5: removeRunnable preserves dualQueueEndpointWellFormed. -/
-theorem removeRunnable_preserves_dualQueueEndpointWellFormed
+private theorem removeRunnable_preserves_dualQueueEndpointWellFormed
     (st : SystemState) (tid : SeLe4n.ThreadId) (epId : SeLe4n.ObjId)
     (hWf : dualQueueEndpointWellFormed epId st) :
     dualQueueEndpointWellFormed epId (removeRunnable st tid) := by
@@ -182,7 +182,7 @@ theorem removeRunnable_preserves_dualQueueEndpointWellFormed
                removeRunnable_preserves_intrusiveQueueWellFormed st tid ep.receiveQ hWf.2⟩
 
 /-- WS-H5: ensureRunnable preserves dualQueueSystemInvariant. -/
-theorem ensureRunnable_preserves_dualQueueSystemInvariant
+private theorem ensureRunnable_preserves_dualQueueSystemInvariant
     (st : SystemState) (tid : SeLe4n.ThreadId)
     (hInv : dualQueueSystemInvariant st) :
     dualQueueSystemInvariant (ensureRunnable st tid) := by
@@ -192,7 +192,7 @@ theorem ensureRunnable_preserves_dualQueueSystemInvariant
   exact ensureRunnable_preserves_dualQueueEndpointWellFormed st tid epId (hEp epId ep hObj)
 
 /-- WS-H5: removeRunnable preserves dualQueueSystemInvariant. -/
-theorem removeRunnable_preserves_dualQueueSystemInvariant
+private theorem removeRunnable_preserves_dualQueueSystemInvariant
     (st : SystemState) (tid : SeLe4n.ThreadId)
     (hInv : dualQueueSystemInvariant st) :
     dualQueueSystemInvariant (removeRunnable st tid) := by
@@ -210,7 +210,7 @@ theorem removeRunnable_preserves_dualQueueSystemInvariant
 intrusiveQueueWellFormed for queues whose boundary TCBs either:
 (a) are at different ObjIds (unchanged), or
 (b) are the modified TCB (queue links preserved by with-syntax). -/
-theorem storeObject_tcb_preserves_intrusiveQueueWellFormed
+private theorem storeObject_tcb_preserves_intrusiveQueueWellFormed
     (st st' : SystemState) (tid : SeLe4n.ObjId) (tcb tcb' : TCB)
     (hPrevEq : tcb'.queuePrev = tcb.queuePrev)
     (hNextEq : tcb'.queueNext = tcb.queueNext)
@@ -237,7 +237,7 @@ theorem storeObject_tcb_preserves_intrusiveQueueWellFormed
 
 /-- WS-H5: storeObject of a TCB-variant with preserved queue links maintains
 tcbQueueLinkIntegrity. -/
-theorem storeObject_tcb_preserves_tcbQueueLinkIntegrity
+private theorem storeObject_tcb_preserves_tcbQueueLinkIntegrity
     (st st' : SystemState) (tid : SeLe4n.ObjId) (tcb tcb' : TCB)
     (hPrevEq : tcb'.queuePrev = tcb.queuePrev)
     (hNextEq : tcb'.queueNext = tcb.queueNext)
@@ -285,7 +285,7 @@ theorem storeObject_tcb_preserves_tcbQueueLinkIntegrity
 -- ---- Helper: storeObject endpoint preserves queue invariant properties ----
 
 /-- WS-H5: Storing an endpoint preserves tcbQueueLinkIntegrity (no TCB is modified). -/
-theorem storeObject_endpoint_preserves_tcbQueueLinkIntegrity
+private theorem storeObject_endpoint_preserves_tcbQueueLinkIntegrity
     (st st' : SystemState) (epId : SeLe4n.ObjId) (epNew : Endpoint)
     (hStore : storeObject epId (.endpoint epNew) st = .ok ((), st'))
     (hPreEp : ∀ tcb : TCB, st.objects[epId]? ≠ some (.tcb tcb))
@@ -305,7 +305,7 @@ theorem storeObject_endpoint_preserves_tcbQueueLinkIntegrity
 
 /-- WS-H5: Storing an endpoint preserves intrusiveQueueWellFormed.
 Boundary TCBs can't be at the endpoint ObjId (they are TCBs, not endpoints). -/
-theorem storeObject_endpoint_preserves_intrusiveQueueWellFormed
+private theorem storeObject_endpoint_preserves_intrusiveQueueWellFormed
     (st st' : SystemState) (epId : SeLe4n.ObjId) (epNew : Endpoint)
     (hStore : storeObject epId (.endpoint epNew) st = .ok ((), st'))
     (hPreEp : ∀ tcb : TCB, st.objects[epId]? ≠ some (.tcb tcb))
@@ -324,7 +324,7 @@ theorem storeObject_endpoint_preserves_intrusiveQueueWellFormed
 
 /-- WS-H5: storeTcbIpcState preserves dualQueueSystemInvariant.
 storeTcbIpcState uses { tcb with ipcState := ipc }, preserving queue links. -/
-theorem storeTcbIpcState_preserves_dualQueueSystemInvariant
+private theorem storeTcbIpcState_preserves_dualQueueSystemInvariant
     (st st' : SystemState) (tid : SeLe4n.ThreadId) (ipc : ThreadIpcState)
     (hStep : storeTcbIpcState st tid ipc = .ok st')
     (hInv : dualQueueSystemInvariant st) :
@@ -367,7 +367,7 @@ theorem storeTcbIpcState_preserves_dualQueueSystemInvariant
                      tid.toObjId tcb _ hPrev hNext hTcbPre hStore ep.receiveQ hWfPre.2⟩
 
 /-- WS-H5: storeTcbIpcStateAndMessage preserves dualQueueSystemInvariant. -/
-theorem storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant
+private theorem storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant
     (st st' : SystemState) (tid : SeLe4n.ThreadId)
     (ipc : ThreadIpcState) (msg : Option IpcMessage)
     (hStep : storeTcbIpcStateAndMessage st tid ipc msg = .ok st')
@@ -411,7 +411,7 @@ theorem storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant
                      tid.toObjId tcb _ hPrev hNext hTcbPre hStore ep.receiveQ hWfPre.2⟩
 
 /-- WS-H5: storeTcbPendingMessage preserves dualQueueSystemInvariant. -/
-theorem storeTcbPendingMessage_preserves_dualQueueSystemInvariant
+private theorem storeTcbPendingMessage_preserves_dualQueueSystemInvariant
     (st st' : SystemState) (tid : SeLe4n.ThreadId) (msg : Option IpcMessage)
     (hStep : storeTcbPendingMessage st tid msg = .ok st')
     (hInv : dualQueueSystemInvariant st) :

--- a/SeLe4n/Kernel/InformationFlow/Enforcement/Wrappers.lean
+++ b/SeLe4n/Kernel/InformationFlow/Enforcement/Wrappers.lean
@@ -1,5 +1,4 @@
 import SeLe4n.Kernel.InformationFlow.Policy
-import SeLe4n.Kernel.IPC.Operations
 import SeLe4n.Kernel.IPC.DualQueue
 import SeLe4n.Kernel.Capability.Operations
 import SeLe4n.Kernel.Service.Operations

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
@@ -30,7 +30,7 @@ with CDT-specific frame lemmas.
 
 /-- WS-F3: serviceStart at a non-observable service preserves low-equivalence.
 Service operations only modify the service store, not objects or scheduler. -/
-theorem serviceStart_preserves_lowEquivalent
+private theorem serviceStart_preserves_lowEquivalent
     (ctx : LabelingContext) (observer : IfObserver)
     (sid : ServiceId) (policy : ServicePolicy)
     (s₁ s₂ s₁' s₂' : SystemState)
@@ -103,7 +103,7 @@ theorem serviceStart_preserves_lowEquivalent
     exact congrArg ObservableState.machineRegs hLow
 
 /-- WS-F3: serviceStop at a non-observable service preserves low-equivalence. -/
-theorem serviceStop_preserves_lowEquivalent
+private theorem serviceStop_preserves_lowEquivalent
     (ctx : LabelingContext) (observer : IfObserver)
     (sid : ServiceId) (policy : ServicePolicy)
     (s₁ s₂ s₁' s₂' : SystemState)
@@ -307,7 +307,7 @@ preserves low-equivalence.
 The enforcement bridge extracts the flow check from the wrapper, then delegates
 to the underlying `cspaceCopy` NI theorem (taken as hypothesis pending WS-H9
 decomposition lemmas for CDT-aware operations). -/
-theorem cspaceCopyChecked_NI
+private theorem cspaceCopyChecked_NI
     (ctx : LabelingContext) (observer : IfObserver)
     (src dst : CSpaceAddr)
     (s₁ s₂ s₁' s₂' : SystemState)
@@ -923,7 +923,7 @@ theorem cspaceDeleteSlot_preserves_projection
               storeObject_preserves_projection ctx observer st pair₁.2 addr.cnode _ hAddrHigh hStore]
 
 /-- WS-H9: cspaceDeleteSlot preserves low-equivalence. -/
-theorem cspaceDeleteSlot_preserves_lowEquivalent
+private theorem cspaceDeleteSlot_preserves_lowEquivalent
     (ctx : LabelingContext) (observer : IfObserver)
     (addr : CSpaceAddr) (s₁ s₂ s₁' s₂' : SystemState)
     (hLow : lowEquivalent ctx observer s₁ s₂)
@@ -1044,7 +1044,7 @@ theorem cspaceCopy_preserves_projection
           cspaceInsertSlot_preserves_projection ctx observer dst cap st stIns hDstHigh hInsert]
 
 /-- WS-H9: cspaceCopy preserves low-equivalence. -/
-theorem cspaceCopy_preserves_lowEquivalent
+private theorem cspaceCopy_preserves_lowEquivalent
     (ctx : LabelingContext) (observer : IfObserver)
     (src dst : CSpaceAddr) (s₁ s₂ s₁' s₂' : SystemState)
     (hLow : lowEquivalent ctx observer s₁ s₂)
@@ -1103,7 +1103,7 @@ theorem cspaceMove_preserves_projection
               cspaceInsertSlot_preserves_projection ctx observer dst cap st stIns hDstHigh hInsert]
 
 /-- WS-H9: cspaceMove preserves low-equivalence. -/
-theorem cspaceMove_preserves_lowEquivalent
+private theorem cspaceMove_preserves_lowEquivalent
     (ctx : LabelingContext) (observer : IfObserver)
     (src dst : CSpaceAddr) (s₁ s₂ s₁' s₂' : SystemState)
     (hLow : lowEquivalent ctx observer s₁ s₂)

--- a/SeLe4n/Kernel/Scheduler/Operations/Preservation.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations/Preservation.lean
@@ -22,7 +22,7 @@ theorem setCurrentThread_preserves_queueCurrentConsistent
   cases hStep
   simp [queueCurrentConsistent, hNotMem]
 
-theorem setCurrentThread_preserves_runQueueUnique
+private theorem setCurrentThread_preserves_runQueueUnique
     (st st' : SystemState)
     (tid : Option SeLe4n.ThreadId)
     (hUnique : runQueueUnique st.scheduler)
@@ -32,7 +32,7 @@ theorem setCurrentThread_preserves_runQueueUnique
   cases hStep
   simpa [runQueueUnique] using hUnique
 
-theorem setCurrentThread_none_preserves_currentThreadValid
+private theorem setCurrentThread_none_preserves_currentThreadValid
     (st st' : SystemState)
     (hStep : setCurrentThread none st = .ok ((), st')) :
     currentThreadValid st' := by
@@ -71,7 +71,7 @@ theorem chooseThread_preserves_state
 /-- WS-H12b: `schedule` preserves `queueCurrentConsistent`.
 After dequeue-on-dispatch, the selected thread is removed from the run queue
 before being set as current, establishing `tid ∉ runnable`. -/
-theorem schedule_preserves_queueCurrentConsistent
+private theorem schedule_preserves_queueCurrentConsistent
     (st st' : SystemState)
     (hStep : schedule st = .ok ((), st')) :
     queueCurrentConsistent st'.scheduler := by
@@ -117,7 +117,7 @@ theorem schedule_preserves_wellFormed
     schedulerWellFormed st'.scheduler := by
   exact schedule_preserves_queueCurrentConsistent st st' hStep
 
-theorem chooseThread_preserves_queueCurrentConsistent
+private theorem chooseThread_preserves_queueCurrentConsistent
     (st st' : SystemState)
     (next : Option SeLe4n.ThreadId)
     (hConsistent : queueCurrentConsistent st.scheduler)
@@ -126,7 +126,7 @@ theorem chooseThread_preserves_queueCurrentConsistent
   rcases chooseThread_preserves_state st st' next hStep with rfl
   simpa using hConsistent
 
-theorem chooseThread_preserves_runQueueUnique
+private theorem chooseThread_preserves_runQueueUnique
     (st st' : SystemState)
     (next : Option SeLe4n.ThreadId)
     (hUnique : runQueueUnique st.scheduler)
@@ -135,7 +135,7 @@ theorem chooseThread_preserves_runQueueUnique
   rcases chooseThread_preserves_state st st' next hStep with rfl
   simpa using hUnique
 
-theorem chooseThread_preserves_currentThreadValid
+private theorem chooseThread_preserves_currentThreadValid
     (st st' : SystemState)
     (next : Option SeLe4n.ThreadId)
     (hValid : currentThreadValid st)
@@ -144,7 +144,7 @@ theorem chooseThread_preserves_currentThreadValid
   rcases chooseThread_preserves_state st st' next hStep with rfl
   simpa using hValid
 
-theorem chooseThread_preserves_currentThreadInActiveDomain
+private theorem chooseThread_preserves_currentThreadInActiveDomain
     (st st' : SystemState)
     (next : Option SeLe4n.ThreadId)
     (hInv : currentThreadInActiveDomain st)
@@ -161,7 +161,7 @@ private theorem remove_preserves_nodup (rq : RunQueue) (tid : SeLe4n.ThreadId)
   unfold RunQueue.remove
   exact hNodup.sublist List.filter_sublist
 
-theorem schedule_preserves_runQueueUnique
+private theorem schedule_preserves_runQueueUnique
     (st st' : SystemState)
     (hUnique : runQueueUnique st.scheduler)
     (hStep : schedule st = .ok ((), st')) :
@@ -208,7 +208,7 @@ theorem schedule_preserves_runQueueUnique
                   | vspaceRoot root => simp [hChoose, hObj] at hStep
                   | untyped ut => simp [hChoose, hObj] at hStep
 
-theorem schedule_preserves_currentThreadValid
+private theorem schedule_preserves_currentThreadValid
     (st st' : SystemState)
     (hStep : schedule st = .ok ((), st')) :
     currentThreadValid st' := by
@@ -246,7 +246,7 @@ theorem schedule_preserves_currentThreadValid
                   | vspaceRoot root => simp [hChoose, hObj] at hStep
                   | untyped ut => simp [hChoose, hObj] at hStep
 
-theorem schedule_preserves_currentThreadInActiveDomain
+private theorem schedule_preserves_currentThreadInActiveDomain
     (st st' : SystemState)
     (hStep : schedule st = .ok ((), st')) :
     currentThreadInActiveDomain st' := by
@@ -321,7 +321,7 @@ theorem schedule_preserves_currentThreadInActiveDomain
 
 /-- WS-H12b: `handleYield` preserves `queueCurrentConsistent`.
 Re-enqueue + schedule re-establishes the invariant. -/
-theorem handleYield_preserves_queueCurrentConsistent
+private theorem handleYield_preserves_queueCurrentConsistent
     (st st' : SystemState)
     (hStep : handleYield st = .ok ((), st')) :
     queueCurrentConsistent st'.scheduler := by
@@ -358,7 +358,7 @@ private theorem insert_preserves_nodup (rq : RunQueue) (tid : SeLe4n.ThreadId) (
       subst this; intro hEq; subst hEq
       exact hNotMem ((RunQueue.mem_toList_iff_mem rq x).mp hx)⟩
 
-theorem handleYield_preserves_runQueueUnique
+private theorem handleYield_preserves_runQueueUnique
     (st st' : SystemState)
     (hUnique : runQueueUnique st.scheduler)
     (hQCC : queueCurrentConsistent st.scheduler)
@@ -390,7 +390,7 @@ theorem handleYield_preserves_runQueueUnique
           simp only [runQueueUnique, SchedulerState.runnable]; exact hRotatedNodup) hStep
       | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
 
-theorem handleYield_preserves_currentThreadValid
+private theorem handleYield_preserves_currentThreadValid
     (st st' : SystemState)
     (hStep : handleYield st = .ok ((), st')) :
     currentThreadValid st' := by
@@ -410,7 +410,7 @@ theorem handleYield_preserves_currentThreadValid
         exact schedule_preserves_currentThreadValid _ st' hStep
       | endpoint _ | notification _ | cnode _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
 
-theorem handleYield_preserves_currentThreadInActiveDomain
+private theorem handleYield_preserves_currentThreadInActiveDomain
     (st st' : SystemState)
     (hStep : handleYield st = .ok ((), st')) :
     currentThreadInActiveDomain st' := by
@@ -504,7 +504,7 @@ theorem handleYield_preserves_schedulerInvariantBundle
 
 /-- WS-H12b: `switchDomain` preserves the scheduler invariant bundle.
 Re-enqueues the current thread before advancing the domain schedule. -/
-theorem switchDomain_preserves_schedulerInvariantBundle
+private theorem switchDomain_preserves_schedulerInvariantBundle
     (st st' : SystemState)
     (hInv : schedulerInvariantBundle st)
     (hStep : switchDomain st = .ok ((), st')) :
@@ -835,7 +835,7 @@ private theorem noBetter_implies_edf
 -- ============================================================================
 
 /-- WS-H6: `setCurrentThread` preserves `timeSlicePositive` — only `current` changes. -/
-theorem setCurrentThread_preserves_timeSlicePositive
+private theorem setCurrentThread_preserves_timeSlicePositive
     (st st' : SystemState)
     (tid : Option SeLe4n.ThreadId)
     (hInv : timeSlicePositive st)
@@ -870,7 +870,7 @@ private theorem remove_preserves_timeSlicePositive
 /-- WS-H6/WS-H12b: `schedule` preserves `timeSlicePositive`.
 Updated for dequeue-on-dispatch: the dequeued state's `timeSlicePositive`
 follows from removal being a subset of the original runnable set. -/
-theorem schedule_preserves_timeSlicePositive
+private theorem schedule_preserves_timeSlicePositive
     (st st' : SystemState)
     (hInv : timeSlicePositive st)
     (hStep : schedule st = .ok ((), st')) :
@@ -919,7 +919,7 @@ Under dequeue-on-dispatch, the current thread is NOT in the run queue.
 After insert+rotateToBack, `timeSlicePositive` holds because the current
 thread's TCB (with positive time slice via `hCurTS`) is now in the queue,
 and all previously-runnable threads retain their positive time slices. -/
-theorem handleYield_preserves_timeSlicePositive
+private theorem handleYield_preserves_timeSlicePositive
     (st st' : SystemState)
     (hInv : timeSlicePositive st)
     (hCurTS : currentTimeSlicePositive st)
@@ -964,7 +964,7 @@ theorem handleYield_preserves_timeSlicePositive
 
 /-- WS-H6/WS-H12b: `switchDomain` preserves `timeSlicePositive`.
 Re-enqueues the current thread (if any) before switching domains. -/
-theorem switchDomain_preserves_timeSlicePositive
+private theorem switchDomain_preserves_timeSlicePositive
     (st st' : SystemState)
     (hInv : timeSlicePositive st)
     (hCurTS : currentTimeSlicePositive st)
@@ -1022,7 +1022,7 @@ private theorem threadId_ne_objId_beq_false
 /-- WS-H6/WS-H12b: `timerTick` preserves `timeSlicePositive`.
 Expired case: resets to `defaultTimeSlice` (= 5 > 0), inserts into queue, then schedule.
 Not-expired case: decrements, and since `timeSlice > 1`, the result is still > 0. -/
-theorem timerTick_preserves_timeSlicePositive
+private theorem timerTick_preserves_timeSlicePositive
     (st st' : SystemState)
     (hInv : timeSlicePositive st)
     (hStep : timerTick st = .ok ((), st')) :
@@ -1085,7 +1085,7 @@ theorem timerTick_preserves_timeSlicePositive
 -- ============================================================================
 
 /-- WS-H12b: `setCurrentThread none` trivially preserves `currentTimeSlicePositive`. -/
-theorem setCurrentThread_none_preserves_currentTimeSlicePositive
+private theorem setCurrentThread_none_preserves_currentTimeSlicePositive
     (st st' : SystemState)
     (hStep : setCurrentThread none st = .ok ((), st')) :
     currentTimeSlicePositive st' := by
@@ -1108,7 +1108,7 @@ theorem setCurrentThread_some_preserves_currentTimeSlicePositive
 /-- WS-H12b: `schedule` preserves `currentTimeSlicePositive`.
 When schedule selects a thread from the runnable queue, its `timeSlice > 0`
 follows from `timeSlicePositive`. -/
-theorem schedule_preserves_currentTimeSlicePositive
+private theorem schedule_preserves_currentTimeSlicePositive
     (st st' : SystemState)
     (hTS : timeSlicePositive st)
     (hStep : schedule st = .ok ((), st')) :
@@ -1188,7 +1188,7 @@ theorem schedule_preserves_currentTimeSlicePositive
                       simp [hChoose, hObj] at hStep
 
 /-- WS-H12b: `handleYield` preserves `currentTimeSlicePositive`. -/
-theorem handleYield_preserves_currentTimeSlicePositive
+private theorem handleYield_preserves_currentTimeSlicePositive
     (st st' : SystemState)
     (hTS : timeSlicePositive st)
     (hCurTS : currentTimeSlicePositive st)
@@ -1231,7 +1231,7 @@ theorem handleYield_preserves_currentTimeSlicePositive
 
 /-- WS-H12b: `switchDomain` preserves `currentTimeSlicePositive`.
 Domain switch sets `current := none`, so the predicate is trivially True. -/
-theorem switchDomain_preserves_currentTimeSlicePositive
+private theorem switchDomain_preserves_currentTimeSlicePositive
     (st st' : SystemState)
     (hCurTS : currentTimeSlicePositive st)
     (hStep : switchDomain st = .ok ((), st')) :
@@ -1246,7 +1246,7 @@ theorem switchDomain_preserves_currentTimeSlicePositive
       · simp at hStep; cases hStep; simp [currentTimeSlicePositive]
 
 /-- WS-H12b: `timerTick` preserves `currentTimeSlicePositive`. -/
-theorem timerTick_preserves_currentTimeSlicePositive
+private theorem timerTick_preserves_currentTimeSlicePositive
     (st st' : SystemState)
     (hTS : timeSlicePositive st)
     (_ : currentTimeSlicePositive st)
@@ -1303,7 +1303,7 @@ theorem timerTick_preserves_currentTimeSlicePositive
 -- ============================================================================
 
 /-- WS-H6: `setCurrentThread none` trivially preserves EDF — no current thread. -/
-theorem setCurrentThread_none_preserves_edfCurrentHasEarliestDeadline
+private theorem setCurrentThread_none_preserves_edfCurrentHasEarliestDeadline
     (st st' : SystemState)
     (hStep : setCurrentThread none st = .ok ((), st')) :
     edfCurrentHasEarliestDeadline st' := by
@@ -1313,7 +1313,7 @@ theorem setCurrentThread_none_preserves_edfCurrentHasEarliestDeadline
 
 /-- WS-H6: `switchDomain` preserves `edfCurrentHasEarliestDeadline`.
 Domain switch sets `current := none` in the transition case. -/
-theorem switchDomain_preserves_edfCurrentHasEarliestDeadline
+private theorem switchDomain_preserves_edfCurrentHasEarliestDeadline
     (st st' : SystemState)
     (hInv : edfCurrentHasEarliestDeadline st)
     (hStep : switchDomain st = .ok ((), st')) :
@@ -1683,7 +1683,7 @@ When schedule selects `none`, EDF is trivially `True`. When schedule selects
 
 WS-H12b: The dequeue step means the post-state's runnable list excludes
 the dispatched thread. The EDF bridge is updated accordingly. -/
-theorem schedule_preserves_edfCurrentHasEarliestDeadline
+private theorem schedule_preserves_edfCurrentHasEarliestDeadline
     (st st' : SystemState)
     (hwf : RunQueue.wellFormed st.scheduler.runQueue)
     (hpm : schedulerPriorityMatch st)
@@ -1773,7 +1773,7 @@ Under dequeue-on-dispatch, `handleYield` inserts the current thread back
 into the run queue and then calls `schedule`, which re-selects the best
 candidate from scratch. The EDF property is re-established by the
 `schedule` call. -/
-theorem handleYield_preserves_edfCurrentHasEarliestDeadline
+private theorem handleYield_preserves_edfCurrentHasEarliestDeadline
     (st st' : SystemState)
     (hwf : RunQueue.wellFormed st.scheduler.runQueue)
     (hpm : schedulerPriorityMatch st)
@@ -1851,7 +1851,7 @@ set_option maxHeartbeats 800000 in
   so EDF is preserved.
 - **Time-slice expired**: TCB time-slice reset, re-enqueue via insert, and
   `schedule` call re-establishes EDF from scratch. -/
-theorem timerTick_preserves_edfCurrentHasEarliestDeadline
+private theorem timerTick_preserves_edfCurrentHasEarliestDeadline
     (st st' : SystemState)
     (hwf : RunQueue.wellFormed st.scheduler.runQueue)
     (hpm : schedulerPriorityMatch st)
@@ -1957,7 +1957,7 @@ theorem timerTick_preserves_edfCurrentHasEarliestDeadline
 `contextMatchesCurrent`. The inline context switch in `schedule` atomically
 saves the outgoing thread's registers and restores the incoming thread's
 registers, ensuring machine.regs = currentThread.registerContext. -/
-theorem schedule_preserves_contextMatchesCurrent
+private theorem schedule_preserves_contextMatchesCurrent
     (st st' : SystemState)
     (hStep : schedule st = .ok ((), st')) :
     contextMatchesCurrent st' := by
@@ -2005,7 +2005,7 @@ theorem schedule_preserves_contextMatchesCurrent
 
 /-- WS-H12c/H-03: `handleYield` preserves `contextMatchesCurrent`.
 `handleYield` calls `schedule` which re-establishes the invariant. -/
-theorem handleYield_preserves_contextMatchesCurrent
+private theorem handleYield_preserves_contextMatchesCurrent
     (st st' : SystemState)
     (hStep : handleYield st = .ok ((), st')) :
     contextMatchesCurrent st' := by
@@ -2034,7 +2034,7 @@ theorem handleYield_preserves_contextMatchesCurrent
 - When time slice doesn't expire: decrements timeSlice via storeObject, machine.regs and
   current are unchanged → invariant preserved.
 - When time slice expires: re-enqueues + calls `schedule` → invariant re-established. -/
-theorem timerTick_preserves_contextMatchesCurrent
+private theorem timerTick_preserves_contextMatchesCurrent
     (st st' : SystemState)
     (hInv : contextMatchesCurrent st)
     (hStep : timerTick st = .ok ((), st')) :

--- a/SeLe4n/Kernel/Service/Invariant/Policy.lean
+++ b/SeLe4n/Kernel/Service/Invariant/Policy.lean
@@ -1,6 +1,5 @@
 import SeLe4n.Kernel.Service.Operations
 import SeLe4n.Kernel.Capability.Invariant
-import SeLe4n.Kernel.Lifecycle.Invariant
 
 namespace SeLe4n.Kernel
 

--- a/SeLe4n/Model/Object/Types.lean
+++ b/SeLe4n/Model/Object/Types.lean
@@ -1,4 +1,3 @@
-import SeLe4n.Prelude
 import SeLe4n.Machine
 
 namespace SeLe4n.Model

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/audit-pr-386-vEFvV",
-      "commit_sha": "a284bab93cb5f828fbd6eda51631fbf9889d1fa7",
-      "tree_sha": "c5838842acb495a0a94f099b98b240fb5d7d63c0",
-      "committed_at_utc": "2026-03-10T08:18:50+00:00"
+      "commit_sha": "b2b3b3b88f72cb6cb91272ade8b097deb2ac72ed",
+      "tree_sha": "19a1dc0682ea5562df4b820361b28b870904f965",
+      "committed_at_utc": "2026-03-10T08:40:53+00:00"
     }
   },
   "source_sync": {
@@ -17,7 +17,7 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "d2677fec2f09ab658ed5a5943dcc6c58b6b63ef63c8aad6a904d9bea9d55c3ef"
+    "source_digest": "1413ab6def0040b50201bc8aab25245ea496e88c346518bf3ca0f7f6983f8ff1"
   },
   "summary": {
     "module_count": 68,

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/audit-pr-386-vEFvV",
-      "commit_sha": "b2b3b3b88f72cb6cb91272ade8b097deb2ac72ed",
-      "tree_sha": "19a1dc0682ea5562df4b820361b28b870904f965",
-      "committed_at_utc": "2026-03-10T08:40:53+00:00"
+      "commit_sha": "1823fe468e17a9477558e4b1bec3df773f60dcd3",
+      "tree_sha": "2cd7a90aacf7c471338ac596adf7eac0baec5146",
+      "committed_at_utc": "2026-03-10T08:44:55+00:00"
     }
   },
   "source_sync": {
@@ -17,7 +17,7 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "1413ab6def0040b50201bc8aab25245ea496e88c346518bf3ca0f7f6983f8ff1"
+    "source_digest": "1da1740e4912d9775e6bd53f3eafdd8cd9cf467c549997e4bff1d8dd3714d22c"
   },
   "summary": {
     "module_count": 68,
@@ -27,7 +27,7 @@
     "version": "0.14.5",
     "lean_toolchain": "v4.28.0",
     "production_files": 65,
-    "production_loc": 31295,
+    "production_loc": 31289,
     "test_files": 3,
     "test_loc": 2413,
     "proved_theorem_lemma_decls": 958,
@@ -2740,31 +2740,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 5,
+          "line": 4,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_objects_eq",
-          "line": 15,
+          "line": 12,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_objects_ne",
-          "line": 21,
+          "line": 18,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_scheduler_eq",
-          "line": 30,
+          "line": 27,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "tcb_lookup_of_endpoint_store",
-          "line": 36,
+          "line": 33,
           "called": [
             "storeObject_objects_eq",
             "storeObject_objects_ne"
@@ -2773,7 +2773,7 @@
         {
           "kind": "theorem",
           "name": "runnable_membership_of_endpoint_store",
-          "line": 45,
+          "line": 42,
           "called": [
             "storeObject_scheduler_eq"
           ]
@@ -2781,7 +2781,7 @@
         {
           "kind": "theorem",
           "name": "not_runnable_membership_of_endpoint_store",
-          "line": 52,
+          "line": 49,
           "called": [
             "storeObject_scheduler_eq"
           ]
@@ -2789,13 +2789,13 @@
         {
           "kind": "def",
           "name": "notificationQueueWellFormed",
-          "line": 63,
+          "line": 60,
           "called": []
         },
         {
           "kind": "def",
           "name": "notificationInvariant",
-          "line": 69,
+          "line": 66,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -2803,19 +2803,19 @@
         {
           "kind": "def",
           "name": "intrusiveQueueWellFormed",
-          "line": 95,
+          "line": 92,
           "called": []
         },
         {
           "kind": "def",
           "name": "tcbQueueLinkIntegrity",
-          "line": 109,
+          "line": 106,
           "called": []
         },
         {
           "kind": "def",
           "name": "dualQueueEndpointWellFormed",
-          "line": 125,
+          "line": 122,
           "called": [
             "intrusiveQueueWellFormed"
           ]
@@ -2823,7 +2823,7 @@
         {
           "kind": "def",
           "name": "dualQueueSystemInvariant",
-          "line": 136,
+          "line": 133,
           "called": [
             "dualQueueEndpointWellFormed",
             "tcbQueueLinkIntegrity"
@@ -2832,7 +2832,7 @@
         {
           "kind": "def",
           "name": "ipcInvariant",
-          "line": 146,
+          "line": 143,
           "called": [
             "notificationInvariant"
           ]
@@ -2840,13 +2840,13 @@
         {
           "kind": "def",
           "name": "allPendingMessagesBounded",
-          "line": 153,
+          "line": 150,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcInvariantFull",
-          "line": 166,
+          "line": 163,
           "called": [
             "allPendingMessagesBounded",
             "dualQueueSystemInvariant",
@@ -2856,37 +2856,37 @@
         {
           "kind": "def",
           "name": "runnableThreadIpcReady",
-          "line": 173,
+          "line": 170,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnSendNotRunnable",
-          "line": 177,
+          "line": 174,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnReceiveNotRunnable",
-          "line": 182,
+          "line": 179,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnCallNotRunnable",
-          "line": 188,
+          "line": 185,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnReplyNotRunnable",
-          "line": 194,
+          "line": 191,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerContractPredicates",
-          "line": 199,
+          "line": 196,
           "called": [
             "blockedOnCallNotRunnable",
             "blockedOnReceiveNotRunnable",
@@ -2898,25 +2898,25 @@
         {
           "kind": "def",
           "name": "currentThreadIpcReady",
-          "line": 207,
+          "line": 204,
           "called": []
         },
         {
           "kind": "def",
           "name": "currentNotEndpointQueueHead",
-          "line": 215,
+          "line": 212,
           "called": []
         },
         {
           "kind": "def",
           "name": "currentNotOnNotificationWaitList",
-          "line": 226,
+          "line": 223,
           "called": []
         },
         {
           "kind": "def",
           "name": "currentThreadDequeueCoherent",
-          "line": 237,
+          "line": 234,
           "called": [
             "currentNotEndpointQueueHead",
             "currentNotOnNotificationWaitList",
@@ -2926,13 +2926,13 @@
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_returns_head",
-          "line": 241,
+          "line": 238,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "scheduler_unchanged_through_store_tcb",
-          "line": 293,
+          "line": 290,
           "called": [
             "storeObject_scheduler_eq"
           ]
@@ -2940,7 +2940,7 @@
         {
           "kind": "theorem",
           "name": "tcb_preserved_through_endpoint_store",
-          "line": 303,
+          "line": 300,
           "called": [
             "storeObject_objects_ne"
           ]
@@ -2948,13 +2948,13 @@
         {
           "kind": "def",
           "name": "notificationWaiterConsistent",
-          "line": 320,
+          "line": 317,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "not_mem_waitingThreads_of_ipcState_ne",
-          "line": 329,
+          "line": 326,
           "called": [
             "notificationWaiterConsistent"
           ]
@@ -2962,13 +2962,13 @@
         {
           "kind": "def",
           "name": "uniqueWaiters",
-          "line": 346,
+          "line": 343,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_uniqueWaiters",
-          "line": 352,
+          "line": 349,
           "called": [
             "not_mem_waitingThreads_of_ipcState_ne",
             "notificationWaiterConsistent",
@@ -2979,7 +2979,7 @@
         {
           "kind": "theorem",
           "name": "default_notificationWaiterConsistent",
-          "line": 452,
+          "line": 449,
           "called": [
             "notificationWaiterConsistent"
           ]
@@ -2987,7 +2987,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_wake",
-          "line": 501,
+          "line": 498,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -2995,7 +2995,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_merge",
-          "line": 513,
+          "line": 510,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3003,7 +3003,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_badge",
-          "line": 523,
+          "line": 520,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3011,7 +3011,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_wait",
-          "line": 530,
+          "line": 527,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -4407,31 +4407,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 7,
+          "line": 6,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointSendDualChecked",
-          "line": 20,
+          "line": 19,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceMintChecked",
-          "line": 42,
+          "line": 41,
           "called": []
         },
         {
           "kind": "def",
           "name": "serviceRestartChecked",
-          "line": 60,
+          "line": 59,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDualChecked_eq_endpointSendDual_when_allowed",
-          "line": 80,
+          "line": 79,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4439,7 +4439,7 @@
         {
           "kind": "theorem",
           "name": "endpointSendDualChecked_flowDenied",
-          "line": 106,
+          "line": 105,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4447,7 +4447,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintChecked_eq_cspaceMint_when_allowed",
-          "line": 125,
+          "line": 124,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4455,7 +4455,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintChecked_flowDenied",
-          "line": 140,
+          "line": 139,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4463,7 +4463,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestartChecked_eq_serviceRestart_when_allowed",
-          "line": 155,
+          "line": 154,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4471,7 +4471,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestartChecked_flowDenied",
-          "line": 170,
+          "line": 169,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4479,13 +4479,13 @@
         {
           "kind": "inductive",
           "name": "EnforcementClass",
-          "line": 213,
+          "line": 212,
           "called": []
         },
         {
           "kind": "def",
           "name": "enforcementBoundary",
-          "line": 220,
+          "line": 219,
           "called": [
             "EnforcementClass",
             "cspaceMintChecked",
@@ -4496,7 +4496,7 @@
         {
           "kind": "theorem",
           "name": "endpointSendDualChecked_denied_preserves_state",
-          "line": 247,
+          "line": 246,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4504,7 +4504,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintChecked_denied_preserves_state",
-          "line": 263,
+          "line": 262,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4512,7 +4512,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestartChecked_denied_preserves_state",
-          "line": 274,
+          "line": 273,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4520,7 +4520,7 @@
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_endpointSendDual",
-          "line": 292,
+          "line": 291,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4528,7 +4528,7 @@
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_cspaceMint",
-          "line": 313,
+          "line": 312,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4536,7 +4536,7 @@
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_serviceRestart",
-          "line": 326,
+          "line": 325,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4544,25 +4544,25 @@
         {
           "kind": "def",
           "name": "notificationSignalChecked",
-          "line": 364,
+          "line": 363,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceCopyChecked",
-          "line": 385,
+          "line": 384,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceMoveChecked",
-          "line": 401,
+          "line": 400,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointReceiveDualChecked",
-          "line": 420,
+          "line": 419,
           "called": []
         }
       ]
@@ -8981,19 +8981,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 5,
+          "line": 4,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "ServicePolicyPredicate",
-          "line": 10,
+          "line": 9,
           "called": []
         },
         {
           "kind": "def",
           "name": "policyBackingObjectTyped",
-          "line": 13,
+          "line": 12,
           "called": [
             "ServicePolicyPredicate"
           ]
@@ -9001,7 +9001,7 @@
         {
           "kind": "def",
           "name": "policyOwnerAuthorityRefRecorded",
-          "line": 17,
+          "line": 16,
           "called": [
             "ServicePolicyPredicate"
           ]
@@ -9009,7 +9009,7 @@
         {
           "kind": "def",
           "name": "policyOwnerAuthoritySlotPresent",
-          "line": 24,
+          "line": 23,
           "called": [
             "ServicePolicyPredicate"
           ]
@@ -9017,7 +9017,7 @@
         {
           "kind": "def",
           "name": "servicePolicySurfaceInvariant",
-          "line": 31,
+          "line": 30,
           "called": [
             "policyBackingObjectTyped",
             "policyOwnerAuthorityRefRecorded",
@@ -9027,7 +9027,7 @@
         {
           "kind": "def",
           "name": "serviceLifecycleCapabilityInvariantBundle",
-          "line": 38,
+          "line": 37,
           "called": [
             "servicePolicySurfaceInvariant"
           ]
@@ -9035,7 +9035,7 @@
         {
           "kind": "theorem",
           "name": "serviceLifecycleCapabilityInvariantBundle_of_components",
-          "line": 41,
+          "line": 40,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "servicePolicySurfaceInvariant"
@@ -9044,7 +9044,7 @@
         {
           "kind": "theorem",
           "name": "policyBackingObjectTyped_of_lifecycleInvariant",
-          "line": 50,
+          "line": 49,
           "called": [
             "policyBackingObjectTyped"
           ]
@@ -9052,7 +9052,7 @@
         {
           "kind": "theorem",
           "name": "policyOwnerAuthoritySlotPresent_of_lifecycleInvariant",
-          "line": 64,
+          "line": 63,
           "called": [
             "policyOwnerAuthorityRefRecorded",
             "policyOwnerAuthoritySlotPresent"
@@ -9061,7 +9061,7 @@
         {
           "kind": "theorem",
           "name": "policyOwnerAuthoritySlotPresent_of_capabilityLookup",
-          "line": 78,
+          "line": 77,
           "called": [
             "policyOwnerAuthoritySlotPresent"
           ]
@@ -9069,7 +9069,7 @@
         {
           "kind": "theorem",
           "name": "servicePolicySurfaceInvariant_of_lifecycleInvariant",
-          "line": 96,
+          "line": 95,
           "called": [
             "policyBackingObjectTyped_of_lifecycleInvariant",
             "policyOwnerAuthoritySlotPresent_of_lifecycleInvariant",
@@ -9079,19 +9079,19 @@
         {
           "kind": "theorem",
           "name": "serviceStart_policyDenied_separates_check_from_mutation",
-          "line": 110,
+          "line": 109,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_policyDenied_separates_check_from_mutation",
-          "line": 123,
+          "line": 122,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeServiceState_preserves_servicePolicySurfaceInvariant",
-          "line": 135,
+          "line": 134,
           "called": [
             "policyBackingObjectTyped",
             "policyOwnerAuthorityRefRecorded",
@@ -9102,19 +9102,19 @@
         {
           "kind": "theorem",
           "name": "storeServiceState_preserves_lifecycleInvariantBundle",
-          "line": 164,
+          "line": 163,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeServiceState_preserves_capabilityInvariantBundle",
-          "line": 182,
+          "line": 181,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 198,
+          "line": 197,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "storeServiceState_preserves_capabilityInvariantBundle",
@@ -9125,7 +9125,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 228,
+          "line": 227,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "storeServiceState_preserves_capabilityInvariantBundle",
@@ -9136,7 +9136,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 256,
+          "line": 255,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle",
@@ -9146,7 +9146,7 @@
         {
           "kind": "theorem",
           "name": "serviceStart_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 272,
+          "line": 271,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle"
           ]
@@ -9154,7 +9154,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 282,
+          "line": 281,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle"
           ]
@@ -9162,7 +9162,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 292,
+          "line": 291,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle"
           ]
@@ -9170,7 +9170,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 304,
+          "line": 303,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle"
@@ -10585,25 +10585,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Model",
-          "line": 4,
+          "line": 3,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "ServiceStatus",
-          "line": 8,
+          "line": 7,
           "called": []
         },
         {
           "kind": "structure",
           "name": "ServiceIdentity",
-          "line": 16,
+          "line": 15,
           "called": []
         },
         {
           "kind": "structure",
           "name": "ServiceGraphEntry",
-          "line": 23,
+          "line": 22,
           "called": [
             "ServiceIdentity",
             "ServiceStatus"
@@ -10612,19 +10612,19 @@
         {
           "kind": "inductive",
           "name": "AccessRight",
-          "line": 30,
+          "line": 29,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "CapTarget",
-          "line": 41,
+          "line": 40,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Capability",
-          "line": 47,
+          "line": 46,
           "called": [
             "AccessRight",
             "CapTarget"
@@ -10633,13 +10633,13 @@
         {
           "kind": "namespace",
           "name": "Capability",
-          "line": 53,
+          "line": 52,
           "called": []
         },
         {
           "kind": "def",
           "name": "hasRight",
-          "line": 55,
+          "line": 54,
           "called": [
             "AccessRight",
             "Capability"
@@ -10648,19 +10648,19 @@
         {
           "kind": "def",
           "name": "maxMessageRegisters",
-          "line": 62,
+          "line": 61,
           "called": []
         },
         {
           "kind": "def",
           "name": "maxExtraCaps",
-          "line": 66,
+          "line": 65,
           "called": []
         },
         {
           "kind": "structure",
           "name": "IpcMessage",
-          "line": 74,
+          "line": 73,
           "called": [
             "Capability"
           ]
@@ -10668,13 +10668,13 @@
         {
           "kind": "namespace",
           "name": "IpcMessage",
-          "line": 80,
+          "line": 79,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 82,
+          "line": 81,
           "called": [
             "IpcMessage"
           ]
@@ -10682,7 +10682,7 @@
         {
           "kind": "def",
           "name": "bounded",
-          "line": 86,
+          "line": 85,
           "called": [
             "IpcMessage",
             "maxExtraCaps",
@@ -10692,7 +10692,7 @@
         {
           "kind": "def",
           "name": "checkBounds",
-          "line": 92,
+          "line": 91,
           "called": [
             "IpcMessage",
             "maxExtraCaps",
@@ -10702,7 +10702,7 @@
         {
           "kind": "theorem",
           "name": "empty_bounded",
-          "line": 96,
+          "line": 95,
           "called": [
             "bounded",
             "empty",
@@ -10713,7 +10713,7 @@
         {
           "kind": "theorem",
           "name": "checkBounds_iff_bounded",
-          "line": 100,
+          "line": 99,
           "called": [
             "IpcMessage",
             "bounded",
@@ -10725,19 +10725,19 @@
         {
           "kind": "inductive",
           "name": "ThreadIpcState",
-          "line": 116,
+          "line": 115,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "QueuePPrev",
-          "line": 129,
+          "line": 128,
           "called": []
         },
         {
           "kind": "structure",
           "name": "TCB",
-          "line": 134,
+          "line": 133,
           "called": [
             "IpcMessage",
             "QueuePPrev",
@@ -10746,8 +10746,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:173>",
-          "line": 173,
+          "name": "<anonymous:instance:172>",
+          "line": 172,
           "called": [
             "TCB"
           ]
@@ -10755,13 +10755,13 @@
         {
           "kind": "structure",
           "name": "IntrusiveQueue",
-          "line": 187,
+          "line": 186,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Endpoint",
-          "line": 198,
+          "line": 197,
           "called": [
             "IntrusiveQueue"
           ]
@@ -10769,13 +10769,13 @@
         {
           "kind": "inductive",
           "name": "NotificationState",
-          "line": 203,
+          "line": 202,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Notification",
-          "line": 212,
+          "line": 211,
           "called": [
             "NotificationState"
           ]
@@ -10783,7 +10783,7 @@
         {
           "kind": "structure",
           "name": "CNode",
-          "line": 228,
+          "line": 227,
           "called": [
             "Capability"
           ]
@@ -10791,19 +10791,19 @@
         {
           "kind": "def",
           "name": "maxCSpaceDepth",
-          "line": 237,
+          "line": 236,
           "called": []
         },
         {
           "kind": "structure",
           "name": "UntypedChild",
-          "line": 242,
+          "line": 241,
           "called": []
         },
         {
           "kind": "structure",
           "name": "UntypedObject",
-          "line": 257,
+          "line": 256,
           "called": [
             "UntypedChild"
           ]
@@ -10811,13 +10811,13 @@
         {
           "kind": "namespace",
           "name": "UntypedObject",
-          "line": 273,
+          "line": 272,
           "called": []
         },
         {
           "kind": "def",
           "name": "freeSpace",
-          "line": 276,
+          "line": 275,
           "called": [
             "UntypedObject"
           ]
@@ -10825,7 +10825,7 @@
         {
           "kind": "def",
           "name": "canAllocate",
-          "line": 280,
+          "line": 279,
           "called": [
             "UntypedObject"
           ]
@@ -10833,7 +10833,7 @@
         {
           "kind": "def",
           "name": "allocate",
-          "line": 285,
+          "line": 284,
           "called": [
             "UntypedObject"
           ]
@@ -10841,7 +10841,7 @@
         {
           "kind": "def",
           "name": "reset",
-          "line": 297,
+          "line": 296,
           "called": [
             "UntypedObject"
           ]
@@ -10849,7 +10849,7 @@
         {
           "kind": "def",
           "name": "watermarkValid",
-          "line": 301,
+          "line": 300,
           "called": [
             "UntypedObject"
           ]
@@ -10857,7 +10857,7 @@
         {
           "kind": "def",
           "name": "childrenWithinWatermark",
-          "line": 305,
+          "line": 304,
           "called": [
             "UntypedObject"
           ]
@@ -10865,7 +10865,7 @@
         {
           "kind": "def",
           "name": "childrenNonOverlap",
-          "line": 309,
+          "line": 308,
           "called": [
             "UntypedObject"
           ]
@@ -10873,7 +10873,7 @@
         {
           "kind": "def",
           "name": "childrenUniqueIds",
-          "line": 314,
+          "line": 313,
           "called": [
             "UntypedObject"
           ]
@@ -10881,7 +10881,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 319,
+          "line": 318,
           "called": [
             "UntypedObject"
           ]
@@ -10889,7 +10889,7 @@
         {
           "kind": "theorem",
           "name": "empty_watermarkValid",
-          "line": 323,
+          "line": 322,
           "called": [
             "watermarkValid"
           ]
@@ -10897,7 +10897,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenWithinWatermark",
-          "line": 327,
+          "line": 326,
           "called": [
             "childrenWithinWatermark"
           ]
@@ -10905,7 +10905,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenNonOverlap",
-          "line": 332,
+          "line": 331,
           "called": [
             "childrenNonOverlap"
           ]
@@ -10913,7 +10913,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenUniqueIds",
-          "line": 337,
+          "line": 336,
           "called": [
             "childrenUniqueIds"
           ]
@@ -10921,7 +10921,7 @@
         {
           "kind": "theorem",
           "name": "empty_wellFormed",
-          "line": 342,
+          "line": 341,
           "called": [
             "empty_childrenNonOverlap",
             "empty_childrenUniqueIds",
@@ -10933,7 +10933,7 @@
         {
           "kind": "theorem",
           "name": "canAllocate_implies_fits",
-          "line": 348,
+          "line": 347,
           "called": [
             "UntypedObject",
             "canAllocate"
@@ -10942,7 +10942,7 @@
         {
           "kind": "theorem",
           "name": "allocate_some_iff",
-          "line": 355,
+          "line": 354,
           "called": [
             "UntypedObject",
             "allocate"
@@ -10951,7 +10951,7 @@
         {
           "kind": "theorem",
           "name": "allocate_watermark_advance",
-          "line": 374,
+          "line": 373,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -10960,7 +10960,7 @@
         {
           "kind": "theorem",
           "name": "allocate_offset_eq_watermark",
-          "line": 383,
+          "line": 382,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -10969,7 +10969,7 @@
         {
           "kind": "theorem",
           "name": "allocate_watermark_monotone",
-          "line": 390,
+          "line": 389,
           "called": [
             "UntypedObject",
             "allocate_watermark_advance"
@@ -10978,7 +10978,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_watermarkValid",
-          "line": 397,
+          "line": 396,
           "called": [
             "UntypedObject",
             "allocate_some_iff",
@@ -10989,7 +10989,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_region",
-          "line": 408,
+          "line": 407,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -10998,7 +10998,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenWithinWatermark",
-          "line": 419,
+          "line": 418,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11007,7 +11007,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenNonOverlap",
-          "line": 437,
+          "line": 436,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11016,7 +11016,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenUniqueIds",
-          "line": 459,
+          "line": 458,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11025,7 +11025,7 @@
         {
           "kind": "theorem",
           "name": "reset_watermarkValid",
-          "line": 478,
+          "line": 477,
           "called": [
             "UntypedObject",
             "reset",
@@ -11035,7 +11035,7 @@
         {
           "kind": "theorem",
           "name": "reset_wellFormed",
-          "line": 482,
+          "line": 481,
           "called": [
             "UntypedObject",
             "reset",


### PR DESCRIPTION
## Summary

- Workstream(s) advanced:
- Recommendation IDs closed:
- Scope notes:

## Validation evidence

- [ ] `./scripts/test_smoke.sh`
- [ ] `./scripts/test_full.sh`
- [ ] `./scripts/test_nightly.sh` (or justify omission)
- [ ] Targeted `rg -n` checks for new docs/anchors

## Documentation synchronization checklist (required)

- [ ] Canonical source docs updated first (`docs/*`, `docs/audits/*`)
- [ ] GitBook mirrors synchronized in the same PR (`docs/gitbook/*`)
- [ ] Generated navigation files refreshed (`scripts/generate_doc_navigation.py`)
- [ ] Markdown-link automation passed (`scripts/test_docs_sync.sh`)
- [ ] Active slice/workstream status synchronized across `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`
- [ ] Any deferrals explicitly linked to owning workstream

## Risks / follow-ups

- Residual risks:
- Deferred items + owning workstream:
