### PR TITLE
Add GPL-3.0 license headers to all source files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,9 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/codebase_map_sync.yml
+++ b/.github/workflows/codebase_map_sync.yml
@@ -1,3 +1,9 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 name: Codebase Map Sync
 
 on:

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -1,3 +1,9 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 name: Lean Action CI
 
 on:

--- a/.github/workflows/lean_toolchain_update_proposal.yml
+++ b/.github/workflows/lean_toolchain_update_proposal.yml
@@ -1,3 +1,9 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 name: Lean Toolchain Update Proposal
 
 on:

--- a/.github/workflows/nightly_determinism.yml
+++ b/.github/workflows/nightly_determinism.yml
@@ -1,3 +1,9 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 name: Nightly Determinism
 
 on:

--- a/.github/workflows/platform_security_baseline.yml
+++ b/.github/workflows/platform_security_baseline.yml
@@ -1,3 +1,9 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 name: Platform and Security Baseline
 
 on:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,9 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 title = "seLe4n gitleaks allowlist overrides"
 
 [allowlist]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,21 @@
 Thanks for contributing to seLe4n — a production-oriented microkernel written in
 Lean 4 with machine-checked proofs.
 
+## License
+
+seLe4n is licensed under the [GNU General Public License v3.0 or later](LICENSE).
+By submitting a pull request or contributing code to this project, you agree that
+your contributions will be licensed under the same GPL-3.0-or-later license. You
+also certify that you have the right to submit the contribution under this license.
+
 ## 5-minute contributor path
 
 1. **Workflow + standards:** [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
 2. **Testing tiers:** [`docs/TESTING_FRAMEWORK_PLAN.md`](docs/TESTING_FRAMEWORK_PLAN.md)
 3. **CI policy:** [`docs/CI_POLICY.md`](docs/CI_POLICY.md)
 4. **Project scope + workstreams:** [`docs/spec/SELE4N_SPEC.md`](docs/spec/SELE4N_SPEC.md)
-5. **Active audit findings:** [`docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md`](docs/audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](docs/audits/AUDIT_CODEBASE_v0.12.2_v2.md)
-6. **Workstream execution plan:** [`docs/audits/AUDIT_v0.12.2_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.12.2_WORKSTREAM_PLAN.md)
+5. **Active audit findings:** [`docs/audits/AUDIT_CODEBASE_v0.13.6.md`](docs/audits/AUDIT_CODEBASE_v0.13.6.md)
+6. **Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md)
 
 Full handbook: [`docs/gitbook/README.md`](docs/gitbook/README.md)
 

--- a/Main.lean
+++ b/Main.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 import SeLe4n.Testing.MainTraceHarness
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ introducing substantial architectural improvements:
 |-----------|-------|
 | **Version** | `0.14.6` |
 | **Lean toolchain** | `v4.28.0` |
-| **Production Lean LoC** | 31,600 across 65 files |
-| **Test Lean LoC** | 2,412 across 3 test suites |
+| **Production Lean LoC** | 32,120 across 65 files |
+| **Test Lean LoC** | 2,436 across 3 test suites |
 | **Proved declarations** | 1,034 theorem/lemma declarations (zero sorry/axiom) |
 | **Total declarations** | 1,890 across 68 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |

--- a/SeLe4n.lean
+++ b/SeLe4n.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Prelude
 import SeLe4n.Machine
 import SeLe4n.Model.Object

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Scheduler.Invariant
 import SeLe4n.Kernel.Capability.Operations
 import SeLe4n.Kernel.IPC.DualQueue

--- a/SeLe4n/Kernel/Architecture/Adapter.lean
+++ b/SeLe4n/Kernel/Architecture/Adapter.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Architecture.Assumptions
 
 namespace SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Architecture/Assumptions.lean
+++ b/SeLe4n/Kernel/Architecture/Assumptions.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.State
 
 namespace SeLe4n.Kernel.Architecture

--- a/SeLe4n/Kernel/Architecture/Invariant.lean
+++ b/SeLe4n/Kernel/Architecture/Invariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Architecture.Adapter
 import SeLe4n.Kernel.Architecture.VSpaceInvariant
 import SeLe4n.Kernel.Service.Invariant

--- a/SeLe4n/Kernel/Architecture/TlbModel.lean
+++ b/SeLe4n/Kernel/Architecture/TlbModel.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Architecture.VSpace
 
 /-!

--- a/SeLe4n/Kernel/Architecture/VSpace.lean
+++ b/SeLe4n/Kernel/Architecture/VSpace.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.State
 
 /-!

--- a/SeLe4n/Kernel/Architecture/VSpaceBackend.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceBackend.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.State
 
 /-!

--- a/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Architecture.VSpace
 
 /-!

--- a/SeLe4n/Kernel/Capability/Invariant.lean
+++ b/SeLe4n/Kernel/Capability/Invariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Capability.Invariant.Defs
 import SeLe4n.Kernel.Capability.Invariant.Authority
 import SeLe4n.Kernel.Capability.Invariant.Preservation

--- a/SeLe4n/Kernel/Capability/Invariant/Authority.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Authority.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Capability.Invariant.Defs
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Capability/Invariant/Defs.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Defs.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Invariant
 import SeLe4n.Kernel.Lifecycle.Invariant
 

--- a/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Capability.Invariant.Authority
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Scheduler.Invariant
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/DualQueue.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.DualQueue.Core
 import SeLe4n.Kernel.IPC.DualQueue.Transport
 

--- a/SeLe4n/Kernel/IPC/DualQueue/Core.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue/Core.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Operations
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/DualQueue/Transport.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue/Transport.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.DualQueue.Core
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Invariant.lean
+++ b/SeLe4n/Kernel/IPC/Invariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Invariant.Defs
 import SeLe4n.Kernel.IPC.Invariant.EndpointPreservation
 import SeLe4n.Kernel.IPC.Invariant.CallReplyRecv

--- a/SeLe4n/Kernel/IPC/Invariant/CallReplyRecv.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/CallReplyRecv.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Invariant.EndpointPreservation
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Invariant/Defs.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Defs.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Scheduler.Operations
 import SeLe4n.Kernel.IPC.DualQueue
 

--- a/SeLe4n/Kernel/IPC/Invariant/EndpointPreservation.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/EndpointPreservation.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Invariant.Defs
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Invariant/NotificationPreservation.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/NotificationPreservation.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Invariant.EndpointPreservation
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Invariant/Structural.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Structural.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Invariant.CallReplyRecv
 import SeLe4n.Kernel.IPC.Invariant.NotificationPreservation
 

--- a/SeLe4n/Kernel/IPC/Operations.lean
+++ b/SeLe4n/Kernel/IPC/Operations.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Operations.Endpoint
 import SeLe4n.Kernel.IPC.Operations.SchedulerLemmas
 

--- a/SeLe4n/Kernel/IPC/Operations/Endpoint.lean
+++ b/SeLe4n/Kernel/IPC/Operations/Endpoint.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.State
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/IPC/Operations/SchedulerLemmas.lean
+++ b/SeLe4n/Kernel/IPC/Operations/SchedulerLemmas.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.IPC.Operations.Endpoint
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/InformationFlow/Enforcement.lean
+++ b/SeLe4n/Kernel/InformationFlow/Enforcement.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Enforcement.Wrappers
 import SeLe4n.Kernel.InformationFlow.Enforcement.Soundness
 

--- a/SeLe4n/Kernel/InformationFlow/Enforcement/Soundness.lean
+++ b/SeLe4n/Kernel/InformationFlow/Enforcement/Soundness.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Enforcement.Wrappers
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/InformationFlow/Enforcement/Wrappers.lean
+++ b/SeLe4n/Kernel/InformationFlow/Enforcement/Wrappers.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Policy
 import SeLe4n.Kernel.IPC.DualQueue
 import SeLe4n.Kernel.Capability.Operations

--- a/SeLe4n/Kernel/InformationFlow/Invariant.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Invariant.Helpers
 import SeLe4n.Kernel.InformationFlow.Invariant.Operations
 import SeLe4n.Kernel.InformationFlow.Invariant.Composition

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Invariant.Operations
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Helpers.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Helpers.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Projection
 import SeLe4n.Kernel.InformationFlow.Enforcement
 import SeLe4n.Kernel.IPC.Invariant

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Invariant.Helpers
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/InformationFlow/Policy.lean
+++ b/SeLe4n/Kernel/InformationFlow/Policy.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.State
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/InformationFlow/Projection.lean
+++ b/SeLe4n/Kernel/InformationFlow/Projection.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.InformationFlow.Policy
 import Std.Data.HashSet
 

--- a/SeLe4n/Kernel/Lifecycle/Invariant.lean
+++ b/SeLe4n/Kernel/Lifecycle/Invariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Lifecycle.Operations
 
 /-!

--- a/SeLe4n/Kernel/Lifecycle/Operations.lean
+++ b/SeLe4n/Kernel/Lifecycle/Operations.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Capability.Operations
 import SeLe4n.Kernel.IPC.Operations
 

--- a/SeLe4n/Kernel/Scheduler/Invariant.lean
+++ b/SeLe4n/Kernel/Scheduler/Invariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.State
 
 /-!

--- a/SeLe4n/Kernel/Scheduler/Operations.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Scheduler.Operations.Selection
 import SeLe4n.Kernel.Scheduler.Operations.Core
 import SeLe4n.Kernel.Scheduler.Operations.Preservation

--- a/SeLe4n/Kernel/Scheduler/Operations/Core.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations/Core.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Scheduler.Operations.Selection
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Scheduler/Operations/Preservation.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations/Preservation.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Scheduler.Operations.Core
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Scheduler/Operations/Selection.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations/Selection.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Scheduler.Invariant
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Scheduler/RunQueue.lean
+++ b/SeLe4n/Kernel/Scheduler/RunQueue.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Prelude
 namespace SeLe4n.Kernel
 open SeLe4n

--- a/SeLe4n/Kernel/Service/Invariant.lean
+++ b/SeLe4n/Kernel/Service/Invariant.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Service.Invariant.Policy
 import SeLe4n.Kernel.Service.Invariant.Acyclicity
 

--- a/SeLe4n/Kernel/Service/Invariant/Acyclicity.lean
+++ b/SeLe4n/Kernel/Service/Invariant/Acyclicity.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Service.Invariant.Policy
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Kernel/Service/Invariant/Policy.lean
+++ b/SeLe4n/Kernel/Service/Invariant/Policy.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Service.Operations
 import SeLe4n.Kernel.Capability.Invariant
 

--- a/SeLe4n/Kernel/Service/Operations.lean
+++ b/SeLe4n/Kernel/Service/Operations.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.State
 
 namespace SeLe4n.Kernel

--- a/SeLe4n/Machine.lean
+++ b/SeLe4n/Machine.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Prelude
 
 namespace SeLe4n

--- a/SeLe4n/Model/Object.lean
+++ b/SeLe4n/Model/Object.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.Object.Types
 import SeLe4n.Model.Object.Structures
 

--- a/SeLe4n/Model/Object/Structures.lean
+++ b/SeLe4n/Model/Object/Structures.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Model.Object.Types
 
 namespace SeLe4n.Model

--- a/SeLe4n/Model/Object/Types.lean
+++ b/SeLe4n/Model/Object/Types.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Machine
 
 namespace SeLe4n.Model

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Machine
 import SeLe4n.Model.Object
 import SeLe4n.Kernel.Scheduler.RunQueue

--- a/SeLe4n/Platform/Contract.lean
+++ b/SeLe4n/Platform/Contract.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Architecture.Assumptions
 
 /-!

--- a/SeLe4n/Platform/RPi5/Board.lean
+++ b/SeLe4n/Platform/RPi5/Board.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Machine
 
 /-!

--- a/SeLe4n/Platform/RPi5/BootContract.lean
+++ b/SeLe4n/Platform/RPi5/BootContract.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Platform.RPi5.Board
 import SeLe4n.Kernel.Architecture.Assumptions
 

--- a/SeLe4n/Platform/RPi5/Contract.lean
+++ b/SeLe4n/Platform/RPi5/Contract.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Platform.Contract
 import SeLe4n.Platform.RPi5.RuntimeContract
 import SeLe4n.Platform.RPi5.BootContract

--- a/SeLe4n/Platform/RPi5/RuntimeContract.lean
+++ b/SeLe4n/Platform/RPi5/RuntimeContract.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Platform.RPi5.Board
 import SeLe4n.Kernel.Architecture.Assumptions
 

--- a/SeLe4n/Platform/Sim/BootContract.lean
+++ b/SeLe4n/Platform/Sim/BootContract.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Architecture.Assumptions
 
 /-!

--- a/SeLe4n/Platform/Sim/Contract.lean
+++ b/SeLe4n/Platform/Sim/Contract.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Platform.Contract
 import SeLe4n.Platform.Sim.RuntimeContract
 import SeLe4n.Platform.Sim.BootContract

--- a/SeLe4n/Platform/Sim/RuntimeContract.lean
+++ b/SeLe4n/Platform/Sim/RuntimeContract.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n.Kernel.Architecture.Assumptions
 
 /-!

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import Std.Data.HashMap
 import Std.Data.HashSet
 

--- a/SeLe4n/Testing/InvariantChecks.lean
+++ b/SeLe4n/Testing/InvariantChecks.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 
 open SeLe4n.Model

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 import SeLe4n.Testing.RuntimeContractFixtures
 import SeLe4n.Testing.StateBuilder

--- a/SeLe4n/Testing/RuntimeContractFixtures.lean
+++ b/SeLe4n/Testing/RuntimeContractFixtures.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 
 open SeLe4n.Model

--- a/SeLe4n/Testing/StateBuilder.lean
+++ b/SeLe4n/Testing/StateBuilder.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 
 open SeLe4n.Model

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "main",
-      "commit_sha": "4df590ad5057c59a0e992f9e5230619259e0dbea",
-      "tree_sha": "d3cc6110116571d32e9d8d49253f02d9ebc39107",
-      "committed_at_utc": "2026-03-10T17:48:01-04:00"
+      "branch": "claude/add-copyright-headers-Ot6Qm",
+      "commit_sha": "300295322e3f103d1b5ba312b22dc40df2af5fe9",
+      "tree_sha": "4286ff67aab0a613e86f5d731d9f90e181c8870b",
+      "committed_at_utc": "2026-03-10T21:48:10+00:00"
     }
   },
   "source_sync": {
@@ -17,7 +17,7 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "afb9a5f3fdd2f42e4bff1b2f1ce58f28b683062096456fb0ba168df5cb26e543"
+    "source_digest": "6930a1ddd23280d833a3d958776ffac343e2bc64037fd58cb46ccc8e6ccb6c07"
   },
   "summary": {
     "module_count": 68,
@@ -27,9 +27,9 @@
     "version": "0.14.6",
     "lean_toolchain": "v4.28.0",
     "production_files": 65,
-    "production_loc": 31600,
+    "production_loc": 32120,
     "test_files": 3,
-    "test_loc": 2412,
+    "test_loc": 2436,
     "proved_theorem_lemma_decls": 1034,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
@@ -42,19 +42,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 59,
+          "line": 67,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "apiInvariantBundle",
-          "line": 67,
+          "line": 75,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "apiInvariantBundle_default",
-          "line": 72,
+          "line": 80,
           "called": [
             "apiInvariantBundle"
           ]
@@ -69,19 +69,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel.Architecture",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "AdapterErrorKind",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "def",
           "name": "mapAdapterError",
-          "line": 14,
+          "line": 22,
           "called": [
             "AdapterErrorKind"
           ]
@@ -89,19 +89,19 @@
         {
           "kind": "def",
           "name": "advanceTimerState",
-          "line": 19,
+          "line": 27,
           "called": []
         },
         {
           "kind": "def",
           "name": "writeRegisterState",
-          "line": 23,
+          "line": 31,
           "called": []
         },
         {
           "kind": "def",
           "name": "adapterAdvanceTimer",
-          "line": 27,
+          "line": 35,
           "called": [
             "advanceTimerState",
             "mapAdapterError"
@@ -110,7 +110,7 @@
         {
           "kind": "def",
           "name": "adapterWriteRegister",
-          "line": 40,
+          "line": 48,
           "called": [
             "mapAdapterError",
             "writeRegisterState"
@@ -119,7 +119,7 @@
         {
           "kind": "def",
           "name": "adapterReadMemory",
-          "line": 54,
+          "line": 62,
           "called": [
             "mapAdapterError"
           ]
@@ -127,7 +127,7 @@
         {
           "kind": "theorem",
           "name": "adapterAdvanceTimer_error_invalidContext",
-          "line": 65,
+          "line": 73,
           "called": [
             "adapterAdvanceTimer",
             "mapAdapterError"
@@ -136,7 +136,7 @@
         {
           "kind": "theorem",
           "name": "adapterAdvanceTimer_error_unsupportedBinding",
-          "line": 71,
+          "line": 79,
           "called": [
             "adapterAdvanceTimer",
             "advanceTimerState",
@@ -146,7 +146,7 @@
         {
           "kind": "theorem",
           "name": "adapterWriteRegister_error_unsupportedBinding",
-          "line": 80,
+          "line": 88,
           "called": [
             "adapterWriteRegister",
             "mapAdapterError",
@@ -156,7 +156,7 @@
         {
           "kind": "theorem",
           "name": "adapterReadMemory_error_unsupportedBinding",
-          "line": 89,
+          "line": 97,
           "called": [
             "adapterReadMemory",
             "mapAdapterError"
@@ -165,7 +165,7 @@
         {
           "kind": "theorem",
           "name": "adapterReadMemory_ok_returns_machine_byte",
-          "line": 97,
+          "line": 105,
           "called": [
             "adapterReadMemory"
           ]
@@ -173,7 +173,7 @@
         {
           "kind": "theorem",
           "name": "adapterAdvanceTimer_deterministic",
-          "line": 110,
+          "line": 118,
           "called": [
             "adapterAdvanceTimer"
           ]
@@ -188,55 +188,55 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel.Architecture",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "ArchAssumption",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "TransitionSurface",
-          "line": 17,
+          "line": 25,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "InvariantSurface",
-          "line": 27,
+          "line": 35,
           "called": []
         },
         {
           "kind": "structure",
           "name": "BootBoundaryContract",
-          "line": 37,
+          "line": 45,
           "called": []
         },
         {
           "kind": "structure",
           "name": "RuntimeBoundaryContract",
-          "line": 42,
+          "line": 50,
           "called": []
         },
         {
           "kind": "structure",
           "name": "InterruptBoundaryContract",
-          "line": 51,
+          "line": 59,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "ContractRef",
-          "line": 56,
+          "line": 64,
           "called": []
         },
         {
           "kind": "def",
           "name": "assumptionContractMap",
-          "line": 67,
+          "line": 75,
           "called": [
             "ArchAssumption",
             "ContractRef"
@@ -245,7 +245,7 @@
         {
           "kind": "def",
           "name": "assumptionTransitionMap",
-          "line": 75,
+          "line": 83,
           "called": [
             "ArchAssumption",
             "TransitionSurface"
@@ -254,7 +254,7 @@
         {
           "kind": "def",
           "name": "assumptionInvariantMap",
-          "line": 83,
+          "line": 91,
           "called": [
             "ArchAssumption",
             "InvariantSurface"
@@ -263,7 +263,7 @@
         {
           "kind": "def",
           "name": "assumptionInventory",
-          "line": 91,
+          "line": 99,
           "called": [
             "ArchAssumption"
           ]
@@ -271,7 +271,7 @@
         {
           "kind": "def",
           "name": "assumptionInventoryComplete",
-          "line": 100,
+          "line": 108,
           "called": [
             "assumptionInventory"
           ]
@@ -279,7 +279,7 @@
         {
           "kind": "theorem",
           "name": "assumptionInventoryComplete_holds",
-          "line": 103,
+          "line": 111,
           "called": [
             "assumptionInventory",
             "assumptionInventoryComplete"
@@ -288,7 +288,7 @@
         {
           "kind": "theorem",
           "name": "assumptionContractMap_nonempty",
-          "line": 108,
+          "line": 116,
           "called": [
             "ArchAssumption",
             "assumptionContractMap"
@@ -297,7 +297,7 @@
         {
           "kind": "theorem",
           "name": "assumptionTransitionMap_nonempty",
-          "line": 112,
+          "line": 120,
           "called": [
             "ArchAssumption",
             "assumptionTransitionMap"
@@ -306,7 +306,7 @@
         {
           "kind": "theorem",
           "name": "assumptionInvariantMap_nonempty",
-          "line": 116,
+          "line": 124,
           "called": [
             "ArchAssumption",
             "assumptionInvariantMap"
@@ -315,13 +315,13 @@
         {
           "kind": "inductive",
           "name": "ExceptionLevel",
-          "line": 151,
+          "line": 159,
           "called": []
         },
         {
           "kind": "structure",
           "name": "ExtendedBootBoundaryContract",
-          "line": 170,
+          "line": 178,
           "called": [
             "BootBoundaryContract",
             "ExceptionLevel"
@@ -337,19 +337,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel.Architecture",
-          "line": 30,
+          "line": 38,
           "called": []
         },
         {
           "kind": "def",
           "name": "proofLayerInvariantBundle",
-          "line": 47,
+          "line": 55,
           "called": []
         },
         {
           "kind": "structure",
           "name": "AdapterProofHooks",
-          "line": 57,
+          "line": 65,
           "called": [
             "proofLayerInvariantBundle"
           ]
@@ -357,7 +357,7 @@
         {
           "kind": "theorem",
           "name": "adapterAdvanceTimer_ok_preserves_proofLayerInvariantBundle",
-          "line": 75,
+          "line": 83,
           "called": [
             "AdapterProofHooks",
             "proofLayerInvariantBundle"
@@ -366,7 +366,7 @@
         {
           "kind": "theorem",
           "name": "adapterWriteRegister_ok_preserves_proofLayerInvariantBundle",
-          "line": 97,
+          "line": 105,
           "called": [
             "AdapterProofHooks",
             "proofLayerInvariantBundle"
@@ -375,7 +375,7 @@
         {
           "kind": "theorem",
           "name": "adapterReadMemory_ok_preserves_proofLayerInvariantBundle",
-          "line": 115,
+          "line": 123,
           "called": [
             "AdapterProofHooks",
             "proofLayerInvariantBundle"
@@ -384,14 +384,6 @@
         {
           "kind": "theorem",
           "name": "adapterAdvanceTimer_error_invalidContext_preserves_proofLayerInvariantBundle",
-          "line": 134,
-          "called": [
-            "proofLayerInvariantBundle"
-          ]
-        },
-        {
-          "kind": "theorem",
-          "name": "adapterAdvanceTimer_error_unsupportedBinding_preserves_proofLayerInvariantBundle",
           "line": 142,
           "called": [
             "proofLayerInvariantBundle"
@@ -399,8 +391,16 @@
         },
         {
           "kind": "theorem",
+          "name": "adapterAdvanceTimer_error_unsupportedBinding_preserves_proofLayerInvariantBundle",
+          "line": 150,
+          "called": [
+            "proofLayerInvariantBundle"
+          ]
+        },
+        {
+          "kind": "theorem",
           "name": "adapterWriteRegister_error_unsupportedBinding_preserves_proofLayerInvariantBundle",
-          "line": 153,
+          "line": 161,
           "called": [
             "proofLayerInvariantBundle"
           ]
@@ -408,7 +408,7 @@
         {
           "kind": "theorem",
           "name": "adapterReadMemory_error_unsupportedBinding_preserves_proofLayerInvariantBundle",
-          "line": 164,
+          "line": 172,
           "called": [
             "proofLayerInvariantBundle"
           ]
@@ -416,61 +416,61 @@
         {
           "kind": "theorem",
           "name": "advanceTimerState_preserves_vspaceInvariantBundle",
-          "line": 176,
+          "line": 184,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "writeRegisterState_preserves_vspaceInvariantBundle",
-          "line": 185,
+          "line": 193,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "default_schedulerInvariantBundle",
-          "line": 201,
+          "line": 209,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "default_ipcInvariant",
-          "line": 213,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "default_lifecycleInvariantBundle",
-          "line": 217,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "default_ipcSchedulerContractPredicates",
           "line": 221,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "default_lifecycleInvariantBundle",
+          "line": 225,
+          "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "default_ipcSchedulerContractPredicates",
+          "line": 229,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "default_capabilityInvariantBundle",
-          "line": 234,
+          "line": 242,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "default_dualQueueSystemInvariant",
-          "line": 247,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "default_allPendingMessagesBounded",
           "line": 255,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "default_allPendingMessagesBounded",
+          "line": 263,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "default_ipcInvariantFull",
-          "line": 259,
+          "line": 267,
           "called": [
             "default_allPendingMessagesBounded",
             "default_dualQueueSystemInvariant",
@@ -480,19 +480,19 @@
         {
           "kind": "theorem",
           "name": "default_contextMatchesCurrent",
-          "line": 263,
+          "line": 271,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "default_currentThreadDequeueCoherent",
-          "line": 267,
+          "line": 275,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "default_schedulerInvariantBundleFull",
-          "line": 277,
+          "line": 285,
           "called": [
             "default_contextMatchesCurrent",
             "default_schedulerInvariantBundle"
@@ -501,7 +501,7 @@
         {
           "kind": "theorem",
           "name": "default_system_state_proofLayerInvariantBundle",
-          "line": 289,
+          "line": 297,
           "called": [
             "default_capabilityInvariantBundle",
             "default_contextMatchesCurrent",
@@ -517,7 +517,7 @@
         {
           "kind": "theorem",
           "name": "deterministicTimerProgress_consumed_by_advanceTimer",
-          "line": 352,
+          "line": 360,
           "called": [
             "AdapterProofHooks",
             "proofLayerInvariantBundle"
@@ -526,7 +526,7 @@
         {
           "kind": "theorem",
           "name": "deterministicRegisterContext_consumed_by_writeRegister",
-          "line": 365,
+          "line": 373,
           "called": [
             "AdapterProofHooks",
             "proofLayerInvariantBundle"
@@ -535,7 +535,7 @@
         {
           "kind": "theorem",
           "name": "memoryAccessSafety_consumed_by_readMemory",
-          "line": 378,
+          "line": 386,
           "called": [
             "AdapterProofHooks",
             "proofLayerInvariantBundle"
@@ -551,27 +551,27 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel.Architecture",
-          "line": 32,
+          "line": 40,
           "called": []
         },
         {
           "kind": "structure",
           "name": "TlbEntry",
-          "line": 38,
+          "line": 46,
           "called": []
         },
         {
           "kind": "structure",
           "name": "TlbState",
-          "line": 50,
+          "line": 58,
           "called": [
             "TlbEntry"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:54>",
-          "line": 54,
+          "name": "<anonymous:instance:62>",
+          "line": 62,
           "called": [
             "TlbState"
           ]
@@ -579,7 +579,7 @@
         {
           "kind": "def",
           "name": "TlbState.empty",
-          "line": 58,
+          "line": 66,
           "called": [
             "TlbState"
           ]
@@ -587,7 +587,7 @@
         {
           "kind": "def",
           "name": "adapterFlushTlb",
-          "line": 63,
+          "line": 71,
           "called": [
             "TlbState",
             "TlbState.empty"
@@ -596,7 +596,7 @@
         {
           "kind": "def",
           "name": "adapterFlushTlbByAsid",
-          "line": 69,
+          "line": 77,
           "called": [
             "TlbState"
           ]
@@ -604,7 +604,7 @@
         {
           "kind": "def",
           "name": "adapterFlushTlbByVAddr",
-          "line": 76,
+          "line": 84,
           "called": [
             "TlbState"
           ]
@@ -612,7 +612,7 @@
         {
           "kind": "def",
           "name": "tlbConsistent",
-          "line": 84,
+          "line": 92,
           "called": [
             "TlbState"
           ]
@@ -620,7 +620,7 @@
         {
           "kind": "theorem",
           "name": "tlbConsistent_empty",
-          "line": 95,
+          "line": 103,
           "called": [
             "TlbState.empty",
             "tlbConsistent"
@@ -629,7 +629,7 @@
         {
           "kind": "theorem",
           "name": "adapterFlushTlb_restores_tlbConsistent",
-          "line": 101,
+          "line": 109,
           "called": [
             "TlbState",
             "adapterFlushTlb",
@@ -640,7 +640,7 @@
         {
           "kind": "theorem",
           "name": "adapterFlushTlbByAsid_preserves_tlbConsistent",
-          "line": 107,
+          "line": 115,
           "called": [
             "TlbState",
             "adapterFlushTlbByAsid",
@@ -650,17 +650,6 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPage_then_flush_preserves_tlbConsistent",
-          "line": 120,
-          "called": [
-            "TlbState",
-            "adapterFlushTlb",
-            "adapterFlushTlb_restores_tlbConsistent",
-            "tlbConsistent"
-          ]
-        },
-        {
-          "kind": "theorem",
-          "name": "vspaceUnmapPage_then_flush_preserves_tlbConsistent",
           "line": 128,
           "called": [
             "TlbState",
@@ -671,8 +660,19 @@
         },
         {
           "kind": "theorem",
+          "name": "vspaceUnmapPage_then_flush_preserves_tlbConsistent",
+          "line": 136,
+          "called": [
+            "TlbState",
+            "adapterFlushTlb",
+            "adapterFlushTlb_restores_tlbConsistent",
+            "tlbConsistent"
+          ]
+        },
+        {
+          "kind": "theorem",
           "name": "adapterFlushTlbByAsid_removes_matching",
-          "line": 140,
+          "line": 148,
           "called": [
             "TlbEntry",
             "TlbState",
@@ -682,7 +682,7 @@
         {
           "kind": "theorem",
           "name": "adapterFlushTlbByAsid_preserves_other",
-          "line": 149,
+          "line": 157,
           "called": [
             "TlbEntry",
             "TlbState",
@@ -692,7 +692,7 @@
         {
           "kind": "theorem",
           "name": "sequential_modifications_then_flush_preserves_tlbConsistent",
-          "line": 159,
+          "line": 167,
           "called": [
             "TlbState",
             "adapterFlushTlb",
@@ -703,7 +703,7 @@
         {
           "kind": "theorem",
           "name": "adapterFlushTlbByVAddr_preserves_tlbConsistent",
-          "line": 170,
+          "line": 178,
           "called": [
             "TlbState",
             "adapterFlushTlbByVAddr",
@@ -713,7 +713,7 @@
         {
           "kind": "theorem",
           "name": "adapterFlushTlbByVAddr_removes_matching",
-          "line": 180,
+          "line": 188,
           "called": [
             "TlbEntry",
             "TlbState",
@@ -723,7 +723,7 @@
         {
           "kind": "theorem",
           "name": "adapterFlushTlbByVAddr_preserves_other",
-          "line": 191,
+          "line": 199,
           "called": [
             "TlbEntry",
             "TlbState",
@@ -733,7 +733,7 @@
         {
           "kind": "theorem",
           "name": "vaddrFlush_after_asidFlush_no_asid_entries",
-          "line": 205,
+          "line": 213,
           "called": [
             "TlbEntry",
             "TlbState",
@@ -744,7 +744,7 @@
         {
           "kind": "theorem",
           "name": "cross_asid_tlb_isolation",
-          "line": 227,
+          "line": 235,
           "called": [
             "TlbState",
             "adapterFlushTlbByAsid"
@@ -760,31 +760,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel.Architecture",
-          "line": 12,
+          "line": 20,
           "called": []
         },
         {
           "kind": "def",
           "name": "asidBoundToRoot",
-          "line": 17,
+          "line": 25,
           "called": []
         },
         {
           "kind": "def",
           "name": "resolveAsidRoot",
-          "line": 22,
+          "line": 30,
           "called": []
         },
         {
           "kind": "def",
           "name": "physicalAddressBound",
-          "line": 31,
+          "line": 39,
           "called": []
         },
         {
           "kind": "def",
           "name": "vspaceMapPage",
-          "line": 35,
+          "line": 43,
           "called": [
             "resolveAsidRoot"
           ]
@@ -792,7 +792,7 @@
         {
           "kind": "def",
           "name": "vspaceMapPageChecked",
-          "line": 50,
+          "line": 58,
           "called": [
             "physicalAddressBound",
             "vspaceMapPage"
@@ -801,7 +801,7 @@
         {
           "kind": "def",
           "name": "vspaceUnmapPage",
-          "line": 57,
+          "line": 65,
           "called": [
             "resolveAsidRoot"
           ]
@@ -809,7 +809,7 @@
         {
           "kind": "def",
           "name": "vspaceLookupFull",
-          "line": 68,
+          "line": 76,
           "called": [
             "resolveAsidRoot"
           ]
@@ -817,7 +817,7 @@
         {
           "kind": "def",
           "name": "vspaceLookup",
-          "line": 80,
+          "line": 88,
           "called": [
             "resolveAsidRoot"
           ]
@@ -825,13 +825,13 @@
         {
           "kind": "def",
           "name": "vspaceAsidRootsUnique",
-          "line": 94,
+          "line": 102,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "resolveAsidRoot_some_implies_obj",
-          "line": 103,
+          "line": 111,
           "called": [
             "resolveAsidRoot"
           ]
@@ -839,7 +839,7 @@
         {
           "kind": "theorem",
           "name": "resolveAsidRoot_of_asidTable_entry",
-          "line": 140,
+          "line": 148,
           "called": [
             "resolveAsidRoot"
           ]
@@ -847,7 +847,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objectIndex_eq_of_mem",
-          "line": 156,
+          "line": 164,
           "called": []
         }
       ]
@@ -860,19 +860,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel.Architecture",
-          "line": 47,
+          "line": 55,
           "called": []
         },
         {
           "kind": "class",
           "name": "VSpaceBackend",
-          "line": 67,
+          "line": 75,
           "called": []
         },
         {
           "kind": "instance",
           "name": "hashMapVSpaceBackend",
-          "line": 123,
+          "line": 131,
           "called": [
             "VSpaceBackend"
           ]
@@ -887,37 +887,37 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel.Architecture",
-          "line": 33,
+          "line": 41,
           "called": []
         },
         {
           "kind": "def",
           "name": "vspaceRootNonOverlap",
-          "line": 38,
+          "line": 46,
           "called": []
         },
         {
           "kind": "def",
           "name": "asidTableConsistent",
-          "line": 48,
+          "line": 56,
           "called": []
         },
         {
           "kind": "def",
           "name": "boundedAddressTranslation",
-          "line": 58,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "wxExclusiveInvariant",
           "line": 66,
           "called": []
         },
         {
           "kind": "def",
+          "name": "wxExclusiveInvariant",
+          "line": 74,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "vspaceInvariantBundle",
-          "line": 76,
+          "line": 84,
           "called": [
             "asidTableConsistent",
             "boundedAddressTranslation",
@@ -928,7 +928,7 @@
         {
           "kind": "theorem",
           "name": "asidTableConsistent_of_storeObject_vspaceRoot",
-          "line": 90,
+          "line": 98,
           "called": [
             "asidTableConsistent"
           ]
@@ -936,7 +936,7 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPage_error_asidNotBound_preserves_vspaceInvariantBundle",
-          "line": 160,
+          "line": 168,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -944,7 +944,7 @@
         {
           "kind": "theorem",
           "name": "vspaceUnmapPage_error_translationFault_preserves_vspaceInvariantBundle",
-          "line": 171,
+          "line": 179,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -952,25 +952,25 @@
         {
           "kind": "theorem",
           "name": "VSpaceRoot.mapPage_mappings_insert",
-          "line": 186,
+          "line": 194,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "VSpaceRoot.unmapPage_mappings_erase",
-          "line": 198,
+          "line": 206,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashMap_lookup_of_erase_lookup",
-          "line": 208,
+          "line": 216,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "vspaceMapPage_success_preserves_vspaceInvariantBundle",
-          "line": 232,
+          "line": 240,
           "called": [
             "VSpaceRoot.mapPage_mappings_insert",
             "asidTableConsistent_of_storeObject_vspaceRoot",
@@ -980,7 +980,7 @@
         {
           "kind": "theorem",
           "name": "vspaceUnmapPage_success_preserves_vspaceInvariantBundle",
-          "line": 335,
+          "line": 343,
           "called": [
             "HashMap_lookup_of_erase_lookup",
             "VSpaceRoot.unmapPage_mappings_erase",
@@ -991,7 +991,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_after_map",
-          "line": 422,
+          "line": 430,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -999,7 +999,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_map_other",
-          "line": 462,
+          "line": 470,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -1007,7 +1007,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_after_unmap",
-          "line": 506,
+          "line": 514,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -1015,7 +1015,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_unmap_other",
-          "line": 541,
+          "line": 549,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -1023,7 +1023,7 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPageChecked_success_preserves_vspaceInvariantBundle",
-          "line": 582,
+          "line": 590,
           "called": [
             "vspaceInvariantBundle",
             "vspaceMapPage_success_preserves_vspaceInvariantBundle"
@@ -1032,7 +1032,7 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPageChecked_error_preserves_vspaceInvariantBundle",
-          "line": 600,
+          "line": 608,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -1040,7 +1040,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookupFull_after_map",
-          "line": 615,
+          "line": 623,
           "called": [
             "vspaceInvariantBundle"
           ]
@@ -1048,13 +1048,13 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPage_resolveAsidRoot_agreement",
-          "line": 660,
+          "line": 668,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "vspaceUnmapPage_resolveAsidRoot_agreement",
-          "line": 697,
+          "line": 705,
           "called": []
         }
       ]
@@ -1067,37 +1067,37 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_authority_reduction",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceRevoke_local_target_reduction",
-          "line": 31,
+          "line": 39,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceLookupSlot_preserves_state",
-          "line": 115,
+          "line": 123,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_lookup_eq",
-          "line": 132,
+          "line": 140,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_establishes_ownsSlot",
-          "line": 157,
+          "line": 165,
           "called": [
             "cspaceInsertSlot_lookup_eq"
           ]
@@ -1105,13 +1105,13 @@
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_lookup_eq_none",
-          "line": 167,
+          "line": 175,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceRevoke_preserves_source",
-          "line": 189,
+          "line": 197,
           "called": [
             "cspaceLookupSlot_preserves_state"
           ]
@@ -1119,13 +1119,13 @@
         {
           "kind": "theorem",
           "name": "mintDerivedCap_attenuates",
-          "line": 250,
+          "line": 258,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "mintDerivedCap_rights_attenuated_with_badge_override",
-          "line": 274,
+          "line": 282,
           "called": [
             "mintDerivedCap_attenuates"
           ]
@@ -1133,7 +1133,7 @@
         {
           "kind": "theorem",
           "name": "mintDerivedCap_target_preserved_with_badge_override",
-          "line": 290,
+          "line": 298,
           "called": [
             "mintDerivedCap_attenuates"
           ]
@@ -1141,7 +1141,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMint_child_attenuates",
-          "line": 299,
+          "line": 307,
           "called": [
             "cspaceInsertSlot_lookup_eq",
             "cspaceLookupSlot_preserves_state",
@@ -1151,7 +1151,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMint_badge_override_safe",
-          "line": 333,
+          "line": 341,
           "called": [
             "cspaceMint_child_attenuates"
           ]
@@ -1159,13 +1159,13 @@
         {
           "kind": "theorem",
           "name": "mintDerivedCap_badge_propagated",
-          "line": 354,
+          "line": 362,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMint_child_badge_preserved",
-          "line": 366,
+          "line": 374,
           "called": [
             "cspaceInsertSlot_lookup_eq",
             "cspaceLookupSlot_preserves_state"
@@ -1174,19 +1174,19 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_badge_stored_fresh",
-          "line": 396,
+          "line": 404,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_recovers_pending_badge",
-          "line": 415,
+          "line": 423,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "badge_notification_routing_consistent",
-          "line": 480,
+          "line": 488,
           "called": [
             "notificationSignal_badge_stored_fresh",
             "notificationWait_recovers_pending_badge"
@@ -1195,31 +1195,31 @@
         {
           "kind": "theorem",
           "name": "badge_merge_idempotent",
-          "line": 507,
+          "line": 515,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceLookupSound_of_cspaceSlotUnique",
-          "line": 521,
+          "line": 529,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeObject_nonCNode",
-          "line": 532,
+          "line": 540,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeObject_cnode",
-          "line": 551,
+          "line": 559,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_endpoint_store",
-          "line": 569,
+          "line": 577,
           "called": [
             "cspaceSlotUnique_of_storeObject_nonCNode"
           ]
@@ -1227,13 +1227,13 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_objects_eq",
-          "line": 578,
+          "line": 586,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceAttenuationRule_holds",
-          "line": 586,
+          "line": 594,
           "called": [
             "mintDerivedCap_attenuates"
           ]
@@ -1241,7 +1241,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleAuthorityMonotonicity_holds",
-          "line": 592,
+          "line": 600,
           "called": [
             "cspaceDeleteSlot_authority_reduction",
             "cspaceRevoke_local_target_reduction"
@@ -1250,7 +1250,7 @@
         {
           "kind": "theorem",
           "name": "capabilityInvariantBundle_of_slotUnique",
-          "line": 604,
+          "line": 612,
           "called": [
             "cspaceAttenuationRule_holds",
             "cspaceLookupSound_of_cspaceSlotUnique",
@@ -1267,61 +1267,61 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 4,
+          "line": 12,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceSlotUnique",
-          "line": 18,
+          "line": 26,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceLookupSound",
-          "line": 29,
+          "line": 37,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceAttenuationRule",
-          "line": 36,
+          "line": 44,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleAuthorityMonotonicity",
-          "line": 48,
+          "line": 56,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceSlotCountBounded",
-          "line": 67,
+          "line": 75,
           "called": []
         },
         {
           "kind": "def",
           "name": "cdtCompleteness",
-          "line": 83,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "cdtAcyclicity",
           "line": 91,
           "called": []
         },
         {
           "kind": "def",
+          "name": "cdtAcyclicity",
+          "line": 99,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "cspaceDepthConsistent",
-          "line": 102,
+          "line": 110,
           "called": []
         },
         {
           "kind": "def",
           "name": "capabilityInvariantBundle",
-          "line": 132,
+          "line": 140,
           "called": [
             "cdtAcyclicity",
             "cdtCompleteness",
@@ -1336,7 +1336,7 @@
         {
           "kind": "def",
           "name": "lifecycleCapabilityStaleAuthorityInvariant",
-          "line": 140,
+          "line": 148,
           "called": [
             "lifecycleAuthorityMonotonicity"
           ]
@@ -1344,7 +1344,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleCapabilityStaleAuthorityInvariant_of_bundles",
-          "line": 143,
+          "line": 151,
           "called": [
             "capabilityInvariantBundle",
             "lifecycleCapabilityStaleAuthorityInvariant"
@@ -1353,7 +1353,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotCountBounded_of_capabilityInvariantBundle",
-          "line": 155,
+          "line": 163,
           "called": [
             "capabilityInvariantBundle",
             "cspaceSlotCountBounded"
@@ -1362,7 +1362,7 @@
         {
           "kind": "theorem",
           "name": "cdtCompleteness_of_capabilityInvariantBundle",
-          "line": 159,
+          "line": 167,
           "called": [
             "capabilityInvariantBundle",
             "cdtCompleteness"
@@ -1371,7 +1371,7 @@
         {
           "kind": "theorem",
           "name": "cdtAcyclicity_of_capabilityInvariantBundle",
-          "line": 163,
+          "line": 171,
           "called": [
             "capabilityInvariantBundle",
             "cdtAcyclicity"
@@ -1380,7 +1380,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDepthConsistent_of_capabilityInvariantBundle",
-          "line": 167,
+          "line": 175,
           "called": [
             "capabilityInvariantBundle",
             "cspaceDepthConsistent"
@@ -1389,7 +1389,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotCountBounded_of_storeObject_nonCNode",
-          "line": 177,
+          "line": 185,
           "called": [
             "cspaceSlotCountBounded"
           ]
@@ -1397,7 +1397,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotCountBounded_of_storeObject_cnode",
-          "line": 197,
+          "line": 205,
           "called": [
             "cspaceSlotCountBounded"
           ]
@@ -1405,7 +1405,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotCountBounded_of_objects_eq",
-          "line": 214,
+          "line": 222,
           "called": [
             "cspaceSlotCountBounded"
           ]
@@ -1413,7 +1413,7 @@
         {
           "kind": "theorem",
           "name": "cdtCompleteness_of_objects_nodeSlot_eq",
-          "line": 224,
+          "line": 232,
           "called": [
             "cdtCompleteness"
           ]
@@ -1421,7 +1421,7 @@
         {
           "kind": "theorem",
           "name": "cdtCompleteness_of_storeObject",
-          "line": 237,
+          "line": 245,
           "called": [
             "cdtCompleteness"
           ]
@@ -1429,7 +1429,7 @@
         {
           "kind": "theorem",
           "name": "cdtAcyclicity_of_cdt_eq",
-          "line": 251,
+          "line": 259,
           "called": [
             "cdtAcyclicity"
           ]
@@ -1437,13 +1437,13 @@
         {
           "kind": "theorem",
           "name": "storeObject_cdtNodeSlot_eq",
-          "line": 261,
+          "line": 269,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotCountBounded_of_storeTcbIpcState",
-          "line": 270,
+          "line": 278,
           "called": [
             "cspaceSlotCountBounded"
           ]
@@ -1451,7 +1451,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_cdt_eq",
-          "line": 281,
+          "line": 289,
           "called": [
             "storeObject_cdtNodeSlot_eq"
           ]
@@ -1459,7 +1459,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_cdt_eq",
-          "line": 300,
+          "line": 308,
           "called": [
             "storeObject_cdtNodeSlot_eq"
           ]
@@ -1467,19 +1467,19 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_cdt_eq",
-          "line": 320,
+          "line": 328,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_cdt_eq",
-          "line": 329,
+          "line": 337,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "clearCapabilityRefs_cdt_eq",
-          "line": 342,
+          "line": 350,
           "called": [
             "clearCapabilityRefsState_cdt_eq"
           ]
@@ -1487,7 +1487,7 @@
         {
           "kind": "theorem",
           "name": "cdtPredicates_of_storeObject_nonCNode",
-          "line": 352,
+          "line": 360,
           "called": [
             "cdtAcyclicity",
             "cdtAcyclicity_of_cdt_eq",
@@ -1501,7 +1501,7 @@
         {
           "kind": "theorem",
           "name": "cdtPredicates_of_objects_cdtNodeSlot_eq",
-          "line": 367,
+          "line": 375,
           "called": [
             "cdtAcyclicity",
             "cdtAcyclicity_of_cdt_eq",
@@ -1514,7 +1514,7 @@
         {
           "kind": "theorem",
           "name": "cdtCompleteness_of_detachSlotFromCdt",
-          "line": 382,
+          "line": 390,
           "called": [
             "cdtCompleteness"
           ]
@@ -1522,7 +1522,7 @@
         {
           "kind": "theorem",
           "name": "cdtAcyclicity_of_detachSlotFromCdt",
-          "line": 405,
+          "line": 413,
           "called": [
             "cdtAcyclicity"
           ]
@@ -1530,7 +1530,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotCountBounded_of_detachSlotFromCdt",
-          "line": 416,
+          "line": 424,
           "called": [
             "cspaceSlotCountBounded",
             "cspaceSlotCountBounded_of_objects_eq"
@@ -1539,7 +1539,7 @@
         {
           "kind": "theorem",
           "name": "cdtPredicates_of_detachSlotFromCdt",
-          "line": 424,
+          "line": 432,
           "called": [
             "cdtAcyclicity",
             "cdtAcyclicity_of_detachSlotFromCdt",
@@ -1552,7 +1552,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDepthConsistent_of_objects_eq",
-          "line": 436,
+          "line": 444,
           "called": [
             "cspaceDepthConsistent"
           ]
@@ -1560,7 +1560,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDepthConsistent_of_storeObject_nonCNode",
-          "line": 445,
+          "line": 453,
           "called": [
             "cspaceDepthConsistent"
           ]
@@ -1568,7 +1568,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDepthConsistent_of_storeObject_sameCNode",
-          "line": 464,
+          "line": 472,
           "called": [
             "cspaceDepthConsistent"
           ]
@@ -1576,7 +1576,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDepthConsistent_of_storeObject_insertCNode",
-          "line": 493,
+          "line": 501,
           "called": [
             "cspaceDepthConsistent"
           ]
@@ -1584,7 +1584,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDepthConsistent_of_detachSlotFromCdt",
-          "line": 509,
+          "line": 517,
           "called": [
             "cspaceDepthConsistent",
             "cspaceDepthConsistent_of_objects_eq"
@@ -1593,73 +1593,73 @@
         {
           "kind": "theorem",
           "name": "CNode.remove_depth_eq",
-          "line": 517,
+          "line": 525,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.remove_guardWidth_eq",
-          "line": 520,
+          "line": 528,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.remove_radixWidth_eq",
-          "line": 523,
+          "line": 531,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.remove_slots_sub",
-          "line": 526,
+          "line": 534,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.revokeTargetLocal_depth_eq",
-          "line": 536,
+          "line": 544,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.revokeTargetLocal_guardWidth_eq",
-          "line": 539,
+          "line": 547,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.revokeTargetLocal_radixWidth_eq",
-          "line": 542,
+          "line": 550,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.revokeTargetLocal_slots_sub",
-          "line": 545,
+          "line": 553,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.insert_depth_eq",
-          "line": 565,
+          "line": 573,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.insert_guardWidth_eq",
-          "line": 568,
+          "line": 576,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.insert_radixWidth_eq",
-          "line": 571,
+          "line": 579,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "boundedCompleteness_of_cdt_only_update",
-          "line": 576,
+          "line": 584,
           "called": [
             "cdtCompleteness",
             "cspaceSlotCountBounded"
@@ -1668,7 +1668,7 @@
         {
           "kind": "theorem",
           "name": "cdtPredicates_through_blocking_path",
-          "line": 586,
+          "line": 594,
           "called": [
             "cdtAcyclicity",
             "cdtAcyclicity_of_cdt_eq",
@@ -1686,7 +1686,7 @@
         {
           "kind": "theorem",
           "name": "cdtPredicates_through_handshake_path",
-          "line": 628,
+          "line": 636,
           "called": [
             "cdtAcyclicity",
             "cdtAcyclicity_of_cdt_eq",
@@ -1704,7 +1704,7 @@
         {
           "kind": "theorem",
           "name": "cdtPredicates_through_reply_path",
-          "line": 676,
+          "line": 684,
           "called": [
             "cdtAcyclicity",
             "cdtAcyclicity_of_cdt_eq",
@@ -1728,25 +1728,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceLookupSlot_preserves_capabilityInvariantBundle",
-          "line": 7,
+          "line": 15,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_capabilityInvariantBundle",
-          "line": 21,
+          "line": 29,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMint_preserves_capabilityInvariantBundle",
-          "line": 101,
+          "line": 109,
           "called": [
             "cspaceInsertSlot_preserves_capabilityInvariantBundle"
           ]
@@ -1754,19 +1754,19 @@
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
-          "line": 129,
+          "line": 137,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceRevoke_preserves_capabilityInvariantBundle",
-          "line": 218,
+          "line": 226,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceCopy_preserves_capabilityInvariantBundle",
-          "line": 308,
+          "line": 316,
           "called": [
             "cspaceInsertSlot_preserves_capabilityInvariantBundle"
           ]
@@ -1774,7 +1774,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_preserves_capabilityInvariantBundle",
-          "line": 354,
+          "line": 362,
           "called": [
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
             "cspaceInsertSlot_preserves_capabilityInvariantBundle"
@@ -1783,7 +1783,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintWithCdt_preserves_capabilityInvariantBundle",
-          "line": 404,
+          "line": 412,
           "called": [
             "cspaceMint_preserves_capabilityInvariantBundle"
           ]
@@ -1791,25 +1791,25 @@
         {
           "kind": "theorem",
           "name": "cspaceMutate_preserves_capabilityInvariantBundle",
-          "line": 449,
+          "line": 457,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "capabilityInvariantBundle_of_cdt_update",
-          "line": 560,
+          "line": 568,
           "called": []
         },
         {
           "kind": "def",
           "name": "revokeCdtFoldBody",
-          "line": 573,
+          "line": 581,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_preserves",
-          "line": 589,
+          "line": 597,
           "called": [
             "capabilityInvariantBundle_of_cdt_update",
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
@@ -1819,7 +1819,7 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_error",
-          "line": 626,
+          "line": 634,
           "called": [
             "revokeCdtFoldBody"
           ]
@@ -1827,7 +1827,7 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_foldl_error",
-          "line": 631,
+          "line": 639,
           "called": [
             "revokeCdtFoldBody",
             "revokeCdtFoldBody_error"
@@ -1836,7 +1836,7 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFold_preserves",
-          "line": 639,
+          "line": 647,
           "called": [
             "revokeCdtFoldBody",
             "revokeCdtFoldBody_foldl_error",
@@ -1846,7 +1846,7 @@
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdt_preserves_capabilityInvariantBundle",
-          "line": 661,
+          "line": 669,
           "called": [
             "cspaceRevoke_preserves_capabilityInvariantBundle",
             "revokeCdtFoldBody",
@@ -1856,7 +1856,7 @@
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle",
-          "line": 683,
+          "line": 691,
           "called": [
             "capabilityInvariantBundle_of_cdt_update",
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
@@ -1866,19 +1866,19 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_capabilityInvariantBundle",
-          "line": 780,
+          "line": 788,
           "called": []
         },
         {
           "kind": "def",
           "name": "coreIpcInvariantBundle",
-          "line": 869,
+          "line": 877,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_ipcInvariant",
-          "line": 874,
+          "line": 882,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -1886,7 +1886,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_dualQueueSystemInvariant",
-          "line": 879,
+          "line": 887,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -1894,7 +1894,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_allPendingMessagesBounded",
-          "line": 884,
+          "line": 892,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -1902,37 +1902,37 @@
         {
           "kind": "def",
           "name": "ipcSchedulerRunnableReadyComponent",
-          "line": 889,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ipcSchedulerBlockedSendComponent",
-          "line": 893,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ipcSchedulerBlockedReceiveComponent",
           "line": 897,
           "called": []
         },
         {
           "kind": "def",
-          "name": "ipcSchedulerBlockedCallComponent",
+          "name": "ipcSchedulerBlockedSendComponent",
           "line": 901,
           "called": []
         },
         {
           "kind": "def",
-          "name": "ipcSchedulerBlockedReplyComponent",
+          "name": "ipcSchedulerBlockedReceiveComponent",
           "line": 905,
           "called": []
         },
         {
           "kind": "def",
-          "name": "ipcSchedulerCoherenceComponent",
+          "name": "ipcSchedulerBlockedCallComponent",
           "line": 909,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ipcSchedulerBlockedReplyComponent",
+          "line": 913,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ipcSchedulerCoherenceComponent",
+          "line": 917,
           "called": [
             "ipcSchedulerBlockedCallComponent",
             "ipcSchedulerBlockedReceiveComponent",
@@ -1944,7 +1944,7 @@
         {
           "kind": "theorem",
           "name": "ipcSchedulerCoherenceComponent_iff_contractPredicates",
-          "line": 916,
+          "line": 924,
           "called": [
             "ipcSchedulerCoherenceComponent"
           ]
@@ -1952,7 +1952,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerCouplingInvariantBundle",
-          "line": 926,
+          "line": 934,
           "called": [
             "coreIpcInvariantBundle",
             "ipcSchedulerCoherenceComponent"
@@ -1961,7 +1961,7 @@
         {
           "kind": "def",
           "name": "lifecycleCompositionInvariantBundle",
-          "line": 932,
+          "line": 940,
           "called": [
             "ipcSchedulerCouplingInvariantBundle"
           ]
@@ -1969,25 +1969,25 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_schedulerInvariantBundle",
-          "line": 935,
+          "line": 943,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
-          "line": 954,
+          "line": 962,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_ipcInvariant",
-          "line": 1010,
+          "line": 1018,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_coreIpcInvariantBundle",
-          "line": 1036,
+          "line": 1044,
           "called": [
             "coreIpcInvariantBundle",
             "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
@@ -1998,7 +1998,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1061,
+          "line": 1069,
           "called": [
             "coreIpcInvariantBundle",
             "ipcSchedulerCoherenceComponent",
@@ -2009,7 +2009,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle",
-          "line": 1091,
+          "line": 1099,
           "called": [
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
             "cspaceRevoke_preserves_capabilityInvariantBundle",
@@ -2019,7 +2019,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityInvariant",
-          "line": 1112,
+          "line": 1120,
           "called": [
             "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle"
           ]
@@ -2027,7 +2027,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_error_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1142,
+          "line": 1150,
           "called": [
             "lifecycleCompositionInvariantBundle"
           ]
@@ -2035,13 +2035,13 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeTcbIpcState",
-          "line": 1155,
+          "line": 1163,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_blocking_path",
-          "line": 1174,
+          "line": 1182,
           "called": [
             "cspaceSlotUnique_of_storeTcbIpcState"
           ]
@@ -2049,7 +2049,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_handshake_path",
-          "line": 1187,
+          "line": 1195,
           "called": [
             "cspaceSlotUnique_of_storeTcbIpcState"
           ]
@@ -2070,31 +2070,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "CSpaceAddr",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "structure",
           "name": "CSpacePathAddr",
-          "line": 11,
+          "line": 19,
           "called": []
         },
         {
           "kind": "def",
           "name": "capAttenuates",
-          "line": 21,
+          "line": 29,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceLookupSlot",
-          "line": 25,
+          "line": 33,
           "called": [
             "CSpaceAddr"
           ]
@@ -2102,7 +2102,7 @@
         {
           "kind": "def",
           "name": "cspaceResolvePath",
-          "line": 35,
+          "line": 43,
           "called": [
             "CSpaceAddr",
             "CSpacePathAddr"
@@ -2111,7 +2111,7 @@
         {
           "kind": "def",
           "name": "cspaceLookupPath",
-          "line": 46,
+          "line": 54,
           "called": [
             "CSpacePathAddr",
             "cspaceLookupSlot",
@@ -2121,13 +2121,13 @@
         {
           "kind": "def",
           "name": "resolveCapAddress",
-          "line": 68,
+          "line": 76,
           "called": []
         },
         {
           "kind": "def",
           "name": "resolveCapAddressK",
-          "line": 105,
+          "line": 113,
           "called": [
             "resolveCapAddress"
           ]
@@ -2135,7 +2135,7 @@
         {
           "kind": "def",
           "name": "cspaceLookupMultiLevel",
-          "line": 113,
+          "line": 121,
           "called": [
             "cspaceLookupSlot",
             "resolveCapAddress"
@@ -2144,7 +2144,7 @@
         {
           "kind": "theorem",
           "name": "resolveCapAddress_deterministic",
-          "line": 126,
+          "line": 134,
           "called": [
             "resolveCapAddress"
           ]
@@ -2152,7 +2152,7 @@
         {
           "kind": "theorem",
           "name": "resolveCapAddress_zero_bits",
-          "line": 132,
+          "line": 140,
           "called": [
             "resolveCapAddress"
           ]
@@ -2160,7 +2160,7 @@
         {
           "kind": "theorem",
           "name": "resolveCapAddress_result_valid_cnode",
-          "line": 144,
+          "line": 152,
           "called": [
             "resolveCapAddress"
           ]
@@ -2168,7 +2168,7 @@
         {
           "kind": "theorem",
           "name": "resolveCapAddress_guard_reject",
-          "line": 190,
+          "line": 198,
           "called": [
             "resolveCapAddress"
           ]
@@ -2176,7 +2176,7 @@
         {
           "kind": "def",
           "name": "cspaceInsertSlot",
-          "line": 216,
+          "line": 224,
           "called": [
             "CSpaceAddr"
           ]
@@ -2184,7 +2184,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_scheduler",
-          "line": 229,
+          "line": 237,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot"
@@ -2193,7 +2193,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_services",
-          "line": 258,
+          "line": 266,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot"
@@ -2202,7 +2202,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_objects_ne",
-          "line": 285,
+          "line": 293,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot"
@@ -2211,7 +2211,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_machine",
-          "line": 315,
+          "line": 323,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot"
@@ -2220,7 +2220,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_irqHandlers",
-          "line": 341,
+          "line": 349,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot"
@@ -2229,7 +2229,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_rejects_occupied_slot",
-          "line": 367,
+          "line": 375,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot"
@@ -2238,7 +2238,7 @@
         {
           "kind": "theorem",
           "name": "cspaceLookupSlot_ok_iff_lookupSlotCap",
-          "line": 376,
+          "line": 384,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot"
@@ -2247,7 +2247,7 @@
         {
           "kind": "theorem",
           "name": "cspaceLookupSlot_ok_implies_ownsSlot",
-          "line": 400,
+          "line": 408,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot",
@@ -2257,13 +2257,13 @@
         {
           "kind": "def",
           "name": "rightsSubset",
-          "line": 411,
+          "line": 419,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "rightsSubset_sound",
-          "line": 414,
+          "line": 422,
           "called": [
             "rightsSubset"
           ]
@@ -2271,7 +2271,7 @@
         {
           "kind": "def",
           "name": "mintDerivedCap",
-          "line": 424,
+          "line": 432,
           "called": [
             "rightsSubset"
           ]
@@ -2279,7 +2279,7 @@
         {
           "kind": "def",
           "name": "cspaceMint",
-          "line": 432,
+          "line": 440,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -2290,7 +2290,7 @@
         {
           "kind": "def",
           "name": "cspaceDeleteSlot",
-          "line": 445,
+          "line": 453,
           "called": [
             "CSpaceAddr"
           ]
@@ -2298,7 +2298,7 @@
         {
           "kind": "def",
           "name": "cspaceRevoke",
-          "line": 465,
+          "line": 473,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot"
@@ -2307,7 +2307,7 @@
         {
           "kind": "def",
           "name": "cspaceCopy",
-          "line": 493,
+          "line": 501,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -2317,7 +2317,7 @@
         {
           "kind": "def",
           "name": "cspaceMove",
-          "line": 511,
+          "line": 519,
           "called": [
             "CSpaceAddr",
             "cspaceDeleteSlot",
@@ -2328,7 +2328,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_error_no_state",
-          "line": 536,
+          "line": 544,
           "called": [
             "CSpaceAddr",
             "cspaceMove"
@@ -2337,7 +2337,7 @@
         {
           "kind": "theorem",
           "name": "cspaceLookupSlot_state_eq",
-          "line": 548,
+          "line": 556,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot"
@@ -2346,7 +2346,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_ok_implies_source_exists",
-          "line": 557,
+          "line": 565,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot",
@@ -2356,7 +2356,7 @@
         {
           "kind": "def",
           "name": "cspaceMutate",
-          "line": 578,
+          "line": 586,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot",
@@ -2366,7 +2366,7 @@
         {
           "kind": "def",
           "name": "cspaceMintWithCdt",
-          "line": 602,
+          "line": 610,
           "called": [
             "CSpaceAddr",
             "cspaceMint"
@@ -2375,7 +2375,7 @@
         {
           "kind": "def",
           "name": "cspaceRevokeCdt",
-          "line": 625,
+          "line": 633,
           "called": [
             "CSpaceAddr",
             "cspaceDeleteSlot",
@@ -2385,7 +2385,7 @@
         {
           "kind": "structure",
           "name": "RevokeCdtStrictFailure",
-          "line": 656,
+          "line": 664,
           "called": [
             "CSpaceAddr"
           ]
@@ -2393,7 +2393,7 @@
         {
           "kind": "structure",
           "name": "RevokeCdtStrictReport",
-          "line": 666,
+          "line": 674,
           "called": [
             "CSpaceAddr",
             "RevokeCdtStrictFailure"
@@ -2402,7 +2402,7 @@
         {
           "kind": "def",
           "name": "cspaceRevokeCdtStrict",
-          "line": 681,
+          "line": 689,
           "called": [
             "CSpaceAddr",
             "RevokeCdtStrictFailure",
@@ -2421,19 +2421,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "tcbWithQueueLinks",
           "line": 11,
           "called": []
         },
         {
           "kind": "def",
+          "name": "tcbWithQueueLinks",
+          "line": 19,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "storeTcbQueueLinks",
-          "line": 18,
+          "line": 26,
           "called": [
             "tcbWithQueueLinks"
           ]
@@ -2441,7 +2441,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_objects_ne",
-          "line": 32,
+          "line": 40,
           "called": [
             "storeTcbQueueLinks",
             "tcbWithQueueLinks"
@@ -2450,7 +2450,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_scheduler_eq",
-          "line": 51,
+          "line": 59,
           "called": [
             "storeTcbQueueLinks",
             "tcbWithQueueLinks"
@@ -2459,7 +2459,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_endpoint_backward",
-          "line": 69,
+          "line": 77,
           "called": [
             "storeTcbQueueLinks",
             "storeTcbQueueLinks_preserves_objects_ne",
@@ -2469,7 +2469,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_notification_backward",
-          "line": 91,
+          "line": 99,
           "called": [
             "storeTcbQueueLinks",
             "storeTcbQueueLinks_preserves_objects_ne",
@@ -2479,7 +2479,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_tcb_ipcState_backward",
-          "line": 115,
+          "line": 123,
           "called": [
             "storeTcbQueueLinks",
             "storeTcbQueueLinks_preserves_objects_ne",
@@ -2489,7 +2489,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_tcb_forward",
-          "line": 144,
+          "line": 152,
           "called": [
             "storeTcbQueueLinks",
             "storeTcbQueueLinks_preserves_objects_ne",
@@ -2499,7 +2499,7 @@
         {
           "kind": "def",
           "name": "endpointQueuePopHead",
-          "line": 164,
+          "line": 172,
           "called": [
             "storeTcbQueueLinks"
           ]
@@ -2507,7 +2507,7 @@
         {
           "kind": "def",
           "name": "endpointQueueEnqueue",
-          "line": 202,
+          "line": 210,
           "called": [
             "storeTcbQueueLinks"
           ]
@@ -2522,79 +2522,79 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_scheduler_eq",
-          "line": 12,
+          "line": 20,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_endpoint_backward_ne",
-          "line": 64,
+          "line": 72,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_notification_backward",
-          "line": 118,
+          "line": 126,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_tcb_forward",
-          "line": 176,
+          "line": 184,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_tcb_ipcState_backward",
-          "line": 233,
+          "line": 241,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_scheduler_eq",
-          "line": 298,
+          "line": 306,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_endpoint_backward_ne",
-          "line": 347,
+          "line": 355,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_notification_backward",
-          "line": 398,
+          "line": 406,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_tcb_forward",
-          "line": 453,
+          "line": 461,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_tcb_ipcState_backward",
-          "line": 505,
+          "line": 513,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointQueueRemoveDual",
-          "line": 563,
+          "line": 571,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_scheduler_eq",
-          "line": 643,
+          "line": 651,
           "called": [
             "endpointQueueRemoveDual"
           ]
@@ -2602,7 +2602,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_tcb_forward",
-          "line": 766,
+          "line": 774,
           "called": [
             "endpointQueueRemoveDual"
           ]
@@ -2610,7 +2610,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_endpoint_backward_ne",
-          "line": 896,
+          "line": 904,
           "called": [
             "endpointQueueRemoveDual"
           ]
@@ -2618,7 +2618,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_notification_backward",
-          "line": 1016,
+          "line": 1024,
           "called": [
             "endpointQueueRemoveDual"
           ]
@@ -2626,7 +2626,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_tcb_ipcState_backward",
-          "line": 1145,
+          "line": 1153,
           "called": [
             "endpointQueueRemoveDual"
           ]
@@ -2634,31 +2634,31 @@
         {
           "kind": "def",
           "name": "endpointSendDual",
-          "line": 1289,
+          "line": 1297,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointReceiveDual",
-          "line": 1334,
+          "line": 1342,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointCall",
-          "line": 1393,
+          "line": 1401,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointReply",
-          "line": 1436,
+          "line": 1444,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointReplyRecv",
-          "line": 1463,
+          "line": 1471,
           "called": [
             "endpointReceiveDual"
           ]
@@ -2679,55 +2679,55 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_ipcInvariant",
-          "line": 21,
+          "line": 29,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_schedulerInvariantBundle",
-          "line": 77,
+          "line": 85,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_ipcSchedulerContractPredicates",
-          "line": 215,
+          "line": 223,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_blocked_stays_blocked",
-          "line": 413,
+          "line": 421,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_ipcInvariant",
-          "line": 463,
+          "line": 471,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_schedulerInvariantBundle",
-          "line": 522,
+          "line": 530,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_ipcSchedulerContractPredicates",
-          "line": 631,
+          "line": 639,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_ipcSchedulerContractPredicates",
-          "line": 746,
+          "line": 754,
           "called": []
         }
       ]
@@ -2740,31 +2740,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 4,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "storeObject_objects_eq",
           "line": 12,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "storeObject_objects_eq",
+          "line": 20,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "storeObject_objects_ne",
-          "line": 18,
+          "line": 26,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_scheduler_eq",
-          "line": 27,
+          "line": 35,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "tcb_lookup_of_endpoint_store",
-          "line": 33,
+          "line": 41,
           "called": [
             "storeObject_objects_eq",
             "storeObject_objects_ne"
@@ -2773,7 +2773,7 @@
         {
           "kind": "theorem",
           "name": "runnable_membership_of_endpoint_store",
-          "line": 42,
+          "line": 50,
           "called": [
             "storeObject_scheduler_eq"
           ]
@@ -2781,7 +2781,7 @@
         {
           "kind": "theorem",
           "name": "not_runnable_membership_of_endpoint_store",
-          "line": 49,
+          "line": 57,
           "called": [
             "storeObject_scheduler_eq"
           ]
@@ -2789,13 +2789,13 @@
         {
           "kind": "def",
           "name": "notificationQueueWellFormed",
-          "line": 60,
+          "line": 68,
           "called": []
         },
         {
           "kind": "def",
           "name": "notificationInvariant",
-          "line": 66,
+          "line": 74,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -2803,19 +2803,19 @@
         {
           "kind": "def",
           "name": "intrusiveQueueWellFormed",
-          "line": 92,
+          "line": 100,
           "called": []
         },
         {
           "kind": "def",
           "name": "tcbQueueLinkIntegrity",
-          "line": 106,
+          "line": 114,
           "called": []
         },
         {
           "kind": "def",
           "name": "dualQueueEndpointWellFormed",
-          "line": 122,
+          "line": 130,
           "called": [
             "intrusiveQueueWellFormed"
           ]
@@ -2823,7 +2823,7 @@
         {
           "kind": "def",
           "name": "dualQueueSystemInvariant",
-          "line": 133,
+          "line": 141,
           "called": [
             "dualQueueEndpointWellFormed",
             "tcbQueueLinkIntegrity"
@@ -2832,7 +2832,7 @@
         {
           "kind": "def",
           "name": "ipcInvariant",
-          "line": 143,
+          "line": 151,
           "called": [
             "notificationInvariant"
           ]
@@ -2840,13 +2840,13 @@
         {
           "kind": "def",
           "name": "allPendingMessagesBounded",
-          "line": 150,
+          "line": 158,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcInvariantFull",
-          "line": 163,
+          "line": 171,
           "called": [
             "allPendingMessagesBounded",
             "dualQueueSystemInvariant",
@@ -2856,37 +2856,37 @@
         {
           "kind": "def",
           "name": "runnableThreadIpcReady",
-          "line": 170,
+          "line": 178,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnSendNotRunnable",
-          "line": 174,
+          "line": 182,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnReceiveNotRunnable",
-          "line": 179,
+          "line": 187,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnCallNotRunnable",
-          "line": 185,
+          "line": 193,
           "called": []
         },
         {
           "kind": "def",
           "name": "blockedOnReplyNotRunnable",
-          "line": 191,
+          "line": 199,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerContractPredicates",
-          "line": 196,
+          "line": 204,
           "called": [
             "blockedOnCallNotRunnable",
             "blockedOnReceiveNotRunnable",
@@ -2898,25 +2898,25 @@
         {
           "kind": "def",
           "name": "currentThreadIpcReady",
-          "line": 204,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "currentNotEndpointQueueHead",
           "line": 212,
           "called": []
         },
         {
           "kind": "def",
+          "name": "currentNotEndpointQueueHead",
+          "line": 220,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "currentNotOnNotificationWaitList",
-          "line": 223,
+          "line": 231,
           "called": []
         },
         {
           "kind": "def",
           "name": "currentThreadDequeueCoherent",
-          "line": 234,
+          "line": 242,
           "called": [
             "currentNotEndpointQueueHead",
             "currentNotOnNotificationWaitList",
@@ -2926,13 +2926,13 @@
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_returns_head",
-          "line": 238,
+          "line": 246,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "scheduler_unchanged_through_store_tcb",
-          "line": 290,
+          "line": 298,
           "called": [
             "storeObject_scheduler_eq"
           ]
@@ -2940,7 +2940,7 @@
         {
           "kind": "theorem",
           "name": "tcb_preserved_through_endpoint_store",
-          "line": 300,
+          "line": 308,
           "called": [
             "storeObject_objects_ne"
           ]
@@ -2948,13 +2948,13 @@
         {
           "kind": "def",
           "name": "notificationWaiterConsistent",
-          "line": 317,
+          "line": 325,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "not_mem_waitingThreads_of_ipcState_ne",
-          "line": 326,
+          "line": 334,
           "called": [
             "notificationWaiterConsistent"
           ]
@@ -2962,13 +2962,13 @@
         {
           "kind": "def",
           "name": "uniqueWaiters",
-          "line": 343,
+          "line": 351,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_uniqueWaiters",
-          "line": 349,
+          "line": 357,
           "called": [
             "not_mem_waitingThreads_of_ipcState_ne",
             "notificationWaiterConsistent",
@@ -2979,7 +2979,7 @@
         {
           "kind": "theorem",
           "name": "default_notificationWaiterConsistent",
-          "line": 449,
+          "line": 457,
           "called": [
             "notificationWaiterConsistent"
           ]
@@ -2987,7 +2987,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_wake",
-          "line": 498,
+          "line": 506,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -2995,7 +2995,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_merge",
-          "line": 510,
+          "line": 518,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3003,7 +3003,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_badge",
-          "line": 520,
+          "line": 528,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3011,7 +3011,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_wait",
-          "line": 527,
+          "line": 535,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3026,79 +3026,79 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_schedulerInvariantBundle",
-          "line": 14,
+          "line": 22,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_ipcInvariant",
-          "line": 135,
+          "line": 143,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "scheduler_unchanged_through_store_tcb_msg",
-          "line": 196,
+          "line": 204,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_ipcInvariant",
-          "line": 240,
+          "line": 248,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_endpoint_preserves_ipcInvariant",
-          "line": 250,
+          "line": 258,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_ipcInvariant",
-          "line": 262,
+          "line": 270,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_ipcInvariant",
-          "line": 269,
+          "line": 277,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_ipcInvariant",
-          "line": 276,
+          "line": 284,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_preserves_ipcInvariant",
-          "line": 285,
+          "line": 293,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_preserves_ipcInvariant",
-          "line": 294,
+          "line": 302,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "contracts_of_same_scheduler_ipcState",
-          "line": 310,
+          "line": 318,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_ipcInvariant",
-          "line": 349,
+          "line": 357,
           "called": [
             "endpointQueueEnqueue_preserves_ipcInvariant",
             "endpointQueuePopHead_preserves_ipcInvariant",
@@ -3108,37 +3108,37 @@
         {
           "kind": "theorem",
           "name": "endpointSendDual_message_bounded",
-          "line": 400,
+          "line": 408,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_message_bounded",
-          "line": 414,
+          "line": 422,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_message_bounded",
-          "line": 427,
+          "line": 435,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_message_bounded",
-          "line": 440,
+          "line": 448,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_schedulerInvariantBundle",
-          "line": 454,
+          "line": 462,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_ipcSchedulerContractPredicates",
-          "line": 567,
+          "line": 575,
           "called": [
             "contracts_of_same_scheduler_ipcState"
           ]
@@ -3146,7 +3146,7 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_ipcInvariant",
-          "line": 734,
+          "line": 742,
           "called": [
             "endpointQueueEnqueue_preserves_ipcInvariant",
             "endpointQueuePopHead_preserves_ipcInvariant",
@@ -3158,13 +3158,13 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_schedulerInvariantBundle",
-          "line": 819,
+          "line": 827,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_ipcSchedulerContractPredicates",
-          "line": 1039,
+          "line": 1047,
           "called": [
             "contracts_of_same_scheduler_ipcState"
           ]
@@ -3172,19 +3172,19 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_preserves_ipcInvariant",
-          "line": 1348,
+          "line": 1356,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_preserves_schedulerInvariantBundle",
-          "line": 1357,
+          "line": 1365,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_preserves_ipcSchedulerContractPredicates",
-          "line": 1381,
+          "line": 1389,
           "called": [
             "contracts_of_same_scheduler_ipcState"
           ]
@@ -3199,19 +3199,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_notification_preserves_ipcInvariant",
-          "line": 13,
+          "line": 21,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_ipcInvariant",
-          "line": 29,
+          "line": 37,
           "called": [
             "storeObject_notification_preserves_ipcInvariant"
           ]
@@ -3219,13 +3219,13 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_schedulerInvariantBundle",
-          "line": 71,
+          "line": 79,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_ipcInvariant",
-          "line": 167,
+          "line": 175,
           "called": [
             "storeObject_notification_preserves_ipcInvariant"
           ]
@@ -3233,19 +3233,19 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_schedulerInvariantBundle",
-          "line": 231,
+          "line": 239,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_ipcSchedulerContractPredicates",
-          "line": 352,
+          "line": 360,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_ipcSchedulerContractPredicates",
-          "line": 498,
+          "line": 506,
           "called": []
         }
       ]
@@ -3258,25 +3258,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 4,
+          "line": 12,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "intrusiveQueueWellFormed_empty",
-          "line": 19,
+          "line": 27,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "tcbQueueLinkIntegrity_initial",
-          "line": 24,
+          "line": 32,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "dualQueueEndpointWellFormed_empty_endpoint",
-          "line": 34,
+          "line": 42,
           "called": [
             "intrusiveQueueWellFormed_empty"
           ]
@@ -3284,31 +3284,31 @@
         {
           "kind": "theorem",
           "name": "dualQueueEndpointWellFormed_non_endpoint",
-          "line": 43,
+          "line": 51,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "tcbQueueLink_forward_safe",
-          "line": 58,
+          "line": 66,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "tcbQueueLink_reverse_safe",
-          "line": 67,
+          "line": 75,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_sender_exists",
-          "line": 76,
+          "line": 84,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_sender_exists",
-          "line": 86,
+          "line": 94,
           "called": [
             "endpointQueuePopHead_sender_exists"
           ]
@@ -3316,37 +3316,37 @@
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_link_safe",
-          "line": 97,
+          "line": 105,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_intrusiveQueueWellFormed",
-          "line": 111,
+          "line": 119,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_intrusiveQueueWellFormed",
-          "line": 121,
+          "line": 129,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_tcbQueueLinkIntegrity",
-          "line": 131,
+          "line": 139,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_tcbQueueLinkIntegrity",
-          "line": 143,
+          "line": 151,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_dualQueueEndpointWellFormed",
-          "line": 155,
+          "line": 163,
           "called": [
             "ensureRunnable_preserves_intrusiveQueueWellFormed"
           ]
@@ -3354,7 +3354,7 @@
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_dualQueueEndpointWellFormed",
-          "line": 170,
+          "line": 178,
           "called": [
             "removeRunnable_preserves_intrusiveQueueWellFormed"
           ]
@@ -3362,7 +3362,7 @@
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_dualQueueSystemInvariant",
-          "line": 185,
+          "line": 193,
           "called": [
             "ensureRunnable_preserves_dualQueueEndpointWellFormed",
             "ensureRunnable_preserves_tcbQueueLinkIntegrity"
@@ -3371,7 +3371,7 @@
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_dualQueueSystemInvariant",
-          "line": 195,
+          "line": 203,
           "called": [
             "removeRunnable_preserves_dualQueueEndpointWellFormed",
             "removeRunnable_preserves_tcbQueueLinkIntegrity"
@@ -3380,31 +3380,31 @@
         {
           "kind": "theorem",
           "name": "storeObject_tcb_preserves_intrusiveQueueWellFormed",
-          "line": 213,
+          "line": 221,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_tcb_preserves_tcbQueueLinkIntegrity",
-          "line": 240,
+          "line": 248,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_endpoint_preserves_tcbQueueLinkIntegrity",
-          "line": 288,
+          "line": 296,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_endpoint_preserves_intrusiveQueueWellFormed",
-          "line": 308,
+          "line": 316,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_dualQueueSystemInvariant",
-          "line": 327,
+          "line": 335,
           "called": [
             "storeObject_tcb_preserves_intrusiveQueueWellFormed",
             "storeObject_tcb_preserves_tcbQueueLinkIntegrity"
@@ -3413,7 +3413,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant",
-          "line": 370,
+          "line": 378,
           "called": [
             "storeObject_tcb_preserves_intrusiveQueueWellFormed",
             "storeObject_tcb_preserves_tcbQueueLinkIntegrity"
@@ -3422,7 +3422,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_dualQueueSystemInvariant",
-          "line": 414,
+          "line": 422,
           "called": [
             "storeObject_tcb_preserves_intrusiveQueueWellFormed",
             "storeObject_tcb_preserves_tcbQueueLinkIntegrity"
@@ -3431,7 +3431,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_dualQueueSystemInvariant",
-          "line": 465,
+          "line": 473,
           "called": [
             "ensureRunnable_preserves_dualQueueSystemInvariant",
             "storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant"
@@ -3440,13 +3440,13 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_result_tcb",
-          "line": 511,
+          "line": 519,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_iqwf",
-          "line": 531,
+          "line": 539,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -3454,7 +3454,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_clearing_preserves_linkInteg",
-          "line": 557,
+          "line": 565,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -3462,7 +3462,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_noprevnext_preserves_linkInteg",
-          "line": 593,
+          "line": 601,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -3470,7 +3470,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_append_tail_preserves_linkInteg",
-          "line": 629,
+          "line": 637,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -3478,7 +3478,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
-          "line": 739,
+          "line": 747,
           "called": [
             "intrusiveQueueWellFormed_empty",
             "storeObject_endpoint_preserves_intrusiveQueueWellFormed",
@@ -3491,7 +3491,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
-          "line": 1079,
+          "line": 1087,
           "called": [
             "storeObject_endpoint_preserves_intrusiveQueueWellFormed",
             "storeObject_endpoint_preserves_tcbQueueLinkIntegrity",
@@ -3504,7 +3504,7 @@
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_dualQueueSystemInvariant",
-          "line": 1394,
+          "line": 1402,
           "called": [
             "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
             "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
@@ -3516,7 +3516,7 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_dualQueueSystemInvariant",
-          "line": 1461,
+          "line": 1469,
           "called": [
             "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
             "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
@@ -3530,7 +3530,7 @@
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_dualQueueSystemInvariant",
-          "line": 1570,
+          "line": 1578,
           "called": [
             "endpointReceiveDual_preserves_dualQueueSystemInvariant",
             "ensureRunnable_preserves_dualQueueSystemInvariant",
@@ -3540,7 +3540,7 @@
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_dualQueueSystemInvariant",
-          "line": 1669,
+          "line": 1677,
           "called": [
             "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
             "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
@@ -3553,13 +3553,13 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_contextMatchesCurrent",
-          "line": 1753,
+          "line": 1761,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_contextMatchesCurrent",
-          "line": 1784,
+          "line": 1792,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -3567,7 +3567,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_contextMatchesCurrent",
-          "line": 1805,
+          "line": 1813,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -3575,7 +3575,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_contextMatchesCurrent",
-          "line": 1826,
+          "line": 1834,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -3583,7 +3583,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_contextMatchesCurrent",
-          "line": 1847,
+          "line": 1855,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -3591,67 +3591,67 @@
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_contextMatchesCurrent",
-          "line": 1872,
+          "line": 1880,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_contextMatchesCurrent",
-          "line": 1893,
+          "line": 1901,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_allPendingMessagesBounded",
-          "line": 1913,
+          "line": 1921,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_allPendingMessagesBounded",
-          "line": 1923,
+          "line": 1931,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_allPendingMessagesBounded",
-          "line": 1933,
+          "line": 1941,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_allPendingMessagesBounded",
-          "line": 1960,
+          "line": 1968,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_allPendingMessagesBounded",
-          "line": 1988,
+          "line": 1996,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_endpoint_preserves_allPendingMessagesBounded",
-          "line": 2014,
+          "line": 2022,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_allPendingMessagesBounded",
-          "line": 2029,
+          "line": 2037,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_notification_preserves_allPendingMessagesBounded",
-          "line": 2059,
+          "line": 2067,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_allPendingMessagesBounded",
-          "line": 2078,
+          "line": 2086,
           "called": [
             "ensureRunnable_preserves_allPendingMessagesBounded",
             "storeObject_notification_preserves_allPendingMessagesBounded",
@@ -3661,7 +3661,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_allPendingMessagesBounded",
-          "line": 2119,
+          "line": 2127,
           "called": [
             "removeRunnable_preserves_allPendingMessagesBounded",
             "storeObject_notification_preserves_allPendingMessagesBounded",
@@ -3671,7 +3671,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_allPendingMessagesBounded",
-          "line": 2182,
+          "line": 2190,
           "called": [
             "ensureRunnable_preserves_allPendingMessagesBounded",
             "storeTcbIpcStateAndMessage_preserves_allPendingMessagesBounded"
@@ -3680,7 +3680,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_ipcInvariantFull",
-          "line": 2244,
+          "line": 2252,
           "called": [
             "notificationSignal_preserves_allPendingMessagesBounded"
           ]
@@ -3688,7 +3688,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_ipcInvariantFull",
-          "line": 2257,
+          "line": 2265,
           "called": [
             "notificationWait_preserves_allPendingMessagesBounded"
           ]
@@ -3696,7 +3696,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_ipcInvariantFull",
-          "line": 2274,
+          "line": 2282,
           "called": [
             "endpointReply_preserves_allPendingMessagesBounded"
           ]
@@ -3704,25 +3704,25 @@
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_ipcInvariantFull",
-          "line": 2290,
+          "line": 2298,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_ipcInvariantFull",
-          "line": 2302,
+          "line": 2310,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_ipcInvariantFull",
-          "line": 2314,
+          "line": 2322,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_ipcInvariantFull",
-          "line": 2326,
+          "line": 2334,
           "called": []
         }
       ]
@@ -3741,31 +3741,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "def",
           "name": "removeRunnable",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "def",
           "name": "ensureRunnable",
-          "line": 19,
+          "line": 27,
           "called": []
         },
         {
           "kind": "def",
           "name": "lookupTcb",
-          "line": 33,
+          "line": 41,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lookupTcb_some_objects",
-          "line": 42,
+          "line": 50,
           "called": [
             "lookupTcb"
           ]
@@ -3773,7 +3773,7 @@
         {
           "kind": "def",
           "name": "storeTcbIpcState",
-          "line": 56,
+          "line": 64,
           "called": [
             "lookupTcb"
           ]
@@ -3781,7 +3781,7 @@
         {
           "kind": "def",
           "name": "storeTcbPendingMessage",
-          "line": 66,
+          "line": 74,
           "called": [
             "lookupTcb"
           ]
@@ -3789,7 +3789,7 @@
         {
           "kind": "def",
           "name": "storeTcbIpcStateAndMessage",
-          "line": 76,
+          "line": 84,
           "called": [
             "lookupTcb"
           ]
@@ -3797,7 +3797,7 @@
         {
           "kind": "def",
           "name": "notificationSignal",
-          "line": 86,
+          "line": 94,
           "called": [
             "ensureRunnable",
             "storeTcbIpcState"
@@ -3806,7 +3806,7 @@
         {
           "kind": "def",
           "name": "notificationWait",
-          "line": 129,
+          "line": 137,
           "called": [
             "lookupTcb",
             "removeRunnable",
@@ -3816,7 +3816,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_objects_ne",
-          "line": 171,
+          "line": 179,
           "called": [
             "lookupTcb",
             "storeTcbIpcState"
@@ -3825,7 +3825,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_notification",
-          "line": 195,
+          "line": 203,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -3835,7 +3835,7 @@
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_objects",
-          "line": 214,
+          "line": 222,
           "called": [
             "removeRunnable"
           ]
@@ -3843,7 +3843,7 @@
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_objects",
-          "line": 221,
+          "line": 229,
           "called": [
             "ensureRunnable"
           ]
@@ -3851,7 +3851,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_scheduler_eq",
-          "line": 231,
+          "line": 239,
           "called": [
             "lookupTcb",
             "storeTcbIpcState"
@@ -3860,7 +3860,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_endpoint",
-          "line": 252,
+          "line": 260,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -3870,7 +3870,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_cnode",
-          "line": 271,
+          "line": 279,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -3880,7 +3880,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_vspaceRoot",
-          "line": 290,
+          "line": 298,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -3890,7 +3890,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_cnode_backward",
-          "line": 310,
+          "line": 318,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -3900,7 +3900,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_endpoint_backward",
-          "line": 336,
+          "line": 344,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -3910,7 +3910,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_notification_backward",
-          "line": 362,
+          "line": 370,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -3920,7 +3920,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_error_alreadyWaiting",
-          "line": 390,
+          "line": 398,
           "called": [
             "lookupTcb",
             "notificationWait"
@@ -3929,7 +3929,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_badge_path_notification",
-          "line": 406,
+          "line": 414,
           "called": [
             "lookupTcb",
             "notificationWait",
@@ -3940,7 +3940,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_wait_path_notification",
-          "line": 469,
+          "line": 477,
           "called": [
             "lookupTcb",
             "notificationWait",
@@ -3959,91 +3959,91 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "removeRunnable_scheduler_current",
           "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "removeRunnable_scheduler_current",
+          "line": 19,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "removeRunnable_mem",
-          "line": 17,
+          "line": 25,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_runnable_mem",
-          "line": 26,
+          "line": 34,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_nodup",
-          "line": 39,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "ensureRunnable_scheduler_current",
           "line": 47,
           "called": []
         },
         {
           "kind": "theorem",
-          "name": "ensureRunnable_mem_self",
+          "name": "ensureRunnable_scheduler_current",
           "line": 55,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "ensureRunnable_mem_self",
+          "line": 63,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "ensureRunnable_mem_old",
-          "line": 67,
+          "line": 75,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_runnable_mem_old",
-          "line": 80,
+          "line": 88,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_nodup",
-          "line": 95,
+          "line": 103,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "threadId_toObjId_injective",
-          "line": 117,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "storeTcbIpcState_ipcState_eq",
           "line": 125,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "storeTcbIpcState_ipcState_eq",
+          "line": 133,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "ensureRunnable_mem_reverse",
-          "line": 146,
+          "line": 154,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_not_mem_self",
-          "line": 165,
+          "line": 173,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_not_mem_of_not_mem",
-          "line": 173,
+          "line": 181,
           "called": [
             "ensureRunnable_mem_reverse"
           ]
@@ -4051,7 +4051,7 @@
         {
           "kind": "theorem",
           "name": "removeRunnable_not_mem_of_not_mem",
-          "line": 184,
+          "line": 192,
           "called": [
             "removeRunnable_runnable_mem"
           ]
@@ -4059,25 +4059,25 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_tcb_exists_at_target",
-          "line": 193,
+          "line": 201,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_objects_ne",
-          "line": 216,
+          "line": 224,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_scheduler_eq",
-          "line": 235,
+          "line": 243,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_endpoint",
-          "line": 253,
+          "line": 261,
           "called": [
             "storeTcbIpcStateAndMessage_preserves_objects_ne"
           ]
@@ -4085,7 +4085,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_notification",
-          "line": 268,
+          "line": 276,
           "called": [
             "storeTcbIpcStateAndMessage_preserves_objects_ne"
           ]
@@ -4093,7 +4093,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_endpoint_backward",
-          "line": 283,
+          "line": 291,
           "called": [
             "storeTcbIpcStateAndMessage_preserves_objects_ne"
           ]
@@ -4101,7 +4101,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_notification_backward",
-          "line": 306,
+          "line": 314,
           "called": [
             "storeTcbIpcStateAndMessage_preserves_objects_ne"
           ]
@@ -4109,31 +4109,31 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_ipcState_eq",
-          "line": 329,
+          "line": 337,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_tcb_exists_at_target",
-          "line": 349,
+          "line": 357,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_objects_ne",
-          "line": 368,
+          "line": 376,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_scheduler_eq",
-          "line": 386,
+          "line": 394,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_endpoint",
-          "line": 404,
+          "line": 412,
           "called": [
             "storeTcbPendingMessage_preserves_objects_ne"
           ]
@@ -4141,7 +4141,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_endpoint_backward",
-          "line": 417,
+          "line": 425,
           "called": [
             "storeTcbPendingMessage_preserves_objects_ne"
           ]
@@ -4149,7 +4149,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_notification_backward",
-          "line": 438,
+          "line": 446,
           "called": [
             "storeTcbPendingMessage_preserves_objects_ne"
           ]
@@ -4157,7 +4157,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_tcb_forward",
-          "line": 459,
+          "line": 467,
           "called": [
             "storeTcbPendingMessage_preserves_objects_ne"
           ]
@@ -4165,7 +4165,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_tcb_ipcState_backward",
-          "line": 479,
+          "line": 487,
           "called": [
             "storeTcbPendingMessage_preserves_objects_ne"
           ]
@@ -4186,121 +4186,121 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignalChecked_eq_notificationSignal_when_allowed",
-          "line": 13,
+          "line": 21,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignalChecked_flowDenied",
-          "line": 28,
+          "line": 36,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceCopyChecked_eq_cspaceCopy_when_allowed",
-          "line": 43,
+          "line": 51,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceCopyChecked_flowDenied",
-          "line": 55,
+          "line": 63,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMoveChecked_eq_cspaceMove_when_allowed",
-          "line": 68,
+          "line": 76,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMoveChecked_flowDenied",
-          "line": 80,
+          "line": 88,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDualChecked_eq_endpointReceiveDual_when_allowed",
-          "line": 93,
+          "line": 101,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDualChecked_flowDenied",
-          "line": 107,
+          "line": 115,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignalChecked_denied_preserves_state",
-          "line": 124,
+          "line": 132,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceCopyChecked_denied_preserves_state",
-          "line": 135,
+          "line": 143,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMoveChecked_denied_preserves_state",
-          "line": 145,
+          "line": 153,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDualChecked_denied_preserves_state",
-          "line": 155,
+          "line": 163,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_notificationSignal",
-          "line": 171,
+          "line": 179,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_cspaceCopy",
-          "line": 186,
+          "line": 194,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_cspaceMove",
-          "line": 198,
+          "line": 206,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_endpointReceiveDual",
-          "line": 210,
+          "line": 218,
           "called": []
         },
         {
           "kind": "def",
           "name": "enforcementBoundaryExtended",
-          "line": 235,
+          "line": 243,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "enforcementSoundness_endpointSendDualChecked",
-          "line": 267,
+          "line": 275,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "enforcementSoundness_notificationSignalChecked",
-          "line": 284,
+          "line": 292,
           "called": [
             "notificationSignalChecked_flowDenied"
           ]
@@ -4308,7 +4308,7 @@
         {
           "kind": "theorem",
           "name": "enforcementSoundness_cspaceCopyChecked",
-          "line": 297,
+          "line": 305,
           "called": [
             "cspaceCopyChecked_flowDenied"
           ]
@@ -4316,7 +4316,7 @@
         {
           "kind": "theorem",
           "name": "enforcementSoundness_cspaceMoveChecked",
-          "line": 309,
+          "line": 317,
           "called": [
             "cspaceMoveChecked_flowDenied"
           ]
@@ -4324,7 +4324,7 @@
         {
           "kind": "theorem",
           "name": "enforcementSoundness_endpointReceiveDualChecked",
-          "line": 321,
+          "line": 329,
           "called": [
             "endpointReceiveDualChecked_flowDenied"
           ]
@@ -4332,13 +4332,13 @@
         {
           "kind": "def",
           "name": "declassifyStore",
-          "line": 359,
+          "line": 367,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "declassifyStore_eq_storeObject_when_authorized",
-          "line": 376,
+          "line": 384,
           "called": [
             "declassifyStore"
           ]
@@ -4346,7 +4346,7 @@
         {
           "kind": "theorem",
           "name": "declassifyStore_error_when_normal_allowed",
-          "line": 390,
+          "line": 398,
           "called": [
             "declassifyStore"
           ]
@@ -4354,7 +4354,7 @@
         {
           "kind": "theorem",
           "name": "declassifyStore_error_when_declass_denied",
-          "line": 403,
+          "line": 411,
           "called": [
             "declassifyStore"
           ]
@@ -4362,7 +4362,7 @@
         {
           "kind": "theorem",
           "name": "declassifyStore_denied_no_state_change",
-          "line": 417,
+          "line": 425,
           "called": [
             "declassifyStore"
           ]
@@ -4370,7 +4370,7 @@
         {
           "kind": "theorem",
           "name": "enforcementSoundness_declassifyStore",
-          "line": 431,
+          "line": 439,
           "called": [
             "declassifyStore"
           ]
@@ -4378,13 +4378,13 @@
         {
           "kind": "structure",
           "name": "InformationFlowConfigInvariant",
-          "line": 478,
+          "line": 486,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "defaultConfigInvariant",
-          "line": 489,
+          "line": 497,
           "called": [
             "InformationFlowConfigInvariant"
           ]
@@ -4392,7 +4392,7 @@
         {
           "kind": "theorem",
           "name": "kernelTransition_preserves_ifConfigInvariant",
-          "line": 506,
+          "line": 514,
           "called": [
             "InformationFlowConfigInvariant"
           ]
@@ -4407,31 +4407,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 6,
+          "line": 14,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointSendDualChecked",
-          "line": 19,
+          "line": 27,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceMintChecked",
-          "line": 41,
+          "line": 49,
           "called": []
         },
         {
           "kind": "def",
           "name": "serviceRestartChecked",
-          "line": 59,
+          "line": 67,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDualChecked_eq_endpointSendDual_when_allowed",
-          "line": 79,
+          "line": 87,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4439,7 +4439,7 @@
         {
           "kind": "theorem",
           "name": "endpointSendDualChecked_flowDenied",
-          "line": 105,
+          "line": 113,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4447,7 +4447,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintChecked_eq_cspaceMint_when_allowed",
-          "line": 124,
+          "line": 132,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4455,7 +4455,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintChecked_flowDenied",
-          "line": 139,
+          "line": 147,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4463,7 +4463,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestartChecked_eq_serviceRestart_when_allowed",
-          "line": 154,
+          "line": 162,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4471,7 +4471,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestartChecked_flowDenied",
-          "line": 169,
+          "line": 177,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4479,13 +4479,13 @@
         {
           "kind": "inductive",
           "name": "EnforcementClass",
-          "line": 212,
+          "line": 220,
           "called": []
         },
         {
           "kind": "def",
           "name": "enforcementBoundary",
-          "line": 219,
+          "line": 227,
           "called": [
             "EnforcementClass",
             "cspaceMintChecked",
@@ -4496,7 +4496,7 @@
         {
           "kind": "theorem",
           "name": "endpointSendDualChecked_denied_preserves_state",
-          "line": 246,
+          "line": 254,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4504,7 +4504,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintChecked_denied_preserves_state",
-          "line": 262,
+          "line": 270,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4512,7 +4512,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestartChecked_denied_preserves_state",
-          "line": 273,
+          "line": 281,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4520,7 +4520,7 @@
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_endpointSendDual",
-          "line": 291,
+          "line": 299,
           "called": [
             "endpointSendDualChecked"
           ]
@@ -4528,7 +4528,7 @@
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_cspaceMint",
-          "line": 312,
+          "line": 320,
           "called": [
             "cspaceMintChecked"
           ]
@@ -4536,7 +4536,7 @@
         {
           "kind": "theorem",
           "name": "enforcement_sufficiency_serviceRestart",
-          "line": 325,
+          "line": 333,
           "called": [
             "serviceRestartChecked"
           ]
@@ -4544,25 +4544,25 @@
         {
           "kind": "def",
           "name": "notificationSignalChecked",
-          "line": 363,
+          "line": 371,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceCopyChecked",
-          "line": 384,
+          "line": 392,
           "called": []
         },
         {
           "kind": "def",
           "name": "cspaceMoveChecked",
-          "line": 400,
+          "line": 408,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointReceiveDualChecked",
-          "line": 419,
+          "line": 427,
           "called": []
         }
       ]
@@ -4581,19 +4581,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "NonInterferenceStep",
-          "line": 26,
+          "line": 34,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "step_preserves_projection",
-          "line": 217,
+          "line": 225,
           "called": [
             "NonInterferenceStep"
           ]
@@ -4601,7 +4601,7 @@
         {
           "kind": "theorem",
           "name": "composedNonInterference_step",
-          "line": 479,
+          "line": 487,
           "called": [
             "NonInterferenceStep",
             "step_preserves_projection"
@@ -4610,7 +4610,7 @@
         {
           "kind": "inductive",
           "name": "NonInterferenceTrace",
-          "line": 491,
+          "line": 499,
           "called": [
             "NonInterferenceStep"
           ]
@@ -4618,7 +4618,7 @@
         {
           "kind": "theorem",
           "name": "trace_preserves_projection",
-          "line": 501,
+          "line": 509,
           "called": [
             "NonInterferenceTrace",
             "step_preserves_projection"
@@ -4627,7 +4627,7 @@
         {
           "kind": "theorem",
           "name": "composedNonInterference_trace",
-          "line": 512,
+          "line": 520,
           "called": [
             "NonInterferenceTrace",
             "trace_preserves_projection"
@@ -4636,19 +4636,19 @@
         {
           "kind": "theorem",
           "name": "declassifyStore_NI",
-          "line": 540,
+          "line": 548,
           "called": []
         },
         {
           "kind": "def",
           "name": "preservesLowEquivalence",
-          "line": 564,
+          "line": 572,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "compose_preservesLowEquivalence",
-          "line": 574,
+          "line": 582,
           "called": [
             "preservesLowEquivalence"
           ]
@@ -4656,7 +4656,7 @@
         {
           "kind": "theorem",
           "name": "errorAction_preserves_lowEquiv",
-          "line": 593,
+          "line": 601,
           "called": [
             "preservesLowEquivalence"
           ]
@@ -4671,19 +4671,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 10,
+          "line": 18,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_preserves_projectObjectIndex",
-          "line": 20,
+          "line": 28,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_projectObjectIndex",
-          "line": 34,
+          "line": 42,
           "called": [
             "storeObject_preserves_projectObjectIndex"
           ]
@@ -4691,7 +4691,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_at_unobservable_preserves_lowEquivalent",
-          "line": 69,
+          "line": 77,
           "called": [
             "storeObject_preserves_projectObjectIndex"
           ]
@@ -4699,25 +4699,25 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_preserves_projectState",
-          "line": 164,
+          "line": 172,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "list_filter_ne_then_filter_eq",
-          "line": 188,
+          "line": 196,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "list_filter_append_singleton_unobs",
-          "line": 210,
+          "line": 218,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_projection",
-          "line": 218,
+          "line": 226,
           "called": [
             "list_filter_ne_then_filter_eq"
           ]
@@ -4725,13 +4725,13 @@
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_projection",
-          "line": 261,
+          "line": 269,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_projection",
-          "line": 290,
+          "line": 298,
           "called": [
             "storeObject_preserves_projectObjectIndex"
           ]
@@ -4739,7 +4739,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_projection",
-          "line": 340,
+          "line": 348,
           "called": [
             "storeObject_preserves_projectObjectIndex"
           ]
@@ -4747,7 +4747,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_projection",
-          "line": 376,
+          "line": 384,
           "called": [
             "storeObject_preserves_projectObjectIndex"
           ]
@@ -4755,7 +4755,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_projection",
-          "line": 414,
+          "line": 422,
           "called": [
             "storeObject_preserves_projectObjectIndex"
           ]
@@ -4763,13 +4763,13 @@
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_lowEquivalent",
-          "line": 446,
+          "line": 454,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMint_preserves_lowEquivalent",
-          "line": 465,
+          "line": 473,
           "called": [
             "cspaceInsertSlot_preserves_projectObjectIndex"
           ]
@@ -4777,13 +4777,13 @@
         {
           "kind": "theorem",
           "name": "cspaceRevoke_preserves_lowEquivalent",
-          "line": 548,
+          "line": 556,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lowEquivalent",
-          "line": 657,
+          "line": 665,
           "called": [
             "storeObject_at_unobservable_preserves_lowEquivalent"
           ]
@@ -4791,7 +4791,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_projection_preserved",
-          "line": 681,
+          "line": 689,
           "called": [
             "ensureRunnable_preserves_projection",
             "storeObject_preserves_projection",
@@ -4801,7 +4801,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_lowEquivalent",
-          "line": 725,
+          "line": 733,
           "called": [
             "notificationSignal_projection_preserved"
           ]
@@ -4809,7 +4809,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_projection_preserved",
-          "line": 754,
+          "line": 762,
           "called": [
             "removeRunnable_preserves_projection",
             "storeObject_preserves_projection",
@@ -4819,7 +4819,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_lowEquivalent",
-          "line": 810,
+          "line": 818,
           "called": [
             "notificationWait_projection_preserved"
           ]
@@ -4827,7 +4827,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_lowEquivalent",
-          "line": 835,
+          "line": 843,
           "called": [
             "cspaceInsertSlot_preserves_projectObjectIndex"
           ]
@@ -4842,25 +4842,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_lowEquivalent",
-          "line": 33,
+          "line": 41,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_lowEquivalent",
-          "line": 106,
+          "line": 114,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceRestart_preserves_lowEquivalent",
-          "line": 174,
+          "line": 182,
           "called": [
             "serviceStart_preserves_lowEquivalent",
             "serviceStop_preserves_lowEquivalent"
@@ -4869,13 +4869,13 @@
         {
           "kind": "theorem",
           "name": "cspaceMintChecked_NI",
-          "line": 198,
+          "line": 206,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceRestartChecked_NI",
-          "line": 221,
+          "line": 229,
           "called": [
             "serviceRestart_preserves_lowEquivalent"
           ]
@@ -4883,103 +4883,103 @@
         {
           "kind": "theorem",
           "name": "endpointSendDualChecked_NI",
-          "line": 253,
+          "line": 261,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignalChecked_NI",
-          "line": 276,
+          "line": 284,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceCopyChecked_NI",
-          "line": 310,
+          "line": 318,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMoveChecked_NI",
-          "line": 333,
+          "line": 341,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "setCurrentThread_preserves_projection",
-          "line": 359,
+          "line": 367,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "remove_rq_preserves_projection",
-          "line": 399,
+          "line": 407,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "insert_rq_preserves_projection",
-          "line": 412,
+          "line": 420,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_machine",
-          "line": 427,
+          "line": 435,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_services",
-          "line": 437,
+          "line": 445,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_irqHandlers",
-          "line": 447,
+          "line": 455,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_objectIndex",
-          "line": 457,
+          "line": 465,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_preserves_projectObjects",
-          "line": 469,
+          "line": 477,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_preserves_projection",
-          "line": 503,
+          "line": 511,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "restoreIncomingContext_preserves_projection",
-          "line": 539,
+          "line": 547,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "projectObjects_ext_objects",
-          "line": 566,
+          "line": 574,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_with_sched_preserves_projection",
-          "line": 575,
+          "line": 583,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "schedule_preserves_projection",
-          "line": 616,
+          "line": 624,
           "called": [
             "remove_rq_preserves_projection",
             "restoreIncomingContext_preserves_projection",
@@ -4991,19 +4991,19 @@
         {
           "kind": "theorem",
           "name": "switchDomain_preserves_lowEquivalent",
-          "line": 685,
+          "line": 693,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "vspaceMapPage_preserves_projection",
-          "line": 765,
+          "line": 773,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "vspaceMapPage_preserves_lowEquivalent",
-          "line": 788,
+          "line": 796,
           "called": [
             "vspaceMapPage_preserves_projection"
           ]
@@ -5011,13 +5011,13 @@
         {
           "kind": "theorem",
           "name": "vspaceUnmapPage_preserves_projection",
-          "line": 806,
+          "line": 814,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "vspaceUnmapPage_preserves_lowEquivalent",
-          "line": 828,
+          "line": 836,
           "called": [
             "vspaceUnmapPage_preserves_projection"
           ]
@@ -5025,13 +5025,13 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_preserves_state",
-          "line": 846,
+          "line": 854,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "vspaceLookup_preserves_lowEquivalent",
-          "line": 864,
+          "line": 872,
           "called": [
             "vspaceLookup_preserves_state"
           ]
@@ -5039,13 +5039,13 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_projection",
-          "line": 881,
+          "line": 889,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_preserves_projection",
-          "line": 892,
+          "line": 900,
           "called": [
             "storeCapabilityRef_preserves_projection"
           ]
@@ -5053,7 +5053,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_preserves_lowEquivalent",
-          "line": 926,
+          "line": 934,
           "called": [
             "cspaceDeleteSlot_preserves_projection"
           ]
@@ -5061,13 +5061,13 @@
         {
           "kind": "theorem",
           "name": "cdt_only_preserves_projection",
-          "line": 940,
+          "line": 948,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureCdtNodeForSlot_preserves_projection",
-          "line": 965,
+          "line": 973,
           "called": [
             "cdt_only_preserves_projection"
           ]
@@ -5075,7 +5075,7 @@
         {
           "kind": "theorem",
           "name": "attachSlotToCdtNode_preserves_projection",
-          "line": 976,
+          "line": 984,
           "called": [
             "cdt_only_preserves_projection"
           ]
@@ -5083,13 +5083,13 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_projection",
-          "line": 985,
+          "line": 993,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceCopy_preserves_projection",
-          "line": 1017,
+          "line": 1025,
           "called": [
             "cspaceInsertSlot_preserves_projection",
             "ensureCdtNodeForSlot_preserves_projection"
@@ -5098,7 +5098,7 @@
         {
           "kind": "theorem",
           "name": "cspaceCopy_preserves_lowEquivalent",
-          "line": 1047,
+          "line": 1055,
           "called": [
             "cspaceCopy_preserves_projection"
           ]
@@ -5106,7 +5106,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_preserves_projection",
-          "line": 1062,
+          "line": 1070,
           "called": [
             "cspaceDeleteSlot_preserves_projection",
             "cspaceInsertSlot_preserves_projection"
@@ -5115,7 +5115,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_preserves_lowEquivalent",
-          "line": 1106,
+          "line": 1114,
           "called": [
             "cspaceMove_preserves_projection"
           ]
@@ -5123,19 +5123,19 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_projection",
-          "line": 1126,
+          "line": 1134,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_projection",
-          "line": 1147,
+          "line": 1155,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_lowEquivalent",
-          "line": 1182,
+          "line": 1190,
           "called": [
             "endpointReply_preserves_projection"
           ]
@@ -5143,37 +5143,37 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDualChecked_NI",
-          "line": 1207,
+          "line": 1215,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_lowEquivalent",
-          "line": 1235,
+          "line": 1243,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_lowEquivalent",
-          "line": 1253,
+          "line": 1261,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_lowEquivalent",
-          "line": 1271,
+          "line": 1279,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "rotateToBack_preserves_projection",
-          "line": 1295,
+          "line": 1303,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "handleYield_preserves_projection",
-          "line": 1308,
+          "line": 1316,
           "called": [
             "schedule_preserves_projection"
           ]
@@ -5181,7 +5181,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_lowEquivalent",
-          "line": 1357,
+          "line": 1365,
           "called": [
             "handleYield_preserves_projection"
           ]
@@ -5189,13 +5189,13 @@
         {
           "kind": "theorem",
           "name": "insert_tick_preserves_projection",
-          "line": 1379,
+          "line": 1387,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "timerTick_preserves_projection",
-          "line": 1398,
+          "line": 1406,
           "called": [
             "insert_tick_preserves_projection",
             "schedule_preserves_projection"
@@ -5204,7 +5204,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_lowEquivalent",
-          "line": 1461,
+          "line": 1469,
           "called": [
             "timerTick_preserves_projection"
           ]
@@ -5225,25 +5225,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "Confidentiality",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "Integrity",
-          "line": 14,
+          "line": 22,
           "called": []
         },
         {
           "kind": "structure",
           "name": "SecurityLabel",
-          "line": 20,
+          "line": 28,
           "called": [
             "Confidentiality",
             "Integrity"
@@ -5252,13 +5252,13 @@
         {
           "kind": "namespace",
           "name": "SecurityLabel",
-          "line": 25,
+          "line": 33,
           "called": []
         },
         {
           "kind": "def",
           "name": "publicLabel",
-          "line": 27,
+          "line": 35,
           "called": [
             "SecurityLabel"
           ]
@@ -5266,7 +5266,7 @@
         {
           "kind": "def",
           "name": "kernelTrusted",
-          "line": 30,
+          "line": 38,
           "called": [
             "SecurityLabel"
           ]
@@ -5274,7 +5274,7 @@
         {
           "kind": "def",
           "name": "confidentialityFlowsTo",
-          "line": 36,
+          "line": 44,
           "called": [
             "Confidentiality"
           ]
@@ -5282,7 +5282,7 @@
         {
           "kind": "def",
           "name": "integrityFlowsTo",
-          "line": 42,
+          "line": 50,
           "called": [
             "Integrity"
           ]
@@ -5290,7 +5290,7 @@
         {
           "kind": "def",
           "name": "securityFlowsTo",
-          "line": 56,
+          "line": 64,
           "called": [
             "SecurityLabel",
             "confidentialityFlowsTo",
@@ -5300,7 +5300,7 @@
         {
           "kind": "structure",
           "name": "LabelingContext",
-          "line": 61,
+          "line": 69,
           "called": [
             "SecurityLabel"
           ]
@@ -5308,7 +5308,7 @@
         {
           "kind": "def",
           "name": "defaultLabelingContext",
-          "line": 68,
+          "line": 76,
           "called": [
             "LabelingContext"
           ]
@@ -5316,7 +5316,7 @@
         {
           "kind": "theorem",
           "name": "confidentialityFlowsTo_refl",
-          "line": 76,
+          "line": 84,
           "called": [
             "Confidentiality",
             "confidentialityFlowsTo"
@@ -5325,7 +5325,7 @@
         {
           "kind": "theorem",
           "name": "integrityFlowsTo_refl",
-          "line": 80,
+          "line": 88,
           "called": [
             "Integrity",
             "integrityFlowsTo"
@@ -5334,7 +5334,7 @@
         {
           "kind": "theorem",
           "name": "securityFlowsTo_refl",
-          "line": 84,
+          "line": 92,
           "called": [
             "SecurityLabel",
             "confidentialityFlowsTo_refl",
@@ -5345,7 +5345,7 @@
         {
           "kind": "theorem",
           "name": "confidentialityFlowsTo_trans",
-          "line": 90,
+          "line": 98,
           "called": [
             "Confidentiality",
             "confidentialityFlowsTo"
@@ -5354,7 +5354,7 @@
         {
           "kind": "theorem",
           "name": "integrityFlowsTo_trans",
-          "line": 97,
+          "line": 105,
           "called": [
             "Integrity",
             "integrityFlowsTo"
@@ -5363,7 +5363,7 @@
         {
           "kind": "theorem",
           "name": "securityFlowsTo_trans",
-          "line": 104,
+          "line": 112,
           "called": [
             "SecurityLabel",
             "confidentialityFlowsTo_trans",
@@ -5374,13 +5374,13 @@
         {
           "kind": "structure",
           "name": "SecurityDomain",
-          "line": 143,
+          "line": 151,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:148>",
-          "line": 148,
+          "name": "<anonymous:instance:156>",
+          "line": 156,
           "called": [
             "SecurityDomain"
           ]
@@ -5388,13 +5388,13 @@
         {
           "kind": "namespace",
           "name": "SecurityDomain",
-          "line": 151,
+          "line": 159,
           "called": []
         },
         {
           "kind": "def",
           "name": "lowest",
-          "line": 154,
+          "line": 162,
           "called": [
             "SecurityDomain"
           ]
@@ -5402,7 +5402,7 @@
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 157,
+          "line": 165,
           "called": [
             "SecurityDomain"
           ]
@@ -5410,15 +5410,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 160,
+          "line": 168,
           "called": [
             "SecurityDomain"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:162>",
-          "line": 162,
+          "name": "<anonymous:instance:170>",
+          "line": 170,
           "called": [
             "SecurityDomain"
           ]
@@ -5426,7 +5426,7 @@
         {
           "kind": "theorem",
           "name": "toNat_ofNat",
-          "line": 166,
+          "line": 174,
           "called": [
             "toNat"
           ]
@@ -5434,7 +5434,7 @@
         {
           "kind": "theorem",
           "name": "ofNat_toNat",
-          "line": 168,
+          "line": 176,
           "called": [
             "SecurityDomain"
           ]
@@ -5442,28 +5442,12 @@
         {
           "kind": "theorem",
           "name": "ofNat_injective",
-          "line": 170,
+          "line": 178,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ext",
-          "line": 173,
-          "called": [
-            "SecurityDomain"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:179>",
-          "line": 179,
-          "called": [
-            "SecurityDomain"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:181>",
           "line": 181,
           "called": [
             "SecurityDomain"
@@ -5471,8 +5455,24 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:185>",
-          "line": 185,
+          "name": "<anonymous:instance:187>",
+          "line": 187,
+          "called": [
+            "SecurityDomain"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:189>",
+          "line": 189,
+          "called": [
+            "SecurityDomain"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:193>",
+          "line": 193,
           "called": [
             "SecurityDomain"
           ]
@@ -5480,7 +5480,7 @@
         {
           "kind": "structure",
           "name": "DomainFlowPolicy",
-          "line": 193,
+          "line": 201,
           "called": [
             "SecurityDomain"
           ]
@@ -5488,13 +5488,13 @@
         {
           "kind": "namespace",
           "name": "DomainFlowPolicy",
-          "line": 196,
+          "line": 204,
           "called": []
         },
         {
           "kind": "def",
           "name": "isReflexive",
-          "line": 199,
+          "line": 207,
           "called": [
             "DomainFlowPolicy",
             "SecurityDomain"
@@ -5503,7 +5503,7 @@
         {
           "kind": "def",
           "name": "isTransitive",
-          "line": 203,
+          "line": 211,
           "called": [
             "DomainFlowPolicy",
             "SecurityDomain"
@@ -5512,7 +5512,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 208,
+          "line": 216,
           "called": [
             "DomainFlowPolicy"
           ]
@@ -5520,7 +5520,7 @@
         {
           "kind": "def",
           "name": "allowAll",
-          "line": 212,
+          "line": 220,
           "called": [
             "DomainFlowPolicy"
           ]
@@ -5528,7 +5528,7 @@
         {
           "kind": "def",
           "name": "linearOrder",
-          "line": 217,
+          "line": 225,
           "called": [
             "DomainFlowPolicy"
           ]
@@ -5536,25 +5536,25 @@
         {
           "kind": "theorem",
           "name": "DomainFlowPolicy.allowAll_reflexive",
-          "line": 226,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "DomainFlowPolicy.allowAll_transitive",
-          "line": 230,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "DomainFlowPolicy.allowAll_wellFormed",
           "line": 234,
           "called": []
         },
         {
           "kind": "theorem",
-          "name": "DomainFlowPolicy.linearOrder_reflexive",
+          "name": "DomainFlowPolicy.allowAll_transitive",
           "line": 238,
+          "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "DomainFlowPolicy.allowAll_wellFormed",
+          "line": 242,
+          "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "DomainFlowPolicy.linearOrder_reflexive",
+          "line": 246,
           "called": [
             "linearOrder"
           ]
@@ -5562,7 +5562,7 @@
         {
           "kind": "theorem",
           "name": "DomainFlowPolicy.linearOrder_transitive",
-          "line": 242,
+          "line": 250,
           "called": [
             "linearOrder"
           ]
@@ -5570,13 +5570,13 @@
         {
           "kind": "theorem",
           "name": "DomainFlowPolicy.linearOrder_wellFormed",
-          "line": 248,
+          "line": 256,
           "called": []
         },
         {
           "kind": "def",
           "name": "domainFlowsTo",
-          "line": 256,
+          "line": 264,
           "called": [
             "DomainFlowPolicy",
             "SecurityDomain"
@@ -5585,7 +5585,7 @@
         {
           "kind": "theorem",
           "name": "domainFlowsTo_refl",
-          "line": 259,
+          "line": 267,
           "called": [
             "DomainFlowPolicy",
             "SecurityDomain",
@@ -5595,7 +5595,7 @@
         {
           "kind": "theorem",
           "name": "domainFlowsTo_trans",
-          "line": 265,
+          "line": 273,
           "called": [
             "DomainFlowPolicy",
             "SecurityDomain",
@@ -5605,7 +5605,7 @@
         {
           "kind": "structure",
           "name": "GenericLabelingContext",
-          "line": 279,
+          "line": 287,
           "called": [
             "DomainFlowPolicy",
             "SecurityDomain"
@@ -5614,7 +5614,7 @@
         {
           "kind": "def",
           "name": "defaultGenericLabelingContext",
-          "line": 288,
+          "line": 296,
           "called": [
             "GenericLabelingContext",
             "allowAll"
@@ -5623,7 +5623,7 @@
         {
           "kind": "def",
           "name": "genericFlowCheck",
-          "line": 299,
+          "line": 307,
           "called": [
             "GenericLabelingContext",
             "SecurityDomain",
@@ -5633,7 +5633,7 @@
         {
           "kind": "structure",
           "name": "EndpointFlowPolicy",
-          "line": 312,
+          "line": 320,
           "called": [
             "DomainFlowPolicy"
           ]
@@ -5641,7 +5641,7 @@
         {
           "kind": "def",
           "name": "endpointFlowCheck",
-          "line": 317,
+          "line": 325,
           "called": [
             "EndpointFlowPolicy",
             "GenericLabelingContext",
@@ -5654,7 +5654,7 @@
         {
           "kind": "theorem",
           "name": "endpointFlowCheck_fallback",
-          "line": 327,
+          "line": 335,
           "called": [
             "EndpointFlowPolicy",
             "GenericLabelingContext",
@@ -5667,7 +5667,7 @@
         {
           "kind": "theorem",
           "name": "endpointFlowCheck_override",
-          "line": 338,
+          "line": 346,
           "called": [
             "DomainFlowPolicy",
             "EndpointFlowPolicy",
@@ -5680,7 +5680,7 @@
         {
           "kind": "def",
           "name": "embedLegacyLabel",
-          "line": 363,
+          "line": 371,
           "called": [
             "SecurityDomain",
             "SecurityLabel"
@@ -5689,7 +5689,7 @@
         {
           "kind": "theorem",
           "name": "embedLegacyLabel_public",
-          "line": 371,
+          "line": 379,
           "called": [
             "embedLegacyLabel"
           ]
@@ -5697,7 +5697,7 @@
         {
           "kind": "theorem",
           "name": "embedLegacyLabel_kernelTrusted",
-          "line": 375,
+          "line": 383,
           "called": [
             "embedLegacyLabel"
           ]
@@ -5705,7 +5705,7 @@
         {
           "kind": "theorem",
           "name": "embedLegacyLabel_preserves_flow",
-          "line": 380,
+          "line": 388,
           "called": [
             "SecurityLabel",
             "confidentialityFlowsTo",
@@ -5717,7 +5717,7 @@
         {
           "kind": "def",
           "name": "liftLegacyContext",
-          "line": 394,
+          "line": 402,
           "called": [
             "GenericLabelingContext",
             "LabelingContext",
@@ -5728,7 +5728,7 @@
         {
           "kind": "def",
           "name": "threeDomainExample",
-          "line": 411,
+          "line": 419,
           "called": [
             "DomainFlowPolicy",
             "linearOrder"
@@ -5737,7 +5737,7 @@
         {
           "kind": "theorem",
           "name": "threeDomainExample_wellFormed",
-          "line": 414,
+          "line": 422,
           "called": [
             "DomainFlowPolicy.linearOrder_wellFormed"
           ]
@@ -5745,7 +5745,7 @@
         {
           "kind": "theorem",
           "name": "threeDomain_userland_to_driver",
-          "line": 419,
+          "line": 427,
           "called": [
             "domainFlowsTo",
             "threeDomainExample"
@@ -5754,7 +5754,7 @@
         {
           "kind": "theorem",
           "name": "threeDomain_driver_to_kernel",
-          "line": 424,
+          "line": 432,
           "called": [
             "domainFlowsTo",
             "threeDomainExample"
@@ -5763,7 +5763,7 @@
         {
           "kind": "theorem",
           "name": "threeDomain_kernel_not_to_userland",
-          "line": 429,
+          "line": 437,
           "called": [
             "domainFlowsTo",
             "threeDomainExample"
@@ -5772,7 +5772,7 @@
         {
           "kind": "def",
           "name": "bibaIntegrityFlowsTo",
-          "line": 466,
+          "line": 474,
           "called": [
             "Integrity"
           ]
@@ -5780,7 +5780,7 @@
         {
           "kind": "def",
           "name": "bibaSecurityFlowsTo",
-          "line": 475,
+          "line": 483,
           "called": [
             "SecurityLabel",
             "bibaIntegrityFlowsTo",
@@ -5790,7 +5790,7 @@
         {
           "kind": "theorem",
           "name": "bibaIntegrityFlowsTo_refl",
-          "line": 479,
+          "line": 487,
           "called": [
             "Integrity",
             "bibaIntegrityFlowsTo"
@@ -5799,7 +5799,7 @@
         {
           "kind": "theorem",
           "name": "bibaSecurityFlowsTo_refl",
-          "line": 483,
+          "line": 491,
           "called": [
             "SecurityLabel",
             "bibaIntegrityFlowsTo_refl",
@@ -5810,7 +5810,7 @@
         {
           "kind": "theorem",
           "name": "bibaIntegrityFlowsTo_trans",
-          "line": 489,
+          "line": 497,
           "called": [
             "Integrity",
             "bibaIntegrityFlowsTo"
@@ -5819,7 +5819,7 @@
         {
           "kind": "theorem",
           "name": "bibaSecurityFlowsTo_trans",
-          "line": 496,
+          "line": 504,
           "called": [
             "SecurityLabel",
             "bibaIntegrityFlowsTo_trans",
@@ -5830,7 +5830,7 @@
         {
           "kind": "def",
           "name": "bibaPolicy",
-          "line": 516,
+          "line": 524,
           "called": [
             "DomainFlowPolicy"
           ]
@@ -5838,7 +5838,7 @@
         {
           "kind": "theorem",
           "name": "bibaPolicy_reflexive",
-          "line": 519,
+          "line": 527,
           "called": [
             "bibaPolicy"
           ]
@@ -5846,7 +5846,7 @@
         {
           "kind": "theorem",
           "name": "bibaPolicy_transitive",
-          "line": 522,
+          "line": 530,
           "called": [
             "bibaPolicy"
           ]
@@ -5854,7 +5854,7 @@
         {
           "kind": "theorem",
           "name": "bibaPolicy_wellFormed",
-          "line": 527,
+          "line": 535,
           "called": [
             "bibaPolicy_reflexive",
             "bibaPolicy_transitive"
@@ -5863,7 +5863,7 @@
         {
           "kind": "theorem",
           "name": "securityLattice_reflexive",
-          "line": 532,
+          "line": 540,
           "called": [
             "SecurityLabel",
             "securityFlowsTo",
@@ -5873,7 +5873,7 @@
         {
           "kind": "theorem",
           "name": "securityLattice_transitive",
-          "line": 535,
+          "line": 543,
           "called": [
             "SecurityLabel",
             "securityFlowsTo",
@@ -5883,7 +5883,7 @@
         {
           "kind": "structure",
           "name": "DeclassificationPolicy",
-          "line": 569,
+          "line": 577,
           "called": [
             "SecurityDomain"
           ]
@@ -5891,13 +5891,13 @@
         {
           "kind": "namespace",
           "name": "DeclassificationPolicy",
-          "line": 572,
+          "line": 580,
           "called": []
         },
         {
           "kind": "def",
           "name": "none",
-          "line": 575,
+          "line": 583,
           "called": [
             "DeclassificationPolicy"
           ]
@@ -5905,7 +5905,7 @@
         {
           "kind": "def",
           "name": "isDeclassificationAuthorized",
-          "line": 581,
+          "line": 589,
           "called": [
             "DeclassificationPolicy",
             "DomainFlowPolicy",
@@ -5915,7 +5915,7 @@
         {
           "kind": "theorem",
           "name": "isDeclassificationAuthorized_not_reflexive",
-          "line": 589,
+          "line": 597,
           "called": [
             "DeclassificationPolicy",
             "DomainFlowPolicy",
@@ -5926,7 +5926,7 @@
         {
           "kind": "def",
           "name": "endpointFlowPolicyWellFormed",
-          "line": 614,
+          "line": 622,
           "called": [
             "DomainFlowPolicy",
             "EndpointFlowPolicy"
@@ -5935,7 +5935,7 @@
         {
           "kind": "theorem",
           "name": "endpointFlowPolicyWellFormed_no_overrides",
-          "line": 622,
+          "line": 630,
           "called": [
             "DomainFlowPolicy",
             "endpointFlowPolicyWellFormed",
@@ -5945,7 +5945,7 @@
         {
           "kind": "theorem",
           "name": "endpointFlowCheck_reflexive",
-          "line": 633,
+          "line": 641,
           "called": [
             "EndpointFlowPolicy",
             "GenericLabelingContext",
@@ -5960,7 +5960,7 @@
         {
           "kind": "theorem",
           "name": "endpointFlowCheck_transitive",
-          "line": 649,
+          "line": 657,
           "called": [
             "EndpointFlowPolicy",
             "GenericLabelingContext",
@@ -5982,40 +5982,24 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 13,
+          "line": 21,
           "called": []
         },
         {
           "kind": "structure",
           "name": "IfObserver",
-          "line": 18,
+          "line": 26,
           "called": []
         },
         {
           "kind": "structure",
           "name": "ObservableState",
-          "line": 36,
+          "line": 44,
           "called": []
         },
         {
           "kind": "def",
           "name": "objectObservable",
-          "line": 75,
-          "called": [
-            "IfObserver"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "threadObservable",
-          "line": 79,
-          "called": [
-            "IfObserver"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "serviceObservable",
           "line": 83,
           "called": [
             "IfObserver"
@@ -6023,8 +6007,24 @@
         },
         {
           "kind": "def",
-          "name": "projectServiceStatus",
+          "name": "threadObservable",
           "line": 87,
+          "called": [
+            "IfObserver"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "serviceObservable",
+          "line": 91,
+          "called": [
+            "IfObserver"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "projectServiceStatus",
+          "line": 95,
           "called": [
             "IfObserver",
             "serviceObservable"
@@ -6033,7 +6033,7 @@
         {
           "kind": "def",
           "name": "capTargetObservable",
-          "line": 103,
+          "line": 111,
           "called": [
             "IfObserver",
             "objectObservable",
@@ -6043,7 +6043,7 @@
         {
           "kind": "def",
           "name": "projectKernelObject",
-          "line": 114,
+          "line": 122,
           "called": [
             "IfObserver",
             "capTargetObservable"
@@ -6052,7 +6052,7 @@
         {
           "kind": "theorem",
           "name": "projectKernelObject_idempotent",
-          "line": 137,
+          "line": 145,
           "called": [
             "IfObserver",
             "projectKernelObject"
@@ -6061,7 +6061,7 @@
         {
           "kind": "theorem",
           "name": "projectKernelObject_objectType",
-          "line": 151,
+          "line": 159,
           "called": [
             "IfObserver",
             "projectKernelObject"
@@ -6070,7 +6070,7 @@
         {
           "kind": "def",
           "name": "projectObjects",
-          "line": 160,
+          "line": 168,
           "called": [
             "IfObserver",
             "objectObservable",
@@ -6080,7 +6080,7 @@
         {
           "kind": "def",
           "name": "projectRunnable",
-          "line": 169,
+          "line": 177,
           "called": [
             "IfObserver",
             "threadObservable"
@@ -6089,7 +6089,7 @@
         {
           "kind": "def",
           "name": "projectCurrent",
-          "line": 174,
+          "line": 182,
           "called": [
             "IfObserver",
             "threadObservable"
@@ -6098,7 +6098,7 @@
         {
           "kind": "def",
           "name": "projectActiveDomain",
-          "line": 181,
+          "line": 189,
           "called": [
             "IfObserver"
           ]
@@ -6106,15 +6106,6 @@
         {
           "kind": "def",
           "name": "projectIrqHandlers",
-          "line": 187,
-          "called": [
-            "IfObserver",
-            "objectObservable"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "projectObjectIndex",
           "line": 195,
           "called": [
             "IfObserver",
@@ -6123,8 +6114,17 @@
         },
         {
           "kind": "def",
+          "name": "projectObjectIndex",
+          "line": 203,
+          "called": [
+            "IfObserver",
+            "objectObservable"
+          ]
+        },
+        {
+          "kind": "def",
           "name": "projectDomainTimeRemaining",
-          "line": 200,
+          "line": 208,
           "called": [
             "IfObserver"
           ]
@@ -6132,7 +6132,7 @@
         {
           "kind": "def",
           "name": "projectDomainSchedule",
-          "line": 205,
+          "line": 213,
           "called": [
             "IfObserver"
           ]
@@ -6140,7 +6140,7 @@
         {
           "kind": "def",
           "name": "projectDomainScheduleIndex",
-          "line": 210,
+          "line": 218,
           "called": [
             "IfObserver"
           ]
@@ -6148,7 +6148,7 @@
         {
           "kind": "def",
           "name": "projectMachineRegs",
-          "line": 224,
+          "line": 232,
           "called": [
             "IfObserver",
             "threadObservable"
@@ -6157,7 +6157,7 @@
         {
           "kind": "def",
           "name": "projectState",
-          "line": 244,
+          "line": 252,
           "called": [
             "IfObserver",
             "ObservableState",
@@ -6177,15 +6177,6 @@
         {
           "kind": "def",
           "name": "computeObservableSet",
-          "line": 270,
-          "called": [
-            "IfObserver",
-            "objectObservable"
-          ]
-        },
-        {
-          "kind": "theorem",
-          "name": "foldl_observable_set_mem",
           "line": 278,
           "called": [
             "IfObserver",
@@ -6194,8 +6185,17 @@
         },
         {
           "kind": "theorem",
+          "name": "foldl_observable_set_mem",
+          "line": 286,
+          "called": [
+            "IfObserver",
+            "objectObservable"
+          ]
+        },
+        {
+          "kind": "theorem",
           "name": "computeObservableSet_mem",
-          "line": 317,
+          "line": 325,
           "called": [
             "IfObserver",
             "computeObservableSet",
@@ -6206,7 +6206,7 @@
         {
           "kind": "theorem",
           "name": "computeObservableSet_not_mem",
-          "line": 328,
+          "line": 336,
           "called": [
             "IfObserver",
             "computeObservableSet",
@@ -6216,7 +6216,7 @@
         {
           "kind": "def",
           "name": "projectObjectsFast",
-          "line": 340,
+          "line": 348,
           "called": [
             "IfObserver",
             "projectKernelObject"
@@ -6225,19 +6225,19 @@
         {
           "kind": "def",
           "name": "projectIrqHandlersFast",
-          "line": 350,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "projectObjectIndexFast",
           "line": 358,
           "called": []
         },
         {
           "kind": "def",
+          "name": "projectObjectIndexFast",
+          "line": 366,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "projectStateFast",
-          "line": 379,
+          "line": 387,
           "called": [
             "IfObserver",
             "ObservableState",
@@ -6258,7 +6258,7 @@
         {
           "kind": "theorem",
           "name": "projectObjectsFast_eq",
-          "line": 397,
+          "line": 405,
           "called": [
             "IfObserver",
             "computeObservableSet",
@@ -6271,7 +6271,7 @@
         {
           "kind": "theorem",
           "name": "projectIrqHandlersFast_eq",
-          "line": 415,
+          "line": 423,
           "called": [
             "IfObserver",
             "computeObservableSet",
@@ -6284,7 +6284,7 @@
         {
           "kind": "theorem",
           "name": "projectObjectIndexFast_eq",
-          "line": 431,
+          "line": 439,
           "called": [
             "IfObserver",
             "computeObservableSet",
@@ -6296,7 +6296,7 @@
         {
           "kind": "theorem",
           "name": "projectStateFast_eq",
-          "line": 446,
+          "line": 454,
           "called": [
             "IfObserver",
             "projectIrqHandlersFast_eq",
@@ -6309,7 +6309,7 @@
         {
           "kind": "def",
           "name": "lowEquivalent",
-          "line": 458,
+          "line": 466,
           "called": [
             "IfObserver",
             "projectState"
@@ -6318,7 +6318,7 @@
         {
           "kind": "theorem",
           "name": "lowEquivalent_refl",
-          "line": 461,
+          "line": 469,
           "called": [
             "IfObserver",
             "lowEquivalent"
@@ -6327,7 +6327,7 @@
         {
           "kind": "theorem",
           "name": "lowEquivalent_symm",
-          "line": 468,
+          "line": 476,
           "called": [
             "IfObserver",
             "lowEquivalent"
@@ -6336,7 +6336,7 @@
         {
           "kind": "theorem",
           "name": "lowEquivalent_trans",
-          "line": 476,
+          "line": 484,
           "called": [
             "IfObserver",
             "lowEquivalent"
@@ -6352,25 +6352,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 34,
+          "line": 42,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleIdentityTypeExact",
-          "line": 40,
+          "line": 48,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleIdentityNoTypeAliasConflict",
-          "line": 45,
+          "line": 53,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleIdentityAliasingInvariant",
-          "line": 52,
+          "line": 60,
           "called": [
             "lifecycleIdentityNoTypeAliasConflict",
             "lifecycleIdentityTypeExact"
@@ -6379,19 +6379,19 @@
         {
           "kind": "def",
           "name": "lifecycleCapabilityRefExact",
-          "line": 57,
+          "line": 65,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleCapabilityRefObjectTargetBacked",
-          "line": 62,
+          "line": 70,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleCapabilityReferenceInvariant",
-          "line": 68,
+          "line": 76,
           "called": [
             "lifecycleCapabilityRefExact",
             "lifecycleCapabilityRefObjectTargetBacked"
@@ -6400,19 +6400,19 @@
         {
           "kind": "def",
           "name": "lifecycleCapabilityRefObjectTargetTypeAligned",
-          "line": 73,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "lifecycleCapabilityRefNoTypeAliasConflict",
           "line": 81,
           "called": []
         },
         {
           "kind": "def",
-          "name": "lifecycleStaleReferenceExclusionInvariant",
+          "name": "lifecycleCapabilityRefNoTypeAliasConflict",
           "line": 89,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "lifecycleStaleReferenceExclusionInvariant",
+          "line": 97,
           "called": [
             "lifecycleCapabilityRefNoTypeAliasConflict",
             "lifecycleCapabilityRefObjectTargetBacked",
@@ -6422,7 +6422,7 @@
         {
           "kind": "def",
           "name": "lifecycleIdentityStaleReferenceInvariant",
-          "line": 96,
+          "line": 104,
           "called": [
             "lifecycleIdentityAliasingInvariant",
             "lifecycleStaleReferenceExclusionInvariant"
@@ -6431,7 +6431,7 @@
         {
           "kind": "def",
           "name": "lifecycleInvariantBundle",
-          "line": 100,
+          "line": 108,
           "called": [
             "lifecycleCapabilityReferenceInvariant",
             "lifecycleIdentityAliasingInvariant"
@@ -6440,7 +6440,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleIdentityNoTypeAliasConflict_of_exact",
-          "line": 103,
+          "line": 111,
           "called": [
             "lifecycleIdentityNoTypeAliasConflict",
             "lifecycleIdentityTypeExact"
@@ -6449,7 +6449,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleCapabilityRefObjectTargetBacked_of_exact",
-          "line": 124,
+          "line": 132,
           "called": [
             "lifecycleCapabilityRefExact",
             "lifecycleCapabilityRefObjectTargetBacked"
@@ -6458,7 +6458,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleInvariantBundle_of_metadata_consistent",
-          "line": 137,
+          "line": 145,
           "called": [
             "lifecycleCapabilityRefObjectTargetBacked_of_exact",
             "lifecycleIdentityNoTypeAliasConflict_of_exact",
@@ -6468,7 +6468,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleMetadataConsistent_of_lifecycleInvariantBundle",
-          "line": 146,
+          "line": 154,
           "called": [
             "lifecycleInvariantBundle"
           ]
@@ -6476,7 +6476,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleCapabilityRefObjectTargetTypeAligned_of_exact",
-          "line": 155,
+          "line": 163,
           "called": [
             "lifecycleCapabilityRefObjectTargetTypeAligned",
             "lifecycleIdentityTypeExact"
@@ -6485,7 +6485,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleCapabilityRefNoTypeAliasConflict_of_identity",
-          "line": 163,
+          "line": 171,
           "called": [
             "lifecycleCapabilityRefNoTypeAliasConflict",
             "lifecycleIdentityNoTypeAliasConflict"
@@ -6494,7 +6494,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleStaleReferenceExclusionInvariant_of_lifecycleInvariantBundle",
-          "line": 170,
+          "line": 178,
           "called": [
             "lifecycleCapabilityRefNoTypeAliasConflict_of_identity",
             "lifecycleCapabilityRefObjectTargetTypeAligned_of_exact",
@@ -6505,7 +6505,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleIdentityStaleReferenceInvariant_of_lifecycleInvariantBundle",
-          "line": 181,
+          "line": 189,
           "called": [
             "lifecycleIdentityStaleReferenceInvariant",
             "lifecycleInvariantBundle",
@@ -6515,7 +6515,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lifecycleInvariantBundle",
-          "line": 187,
+          "line": 195,
           "called": [
             "lifecycleInvariantBundle",
             "lifecycleInvariantBundle_of_metadata_consistent",
@@ -6525,7 +6525,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lifecycleStaleReferenceExclusionInvariant",
-          "line": 203,
+          "line": 211,
           "called": [
             "lifecycleInvariantBundle",
             "lifecycleRetypeObject_preserves_lifecycleInvariantBundle",
@@ -6536,7 +6536,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lifecycleIdentityStaleReferenceInvariant",
-          "line": 215,
+          "line": 223,
           "called": [
             "lifecycleIdentityStaleReferenceInvariant",
             "lifecycleIdentityStaleReferenceInvariant_of_lifecycleInvariantBundle",
@@ -6547,31 +6547,31 @@
         {
           "kind": "def",
           "name": "untypedWatermarkInvariant",
-          "line": 233,
+          "line": 241,
           "called": []
         },
         {
           "kind": "def",
           "name": "untypedChildrenBoundsInvariant",
-          "line": 240,
+          "line": 248,
           "called": []
         },
         {
           "kind": "def",
           "name": "untypedChildrenNonOverlapInvariant",
-          "line": 247,
+          "line": 255,
           "called": []
         },
         {
           "kind": "def",
           "name": "untypedChildrenUniqueIdsInvariant",
-          "line": 254,
+          "line": 262,
           "called": []
         },
         {
           "kind": "def",
           "name": "untypedMemoryInvariant",
-          "line": 260,
+          "line": 268,
           "called": [
             "untypedChildrenBoundsInvariant",
             "untypedChildrenNonOverlapInvariant",
@@ -6582,7 +6582,7 @@
         {
           "kind": "theorem",
           "name": "default_systemState_untypedMemoryInvariant",
-          "line": 268,
+          "line": 276,
           "called": [
             "untypedMemoryInvariant"
           ]
@@ -6590,7 +6590,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_untypedWatermarkInvariant_ne",
-          "line": 274,
+          "line": 282,
           "called": [
             "untypedWatermarkInvariant"
           ]
@@ -6598,13 +6598,13 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_preserves_lifecycleMetadataConsistent",
-          "line": 292,
+          "line": 300,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_preserves_lifecycleInvariantBundle",
-          "line": 312,
+          "line": 320,
           "called": [
             "lifecycleInvariantBundle",
             "lifecycleInvariantBundle_of_metadata_consistent",
@@ -6615,7 +6615,7 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_preserves_untypedMemoryInvariant",
-          "line": 333,
+          "line": 341,
           "called": [
             "untypedMemoryInvariant"
           ]
@@ -6623,13 +6623,13 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_ok_childId_ne",
-          "line": 413,
+          "line": 421,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_ok_childId_fresh",
-          "line": 436,
+          "line": 444,
           "called": [
             "retypeFromUntyped_ok_childId_ne"
           ]
@@ -6637,7 +6637,7 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_preserves_untypedMemoryInvariant_auto",
-          "line": 471,
+          "line": 479,
           "called": [
             "retypeFromUntyped_ok_childId_fresh",
             "retypeFromUntyped_ok_childId_ne",
@@ -6655,25 +6655,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 4,
+          "line": 12,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleRetypeAuthority",
-          "line": 11,
+          "line": 19,
           "called": []
         },
         {
           "kind": "def",
           "name": "cleanupTcbReferences",
-          "line": 30,
+          "line": 38,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cleanupTcbReferences_removes_from_runnable",
-          "line": 34,
+          "line": 42,
           "called": [
             "cleanupTcbReferences"
           ]
@@ -6681,7 +6681,7 @@
         {
           "kind": "theorem",
           "name": "cleanupTcbReferences_preserves_runnable_ne",
-          "line": 41,
+          "line": 49,
           "called": [
             "cleanupTcbReferences"
           ]
@@ -6689,7 +6689,7 @@
         {
           "kind": "theorem",
           "name": "cleanupTcbReferences_objects_eq",
-          "line": 50,
+          "line": 58,
           "called": [
             "cleanupTcbReferences"
           ]
@@ -6697,7 +6697,7 @@
         {
           "kind": "theorem",
           "name": "cleanupTcbReferences_lifecycle_eq",
-          "line": 56,
+          "line": 64,
           "called": [
             "cleanupTcbReferences"
           ]
@@ -6705,25 +6705,25 @@
         {
           "kind": "theorem",
           "name": "detachSlotFromCdt_objects_eq",
-          "line": 62,
+          "line": 70,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "detachSlotFromCdt_lifecycle_eq",
-          "line": 67,
+          "line": 75,
           "called": []
         },
         {
           "kind": "def",
           "name": "detachCNodeSlots",
-          "line": 74,
+          "line": 82,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "detachCNodeSlots_objects_eq",
-          "line": 80,
+          "line": 88,
           "called": [
             "detachCNodeSlots",
             "detachSlotFromCdt_objects_eq"
@@ -6732,7 +6732,7 @@
         {
           "kind": "theorem",
           "name": "detachCNodeSlots_lifecycle_eq",
-          "line": 98,
+          "line": 106,
           "called": [
             "detachCNodeSlots",
             "detachSlotFromCdt_lifecycle_eq"
@@ -6741,7 +6741,7 @@
         {
           "kind": "def",
           "name": "lifecyclePreRetypeCleanup",
-          "line": 119,
+          "line": 127,
           "called": [
             "cleanupTcbReferences",
             "detachCNodeSlots"
@@ -6750,7 +6750,7 @@
         {
           "kind": "theorem",
           "name": "lifecyclePreRetypeCleanup_objects_eq",
-          "line": 132,
+          "line": 140,
           "called": [
             "cleanupTcbReferences_objects_eq",
             "detachCNodeSlots_objects_eq",
@@ -6760,7 +6760,7 @@
         {
           "kind": "theorem",
           "name": "lifecyclePreRetypeCleanup_lifecycle_eq",
-          "line": 145,
+          "line": 153,
           "called": [
             "cleanupTcbReferences_lifecycle_eq",
             "detachCNodeSlots_lifecycle_eq",
@@ -6770,7 +6770,7 @@
         {
           "kind": "theorem",
           "name": "cleanupTcbReferences_flat_subset",
-          "line": 159,
+          "line": 167,
           "called": [
             "cleanupTcbReferences"
           ]
@@ -6778,7 +6778,7 @@
         {
           "kind": "theorem",
           "name": "detachCNodeSlots_scheduler_eq",
-          "line": 168,
+          "line": 176,
           "called": [
             "detachCNodeSlots"
           ]
@@ -6786,7 +6786,7 @@
         {
           "kind": "theorem",
           "name": "lifecyclePreRetypeCleanup_flat_subset",
-          "line": 189,
+          "line": 197,
           "called": [
             "cleanupTcbReferences_flat_subset",
             "detachCNodeSlots",
@@ -6797,7 +6797,7 @@
         {
           "kind": "def",
           "name": "lifecycleRetypeObject",
-          "line": 217,
+          "line": 225,
           "called": [
             "lifecycleRetypeAuthority"
           ]
@@ -6805,7 +6805,7 @@
         {
           "kind": "def",
           "name": "lifecycleRevokeDeleteRetype",
-          "line": 249,
+          "line": 257,
           "called": [
             "lifecycleRetypeObject"
           ]
@@ -6813,13 +6813,13 @@
         {
           "kind": "def",
           "name": "objectTypeAllocSize",
-          "line": 277,
+          "line": 285,
           "called": []
         },
         {
           "kind": "def",
           "name": "retypeFromUntyped",
-          "line": 299,
+          "line": 307,
           "called": [
             "lifecycleRetypeAuthority",
             "objectTypeAllocSize"
@@ -6828,13 +6828,13 @@
         {
           "kind": "def",
           "name": "lookupUntyped",
-          "line": 344,
+          "line": 352,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_ok_decompose",
-          "line": 350,
+          "line": 358,
           "called": [
             "lifecycleRetypeAuthority",
             "objectTypeAllocSize",
@@ -6844,7 +6844,7 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_error_typeMismatch",
-          "line": 450,
+          "line": 458,
           "called": [
             "retypeFromUntyped"
           ]
@@ -6852,7 +6852,7 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_error_allocSizeTooSmall",
-          "line": 468,
+          "line": 476,
           "called": [
             "objectTypeAllocSize",
             "retypeFromUntyped"
@@ -6861,7 +6861,7 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_error_regionExhausted",
-          "line": 491,
+          "line": 499,
           "called": [
             "lifecycleRetypeAuthority",
             "objectTypeAllocSize",
@@ -6871,31 +6871,31 @@
         {
           "kind": "theorem",
           "name": "lifecycle_storeObject_objects_eq",
-          "line": 520,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "lifecycle_storeObject_objects_ne",
           "line": 528,
           "called": []
         },
         {
           "kind": "theorem",
-          "name": "lifecycle_storeObject_scheduler_eq",
-          "line": 537,
+          "name": "lifecycle_storeObject_objects_ne",
+          "line": 536,
           "called": []
         },
         {
           "kind": "theorem",
-          "name": "cspaceLookupSlot_ok_state_eq",
+          "name": "lifecycle_storeObject_scheduler_eq",
           "line": 545,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "cspaceLookupSlot_ok_state_eq",
+          "line": 553,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "lifecycleRetypeObject_ok_as_storeObject",
-          "line": 564,
+          "line": 572,
           "called": [
             "cspaceLookupSlot_ok_state_eq",
             "lifecycleRetypeAuthority",
@@ -6905,7 +6905,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_ok_lookup_preserved_ne",
-          "line": 595,
+          "line": 603,
           "called": [
             "lifecycleRetypeObject",
             "lifecycleRetypeObject_ok_as_storeObject",
@@ -6915,7 +6915,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_ok_runnable_membership",
-          "line": 607,
+          "line": 615,
           "called": [
             "lifecycleRetypeObject",
             "lifecycleRetypeObject_ok_as_storeObject",
@@ -6925,7 +6925,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_ok_not_runnable_membership",
-          "line": 622,
+          "line": 630,
           "called": [
             "lifecycleRetypeObject",
             "lifecycleRetypeObject_ok_as_storeObject",
@@ -6935,7 +6935,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_error_illegalState",
-          "line": 637,
+          "line": 645,
           "called": [
             "lifecycleRetypeObject"
           ]
@@ -6943,7 +6943,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_error_illegalAuthority",
-          "line": 648,
+          "line": 656,
           "called": [
             "lifecycleRetypeAuthority",
             "lifecycleRetypeObject"
@@ -6952,7 +6952,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_success_updates_object",
-          "line": 663,
+          "line": 671,
           "called": [
             "lifecycleRetypeAuthority",
             "lifecycleRetypeObject",
@@ -6963,7 +6963,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_error_authority_cleanup_alias",
-          "line": 692,
+          "line": 700,
           "called": [
             "lifecycleRevokeDeleteRetype"
           ]
@@ -6971,7 +6971,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_ok_implies_authority_ne_cleanup",
-          "line": 702,
+          "line": 710,
           "called": [
             "lifecycleRevokeDeleteRetype",
             "lifecycleRevokeDeleteRetype_error_authority_cleanup_alias"
@@ -6980,7 +6980,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_ok_implies_staged_steps",
-          "line": 715,
+          "line": 723,
           "called": [
             "lifecycleRetypeObject",
             "lifecycleRevokeDeleteRetype"
@@ -6989,7 +6989,7 @@
         {
           "kind": "def",
           "name": "lifecycleRetypeWithCleanup",
-          "line": 776,
+          "line": 784,
           "called": [
             "lifecyclePreRetypeCleanup",
             "lifecycleRetypeObject"
@@ -6998,7 +6998,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeWithCleanup_ok_runnable_no_dangling",
-          "line": 789,
+          "line": 797,
           "called": [
             "cleanupTcbReferences_removes_from_runnable",
             "lifecyclePreRetypeCleanup",
@@ -7017,19 +7017,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 21,
+          "line": 29,
           "called": []
         },
         {
           "kind": "def",
           "name": "queueCurrentConsistent",
-          "line": 33,
+          "line": 41,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "schedulerWellFormed",
-          "line": 41,
+          "line": 49,
           "called": [
             "queueCurrentConsistent"
           ]
@@ -7037,25 +7037,25 @@
         {
           "kind": "def",
           "name": "runQueueUnique",
-          "line": 45,
+          "line": 53,
           "called": []
         },
         {
           "kind": "def",
           "name": "currentThreadValid",
-          "line": 50,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "currentThreadInActiveDomain",
           "line": 58,
           "called": []
         },
         {
           "kind": "def",
+          "name": "currentThreadInActiveDomain",
+          "line": 66,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "kernelInvariant",
-          "line": 70,
+          "line": 78,
           "called": [
             "currentThreadInActiveDomain",
             "currentThreadValid",
@@ -7066,7 +7066,7 @@
         {
           "kind": "def",
           "name": "schedulerInvariantBundle",
-          "line": 81,
+          "line": 89,
           "called": [
             "currentThreadValid",
             "queueCurrentConsistent",
@@ -7076,7 +7076,7 @@
         {
           "kind": "abbrev",
           "name": "canonicalSchedulerInvariantBundle",
-          "line": 88,
+          "line": 96,
           "called": [
             "kernelInvariant"
           ]
@@ -7084,7 +7084,7 @@
         {
           "kind": "theorem",
           "name": "schedulerWellFormed_iff_queueCurrentConsistent",
-          "line": 91,
+          "line": 99,
           "called": [
             "queueCurrentConsistent",
             "schedulerWellFormed"
@@ -7093,7 +7093,7 @@
         {
           "kind": "theorem",
           "name": "queueCurrentConsistent_when_no_current",
-          "line": 95,
+          "line": 103,
           "called": [
             "queueCurrentConsistent"
           ]
@@ -7101,31 +7101,31 @@
         {
           "kind": "def",
           "name": "timeSlicePositive",
-          "line": 108,
+          "line": 116,
           "called": []
         },
         {
           "kind": "def",
           "name": "currentTimeSlicePositive",
-          "line": 120,
+          "line": 128,
           "called": []
         },
         {
           "kind": "def",
           "name": "edfCurrentHasEarliestDeadline",
-          "line": 141,
+          "line": 149,
           "called": []
         },
         {
           "kind": "def",
           "name": "contextMatchesCurrent",
-          "line": 168,
+          "line": 176,
           "called": []
         },
         {
           "kind": "def",
           "name": "schedulerInvariantBundleFull",
-          "line": 193,
+          "line": 201,
           "called": [
             "contextMatchesCurrent",
             "currentTimeSlicePositive",
@@ -7137,7 +7137,7 @@
         {
           "kind": "theorem",
           "name": "schedulerInvariantBundleFull_to_base",
-          "line": 199,
+          "line": 207,
           "called": [
             "schedulerInvariantBundle",
             "schedulerInvariantBundleFull"
@@ -7146,7 +7146,7 @@
         {
           "kind": "theorem",
           "name": "schedulerInvariantBundleFull_to_contextMatchesCurrent",
-          "line": 204,
+          "line": 212,
           "called": [
             "contextMatchesCurrent",
             "schedulerInvariantBundleFull"
@@ -7155,7 +7155,7 @@
         {
           "kind": "def",
           "name": "schedulerPriorityMatch",
-          "line": 220,
+          "line": 228,
           "called": []
         }
       ]
@@ -7168,49 +7168,49 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_scheduler",
-          "line": 9,
+          "line": 17,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "restoreIncomingContext_scheduler",
-          "line": 21,
+          "line": 29,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "restoreIncomingContext_objects",
-          "line": 30,
+          "line": 38,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_preserves_tcb",
-          "line": 42,
+          "line": 50,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_tcb_fields",
-          "line": 68,
+          "line": 76,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_preserves_non_tcb_lookup",
-          "line": 105,
+          "line": 113,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "saveOutgoingContext_preserves_timeSlicePositive",
-          "line": 135,
+          "line": 143,
           "called": [
             "saveOutgoingContext_scheduler"
           ]
@@ -7218,7 +7218,7 @@
         {
           "kind": "theorem",
           "name": "restoreIncomingContext_preserves_timeSlicePositive",
-          "line": 168,
+          "line": 176,
           "called": [
             "restoreIncomingContext_objects",
             "restoreIncomingContext_scheduler"
@@ -7227,25 +7227,25 @@
         {
           "kind": "theorem",
           "name": "restoreIncomingContext_establishes_context",
-          "line": 179,
+          "line": 187,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "restoreIncomingContext_machine_no_tcb",
-          "line": 187,
+          "line": 195,
           "called": []
         },
         {
           "kind": "def",
           "name": "schedule",
-          "line": 227,
+          "line": 235,
           "called": []
         },
         {
           "kind": "def",
           "name": "handleYield",
-          "line": 263,
+          "line": 271,
           "called": [
             "schedule"
           ]
@@ -7253,13 +7253,13 @@
         {
           "kind": "def",
           "name": "defaultTimeSlice",
-          "line": 283,
+          "line": 291,
           "called": []
         },
         {
           "kind": "def",
           "name": "timerTick",
-          "line": 301,
+          "line": 309,
           "called": [
             "defaultTimeSlice",
             "schedule"
@@ -7268,13 +7268,13 @@
         {
           "kind": "def",
           "name": "chooseThreadInDomain",
-          "line": 332,
+          "line": 340,
           "called": []
         },
         {
           "kind": "def",
           "name": "switchDomain",
-          "line": 344,
+          "line": 352,
           "called": [
             "schedule"
           ]
@@ -7282,7 +7282,7 @@
         {
           "kind": "def",
           "name": "scheduleDomain",
-          "line": 372,
+          "line": 380,
           "called": [
             "schedule",
             "switchDomain"
@@ -7298,49 +7298,49 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "setCurrentThread_preserves_queueCurrentConsistent",
-          "line": 15,
+          "line": 23,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "setCurrentThread_preserves_runQueueUnique",
-          "line": 25,
+          "line": 33,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "setCurrentThread_none_preserves_currentThreadValid",
-          "line": 35,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "setCurrentThread_some_preserves_currentThreadValid",
           "line": 43,
           "called": []
         },
         {
           "kind": "theorem",
+          "name": "setCurrentThread_some_preserves_currentThreadValid",
+          "line": 51,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "chooseThread_preserves_state",
-          "line": 53,
+          "line": 61,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "schedule_preserves_queueCurrentConsistent",
-          "line": 74,
+          "line": 82,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "schedule_preserves_wellFormed",
-          "line": 114,
+          "line": 122,
           "called": [
             "schedule_preserves_queueCurrentConsistent"
           ]
@@ -7348,7 +7348,7 @@
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_queueCurrentConsistent",
-          "line": 120,
+          "line": 128,
           "called": [
             "chooseThread_preserves_state"
           ]
@@ -7356,7 +7356,7 @@
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_runQueueUnique",
-          "line": 129,
+          "line": 137,
           "called": [
             "chooseThread_preserves_state"
           ]
@@ -7364,7 +7364,7 @@
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_currentThreadValid",
-          "line": 138,
+          "line": 146,
           "called": [
             "chooseThread_preserves_state"
           ]
@@ -7372,7 +7372,7 @@
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_currentThreadInActiveDomain",
-          "line": 147,
+          "line": 155,
           "called": [
             "chooseThread_preserves_state"
           ]
@@ -7380,13 +7380,13 @@
         {
           "kind": "theorem",
           "name": "remove_preserves_nodup",
-          "line": 157,
+          "line": 165,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "schedule_preserves_runQueueUnique",
-          "line": 164,
+          "line": 172,
           "called": [
             "chooseThread_preserves_state",
             "remove_preserves_nodup",
@@ -7396,7 +7396,7 @@
         {
           "kind": "theorem",
           "name": "schedule_preserves_currentThreadValid",
-          "line": 211,
+          "line": 219,
           "called": [
             "setCurrentThread_none_preserves_currentThreadValid"
           ]
@@ -7404,13 +7404,13 @@
         {
           "kind": "theorem",
           "name": "schedule_preserves_currentThreadInActiveDomain",
-          "line": 249,
+          "line": 257,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "handleYield_preserves_queueCurrentConsistent",
-          "line": 324,
+          "line": 332,
           "called": [
             "schedule_preserves_queueCurrentConsistent"
           ]
@@ -7418,7 +7418,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_wellFormed",
-          "line": 344,
+          "line": 352,
           "called": [
             "handleYield_preserves_queueCurrentConsistent"
           ]
@@ -7426,13 +7426,13 @@
         {
           "kind": "theorem",
           "name": "insert_preserves_nodup",
-          "line": 351,
+          "line": 359,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "handleYield_preserves_runQueueUnique",
-          "line": 361,
+          "line": 369,
           "called": [
             "insert_preserves_nodup",
             "schedule_preserves_runQueueUnique"
@@ -7441,7 +7441,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_currentThreadValid",
-          "line": 393,
+          "line": 401,
           "called": [
             "schedule_preserves_currentThreadValid"
           ]
@@ -7449,7 +7449,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_currentThreadInActiveDomain",
-          "line": 413,
+          "line": 421,
           "called": [
             "schedule_preserves_currentThreadInActiveDomain"
           ]
@@ -7457,7 +7457,7 @@
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_kernelInvariant",
-          "line": 433,
+          "line": 441,
           "called": [
             "chooseThread_preserves_currentThreadInActiveDomain",
             "chooseThread_preserves_currentThreadValid",
@@ -7468,7 +7468,7 @@
         {
           "kind": "theorem",
           "name": "schedule_preserves_kernelInvariant",
-          "line": 446,
+          "line": 454,
           "called": [
             "schedule_preserves_currentThreadInActiveDomain",
             "schedule_preserves_currentThreadValid",
@@ -7479,7 +7479,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_kernelInvariant",
-          "line": 456,
+          "line": 464,
           "called": [
             "handleYield_preserves_currentThreadInActiveDomain",
             "handleYield_preserves_currentThreadValid",
@@ -7490,7 +7490,7 @@
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_schedulerInvariantBundle",
-          "line": 466,
+          "line": 474,
           "called": [
             "chooseThread_preserves_currentThreadValid",
             "chooseThread_preserves_queueCurrentConsistent",
@@ -7500,7 +7500,7 @@
         {
           "kind": "theorem",
           "name": "schedule_preserves_schedulerInvariantBundle",
-          "line": 478,
+          "line": 486,
           "called": [
             "schedule_preserves_currentThreadValid",
             "schedule_preserves_queueCurrentConsistent",
@@ -7510,7 +7510,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_schedulerInvariantBundle",
-          "line": 489,
+          "line": 497,
           "called": [
             "handleYield_preserves_currentThreadValid",
             "handleYield_preserves_queueCurrentConsistent",
@@ -7520,7 +7520,7 @@
         {
           "kind": "theorem",
           "name": "switchDomain_preserves_schedulerInvariantBundle",
-          "line": 507,
+          "line": 515,
           "called": [
             "insert_preserves_nodup"
           ]
@@ -7528,7 +7528,7 @@
         {
           "kind": "theorem",
           "name": "scheduleDomain_preserves_currentThreadInActiveDomain",
-          "line": 549,
+          "line": 557,
           "called": [
             "schedule_preserves_currentThreadInActiveDomain"
           ]
@@ -7536,7 +7536,7 @@
         {
           "kind": "theorem",
           "name": "scheduleDomain_preserves_schedulerInvariantBundle",
-          "line": 569,
+          "line": 577,
           "called": [
             "schedule_preserves_schedulerInvariantBundle",
             "switchDomain_preserves_schedulerInvariantBundle"
@@ -7545,7 +7545,7 @@
         {
           "kind": "theorem",
           "name": "chooseThreadInDomain_preserves_state",
-          "line": 591,
+          "line": 599,
           "called": [
             "chooseThread_preserves_state"
           ]
@@ -7553,7 +7553,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_schedulerInvariantBundle",
-          "line": 608,
+          "line": 616,
           "called": [
             "insert_preserves_nodup",
             "schedule_preserves_currentThreadValid",
@@ -7564,7 +7564,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_kernelInvariant",
-          "line": 648,
+          "line": 656,
           "called": [
             "schedule_preserves_currentThreadInActiveDomain",
             "timerTick_preserves_schedulerInvariantBundle"
@@ -7573,13 +7573,13 @@
         {
           "kind": "theorem",
           "name": "isBetterCandidate_not_better_trans",
-          "line": 687,
+          "line": 695,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "chooseBestRunnableBy_optimal_combined",
-          "line": 708,
+          "line": 716,
           "called": [
             "isBetterCandidate_not_better_trans"
           ]
@@ -7587,7 +7587,7 @@
         {
           "kind": "theorem",
           "name": "chooseBestRunnableBy_optimal",
-          "line": 806,
+          "line": 814,
           "called": [
             "chooseBestRunnableBy_optimal_combined"
           ]
@@ -7595,19 +7595,19 @@
         {
           "kind": "theorem",
           "name": "noBetter_implies_edf",
-          "line": 822,
+          "line": 830,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "setCurrentThread_preserves_timeSlicePositive",
-          "line": 838,
+          "line": 846,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "chooseThread_preserves_timeSlicePositive",
-          "line": 847,
+          "line": 855,
           "called": [
             "chooseThread_preserves_state"
           ]
@@ -7615,13 +7615,13 @@
         {
           "kind": "theorem",
           "name": "remove_preserves_timeSlicePositive",
-          "line": 857,
+          "line": 865,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "schedule_preserves_timeSlicePositive",
-          "line": 873,
+          "line": 881,
           "called": [
             "chooseThread_preserves_state",
             "remove_preserves_timeSlicePositive",
@@ -7631,7 +7631,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_timeSlicePositive",
-          "line": 922,
+          "line": 930,
           "called": [
             "schedule_preserves_timeSlicePositive"
           ]
@@ -7639,19 +7639,19 @@
         {
           "kind": "theorem",
           "name": "switchDomain_preserves_timeSlicePositive",
-          "line": 967,
+          "line": 975,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "threadId_ne_objId_beq_false",
-          "line": 1012,
+          "line": 1020,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "timerTick_preserves_timeSlicePositive",
-          "line": 1025,
+          "line": 1033,
           "called": [
             "schedule_preserves_timeSlicePositive",
             "threadId_ne_objId_beq_false"
@@ -7660,19 +7660,19 @@
         {
           "kind": "theorem",
           "name": "setCurrentThread_none_preserves_currentTimeSlicePositive",
-          "line": 1088,
+          "line": 1096,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "setCurrentThread_some_preserves_currentTimeSlicePositive",
-          "line": 1097,
+          "line": 1105,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "schedule_preserves_currentTimeSlicePositive",
-          "line": 1111,
+          "line": 1119,
           "called": [
             "chooseThread_preserves_state",
             "setCurrentThread_none_preserves_currentTimeSlicePositive"
@@ -7681,7 +7681,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_currentTimeSlicePositive",
-          "line": 1191,
+          "line": 1199,
           "called": [
             "schedule_preserves_currentTimeSlicePositive"
           ]
@@ -7689,13 +7689,13 @@
         {
           "kind": "theorem",
           "name": "switchDomain_preserves_currentTimeSlicePositive",
-          "line": 1234,
+          "line": 1242,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "timerTick_preserves_currentTimeSlicePositive",
-          "line": 1249,
+          "line": 1257,
           "called": [
             "schedule_preserves_currentTimeSlicePositive",
             "threadId_ne_objId_beq_false"
@@ -7704,25 +7704,25 @@
         {
           "kind": "theorem",
           "name": "setCurrentThread_none_preserves_edfCurrentHasEarliestDeadline",
-          "line": 1306,
+          "line": 1314,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "switchDomain_preserves_edfCurrentHasEarliestDeadline",
-          "line": 1316,
+          "line": 1324,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "switchDomain_preserves_contextMatchesCurrent",
-          "line": 1339,
+          "line": 1347,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "switchDomain_preserves_schedulerInvariantBundleFull",
-          "line": 1364,
+          "line": 1372,
           "called": [
             "switchDomain_preserves_contextMatchesCurrent",
             "switchDomain_preserves_currentTimeSlicePositive",
@@ -7734,25 +7734,25 @@
         {
           "kind": "theorem",
           "name": "setCurrentThread_some_preserves_edfCurrentHasEarliestDeadline",
-          "line": 1378,
+          "line": 1386,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "chooseBestRunnableBy_result_fields",
-          "line": 1401,
+          "line": 1409,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "chooseBestRunnableBy_result_mem_aux",
-          "line": 1457,
+          "line": 1465,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "chooseBestRunnableBy_result_mem",
-          "line": 1514,
+          "line": 1522,
           "called": [
             "chooseBestRunnableBy_result_mem_aux"
           ]
@@ -7760,7 +7760,7 @@
         {
           "kind": "theorem",
           "name": "chooseBestInBucket_edf_bridge",
-          "line": 1539,
+          "line": 1547,
           "called": [
             "chooseBestRunnableBy_optimal",
             "chooseBestRunnableBy_result_fields",
@@ -7771,7 +7771,7 @@
         {
           "kind": "theorem",
           "name": "schedule_preserves_edfCurrentHasEarliestDeadline",
-          "line": 1686,
+          "line": 1694,
           "called": [
             "chooseBestInBucket_edf_bridge",
             "setCurrentThread_none_preserves_edfCurrentHasEarliestDeadline"
@@ -7780,7 +7780,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_edfCurrentHasEarliestDeadline",
-          "line": 1776,
+          "line": 1784,
           "called": [
             "schedule_preserves_edfCurrentHasEarliestDeadline"
           ]
@@ -7788,7 +7788,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_edfCurrentHasEarliestDeadline",
-          "line": 1854,
+          "line": 1862,
           "called": [
             "schedule_preserves_edfCurrentHasEarliestDeadline",
             "threadId_ne_objId_beq_false"
@@ -7797,7 +7797,7 @@
         {
           "kind": "theorem",
           "name": "schedule_preserves_contextMatchesCurrent",
-          "line": 1960,
+          "line": 1968,
           "called": [
             "chooseThread_preserves_state"
           ]
@@ -7805,7 +7805,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_contextMatchesCurrent",
-          "line": 2008,
+          "line": 2016,
           "called": [
             "schedule_preserves_contextMatchesCurrent"
           ]
@@ -7813,7 +7813,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_contextMatchesCurrent",
-          "line": 2037,
+          "line": 2045,
           "called": [
             "schedule_preserves_contextMatchesCurrent"
           ]
@@ -7821,13 +7821,13 @@
         {
           "kind": "theorem",
           "name": "contextMatchesCurrent_frame",
-          "line": 2079,
+          "line": 2087,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "schedule_preserves_schedulerInvariantBundleFull",
-          "line": 2114,
+          "line": 2122,
           "called": [
             "schedule_preserves_contextMatchesCurrent",
             "schedule_preserves_currentTimeSlicePositive",
@@ -7839,7 +7839,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_schedulerInvariantBundleFull",
-          "line": 2131,
+          "line": 2139,
           "called": [
             "handleYield_preserves_contextMatchesCurrent",
             "handleYield_preserves_currentTimeSlicePositive",
@@ -7851,7 +7851,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_schedulerInvariantBundleFull",
-          "line": 2148,
+          "line": 2156,
           "called": [
             "timerTick_preserves_contextMatchesCurrent",
             "timerTick_preserves_currentTimeSlicePositive",
@@ -7870,19 +7870,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "def",
           "name": "isBetterCandidate",
-          "line": 24,
+          "line": 32,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "isBetterCandidate_irrefl",
-          "line": 36,
+          "line": 44,
           "called": [
             "isBetterCandidate"
           ]
@@ -7890,7 +7890,7 @@
         {
           "kind": "theorem",
           "name": "isBetterCandidate_asymm",
-          "line": 45,
+          "line": 53,
           "called": [
             "isBetterCandidate"
           ]
@@ -7898,7 +7898,7 @@
         {
           "kind": "theorem",
           "name": "isBetterCandidate_transitive",
-          "line": 78,
+          "line": 86,
           "called": [
             "isBetterCandidate"
           ]
@@ -7906,7 +7906,7 @@
         {
           "kind": "def",
           "name": "chooseBestRunnableBy",
-          "line": 123,
+          "line": 131,
           "called": [
             "isBetterCandidate"
           ]
@@ -7914,7 +7914,7 @@
         {
           "kind": "def",
           "name": "chooseBestRunnableInDomain",
-          "line": 148,
+          "line": 156,
           "called": [
             "chooseBestRunnableBy"
           ]
@@ -7922,7 +7922,7 @@
         {
           "kind": "def",
           "name": "chooseBestInBucket",
-          "line": 163,
+          "line": 171,
           "called": [
             "chooseBestRunnableInDomain"
           ]
@@ -7930,7 +7930,7 @@
         {
           "kind": "theorem",
           "name": "bucketFirst_fullScan_equivalence",
-          "line": 179,
+          "line": 187,
           "called": [
             "chooseBestInBucket",
             "chooseBestRunnableInDomain"
@@ -7939,7 +7939,7 @@
         {
           "kind": "def",
           "name": "chooseThread",
-          "line": 199,
+          "line": 207,
           "called": [
             "chooseBestInBucket"
           ]
@@ -7947,13 +7947,13 @@
         {
           "kind": "def",
           "name": "saveOutgoingContext",
-          "line": 209,
+          "line": 217,
           "called": []
         },
         {
           "kind": "def",
           "name": "restoreIncomingContext",
-          "line": 222,
+          "line": 230,
           "called": []
         }
       ]
@@ -7972,33 +7972,33 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 2,
+          "line": 10,
           "called": []
         },
         {
           "kind": "structure",
           "name": "RunQueue",
-          "line": 4,
+          "line": 12,
           "called": []
         },
         {
           "kind": "namespace",
           "name": "RunQueue",
-          "line": 25,
+          "line": 33,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 26,
+          "line": 34,
           "called": [
             "RunQueue"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:33>",
-          "line": 33,
+          "name": "<anonymous:instance:41>",
+          "line": 41,
           "called": [
             "RunQueue",
             "empty"
@@ -8006,8 +8006,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:34>",
-          "line": 34,
+          "name": "<anonymous:instance:42>",
+          "line": 42,
           "called": [
             "RunQueue",
             "empty"
@@ -8015,8 +8015,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:35>",
-          "line": 35,
+          "name": "<anonymous:instance:43>",
+          "line": 43,
           "called": [
             "RunQueue"
           ]
@@ -8024,23 +8024,23 @@
         {
           "kind": "def",
           "name": "contains",
-          "line": 36,
+          "line": 44,
           "called": [
             "RunQueue"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:38>",
-          "line": 38,
+          "name": "<anonymous:instance:46>",
+          "line": 46,
           "called": [
             "RunQueue"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:40>",
-          "line": 40,
+          "name": "<anonymous:instance:48>",
+          "line": 48,
           "called": [
             "RunQueue"
           ]
@@ -8048,13 +8048,13 @@
         {
           "kind": "def",
           "name": "recomputeMaxPriority",
-          "line": 43,
+          "line": 51,
           "called": []
         },
         {
           "kind": "def",
           "name": "insert",
-          "line": 51,
+          "line": 59,
           "called": [
             "RunQueue"
           ]
@@ -8062,7 +8062,7 @@
         {
           "kind": "def",
           "name": "remove",
-          "line": 79,
+          "line": 87,
           "called": [
             "RunQueue",
             "recomputeMaxPriority"
@@ -8071,7 +8071,7 @@
         {
           "kind": "def",
           "name": "rotateHead",
-          "line": 113,
+          "line": 121,
           "called": [
             "RunQueue"
           ]
@@ -8079,7 +8079,7 @@
         {
           "kind": "def",
           "name": "rotateToBack",
-          "line": 141,
+          "line": 149,
           "called": [
             "RunQueue"
           ]
@@ -8087,7 +8087,7 @@
         {
           "kind": "def",
           "name": "toList",
-          "line": 164,
+          "line": 172,
           "called": [
             "RunQueue"
           ]
@@ -8095,7 +8095,7 @@
         {
           "kind": "def",
           "name": "filterToList",
-          "line": 165,
+          "line": 173,
           "called": [
             "RunQueue"
           ]
@@ -8103,7 +8103,7 @@
         {
           "kind": "def",
           "name": "atPriority",
-          "line": 166,
+          "line": 174,
           "called": [
             "RunQueue"
           ]
@@ -8111,7 +8111,7 @@
         {
           "kind": "def",
           "name": "maxPriorityBucket",
-          "line": 170,
+          "line": 178,
           "called": [
             "RunQueue"
           ]
@@ -8119,7 +8119,7 @@
         {
           "kind": "def",
           "name": "maxPriorityValue",
-          "line": 176,
+          "line": 184,
           "called": [
             "RunQueue"
           ]
@@ -8127,7 +8127,7 @@
         {
           "kind": "def",
           "name": "ofList",
-          "line": 178,
+          "line": 186,
           "called": [
             "RunQueue",
             "empty"
@@ -8136,7 +8136,7 @@
         {
           "kind": "theorem",
           "name": "mem_iff_contains",
-          "line": 183,
+          "line": 191,
           "called": [
             "RunQueue"
           ]
@@ -8144,7 +8144,7 @@
         {
           "kind": "theorem",
           "name": "contains_false_of_not_mem",
-          "line": 186,
+          "line": 194,
           "called": [
             "RunQueue"
           ]
@@ -8152,7 +8152,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_empty",
-          "line": 190,
+          "line": 198,
           "called": [
             "RunQueue",
             "contains",
@@ -8162,7 +8162,7 @@
         {
           "kind": "theorem",
           "name": "mem_insert",
-          "line": 193,
+          "line": 201,
           "called": [
             "RunQueue",
             "contains",
@@ -8172,7 +8172,7 @@
         {
           "kind": "theorem",
           "name": "mem_remove",
-          "line": 205,
+          "line": 213,
           "called": [
             "RunQueue",
             "contains",
@@ -8182,7 +8182,7 @@
         {
           "kind": "theorem",
           "name": "mem_rotateHead",
-          "line": 219,
+          "line": 227,
           "called": [
             "RunQueue",
             "contains",
@@ -8192,7 +8192,7 @@
         {
           "kind": "theorem",
           "name": "mem_rotateToBack",
-          "line": 231,
+          "line": 239,
           "called": [
             "RunQueue",
             "contains",
@@ -8202,7 +8202,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_remove_self",
-          "line": 239,
+          "line": 247,
           "called": [
             "RunQueue",
             "mem_remove"
@@ -8211,7 +8211,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_toList_of_not_mem",
-          "line": 245,
+          "line": 253,
           "called": [
             "RunQueue",
             "mem_iff_contains",
@@ -8221,7 +8221,7 @@
         {
           "kind": "theorem",
           "name": "membership_implies_flat",
-          "line": 253,
+          "line": 261,
           "called": [
             "RunQueue",
             "mem_iff_contains"
@@ -8230,7 +8230,7 @@
         {
           "kind": "theorem",
           "name": "mem_toList_iff_mem",
-          "line": 259,
+          "line": 267,
           "called": [
             "RunQueue",
             "mem_iff_contains",
@@ -8240,7 +8240,7 @@
         {
           "kind": "theorem",
           "name": "toList_empty",
-          "line": 267,
+          "line": 275,
           "called": [
             "RunQueue",
             "empty",
@@ -8250,7 +8250,7 @@
         {
           "kind": "theorem",
           "name": "toList_insert_not_mem",
-          "line": 269,
+          "line": 277,
           "called": [
             "RunQueue",
             "contains",
@@ -8262,13 +8262,13 @@
         {
           "kind": "theorem",
           "name": "filter_filter_ne_of_false",
-          "line": 280,
+          "line": 288,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "toList_filter_insert_neg",
-          "line": 293,
+          "line": 301,
           "called": [
             "RunQueue",
             "toList_insert_not_mem"
@@ -8277,7 +8277,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_insert_neg'",
-          "line": 302,
+          "line": 310,
           "called": [
             "RunQueue",
             "insert",
@@ -8288,7 +8288,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_insert_congr",
-          "line": 315,
+          "line": 323,
           "called": [
             "RunQueue",
             "contains",
@@ -8302,7 +8302,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_remove_neg",
-          "line": 345,
+          "line": 353,
           "called": [
             "RunQueue",
             "filter_filter_ne_of_false",
@@ -8313,7 +8313,7 @@
         {
           "kind": "theorem",
           "name": "toList_nodup_of_flat_nodup",
-          "line": 353,
+          "line": 361,
           "called": [
             "RunQueue"
           ]
@@ -8321,7 +8321,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_remove_toList",
-          "line": 357,
+          "line": 365,
           "called": [
             "RunQueue",
             "remove",
@@ -8331,17 +8331,6 @@
         {
           "kind": "theorem",
           "name": "mem_toList_rotateToBack_self",
-          "line": 366,
-          "called": [
-            "RunQueue",
-            "mem_iff_contains",
-            "rotateToBack",
-            "toList"
-          ]
-        },
-        {
-          "kind": "theorem",
-          "name": "toList_rotateToBack_nodup",
           "line": 374,
           "called": [
             "RunQueue",
@@ -8352,8 +8341,19 @@
         },
         {
           "kind": "theorem",
+          "name": "toList_rotateToBack_nodup",
+          "line": 382,
+          "called": [
+            "RunQueue",
+            "mem_iff_contains",
+            "rotateToBack",
+            "toList"
+          ]
+        },
+        {
+          "kind": "theorem",
           "name": "mem_toList_rotateToBack_ne",
-          "line": 392,
+          "line": 400,
           "called": [
             "RunQueue",
             "rotateToBack",
@@ -8363,13 +8363,13 @@
         {
           "kind": "theorem",
           "name": "filter_erase_of_false",
-          "line": 408,
+          "line": 416,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "toList_filter_rotateToBack_neg",
-          "line": 423,
+          "line": 431,
           "called": [
             "RunQueue",
             "filter_erase_of_false",
@@ -8380,7 +8380,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 449,
+          "line": 457,
           "called": [
             "RunQueue"
           ]
@@ -8388,7 +8388,7 @@
         {
           "kind": "theorem",
           "name": "maxPriorityBucket_subset",
-          "line": 458,
+          "line": 466,
           "called": [
             "RunQueue",
             "atPriority",
@@ -8399,7 +8399,7 @@
         {
           "kind": "theorem",
           "name": "maxPriorityBucket_threadPriority",
-          "line": 470,
+          "line": 478,
           "called": [
             "RunQueue",
             "atPriority",
@@ -8409,7 +8409,7 @@
         {
           "kind": "theorem",
           "name": "mem_maxPriorityBucket_of_threadPriority",
-          "line": 482,
+          "line": 490,
           "called": [
             "RunQueue",
             "atPriority"
@@ -8418,7 +8418,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_membership",
-          "line": 500,
+          "line": 508,
           "called": [
             "RunQueue",
             "rotateToBack"
@@ -8427,7 +8427,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_threadPriority",
-          "line": 506,
+          "line": 514,
           "called": [
             "RunQueue",
             "rotateToBack"
@@ -8436,7 +8436,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_maxPriority",
-          "line": 512,
+          "line": 520,
           "called": [
             "RunQueue",
             "rotateToBack"
@@ -8445,7 +8445,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_contains",
-          "line": 518,
+          "line": 526,
           "called": [
             "RunQueue",
             "contains",
@@ -8455,7 +8455,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_mem_iff",
-          "line": 523,
+          "line": 531,
           "called": [
             "RunQueue",
             "mem_iff_contains",
@@ -8465,7 +8465,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_flat_subset",
-          "line": 528,
+          "line": 536,
           "called": [
             "RunQueue",
             "rotateToBack"
@@ -8474,7 +8474,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_flat_superset",
-          "line": 540,
+          "line": 548,
           "called": [
             "RunQueue",
             "rotateToBack"
@@ -8483,7 +8483,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_preserves_wellFormed",
-          "line": 552,
+          "line": 560,
           "called": [
             "RunQueue",
             "rotateToBack",
@@ -8493,7 +8493,7 @@
         {
           "kind": "theorem",
           "name": "insert_threadPriority",
-          "line": 603,
+          "line": 611,
           "called": [
             "RunQueue",
             "insert"
@@ -8502,7 +8502,7 @@
         {
           "kind": "theorem",
           "name": "insert_preserves_wellFormed",
-          "line": 613,
+          "line": 621,
           "called": [
             "RunQueue",
             "insert",
@@ -8519,19 +8519,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "def",
           "name": "serviceEdge",
-          "line": 13,
+          "line": 21,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "serviceReachable",
-          "line": 17,
+          "line": 25,
           "called": [
             "serviceEdge"
           ]
@@ -8539,7 +8539,7 @@
         {
           "kind": "inductive",
           "name": "serviceNontrivialPath",
-          "line": 23,
+          "line": 31,
           "called": [
             "serviceEdge"
           ]
@@ -8547,7 +8547,7 @@
         {
           "kind": "def",
           "name": "serviceDependencyAcyclic",
-          "line": 35,
+          "line": 43,
           "called": [
             "serviceNontrivialPath"
           ]
@@ -8555,7 +8555,7 @@
         {
           "kind": "theorem",
           "name": "serviceReachable_trans",
-          "line": 42,
+          "line": 50,
           "called": [
             "serviceReachable"
           ]
@@ -8563,7 +8563,7 @@
         {
           "kind": "theorem",
           "name": "serviceReachable_of_edge",
-          "line": 49,
+          "line": 57,
           "called": [
             "serviceEdge",
             "serviceReachable"
@@ -8572,7 +8572,7 @@
         {
           "kind": "theorem",
           "name": "serviceReachable_of_nontrivialPath",
-          "line": 53,
+          "line": 61,
           "called": [
             "serviceNontrivialPath",
             "serviceReachable",
@@ -8582,7 +8582,7 @@
         {
           "kind": "theorem",
           "name": "serviceNontrivialPath_of_edge_reachable",
-          "line": 61,
+          "line": 69,
           "called": [
             "serviceEdge",
             "serviceNontrivialPath",
@@ -8592,7 +8592,7 @@
         {
           "kind": "theorem",
           "name": "serviceNontrivialPath_of_reachable_ne",
-          "line": 70,
+          "line": 78,
           "called": [
             "serviceNontrivialPath",
             "serviceNontrivialPath_of_edge_reachable",
@@ -8602,7 +8602,7 @@
         {
           "kind": "theorem",
           "name": "serviceNontrivialPath_trans",
-          "line": 76,
+          "line": 84,
           "called": [
             "serviceNontrivialPath"
           ]
@@ -8610,7 +8610,7 @@
         {
           "kind": "theorem",
           "name": "serviceNontrivialPath_step_right",
-          "line": 83,
+          "line": 91,
           "called": [
             "serviceEdge",
             "serviceNontrivialPath"
@@ -8619,7 +8619,7 @@
         {
           "kind": "theorem",
           "name": "serviceEdge_storeServiceState_ne",
-          "line": 95,
+          "line": 103,
           "called": [
             "serviceEdge"
           ]
@@ -8627,7 +8627,7 @@
         {
           "kind": "theorem",
           "name": "serviceEdge_storeServiceState_updated",
-          "line": 107,
+          "line": 115,
           "called": [
             "serviceEdge"
           ]
@@ -8635,7 +8635,7 @@
         {
           "kind": "theorem",
           "name": "serviceEdge_post_insert",
-          "line": 119,
+          "line": 127,
           "called": [
             "serviceEdge",
             "serviceEdge_storeServiceState_ne",
@@ -8645,13 +8645,13 @@
         {
           "kind": "def",
           "name": "lookupDeps",
-          "line": 142,
+          "line": 150,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceEdge_iff_lookupDeps",
-          "line": 146,
+          "line": 154,
           "called": [
             "lookupDeps",
             "serviceEdge"
@@ -8660,7 +8660,7 @@
         {
           "kind": "def",
           "name": "bfsClosed",
-          "line": 159,
+          "line": 167,
           "called": [
             "serviceEdge"
           ]
@@ -8668,7 +8668,7 @@
         {
           "kind": "theorem",
           "name": "bfsClosed_init",
-          "line": 163,
+          "line": 171,
           "called": [
             "bfsClosed"
           ]
@@ -8676,7 +8676,7 @@
         {
           "kind": "theorem",
           "name": "bfsClosed_skip",
-          "line": 168,
+          "line": 176,
           "called": [
             "bfsClosed"
           ]
@@ -8684,7 +8684,7 @@
         {
           "kind": "theorem",
           "name": "bfsClosed_expand",
-          "line": 181,
+          "line": 189,
           "called": [
             "bfsClosed",
             "lookupDeps"
@@ -8693,7 +8693,7 @@
         {
           "kind": "theorem",
           "name": "bfs_boundary_lemma",
-          "line": 206,
+          "line": 214,
           "called": [
             "bfsClosed",
             "serviceReachable"
@@ -8702,7 +8702,7 @@
         {
           "kind": "def",
           "name": "bfsUniverse",
-          "line": 224,
+          "line": 232,
           "called": [
             "lookupDeps"
           ]
@@ -8710,7 +8710,7 @@
         {
           "kind": "theorem",
           "name": "reach_in_universe",
-          "line": 230,
+          "line": 238,
           "called": [
             "bfsUniverse",
             "serviceReachable"
@@ -8719,13 +8719,13 @@
         {
           "kind": "theorem",
           "name": "filter_mono",
-          "line": 238,
+          "line": 246,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "filter_strict",
-          "line": 253,
+          "line": 261,
           "called": [
             "filter_mono"
           ]
@@ -8733,7 +8733,7 @@
         {
           "kind": "theorem",
           "name": "filter_vis_decrease",
-          "line": 279,
+          "line": 287,
           "called": [
             "filter_strict"
           ]
@@ -8741,7 +8741,7 @@
         {
           "kind": "theorem",
           "name": "step_of_reachable_ne",
-          "line": 291,
+          "line": 299,
           "called": [
             "serviceEdge",
             "serviceReachable"
@@ -8750,19 +8750,19 @@
         {
           "kind": "theorem",
           "name": "go_tgt_eq",
-          "line": 301,
+          "line": 309,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "go_skip_eq",
-          "line": 306,
+          "line": 314,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "go_expand_eq",
-          "line": 313,
+          "line": 321,
           "called": [
             "lookupDeps"
           ]
@@ -8770,7 +8770,7 @@
         {
           "kind": "theorem",
           "name": "go_complete",
-          "line": 330,
+          "line": 338,
           "called": [
             "bfsClosed",
             "bfsClosed_expand",
@@ -8790,7 +8790,7 @@
         {
           "kind": "def",
           "name": "serviceCountBounded",
-          "line": 407,
+          "line": 415,
           "called": [
             "bfsUniverse"
           ]
@@ -8798,7 +8798,7 @@
         {
           "kind": "theorem",
           "name": "registered_of_nontrivialPath_src",
-          "line": 412,
+          "line": 420,
           "called": [
             "serviceNontrivialPath"
           ]
@@ -8806,7 +8806,7 @@
         {
           "kind": "theorem",
           "name": "bfs_complete_for_nontrivialPath",
-          "line": 433,
+          "line": 441,
           "called": [
             "bfsClosed_init",
             "go_complete",
@@ -8819,7 +8819,7 @@
         {
           "kind": "theorem",
           "name": "nontrivialPath_post_insert_cases",
-          "line": 465,
+          "line": 473,
           "called": [
             "serviceEdge_post_insert",
             "serviceNontrivialPath",
@@ -8830,7 +8830,7 @@
         {
           "kind": "theorem",
           "name": "serviceRegisterDependency_preserves_acyclicity",
-          "line": 516,
+          "line": 524,
           "called": [
             "bfs_complete_for_nontrivialPath",
             "nontrivialPath_post_insert_cases",
@@ -8845,25 +8845,25 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_error_discards_state",
-          "line": 573,
+          "line": 581,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceRestart_error_from_start_phase",
-          "line": 585,
+          "line": 593,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceHasPathTo_fuel_zero",
-          "line": 607,
+          "line": 615,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "bfs_false_implies_no_nontrivialPath",
-          "line": 614,
+          "line": 622,
           "called": [
             "bfs_complete_for_nontrivialPath",
             "serviceCountBounded",
@@ -8873,85 +8873,85 @@
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_objects",
-          "line": 630,
+          "line": 638,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_scheduler",
-          "line": 646,
+          "line": 654,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_irqHandlers",
-          "line": 662,
+          "line": 670,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_objectIndex",
-          "line": 678,
+          "line": 686,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_machine",
-          "line": 694,
+          "line": 702,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_lookupService_ne",
-          "line": 710,
+          "line": 718,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_objects",
-          "line": 733,
+          "line": 741,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_scheduler",
-          "line": 748,
+          "line": 756,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_irqHandlers",
-          "line": 763,
+          "line": 771,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_objectIndex",
-          "line": 778,
+          "line": 786,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_machine",
-          "line": 793,
+          "line": 801,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_lookupService_ne",
-          "line": 808,
+          "line": 816,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceRestart_decompose",
-          "line": 830,
+          "line": 838,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceEdge_of_storeServiceState_sameDeps",
-          "line": 851,
+          "line": 859,
           "called": [
             "serviceEdge",
             "serviceEdge_storeServiceState_ne",
@@ -8961,7 +8961,7 @@
         {
           "kind": "theorem",
           "name": "serviceNontrivialPath_of_storeServiceState_sameDeps",
-          "line": 866,
+          "line": 874,
           "called": [
             "serviceEdge_of_storeServiceState_sameDeps",
             "serviceNontrivialPath"
@@ -8970,7 +8970,7 @@
         {
           "kind": "theorem",
           "name": "serviceDependencyAcyclic_of_storeServiceState_sameDeps",
-          "line": 882,
+          "line": 890,
           "called": [
             "serviceDependencyAcyclic",
             "serviceNontrivialPath_of_storeServiceState_sameDeps"
@@ -8979,7 +8979,7 @@
         {
           "kind": "def",
           "name": "serviceGraphInvariant",
-          "line": 902,
+          "line": 910,
           "called": [
             "serviceCountBounded",
             "serviceDependencyAcyclic"
@@ -8988,7 +8988,7 @@
         {
           "kind": "theorem",
           "name": "bfsUniverse_of_storeServiceState_sameDeps",
-          "line": 907,
+          "line": 915,
           "called": [
             "bfsUniverse",
             "lookupDeps"
@@ -8997,7 +8997,7 @@
         {
           "kind": "theorem",
           "name": "serviceCountBounded_of_storeServiceState_sameDeps",
-          "line": 930,
+          "line": 938,
           "called": [
             "bfsUniverse_of_storeServiceState_sameDeps",
             "serviceCountBounded"
@@ -9006,7 +9006,7 @@
         {
           "kind": "theorem",
           "name": "serviceGraphInvariant_of_storeServiceState_sameDeps",
-          "line": 941,
+          "line": 949,
           "called": [
             "serviceCountBounded_of_storeServiceState_sameDeps",
             "serviceDependencyAcyclic_of_storeServiceState_sameDeps",
@@ -9016,7 +9016,7 @@
         {
           "kind": "theorem",
           "name": "serviceRegisterDependency_preserves_serviceGraphInvariant",
-          "line": 953,
+          "line": 961,
           "called": [
             "lookupDeps",
             "serviceGraphInvariant",
@@ -9026,7 +9026,7 @@
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_serviceGraphInvariant",
-          "line": 1013,
+          "line": 1021,
           "called": [
             "serviceGraphInvariant",
             "serviceGraphInvariant_of_storeServiceState_sameDeps"
@@ -9035,7 +9035,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_serviceGraphInvariant",
-          "line": 1034,
+          "line": 1042,
           "called": [
             "serviceGraphInvariant",
             "serviceGraphInvariant_of_storeServiceState_sameDeps"
@@ -9051,19 +9051,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 4,
+          "line": 12,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "ServicePolicyPredicate",
-          "line": 9,
+          "line": 17,
           "called": []
         },
         {
           "kind": "def",
           "name": "policyBackingObjectTyped",
-          "line": 12,
+          "line": 20,
           "called": [
             "ServicePolicyPredicate"
           ]
@@ -9071,7 +9071,7 @@
         {
           "kind": "def",
           "name": "policyOwnerAuthorityRefRecorded",
-          "line": 16,
+          "line": 24,
           "called": [
             "ServicePolicyPredicate"
           ]
@@ -9079,7 +9079,7 @@
         {
           "kind": "def",
           "name": "policyOwnerAuthoritySlotPresent",
-          "line": 23,
+          "line": 31,
           "called": [
             "ServicePolicyPredicate"
           ]
@@ -9087,7 +9087,7 @@
         {
           "kind": "def",
           "name": "servicePolicySurfaceInvariant",
-          "line": 30,
+          "line": 38,
           "called": [
             "policyBackingObjectTyped",
             "policyOwnerAuthorityRefRecorded",
@@ -9097,7 +9097,7 @@
         {
           "kind": "def",
           "name": "serviceLifecycleCapabilityInvariantBundle",
-          "line": 37,
+          "line": 45,
           "called": [
             "servicePolicySurfaceInvariant"
           ]
@@ -9105,7 +9105,7 @@
         {
           "kind": "theorem",
           "name": "serviceLifecycleCapabilityInvariantBundle_of_components",
-          "line": 40,
+          "line": 48,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "servicePolicySurfaceInvariant"
@@ -9114,7 +9114,7 @@
         {
           "kind": "theorem",
           "name": "policyBackingObjectTyped_of_lifecycleInvariant",
-          "line": 49,
+          "line": 57,
           "called": [
             "policyBackingObjectTyped"
           ]
@@ -9122,7 +9122,7 @@
         {
           "kind": "theorem",
           "name": "policyOwnerAuthoritySlotPresent_of_lifecycleInvariant",
-          "line": 63,
+          "line": 71,
           "called": [
             "policyOwnerAuthorityRefRecorded",
             "policyOwnerAuthoritySlotPresent"
@@ -9131,7 +9131,7 @@
         {
           "kind": "theorem",
           "name": "policyOwnerAuthoritySlotPresent_of_capabilityLookup",
-          "line": 77,
+          "line": 85,
           "called": [
             "policyOwnerAuthoritySlotPresent"
           ]
@@ -9139,7 +9139,7 @@
         {
           "kind": "theorem",
           "name": "servicePolicySurfaceInvariant_of_lifecycleInvariant",
-          "line": 95,
+          "line": 103,
           "called": [
             "policyBackingObjectTyped_of_lifecycleInvariant",
             "policyOwnerAuthoritySlotPresent_of_lifecycleInvariant",
@@ -9149,19 +9149,19 @@
         {
           "kind": "theorem",
           "name": "serviceStart_policyDenied_separates_check_from_mutation",
-          "line": 109,
+          "line": 117,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStop_policyDenied_separates_check_from_mutation",
-          "line": 122,
+          "line": 130,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeServiceState_preserves_servicePolicySurfaceInvariant",
-          "line": 134,
+          "line": 142,
           "called": [
             "policyBackingObjectTyped",
             "policyOwnerAuthorityRefRecorded",
@@ -9172,19 +9172,19 @@
         {
           "kind": "theorem",
           "name": "storeServiceState_preserves_lifecycleInvariantBundle",
-          "line": 163,
+          "line": 171,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeServiceState_preserves_capabilityInvariantBundle",
-          "line": 181,
+          "line": 189,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 197,
+          "line": 205,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "storeServiceState_preserves_capabilityInvariantBundle",
@@ -9195,7 +9195,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 227,
+          "line": 235,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "storeServiceState_preserves_capabilityInvariantBundle",
@@ -9206,7 +9206,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 255,
+          "line": 263,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "serviceStart_preserves_serviceLifecycleCapabilityInvariantBundle",
@@ -9216,7 +9216,7 @@
         {
           "kind": "theorem",
           "name": "serviceStart_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 271,
+          "line": 279,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle"
           ]
@@ -9224,7 +9224,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 281,
+          "line": 289,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle"
           ]
@@ -9232,7 +9232,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_stop_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 291,
+          "line": 299,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle"
           ]
@@ -9240,7 +9240,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_start_failure_preserves_serviceLifecycleCapabilityInvariantBundle",
-          "line": 303,
+          "line": 311,
           "called": [
             "serviceLifecycleCapabilityInvariantBundle",
             "serviceStop_preserves_serviceLifecycleCapabilityInvariantBundle"
@@ -9262,25 +9262,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "ServicePolicy",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "def",
           "name": "storeServiceEntry",
-          "line": 11,
+          "line": 19,
           "called": []
         },
         {
           "kind": "def",
           "name": "serviceStart",
-          "line": 27,
+          "line": 35,
           "called": [
             "ServicePolicy",
             "storeServiceEntry"
@@ -9289,7 +9289,7 @@
         {
           "kind": "def",
           "name": "serviceStop",
-          "line": 59,
+          "line": 67,
           "called": [
             "ServicePolicy",
             "storeServiceEntry"
@@ -9298,7 +9298,7 @@
         {
           "kind": "def",
           "name": "serviceRestart",
-          "line": 91,
+          "line": 99,
           "called": [
             "ServicePolicy",
             "serviceStart",
@@ -9308,19 +9308,19 @@
         {
           "kind": "def",
           "name": "serviceBfsFuel",
-          "line": 114,
+          "line": 122,
           "called": []
         },
         {
           "kind": "def",
           "name": "serviceHasPathTo",
-          "line": 139,
+          "line": 147,
           "called": []
         },
         {
           "kind": "def",
           "name": "serviceRegisterDependency",
-          "line": 174,
+          "line": 182,
           "called": [
             "serviceBfsFuel",
             "serviceHasPathTo",
@@ -9330,7 +9330,7 @@
         {
           "kind": "theorem",
           "name": "serviceRegisterDependency_error_self_loop",
-          "line": 195,
+          "line": 203,
           "called": [
             "serviceRegisterDependency"
           ]
@@ -9338,7 +9338,7 @@
         {
           "kind": "theorem",
           "name": "serviceStart_error_backingObjectMissing",
-          "line": 205,
+          "line": 213,
           "called": [
             "ServicePolicy",
             "serviceStart"
@@ -9347,7 +9347,7 @@
         {
           "kind": "theorem",
           "name": "serviceStart_error_policyDenied",
-          "line": 217,
+          "line": 225,
           "called": [
             "ServicePolicy",
             "serviceStart"
@@ -9356,7 +9356,7 @@
         {
           "kind": "theorem",
           "name": "serviceStart_error_dependencyViolation",
-          "line": 230,
+          "line": 238,
           "called": [
             "ServicePolicy",
             "serviceStart"
@@ -9365,7 +9365,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_error_backingObjectMissing",
-          "line": 244,
+          "line": 252,
           "called": [
             "ServicePolicy",
             "serviceStop"
@@ -9374,7 +9374,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_error_policyDenied",
-          "line": 256,
+          "line": 264,
           "called": [
             "ServicePolicy",
             "serviceStop"
@@ -9383,7 +9383,7 @@
         {
           "kind": "theorem",
           "name": "serviceStop_error_illegalState",
-          "line": 269,
+          "line": 277,
           "called": [
             "ServicePolicy",
             "serviceStop"
@@ -9392,7 +9392,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_error_of_stop_error",
-          "line": 280,
+          "line": 288,
           "called": [
             "ServicePolicy",
             "serviceRestart",
@@ -9402,7 +9402,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_error_of_start_error",
-          "line": 291,
+          "line": 299,
           "called": [
             "ServicePolicy",
             "serviceRestart",
@@ -9413,7 +9413,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_ok_implies_staged_steps",
-          "line": 304,
+          "line": 312,
           "called": [
             "ServicePolicy",
             "serviceRestart",
@@ -9424,7 +9424,7 @@
         {
           "kind": "theorem",
           "name": "serviceStart_ok_backing_object_exists",
-          "line": 324,
+          "line": 332,
           "called": [
             "ServicePolicy",
             "serviceStart"
@@ -9433,7 +9433,7 @@
         {
           "kind": "theorem",
           "name": "serviceRestart_atomicity",
-          "line": 345,
+          "line": 353,
           "called": [
             "ServicePolicy",
             "serviceRestart",
@@ -9445,7 +9445,7 @@
         {
           "kind": "theorem",
           "name": "serviceHasPathTo_fuel_zero_is_true",
-          "line": 363,
+          "line": 371,
           "called": [
             "serviceHasPathTo"
           ]
@@ -9453,7 +9453,7 @@
         {
           "kind": "theorem",
           "name": "serviceHasPathTo_false_implies_not_fuel_exhaustion",
-          "line": 373,
+          "line": 381,
           "called": [
             "serviceHasPathTo"
           ]
@@ -9461,7 +9461,7 @@
         {
           "kind": "theorem",
           "name": "serviceBfsFuel_adequate",
-          "line": 386,
+          "line": 394,
           "called": [
             "serviceBfsFuel"
           ]
@@ -9469,7 +9469,7 @@
         {
           "kind": "theorem",
           "name": "serviceRegisterDependency_rejects_if_path_or_fuel_exhausted",
-          "line": 395,
+          "line": 403,
           "called": [
             "serviceBfsFuel",
             "serviceHasPathTo",
@@ -9486,31 +9486,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "RegName",
-          "line": 6,
+          "line": 14,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "RegValue",
-          "line": 9,
+          "line": 17,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "Memory",
-          "line": 29,
+          "line": 37,
           "called": []
         },
         {
           "kind": "structure",
           "name": "RegisterFile",
-          "line": 32,
+          "line": 40,
           "called": [
             "RegName",
             "RegValue"
@@ -9518,24 +9518,24 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:37>",
-          "line": 37,
+          "name": "<anonymous:instance:45>",
+          "line": 45,
           "called": [
             "RegisterFile"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:42>",
-          "line": 42,
+          "name": "<anonymous:instance:50>",
+          "line": 50,
           "called": [
             "RegisterFile"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:48>",
-          "line": 48,
+          "name": "<anonymous:instance:56>",
+          "line": 56,
           "called": [
             "RegisterFile"
           ]
@@ -9543,7 +9543,7 @@
         {
           "kind": "structure",
           "name": "MachineState",
-          "line": 53,
+          "line": 61,
           "called": [
             "Memory",
             "RegisterFile"
@@ -9551,8 +9551,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:58>",
-          "line": 58,
+          "name": "<anonymous:instance:66>",
+          "line": 66,
           "called": [
             "MachineState"
           ]
@@ -9560,7 +9560,7 @@
         {
           "kind": "def",
           "name": "readReg",
-          "line": 61,
+          "line": 69,
           "called": [
             "RegName",
             "RegValue",
@@ -9570,7 +9570,7 @@
         {
           "kind": "def",
           "name": "writeReg",
-          "line": 64,
+          "line": 72,
           "called": [
             "RegName",
             "RegValue",
@@ -9580,7 +9580,7 @@
         {
           "kind": "def",
           "name": "readMem",
-          "line": 67,
+          "line": 75,
           "called": [
             "MachineState"
           ]
@@ -9588,7 +9588,7 @@
         {
           "kind": "def",
           "name": "writeMem",
-          "line": 70,
+          "line": 78,
           "called": [
             "MachineState"
           ]
@@ -9596,7 +9596,7 @@
         {
           "kind": "def",
           "name": "setPC",
-          "line": 73,
+          "line": 81,
           "called": [
             "MachineState",
             "RegValue"
@@ -9605,7 +9605,7 @@
         {
           "kind": "def",
           "name": "tick",
-          "line": 76,
+          "line": 84,
           "called": [
             "MachineState"
           ]
@@ -9613,7 +9613,7 @@
         {
           "kind": "theorem",
           "name": "readReg_writeReg_eq",
-          "line": 83,
+          "line": 91,
           "called": [
             "RegName",
             "RegValue",
@@ -9625,7 +9625,7 @@
         {
           "kind": "theorem",
           "name": "readReg_writeReg_ne",
-          "line": 87,
+          "line": 95,
           "called": [
             "RegName",
             "RegValue",
@@ -9637,7 +9637,7 @@
         {
           "kind": "theorem",
           "name": "readMem_writeMem_eq",
-          "line": 92,
+          "line": 100,
           "called": [
             "MachineState",
             "readMem",
@@ -9647,7 +9647,7 @@
         {
           "kind": "theorem",
           "name": "readMem_writeMem_ne",
-          "line": 96,
+          "line": 104,
           "called": [
             "MachineState",
             "readMem",
@@ -9657,7 +9657,7 @@
         {
           "kind": "theorem",
           "name": "writeReg_preserves_pc",
-          "line": 101,
+          "line": 109,
           "called": [
             "RegName",
             "RegValue",
@@ -9668,7 +9668,7 @@
         {
           "kind": "theorem",
           "name": "writeReg_preserves_sp",
-          "line": 104,
+          "line": 112,
           "called": [
             "RegName",
             "RegValue",
@@ -9679,7 +9679,7 @@
         {
           "kind": "theorem",
           "name": "writeMem_preserves_regs",
-          "line": 107,
+          "line": 115,
           "called": [
             "MachineState",
             "writeMem"
@@ -9688,7 +9688,7 @@
         {
           "kind": "theorem",
           "name": "writeMem_preserves_timer",
-          "line": 110,
+          "line": 118,
           "called": [
             "MachineState",
             "writeMem"
@@ -9697,7 +9697,7 @@
         {
           "kind": "theorem",
           "name": "setPC_preserves_memory",
-          "line": 113,
+          "line": 121,
           "called": [
             "MachineState",
             "RegValue",
@@ -9707,7 +9707,7 @@
         {
           "kind": "theorem",
           "name": "setPC_preserves_timer",
-          "line": 116,
+          "line": 124,
           "called": [
             "MachineState",
             "RegValue",
@@ -9717,7 +9717,7 @@
         {
           "kind": "theorem",
           "name": "tick_preserves_regs",
-          "line": 119,
+          "line": 127,
           "called": [
             "MachineState",
             "tick"
@@ -9726,7 +9726,7 @@
         {
           "kind": "theorem",
           "name": "tick_preserves_memory",
-          "line": 122,
+          "line": 130,
           "called": [
             "MachineState",
             "tick"
@@ -9735,7 +9735,7 @@
         {
           "kind": "theorem",
           "name": "tick_timer_succ",
-          "line": 125,
+          "line": 133,
           "called": [
             "MachineState",
             "tick"
@@ -9744,7 +9744,7 @@
         {
           "kind": "theorem",
           "name": "default_memory_returns_zero",
-          "line": 134,
+          "line": 142,
           "called": [
             "MachineState"
           ]
@@ -9752,7 +9752,7 @@
         {
           "kind": "theorem",
           "name": "default_registerFile_pc_zero",
-          "line": 139,
+          "line": 147,
           "called": [
             "RegisterFile"
           ]
@@ -9760,7 +9760,7 @@
         {
           "kind": "theorem",
           "name": "default_registerFile_sp_zero",
-          "line": 143,
+          "line": 151,
           "called": [
             "RegisterFile"
           ]
@@ -9768,7 +9768,7 @@
         {
           "kind": "theorem",
           "name": "default_timer_zero",
-          "line": 147,
+          "line": 155,
           "called": [
             "MachineState"
           ]
@@ -9776,13 +9776,13 @@
         {
           "kind": "inductive",
           "name": "MemoryKind",
-          "line": 159,
+          "line": 167,
           "called": []
         },
         {
           "kind": "structure",
           "name": "MemoryRegion",
-          "line": 172,
+          "line": 180,
           "called": [
             "MemoryKind"
           ]
@@ -9790,13 +9790,13 @@
         {
           "kind": "namespace",
           "name": "MemoryRegion",
-          "line": 178,
+          "line": 186,
           "called": []
         },
         {
           "kind": "def",
           "name": "endAddr",
-          "line": 181,
+          "line": 189,
           "called": [
             "MemoryRegion"
           ]
@@ -9804,7 +9804,7 @@
         {
           "kind": "def",
           "name": "contains",
-          "line": 184,
+          "line": 192,
           "called": [
             "MemoryRegion"
           ]
@@ -9812,7 +9812,7 @@
         {
           "kind": "def",
           "name": "overlaps",
-          "line": 188,
+          "line": 196,
           "called": [
             "MemoryRegion",
             "endAddr"
@@ -9821,7 +9821,7 @@
         {
           "kind": "theorem",
           "name": "contains_iff",
-          "line": 191,
+          "line": 199,
           "called": [
             "MemoryRegion",
             "contains",
@@ -9831,7 +9831,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 198,
+          "line": 206,
           "called": [
             "MemoryRegion"
           ]
@@ -9839,7 +9839,7 @@
         {
           "kind": "structure",
           "name": "MachineConfig",
-          "line": 219,
+          "line": 227,
           "called": [
             "MemoryRegion"
           ]
@@ -9847,13 +9847,13 @@
         {
           "kind": "namespace",
           "name": "MachineConfig",
-          "line": 234,
+          "line": 242,
           "called": []
         },
         {
           "kind": "def",
           "name": "totalRAM",
-          "line": 237,
+          "line": 245,
           "called": [
             "MachineConfig"
           ]
@@ -9861,7 +9861,7 @@
         {
           "kind": "def",
           "name": "addressInMap",
-          "line": 241,
+          "line": 249,
           "called": [
             "MachineConfig",
             "contains"
@@ -9870,7 +9870,7 @@
         {
           "kind": "def",
           "name": "noOverlapAux",
-          "line": 245,
+          "line": 253,
           "called": [
             "MemoryRegion"
           ]
@@ -9878,13 +9878,13 @@
         {
           "kind": "def",
           "name": "isPowerOfTwo",
-          "line": 251,
+          "line": 259,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_spec",
-          "line": 255,
+          "line": 263,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9892,7 +9892,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_pos",
-          "line": 261,
+          "line": 269,
           "called": [
             "isPowerOfTwo",
             "isPowerOfTwo_spec"
@@ -9901,7 +9901,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_0",
-          "line": 270,
+          "line": 278,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9909,7 +9909,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_1",
-          "line": 271,
+          "line": 279,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9917,7 +9917,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_2",
-          "line": 272,
+          "line": 280,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9925,7 +9925,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_3",
-          "line": 273,
+          "line": 281,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9933,7 +9933,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_4",
-          "line": 274,
+          "line": 282,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9941,7 +9941,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_5",
-          "line": 275,
+          "line": 283,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9949,7 +9949,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_12",
-          "line": 276,
+          "line": 284,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9957,7 +9957,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_16",
-          "line": 277,
+          "line": 285,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9965,7 +9965,7 @@
         {
           "kind": "theorem",
           "name": "isPowerOfTwo_of_pow2_21",
-          "line": 278,
+          "line": 286,
           "called": [
             "isPowerOfTwo"
           ]
@@ -9973,7 +9973,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 286,
+          "line": 294,
           "called": [
             "MachineConfig",
             "endAddr",
@@ -9991,27 +9991,27 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Model",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "structure",
           "name": "PagePermissions",
-          "line": 11,
+          "line": 19,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:19>",
-          "line": 19,
+          "name": "<anonymous:instance:27>",
+          "line": 27,
           "called": [
             "PagePermissions"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:23>",
-          "line": 23,
+          "name": "<anonymous:instance:31>",
+          "line": 31,
           "called": [
             "PagePermissions"
           ]
@@ -10019,7 +10019,7 @@
         {
           "kind": "def",
           "name": "PagePermissions.wxCompliant",
-          "line": 28,
+          "line": 36,
           "called": [
             "PagePermissions"
           ]
@@ -10027,7 +10027,7 @@
         {
           "kind": "theorem",
           "name": "PagePermissions.default_wxCompliant",
-          "line": 32,
+          "line": 40,
           "called": [
             "PagePermissions"
           ]
@@ -10035,7 +10035,7 @@
         {
           "kind": "structure",
           "name": "VSpaceRoot",
-          "line": 45,
+          "line": 53,
           "called": [
             "PagePermissions"
           ]
@@ -10043,13 +10043,13 @@
         {
           "kind": "namespace",
           "name": "VSpaceRoot",
-          "line": 50,
+          "line": 58,
           "called": []
         },
         {
           "kind": "def",
           "name": "lookup",
-          "line": 54,
+          "line": 62,
           "called": [
             "PagePermissions",
             "VSpaceRoot"
@@ -10058,7 +10058,7 @@
         {
           "kind": "def",
           "name": "lookupAddr",
-          "line": 58,
+          "line": 66,
           "called": [
             "VSpaceRoot"
           ]
@@ -10066,7 +10066,7 @@
         {
           "kind": "def",
           "name": "mapPage",
-          "line": 64,
+          "line": 72,
           "called": [
             "PagePermissions",
             "VSpaceRoot"
@@ -10075,7 +10075,7 @@
         {
           "kind": "def",
           "name": "unmapPage",
-          "line": 72,
+          "line": 80,
           "called": [
             "VSpaceRoot"
           ]
@@ -10083,7 +10083,7 @@
         {
           "kind": "def",
           "name": "noVirtualOverlap",
-          "line": 80,
+          "line": 88,
           "called": [
             "VSpaceRoot"
           ]
@@ -10091,7 +10091,7 @@
         {
           "kind": "theorem",
           "name": "noVirtualOverlap_trivial",
-          "line": 91,
+          "line": 99,
           "called": [
             "VSpaceRoot",
             "noVirtualOverlap"
@@ -10100,7 +10100,7 @@
         {
           "kind": "theorem",
           "name": "noVirtualOverlap_empty",
-          "line": 96,
+          "line": 104,
           "called": [
             "noVirtualOverlap",
             "noVirtualOverlap_trivial"
@@ -10109,7 +10109,7 @@
         {
           "kind": "theorem",
           "name": "lookup_unmapPage_eq_none",
-          "line": 101,
+          "line": 109,
           "called": [
             "VSpaceRoot",
             "lookup",
@@ -10119,7 +10119,7 @@
         {
           "kind": "theorem",
           "name": "lookup_mapPage_eq",
-          "line": 116,
+          "line": 124,
           "called": [
             "PagePermissions",
             "VSpaceRoot",
@@ -10130,7 +10130,7 @@
         {
           "kind": "theorem",
           "name": "lookupAddr_mapPage_eq",
-          "line": 132,
+          "line": 140,
           "called": [
             "PagePermissions",
             "VSpaceRoot",
@@ -10141,7 +10141,7 @@
         {
           "kind": "theorem",
           "name": "mapPage_asid_eq",
-          "line": 142,
+          "line": 150,
           "called": [
             "PagePermissions",
             "VSpaceRoot",
@@ -10151,7 +10151,7 @@
         {
           "kind": "theorem",
           "name": "unmapPage_asid_eq",
-          "line": 156,
+          "line": 164,
           "called": [
             "VSpaceRoot",
             "unmapPage"
@@ -10160,7 +10160,7 @@
         {
           "kind": "theorem",
           "name": "lookup_eq_none_iff",
-          "line": 168,
+          "line": 176,
           "called": [
             "VSpaceRoot",
             "lookup"
@@ -10169,7 +10169,7 @@
         {
           "kind": "theorem",
           "name": "mapPage_noVirtualOverlap",
-          "line": 176,
+          "line": 184,
           "called": [
             "PagePermissions",
             "VSpaceRoot",
@@ -10181,7 +10181,7 @@
         {
           "kind": "theorem",
           "name": "unmapPage_noVirtualOverlap",
-          "line": 193,
+          "line": 201,
           "called": [
             "VSpaceRoot",
             "noVirtualOverlap",
@@ -10192,7 +10192,7 @@
         {
           "kind": "theorem",
           "name": "lookup_mapPage_ne",
-          "line": 208,
+          "line": 216,
           "called": [
             "PagePermissions",
             "VSpaceRoot",
@@ -10203,7 +10203,7 @@
         {
           "kind": "theorem",
           "name": "lookup_unmapPage_ne",
-          "line": 228,
+          "line": 236,
           "called": [
             "VSpaceRoot",
             "lookup",
@@ -10212,8 +10212,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:250>",
-          "line": 250,
+          "name": "<anonymous:instance:258>",
+          "line": 258,
           "called": [
             "VSpaceRoot"
           ]
@@ -10221,7 +10221,7 @@
         {
           "kind": "theorem",
           "name": "VSpaceRoot.beq_sound",
-          "line": 265,
+          "line": 273,
           "called": [
             "VSpaceRoot"
           ]
@@ -10229,49 +10229,49 @@
         {
           "kind": "namespace",
           "name": "CNode",
-          "line": 270,
+          "line": 278,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "ResolveError",
-          "line": 272,
+          "line": 280,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 277,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "mk'",
-          "line": 281,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "slotCount",
           "line": 285,
           "called": []
         },
         {
           "kind": "def",
-          "name": "bitsConsumed",
+          "name": "mk'",
           "line": 289,
           "called": []
         },
         {
           "kind": "def",
+          "name": "slotCount",
+          "line": 293,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "bitsConsumed",
+          "line": 297,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "wellFormed",
-          "line": 294,
+          "line": 302,
           "called": []
         },
         {
           "kind": "def",
           "name": "resolveSlot",
-          "line": 302,
+          "line": 310,
           "called": [
             "ResolveError"
           ]
@@ -10279,31 +10279,31 @@
         {
           "kind": "def",
           "name": "lookup",
-          "line": 317,
+          "line": 325,
           "called": []
         },
         {
           "kind": "def",
           "name": "insert",
-          "line": 322,
+          "line": 330,
           "called": []
         },
         {
           "kind": "def",
           "name": "remove",
-          "line": 326,
+          "line": 334,
           "called": []
         },
         {
           "kind": "def",
           "name": "revokeTargetLocal",
-          "line": 336,
+          "line": 344,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lookup_remove_eq_none",
-          "line": 344,
+          "line": 352,
           "called": [
             "lookup",
             "remove"
@@ -10312,7 +10312,7 @@
         {
           "kind": "theorem",
           "name": "lookup_mem_of_some",
-          "line": 350,
+          "line": 358,
           "called": [
             "lookup"
           ]
@@ -10320,7 +10320,7 @@
         {
           "kind": "theorem",
           "name": "resolveSlot_depthMismatch",
-          "line": 355,
+          "line": 363,
           "called": [
             "bitsConsumed",
             "resolveSlot"
@@ -10329,7 +10329,7 @@
         {
           "kind": "theorem",
           "name": "lookup_revokeTargetLocal_source_eq_lookup",
-          "line": 367,
+          "line": 375,
           "called": [
             "lookup",
             "revokeTargetLocal"
@@ -10338,19 +10338,19 @@
         {
           "kind": "def",
           "name": "slotsUnique",
-          "line": 386,
+          "line": 394,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "empty_slotsUnique",
-          "line": 390,
+          "line": 398,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "insert_slotsUnique",
-          "line": 394,
+          "line": 402,
           "called": [
             "slotsUnique"
           ]
@@ -10358,7 +10358,7 @@
         {
           "kind": "theorem",
           "name": "remove_slotsUnique",
-          "line": 401,
+          "line": 409,
           "called": [
             "slotsUnique"
           ]
@@ -10366,7 +10366,7 @@
         {
           "kind": "theorem",
           "name": "revokeTargetLocal_slotsUnique",
-          "line": 408,
+          "line": 416,
           "called": [
             "slotsUnique"
           ]
@@ -10374,13 +10374,13 @@
         {
           "kind": "def",
           "name": "slotCountBounded",
-          "line": 422,
+          "line": 430,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "empty_slotCountBounded",
-          "line": 426,
+          "line": 434,
           "called": [
             "empty",
             "slotCount",
@@ -10390,7 +10390,7 @@
         {
           "kind": "theorem",
           "name": "remove_slotCountBounded",
-          "line": 431,
+          "line": 439,
           "called": [
             "slotCountBounded"
           ]
@@ -10398,7 +10398,7 @@
         {
           "kind": "theorem",
           "name": "revokeTargetLocal_slotCountBounded",
-          "line": 440,
+          "line": 448,
           "called": [
             "slotCountBounded"
           ]
@@ -10406,13 +10406,13 @@
         {
           "kind": "theorem",
           "name": "mem_lookup_of_slotsUnique",
-          "line": 452,
+          "line": 460,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lookup_insert_eq",
-          "line": 459,
+          "line": 467,
           "called": [
             "insert",
             "lookup"
@@ -10421,7 +10421,7 @@
         {
           "kind": "theorem",
           "name": "lookup_insert_ne",
-          "line": 466,
+          "line": 474,
           "called": [
             "insert",
             "lookup"
@@ -10430,7 +10430,7 @@
         {
           "kind": "theorem",
           "name": "lookup_remove_ne",
-          "line": 478,
+          "line": 486,
           "called": [
             "lookup",
             "remove"
@@ -10438,50 +10438,50 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:493>",
-          "line": 493,
+          "name": "<anonymous:instance:501>",
+          "line": 501,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.beq_sound",
-          "line": 502,
+          "line": 510,
           "called": []
         },
         {
           "kind": "def",
           "name": "cnodeWellFormed",
-          "line": 520,
+          "line": 528,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CNode.empty_not_wellFormed",
-          "line": 525,
+          "line": 533,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "SlotAddr",
-          "line": 534,
+          "line": 542,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "DerivationOp",
-          "line": 537,
+          "line": 545,
           "called": []
         },
         {
           "kind": "abbrev",
           "name": "CdtNodeId",
-          "line": 546,
+          "line": 554,
           "called": []
         },
         {
           "kind": "structure",
           "name": "CapDerivationEdge",
-          "line": 553,
+          "line": 561,
           "called": [
             "CdtNodeId",
             "DerivationOp"
@@ -10490,13 +10490,13 @@
         {
           "kind": "namespace",
           "name": "CapDerivationEdge",
-          "line": 559,
+          "line": 567,
           "called": []
         },
         {
           "kind": "def",
           "name": "isChildOf",
-          "line": 561,
+          "line": 569,
           "called": [
             "CapDerivationEdge",
             "CdtNodeId"
@@ -10505,7 +10505,7 @@
         {
           "kind": "def",
           "name": "isParentOf",
-          "line": 564,
+          "line": 572,
           "called": [
             "CapDerivationEdge",
             "CdtNodeId"
@@ -10514,7 +10514,7 @@
         {
           "kind": "structure",
           "name": "CapDerivationTree",
-          "line": 573,
+          "line": 581,
           "called": [
             "CapDerivationEdge",
             "CdtNodeId"
@@ -10523,13 +10523,13 @@
         {
           "kind": "namespace",
           "name": "CapDerivationTree",
-          "line": 581,
+          "line": 589,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 583,
+          "line": 591,
           "called": [
             "CapDerivationTree"
           ]
@@ -10537,7 +10537,7 @@
         {
           "kind": "def",
           "name": "addEdge",
-          "line": 587,
+          "line": 595,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -10547,7 +10547,7 @@
         {
           "kind": "def",
           "name": "childrenOf",
-          "line": 595,
+          "line": 603,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -10556,7 +10556,7 @@
         {
           "kind": "def",
           "name": "parentOf",
-          "line": 600,
+          "line": 608,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -10565,7 +10565,7 @@
         {
           "kind": "def",
           "name": "removeAsChild",
-          "line": 606,
+          "line": 614,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -10574,7 +10574,7 @@
         {
           "kind": "def",
           "name": "removeAsParent",
-          "line": 615,
+          "line": 623,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -10583,7 +10583,7 @@
         {
           "kind": "def",
           "name": "removeNode",
-          "line": 622,
+          "line": 630,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -10592,7 +10592,7 @@
         {
           "kind": "def",
           "name": "descendantsOf",
-          "line": 636,
+          "line": 644,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -10601,7 +10601,7 @@
         {
           "kind": "def",
           "name": "acyclic",
-          "line": 649,
+          "line": 657,
           "called": [
             "CapDerivationTree"
           ]
@@ -10609,13 +10609,13 @@
         {
           "kind": "theorem",
           "name": "empty_acyclic",
-          "line": 652,
+          "line": 660,
           "called": []
         },
         {
           "kind": "def",
           "name": "edgeWellFounded",
-          "line": 664,
+          "line": 672,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -10624,13 +10624,13 @@
         {
           "kind": "theorem",
           "name": "empty_edgeWellFounded",
-          "line": 674,
+          "line": 682,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "edgeWellFounded_sub",
-          "line": 683,
+          "line": 691,
           "called": [
             "CapDerivationTree"
           ]
@@ -10638,7 +10638,7 @@
         {
           "kind": "theorem",
           "name": "removeNode_edges_sub",
-          "line": 694,
+          "line": 702,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -10648,7 +10648,7 @@
         {
           "kind": "def",
           "name": "childMapConsistent",
-          "line": 702,
+          "line": 710,
           "called": [
             "CapDerivationTree"
           ]
@@ -10656,13 +10656,13 @@
         {
           "kind": "theorem",
           "name": "empty_childMapConsistent",
-          "line": 707,
+          "line": 715,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "addEdge_childMapConsistent",
-          "line": 714,
+          "line": 722,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -10674,7 +10674,7 @@
         {
           "kind": "structure",
           "name": "ObservedDerivationEdge",
-          "line": 758,
+          "line": 766,
           "called": [
             "DerivationOp",
             "SlotAddr"
@@ -10683,7 +10683,7 @@
         {
           "kind": "def",
           "name": "projectObservedEdges",
-          "line": 765,
+          "line": 773,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -10694,15 +10694,15 @@
         {
           "kind": "inductive",
           "name": "KernelObject",
-          "line": 779,
+          "line": 787,
           "called": [
             "VSpaceRoot"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:790>",
-          "line": 790,
+          "name": "<anonymous:instance:798>",
+          "line": 798,
           "called": [
             "KernelObject"
           ]
@@ -10710,19 +10710,19 @@
         {
           "kind": "inductive",
           "name": "KernelObjectType",
-          "line": 800,
+          "line": 808,
           "called": []
         },
         {
           "kind": "namespace",
           "name": "KernelObject",
-          "line": 809,
+          "line": 817,
           "called": []
         },
         {
           "kind": "def",
           "name": "objectType",
-          "line": 811,
+          "line": 819,
           "called": [
             "KernelObject",
             "KernelObjectType"
@@ -10731,7 +10731,7 @@
         {
           "kind": "def",
           "name": "makeObjectCap",
-          "line": 822,
+          "line": 830,
           "called": []
         }
       ]
@@ -10744,25 +10744,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Model",
-          "line": 3,
+          "line": 11,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "ServiceStatus",
-          "line": 7,
-          "called": []
-        },
-        {
-          "kind": "structure",
-          "name": "ServiceIdentity",
           "line": 15,
           "called": []
         },
         {
           "kind": "structure",
+          "name": "ServiceIdentity",
+          "line": 23,
+          "called": []
+        },
+        {
+          "kind": "structure",
           "name": "ServiceGraphEntry",
-          "line": 22,
+          "line": 30,
           "called": [
             "ServiceIdentity",
             "ServiceStatus"
@@ -10771,19 +10771,19 @@
         {
           "kind": "inductive",
           "name": "AccessRight",
-          "line": 29,
+          "line": 37,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "CapTarget",
-          "line": 40,
+          "line": 48,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Capability",
-          "line": 46,
+          "line": 54,
           "called": [
             "AccessRight",
             "CapTarget"
@@ -10792,13 +10792,13 @@
         {
           "kind": "namespace",
           "name": "Capability",
-          "line": 52,
+          "line": 60,
           "called": []
         },
         {
           "kind": "def",
           "name": "hasRight",
-          "line": 54,
+          "line": 62,
           "called": [
             "AccessRight",
             "Capability"
@@ -10807,19 +10807,19 @@
         {
           "kind": "def",
           "name": "maxMessageRegisters",
-          "line": 61,
+          "line": 69,
           "called": []
         },
         {
           "kind": "def",
           "name": "maxExtraCaps",
-          "line": 65,
+          "line": 73,
           "called": []
         },
         {
           "kind": "structure",
           "name": "IpcMessage",
-          "line": 73,
+          "line": 81,
           "called": [
             "Capability"
           ]
@@ -10827,13 +10827,13 @@
         {
           "kind": "namespace",
           "name": "IpcMessage",
-          "line": 79,
+          "line": 87,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 81,
+          "line": 89,
           "called": [
             "IpcMessage"
           ]
@@ -10841,7 +10841,7 @@
         {
           "kind": "def",
           "name": "bounded",
-          "line": 85,
+          "line": 93,
           "called": [
             "IpcMessage",
             "maxExtraCaps",
@@ -10851,7 +10851,7 @@
         {
           "kind": "def",
           "name": "checkBounds",
-          "line": 91,
+          "line": 99,
           "called": [
             "IpcMessage",
             "maxExtraCaps",
@@ -10861,7 +10861,7 @@
         {
           "kind": "theorem",
           "name": "empty_bounded",
-          "line": 95,
+          "line": 103,
           "called": [
             "bounded",
             "empty",
@@ -10872,7 +10872,7 @@
         {
           "kind": "theorem",
           "name": "checkBounds_iff_bounded",
-          "line": 99,
+          "line": 107,
           "called": [
             "IpcMessage",
             "bounded",
@@ -10884,19 +10884,19 @@
         {
           "kind": "inductive",
           "name": "ThreadIpcState",
-          "line": 115,
+          "line": 123,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "QueuePPrev",
-          "line": 128,
+          "line": 136,
           "called": []
         },
         {
           "kind": "structure",
           "name": "TCB",
-          "line": 133,
+          "line": 141,
           "called": [
             "IpcMessage",
             "QueuePPrev",
@@ -10905,8 +10905,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:172>",
-          "line": 172,
+          "name": "<anonymous:instance:180>",
+          "line": 180,
           "called": [
             "TCB"
           ]
@@ -10914,13 +10914,13 @@
         {
           "kind": "structure",
           "name": "IntrusiveQueue",
-          "line": 186,
+          "line": 194,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Endpoint",
-          "line": 197,
+          "line": 205,
           "called": [
             "IntrusiveQueue"
           ]
@@ -10928,13 +10928,13 @@
         {
           "kind": "inductive",
           "name": "NotificationState",
-          "line": 202,
+          "line": 210,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Notification",
-          "line": 211,
+          "line": 219,
           "called": [
             "NotificationState"
           ]
@@ -10942,7 +10942,7 @@
         {
           "kind": "structure",
           "name": "CNode",
-          "line": 227,
+          "line": 235,
           "called": [
             "Capability"
           ]
@@ -10950,19 +10950,19 @@
         {
           "kind": "def",
           "name": "maxCSpaceDepth",
-          "line": 236,
+          "line": 244,
           "called": []
         },
         {
           "kind": "structure",
           "name": "UntypedChild",
-          "line": 241,
+          "line": 249,
           "called": []
         },
         {
           "kind": "structure",
           "name": "UntypedObject",
-          "line": 256,
+          "line": 264,
           "called": [
             "UntypedChild"
           ]
@@ -10970,13 +10970,13 @@
         {
           "kind": "namespace",
           "name": "UntypedObject",
-          "line": 272,
+          "line": 280,
           "called": []
         },
         {
           "kind": "def",
           "name": "freeSpace",
-          "line": 275,
+          "line": 283,
           "called": [
             "UntypedObject"
           ]
@@ -10984,7 +10984,7 @@
         {
           "kind": "def",
           "name": "canAllocate",
-          "line": 279,
+          "line": 287,
           "called": [
             "UntypedObject"
           ]
@@ -10992,7 +10992,7 @@
         {
           "kind": "def",
           "name": "allocate",
-          "line": 284,
+          "line": 292,
           "called": [
             "UntypedObject"
           ]
@@ -11000,22 +11000,6 @@
         {
           "kind": "def",
           "name": "reset",
-          "line": 296,
-          "called": [
-            "UntypedObject"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "watermarkValid",
-          "line": 300,
-          "called": [
-            "UntypedObject"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "childrenWithinWatermark",
           "line": 304,
           "called": [
             "UntypedObject"
@@ -11023,7 +11007,7 @@
         },
         {
           "kind": "def",
-          "name": "childrenNonOverlap",
+          "name": "watermarkValid",
           "line": 308,
           "called": [
             "UntypedObject"
@@ -11031,8 +11015,24 @@
         },
         {
           "kind": "def",
+          "name": "childrenWithinWatermark",
+          "line": 312,
+          "called": [
+            "UntypedObject"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "childrenNonOverlap",
+          "line": 316,
+          "called": [
+            "UntypedObject"
+          ]
+        },
+        {
+          "kind": "def",
           "name": "childrenUniqueIds",
-          "line": 313,
+          "line": 321,
           "called": [
             "UntypedObject"
           ]
@@ -11040,7 +11040,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 318,
+          "line": 326,
           "called": [
             "UntypedObject"
           ]
@@ -11048,7 +11048,7 @@
         {
           "kind": "theorem",
           "name": "empty_watermarkValid",
-          "line": 322,
+          "line": 330,
           "called": [
             "watermarkValid"
           ]
@@ -11056,7 +11056,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenWithinWatermark",
-          "line": 326,
+          "line": 334,
           "called": [
             "childrenWithinWatermark"
           ]
@@ -11064,7 +11064,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenNonOverlap",
-          "line": 331,
+          "line": 339,
           "called": [
             "childrenNonOverlap"
           ]
@@ -11072,7 +11072,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenUniqueIds",
-          "line": 336,
+          "line": 344,
           "called": [
             "childrenUniqueIds"
           ]
@@ -11080,7 +11080,7 @@
         {
           "kind": "theorem",
           "name": "empty_wellFormed",
-          "line": 341,
+          "line": 349,
           "called": [
             "empty_childrenNonOverlap",
             "empty_childrenUniqueIds",
@@ -11092,7 +11092,7 @@
         {
           "kind": "theorem",
           "name": "canAllocate_implies_fits",
-          "line": 347,
+          "line": 355,
           "called": [
             "UntypedObject",
             "canAllocate"
@@ -11101,7 +11101,7 @@
         {
           "kind": "theorem",
           "name": "allocate_some_iff",
-          "line": 354,
+          "line": 362,
           "called": [
             "UntypedObject",
             "allocate"
@@ -11110,7 +11110,7 @@
         {
           "kind": "theorem",
           "name": "allocate_watermark_advance",
-          "line": 373,
+          "line": 381,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11119,7 +11119,7 @@
         {
           "kind": "theorem",
           "name": "allocate_offset_eq_watermark",
-          "line": 382,
+          "line": 390,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11128,7 +11128,7 @@
         {
           "kind": "theorem",
           "name": "allocate_watermark_monotone",
-          "line": 389,
+          "line": 397,
           "called": [
             "UntypedObject",
             "allocate_watermark_advance"
@@ -11137,7 +11137,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_watermarkValid",
-          "line": 396,
+          "line": 404,
           "called": [
             "UntypedObject",
             "allocate_some_iff",
@@ -11148,7 +11148,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_region",
-          "line": 407,
+          "line": 415,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11157,7 +11157,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenWithinWatermark",
-          "line": 418,
+          "line": 426,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11166,7 +11166,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenNonOverlap",
-          "line": 436,
+          "line": 444,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11175,7 +11175,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenUniqueIds",
-          "line": 458,
+          "line": 466,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11184,7 +11184,7 @@
         {
           "kind": "theorem",
           "name": "reset_watermarkValid",
-          "line": 477,
+          "line": 485,
           "called": [
             "UntypedObject",
             "reset",
@@ -11194,7 +11194,7 @@
         {
           "kind": "theorem",
           "name": "reset_wellFormed",
-          "line": 481,
+          "line": 489,
           "called": [
             "UntypedObject",
             "reset",
@@ -11217,25 +11217,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Model",
-          "line": 5,
+          "line": 13,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "KernelError",
-          "line": 7,
+          "line": 15,
           "called": []
         },
         {
           "kind": "structure",
           "name": "DomainScheduleEntry",
-          "line": 42,
+          "line": 50,
           "called": []
         },
         {
           "kind": "structure",
           "name": "SchedulerState",
-          "line": 47,
+          "line": 55,
           "called": [
             "DomainScheduleEntry"
           ]
@@ -11243,7 +11243,7 @@
         {
           "kind": "abbrev",
           "name": "SchedulerState.runnable",
-          "line": 68,
+          "line": 76,
           "called": [
             "SchedulerState"
           ]
@@ -11251,13 +11251,13 @@
         {
           "kind": "structure",
           "name": "SlotRef",
-          "line": 72,
+          "line": 80,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:80>",
-          "line": 80,
+          "name": "<anonymous:instance:88>",
+          "line": 88,
           "called": [
             "SlotRef"
           ]
@@ -11265,7 +11265,7 @@
         {
           "kind": "structure",
           "name": "LifecycleMetadata",
-          "line": 90,
+          "line": 98,
           "called": [
             "SlotRef"
           ]
@@ -11273,7 +11273,7 @@
         {
           "kind": "structure",
           "name": "SystemState",
-          "line": 94,
+          "line": 102,
           "called": [
             "LifecycleMetadata",
             "SchedulerState",
@@ -11283,21 +11283,21 @@
         {
           "kind": "abbrev",
           "name": "CSpaceOwner",
-          "line": 137,
+          "line": 145,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:139>",
-          "line": 139,
+          "name": "<anonymous:instance:147>",
+          "line": 147,
           "called": [
             "SchedulerState"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:142>",
-          "line": 142,
+          "name": "<anonymous:instance:150>",
+          "line": 150,
           "called": [
             "SystemState"
           ]
@@ -11305,7 +11305,7 @@
         {
           "kind": "abbrev",
           "name": "Kernel",
-          "line": 162,
+          "line": 170,
           "called": [
             "KernelError",
             "SystemState"
@@ -11314,7 +11314,7 @@
         {
           "kind": "def",
           "name": "lookupObject",
-          "line": 164,
+          "line": 172,
           "called": [
             "Kernel"
           ]
@@ -11322,7 +11322,7 @@
         {
           "kind": "def",
           "name": "lookupVSpaceRoot",
-          "line": 171,
+          "line": 179,
           "called": [
             "Kernel"
           ]
@@ -11330,7 +11330,7 @@
         {
           "kind": "def",
           "name": "storeObject",
-          "line": 186,
+          "line": 194,
           "called": [
             "Kernel"
           ]
@@ -11338,7 +11338,7 @@
         {
           "kind": "def",
           "name": "storeCapabilityRef",
-          "line": 214,
+          "line": 222,
           "called": [
             "Kernel",
             "LifecycleMetadata",
@@ -11348,7 +11348,7 @@
         {
           "kind": "def",
           "name": "clearCapabilityRefsState",
-          "line": 227,
+          "line": 235,
           "called": [
             "SlotRef",
             "SystemState"
@@ -11357,7 +11357,7 @@
         {
           "kind": "def",
           "name": "clearCapabilityRefs",
-          "line": 239,
+          "line": 247,
           "called": [
             "Kernel",
             "SlotRef",
@@ -11367,7 +11367,7 @@
         {
           "kind": "def",
           "name": "setCurrentThread",
-          "line": 242,
+          "line": 250,
           "called": [
             "Kernel"
           ]
@@ -11375,7 +11375,7 @@
         {
           "kind": "def",
           "name": "lookupService",
-          "line": 248,
+          "line": 256,
           "called": [
             "SystemState"
           ]
@@ -11383,7 +11383,7 @@
         {
           "kind": "def",
           "name": "hasServiceDependency",
-          "line": 252,
+          "line": 260,
           "called": [
             "SystemState",
             "lookupService"
@@ -11392,7 +11392,7 @@
         {
           "kind": "def",
           "name": "hasIsolationEdge",
-          "line": 258,
+          "line": 266,
           "called": [
             "SystemState",
             "lookupService"
@@ -11401,7 +11401,7 @@
         {
           "kind": "def",
           "name": "dependenciesSatisfied",
-          "line": 264,
+          "line": 272,
           "called": [
             "SystemState",
             "lookupService"
@@ -11410,7 +11410,7 @@
         {
           "kind": "def",
           "name": "storeServiceState",
-          "line": 274,
+          "line": 282,
           "called": [
             "SystemState"
           ]
@@ -11418,7 +11418,7 @@
         {
           "kind": "def",
           "name": "setServiceStatusState",
-          "line": 281,
+          "line": 289,
           "called": [
             "SystemState",
             "lookupService",
@@ -11428,7 +11428,7 @@
         {
           "kind": "theorem",
           "name": "storeServiceState_lookup_eq",
-          "line": 286,
+          "line": 294,
           "called": [
             "SystemState",
             "lookupService",
@@ -11438,7 +11438,7 @@
         {
           "kind": "theorem",
           "name": "storeServiceState_lookup_ne",
-          "line": 293,
+          "line": 301,
           "called": [
             "SystemState",
             "lookupService",
@@ -11448,7 +11448,7 @@
         {
           "kind": "theorem",
           "name": "setServiceStatusState_lookup_eq",
-          "line": 306,
+          "line": 314,
           "called": [
             "SystemState",
             "lookupService",
@@ -11459,7 +11459,7 @@
         {
           "kind": "theorem",
           "name": "setServiceStatusState_preserves_objects",
-          "line": 315,
+          "line": 323,
           "called": [
             "SystemState",
             "lookupService",
@@ -11470,7 +11470,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_services",
-          "line": 323,
+          "line": 331,
           "called": [
             "SystemState",
             "storeObject"
@@ -11479,7 +11479,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_scheduler",
-          "line": 333,
+          "line": 341,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11489,7 +11489,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_services",
-          "line": 342,
+          "line": 350,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11499,7 +11499,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_objects",
-          "line": 351,
+          "line": 359,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11509,7 +11509,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_irqHandlers",
-          "line": 361,
+          "line": 369,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11519,7 +11519,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_objectIndex",
-          "line": 371,
+          "line": 379,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11529,7 +11529,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_machine",
-          "line": 381,
+          "line": 389,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11539,7 +11539,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_preserves_objects",
-          "line": 390,
+          "line": 398,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11549,7 +11549,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefs_preserves_objects",
-          "line": 401,
+          "line": 409,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11560,7 +11560,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_preserves_scheduler",
-          "line": 410,
+          "line": 418,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11570,7 +11570,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_preserves_machine",
-          "line": 421,
+          "line": 429,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11580,7 +11580,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_preserves_services",
-          "line": 431,
+          "line": 439,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11590,7 +11590,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_lookupService",
-          "line": 441,
+          "line": 449,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11602,7 +11602,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_preserves_irqHandlers",
-          "line": 449,
+          "line": 457,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11612,7 +11612,7 @@
         {
           "kind": "theorem",
           "name": "clearCapabilityRefsState_preserves_objectIndex",
-          "line": 460,
+          "line": 468,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11622,7 +11622,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_lookup_eq",
-          "line": 470,
+          "line": 478,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11632,7 +11632,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objects_eq",
-          "line": 490,
+          "line": 498,
           "called": [
             "SystemState",
             "storeObject"
@@ -11641,7 +11641,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objects_ne",
-          "line": 500,
+          "line": 508,
           "called": [
             "SystemState",
             "storeObject"
@@ -11650,7 +11650,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_scheduler_eq",
-          "line": 513,
+          "line": 521,
           "called": [
             "SystemState",
             "storeObject"
@@ -11659,7 +11659,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_irqHandlers_eq",
-          "line": 523,
+          "line": 531,
           "called": [
             "SystemState",
             "storeObject"
@@ -11668,7 +11668,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_machine_eq",
-          "line": 533,
+          "line": 541,
           "called": [
             "SystemState",
             "storeObject"
@@ -11677,7 +11677,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_cdt_eq",
-          "line": 544,
+          "line": 552,
           "called": [
             "SystemState",
             "storeObject"
@@ -11686,7 +11686,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_asidTable_vspaceRoot",
-          "line": 559,
+          "line": 567,
           "called": [
             "SystemState",
             "storeObject"
@@ -11695,7 +11695,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_asidTable_vspaceRoot_ne",
-          "line": 570,
+          "line": 578,
           "called": [
             "SystemState",
             "storeObject"
@@ -11704,7 +11704,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_asidTable_non_vspaceRoot",
-          "line": 594,
+          "line": 602,
           "called": [
             "SystemState",
             "storeObject"
@@ -11713,7 +11713,7 @@
         {
           "kind": "def",
           "name": "objectIndexSetSync",
-          "line": 613,
+          "line": 621,
           "called": [
             "SystemState"
           ]
@@ -11721,7 +11721,7 @@
         {
           "kind": "theorem",
           "name": "objectIndexSetSync_contains_of_mem",
-          "line": 617,
+          "line": 625,
           "called": [
             "SystemState",
             "objectIndexSetSync"
@@ -11730,7 +11730,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_updates_objectTypeMeta",
-          "line": 623,
+          "line": 631,
           "called": [
             "SystemState",
             "storeObject"
@@ -11739,13 +11739,13 @@
         {
           "kind": "namespace",
           "name": "SystemState",
-          "line": 633,
+          "line": 641,
           "called": []
         },
         {
           "kind": "def",
           "name": "lookupCNode",
-          "line": 636,
+          "line": 644,
           "called": [
             "SystemState"
           ]
@@ -11753,7 +11753,7 @@
         {
           "kind": "def",
           "name": "lookupSlotCap",
-          "line": 642,
+          "line": 650,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11763,7 +11763,7 @@
         {
           "kind": "def",
           "name": "ownerOfSlot",
-          "line": 648,
+          "line": 656,
           "called": [
             "CSpaceOwner",
             "SlotRef"
@@ -11772,7 +11772,7 @@
         {
           "kind": "def",
           "name": "ownsSlot",
-          "line": 652,
+          "line": 660,
           "called": [
             "CSpaceOwner",
             "SlotRef",
@@ -11784,7 +11784,7 @@
         {
           "kind": "def",
           "name": "ownedSlots",
-          "line": 657,
+          "line": 665,
           "called": [
             "CSpaceOwner",
             "SystemState",
@@ -11794,7 +11794,7 @@
         {
           "kind": "def",
           "name": "lookupObjectTypeMeta",
-          "line": 663,
+          "line": 671,
           "called": [
             "SystemState"
           ]
@@ -11802,7 +11802,7 @@
         {
           "kind": "def",
           "name": "lookupCapabilityRefMeta",
-          "line": 667,
+          "line": 675,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11812,7 +11812,7 @@
         {
           "kind": "def",
           "name": "lookupCdtNodeOfSlot",
-          "line": 672,
+          "line": 680,
           "called": [
             "SlotRef",
             "SystemState"
@@ -11821,7 +11821,7 @@
         {
           "kind": "def",
           "name": "lookupCdtSlotOfNode",
-          "line": 676,
+          "line": 684,
           "called": [
             "SlotRef",
             "SystemState"
@@ -11830,7 +11830,7 @@
         {
           "kind": "def",
           "name": "observedCdtEdges",
-          "line": 680,
+          "line": 688,
           "called": [
             "SystemState",
             "lookupCdtSlotOfNode"
@@ -11839,7 +11839,7 @@
         {
           "kind": "theorem",
           "name": "observedCdtEdges_eq_projection",
-          "line": 686,
+          "line": 694,
           "called": [
             "SystemState",
             "lookupCdtSlotOfNode",
@@ -11849,7 +11849,7 @@
         {
           "kind": "def",
           "name": "attachSlotToCdtNode",
-          "line": 694,
+          "line": 702,
           "called": [
             "SlotRef",
             "SystemState"
@@ -11858,7 +11858,7 @@
         {
           "kind": "def",
           "name": "detachSlotFromCdt",
-          "line": 712,
+          "line": 720,
           "called": [
             "SlotRef",
             "SystemState"
@@ -11867,7 +11867,7 @@
         {
           "kind": "def",
           "name": "ensureCdtNodeForSlot",
-          "line": 723,
+          "line": 731,
           "called": [
             "SlotRef",
             "SystemState"
@@ -11876,7 +11876,7 @@
         {
           "kind": "theorem",
           "name": "attachSlotToCdtNode_objects_eq",
-          "line": 738,
+          "line": 746,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11886,7 +11886,7 @@
         {
           "kind": "theorem",
           "name": "detachSlotFromCdt_objects_eq",
-          "line": 742,
+          "line": 750,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11896,7 +11896,7 @@
         {
           "kind": "theorem",
           "name": "ensureCdtNodeForSlot_objects_eq",
-          "line": 747,
+          "line": 755,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11906,7 +11906,7 @@
         {
           "kind": "theorem",
           "name": "lookupSlotCap_eq_of_objects_eq",
-          "line": 753,
+          "line": 761,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11917,7 +11917,7 @@
         {
           "kind": "def",
           "name": "objectTypeMetadataConsistent",
-          "line": 761,
+          "line": 769,
           "called": [
             "SystemState",
             "lookupObjectTypeMeta"
@@ -11926,7 +11926,7 @@
         {
           "kind": "def",
           "name": "capabilityRefMetadataConsistent",
-          "line": 765,
+          "line": 773,
           "called": [
             "SystemState",
             "lookupCapabilityRefMeta",
@@ -11936,7 +11936,7 @@
         {
           "kind": "def",
           "name": "lifecycleMetadataConsistent",
-          "line": 769,
+          "line": 777,
           "called": [
             "SystemState",
             "capabilityRefMetadataConsistent",
@@ -11946,7 +11946,7 @@
         {
           "kind": "theorem",
           "name": "lookupSlotCap_eq_none_of_lookupCNode_eq_none",
-          "line": 772,
+          "line": 780,
           "called": [
             "SlotRef",
             "SystemState",
@@ -11957,7 +11957,7 @@
         {
           "kind": "theorem",
           "name": "ownsSlot_iff",
-          "line": 779,
+          "line": 787,
           "called": [
             "CSpaceOwner",
             "SlotRef",
@@ -11970,7 +11970,7 @@
         {
           "kind": "theorem",
           "name": "ownedSlots_eq_nil_of_lookupCNode_eq_none",
-          "line": 787,
+          "line": 795,
           "called": [
             "CSpaceOwner",
             "SystemState",
@@ -11981,7 +11981,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_objectTypeMetadataConsistent",
-          "line": 796,
+          "line": 804,
           "called": [
             "SystemState",
             "storeObject"
@@ -11990,7 +11990,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_capabilityRefMetadataConsistent",
-          "line": 814,
+          "line": 822,
           "called": [
             "SystemState",
             "storeObject"
@@ -11999,7 +11999,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_lifecycleMetadataConsistent",
-          "line": 824,
+          "line": 832,
           "called": [
             "SystemState",
             "storeObject",
@@ -12010,7 +12010,7 @@
         {
           "kind": "theorem",
           "name": "default_systemState_lifecycleConsistent",
-          "line": 843,
+          "line": 851,
           "called": [
             "SystemState"
           ]
@@ -12018,7 +12018,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_metadata_sync_type_change",
-          "line": 865,
+          "line": 873,
           "called": [
             "SystemState",
             "storeObject",
@@ -12028,7 +12028,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_metadata_sync_capref_at_stored",
-          "line": 882,
+          "line": 890,
           "called": [
             "SystemState",
             "storeObject"
@@ -12037,7 +12037,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objectIndex_monotone",
-          "line": 905,
+          "line": 913,
           "called": [
             "SystemState",
             "storeObject"
@@ -12053,34 +12053,18 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform",
-          "line": 36,
+          "line": 44,
           "called": []
         },
         {
           "kind": "class",
           "name": "PlatformBinding",
-          "line": 46,
+          "line": 54,
           "called": []
         },
         {
           "kind": "def",
           "name": "PlatformBinding.runtime",
-          "line": 59,
-          "called": [
-            "PlatformBinding"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "PlatformBinding.boot",
-          "line": 63,
-          "called": [
-            "PlatformBinding"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "PlatformBinding.interrupt",
           "line": 67,
           "called": [
             "PlatformBinding"
@@ -12088,8 +12072,24 @@
         },
         {
           "kind": "def",
-          "name": "PlatformBinding.config",
+          "name": "PlatformBinding.boot",
           "line": 71,
+          "called": [
+            "PlatformBinding"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "PlatformBinding.interrupt",
+          "line": 75,
+          "called": [
+            "PlatformBinding"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "PlatformBinding.config",
+          "line": 79,
           "called": [
             "PlatformBinding"
           ]
@@ -12104,55 +12104,55 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform.RPi5",
-          "line": 23,
+          "line": 31,
           "called": []
         },
         {
           "kind": "def",
           "name": "peripheralBaseLow",
-          "line": 30,
+          "line": 38,
           "called": []
         },
         {
           "kind": "def",
           "name": "peripheralBaseHigh",
-          "line": 33,
+          "line": 41,
           "called": []
         },
         {
           "kind": "def",
           "name": "gicDistributorBase",
-          "line": 36,
+          "line": 44,
           "called": []
         },
         {
           "kind": "def",
           "name": "gicCpuInterfaceBase",
-          "line": 39,
+          "line": 47,
           "called": []
         },
         {
           "kind": "def",
           "name": "timerFrequencyHz",
-          "line": 42,
+          "line": 50,
           "called": []
         },
         {
           "kind": "def",
           "name": "uart0Base",
-          "line": 45,
+          "line": 53,
           "called": []
         },
         {
           "kind": "def",
           "name": "rpi5MemoryMap",
-          "line": 59,
+          "line": 67,
           "called": []
         },
         {
           "kind": "def",
           "name": "rpi5MachineConfig",
-          "line": 79,
+          "line": 87,
           "called": [
             "rpi5MemoryMap"
           ]
@@ -12160,19 +12160,19 @@
         {
           "kind": "def",
           "name": "gicSpiCount",
-          "line": 94,
+          "line": 102,
           "called": []
         },
         {
           "kind": "def",
           "name": "timerPpiId",
-          "line": 98,
+          "line": 106,
           "called": []
         },
         {
           "kind": "def",
           "name": "virtualTimerPpiId",
-          "line": 101,
+          "line": 109,
           "called": []
         }
       ]
@@ -12185,19 +12185,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform.RPi5",
-          "line": 26,
+          "line": 34,
           "called": []
         },
         {
           "kind": "def",
           "name": "rpi5BootContract",
-          "line": 35,
+          "line": 43,
           "called": []
         },
         {
           "kind": "def",
           "name": "rpi5InterruptContract",
-          "line": 52,
+          "line": 60,
           "called": []
         }
       ]
@@ -12210,19 +12210,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform.RPi5",
-          "line": 33,
+          "line": 41,
           "called": []
         },
         {
           "kind": "structure",
           "name": "RPi5Platform",
-          "line": 36,
+          "line": 44,
           "called": []
         },
         {
           "kind": "instance",
           "name": "rpi5PlatformBinding",
-          "line": 40,
+          "line": 48,
           "called": [
             "RPi5Platform"
           ]
@@ -12237,13 +12237,13 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform.RPi5",
-          "line": 25,
+          "line": 33,
           "called": []
         },
         {
           "kind": "def",
           "name": "rpi5RuntimeContract",
-          "line": 33,
+          "line": 41,
           "called": []
         }
       ]
@@ -12256,19 +12256,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform.Sim",
-          "line": 11,
+          "line": 19,
           "called": []
         },
         {
           "kind": "def",
           "name": "simBootContract",
-          "line": 18,
+          "line": 26,
           "called": []
         },
         {
           "kind": "def",
           "name": "simInterruptContract",
-          "line": 27,
+          "line": 35,
           "called": []
         }
       ]
@@ -12281,25 +12281,25 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform.Sim",
-          "line": 25,
+          "line": 33,
           "called": []
         },
         {
           "kind": "structure",
           "name": "SimPlatform",
-          "line": 28,
+          "line": 36,
           "called": []
         },
         {
           "kind": "def",
           "name": "simMachineConfig",
-          "line": 32,
+          "line": 40,
           "called": []
         },
         {
           "kind": "instance",
           "name": "simPlatformBinding",
-          "line": 47,
+          "line": 55,
           "called": [
             "SimPlatform",
             "simMachineConfig"
@@ -12315,19 +12315,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Platform.Sim",
-          "line": 16,
+          "line": 24,
           "called": []
         },
         {
           "kind": "def",
           "name": "simRuntimeContractPermissive",
-          "line": 23,
+          "line": 31,
           "called": []
         },
         {
           "kind": "def",
           "name": "simRuntimeContractRestrictive",
-          "line": 35,
+          "line": 43,
           "called": []
         }
       ]
@@ -12340,19 +12340,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n",
-          "line": 4,
+          "line": 12,
           "called": []
         },
         {
           "kind": "structure",
           "name": "ObjId",
-          "line": 21,
+          "line": 29,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:27>",
-          "line": 27,
+          "name": "<anonymous:instance:35>",
+          "line": 35,
           "called": [
             "ObjId"
           ]
@@ -12360,13 +12360,13 @@
         {
           "kind": "namespace",
           "name": "ObjId",
-          "line": 30,
+          "line": 38,
           "called": []
         },
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 33,
+          "line": 41,
           "called": [
             "ObjId"
           ]
@@ -12374,15 +12374,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 36,
+          "line": 44,
           "called": [
             "ObjId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:38>",
-          "line": 38,
+          "name": "<anonymous:instance:46>",
+          "line": 46,
           "called": [
             "ObjId"
           ]
@@ -12390,7 +12390,7 @@
         {
           "kind": "def",
           "name": "isReserved",
-          "line": 42,
+          "line": 50,
           "called": [
             "ObjId"
           ]
@@ -12398,7 +12398,7 @@
         {
           "kind": "def",
           "name": "sentinel",
-          "line": 45,
+          "line": 53,
           "called": [
             "ObjId"
           ]
@@ -12406,7 +12406,7 @@
         {
           "kind": "def",
           "name": "valid",
-          "line": 48,
+          "line": 56,
           "called": [
             "ObjId"
           ]
@@ -12414,13 +12414,13 @@
         {
           "kind": "structure",
           "name": "ThreadId",
-          "line": 53,
+          "line": 61,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:59>",
-          "line": 59,
+          "name": "<anonymous:instance:67>",
+          "line": 67,
           "called": [
             "ThreadId"
           ]
@@ -12428,13 +12428,13 @@
         {
           "kind": "namespace",
           "name": "ThreadId",
-          "line": 62,
+          "line": 70,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ext",
-          "line": 65,
+          "line": 73,
           "called": [
             "ThreadId"
           ]
@@ -12442,7 +12442,7 @@
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 69,
+          "line": 77,
           "called": [
             "ThreadId"
           ]
@@ -12450,7 +12450,7 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 72,
+          "line": 80,
           "called": [
             "ThreadId"
           ]
@@ -12458,7 +12458,7 @@
         {
           "kind": "def",
           "name": "toObjId",
-          "line": 84,
+          "line": 92,
           "called": [
             "ObjId",
             "ThreadId"
@@ -12466,8 +12466,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:86>",
-          "line": 86,
+          "name": "<anonymous:instance:94>",
+          "line": 94,
           "called": [
             "ThreadId"
           ]
@@ -12475,7 +12475,7 @@
         {
           "kind": "def",
           "name": "isReserved",
-          "line": 90,
+          "line": 98,
           "called": [
             "ThreadId"
           ]
@@ -12483,7 +12483,7 @@
         {
           "kind": "def",
           "name": "sentinel",
-          "line": 93,
+          "line": 101,
           "called": [
             "ThreadId"
           ]
@@ -12491,7 +12491,7 @@
         {
           "kind": "def",
           "name": "toObjIdChecked",
-          "line": 97,
+          "line": 105,
           "called": [
             "ObjId",
             "ThreadId",
@@ -12501,7 +12501,7 @@
         {
           "kind": "theorem",
           "name": "toObjIdChecked_eq_some_of_not_reserved",
-          "line": 101,
+          "line": 109,
           "called": [
             "ThreadId",
             "toObjIdChecked"
@@ -12510,7 +12510,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.toObjId_injective",
-          "line": 112,
+          "line": 120,
           "called": [
             "ThreadId"
           ]
@@ -12518,13 +12518,13 @@
         {
           "kind": "structure",
           "name": "DomainId",
-          "line": 119,
+          "line": 127,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:125>",
-          "line": 125,
+          "name": "<anonymous:instance:133>",
+          "line": 133,
           "called": [
             "DomainId"
           ]
@@ -12532,29 +12532,29 @@
         {
           "kind": "namespace",
           "name": "DomainId",
-          "line": 128,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ofNat",
-          "line": 131,
-          "called": [
-            "DomainId"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "toNat",
-          "line": 134,
-          "called": [
-            "DomainId"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:136>",
           "line": 136,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ofNat",
+          "line": 139,
+          "called": [
+            "DomainId"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "toNat",
+          "line": 142,
+          "called": [
+            "DomainId"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:144>",
+          "line": 144,
           "called": [
             "DomainId"
           ]
@@ -12562,13 +12562,13 @@
         {
           "kind": "structure",
           "name": "Priority",
-          "line": 142,
+          "line": 150,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:148>",
-          "line": 148,
+          "name": "<anonymous:instance:156>",
+          "line": 156,
           "called": [
             "Priority"
           ]
@@ -12576,13 +12576,13 @@
         {
           "kind": "namespace",
           "name": "Priority",
-          "line": 151,
+          "line": 159,
           "called": []
         },
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 154,
+          "line": 162,
           "called": [
             "Priority"
           ]
@@ -12590,15 +12590,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 157,
+          "line": 165,
           "called": [
             "Priority"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:159>",
-          "line": 159,
+          "name": "<anonymous:instance:167>",
+          "line": 167,
           "called": [
             "Priority"
           ]
@@ -12606,38 +12606,8 @@
         {
           "kind": "structure",
           "name": "Deadline",
-          "line": 169,
+          "line": 177,
           "called": []
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:175>",
-          "line": 175,
-          "called": [
-            "Deadline"
-          ]
-        },
-        {
-          "kind": "namespace",
-          "name": "Deadline",
-          "line": 178,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ofNat",
-          "line": 180,
-          "called": [
-            "Deadline"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "toNat",
-          "line": 181,
-          "called": [
-            "Deadline"
-          ]
         },
         {
           "kind": "instance",
@@ -12648,9 +12618,39 @@
           ]
         },
         {
+          "kind": "namespace",
+          "name": "Deadline",
+          "line": 186,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ofNat",
+          "line": 188,
+          "called": [
+            "Deadline"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "toNat",
+          "line": 189,
+          "called": [
+            "Deadline"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:191>",
+          "line": 191,
+          "called": [
+            "Deadline"
+          ]
+        },
+        {
           "kind": "def",
           "name": "none",
-          "line": 187,
+          "line": 195,
           "called": [
             "Deadline"
           ]
@@ -12658,7 +12658,7 @@
         {
           "kind": "def",
           "name": "immediate",
-          "line": 190,
+          "line": 198,
           "called": [
             "Deadline"
           ]
@@ -12666,13 +12666,13 @@
         {
           "kind": "structure",
           "name": "Irq",
-          "line": 195,
+          "line": 203,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:201>",
-          "line": 201,
+          "name": "<anonymous:instance:209>",
+          "line": 209,
           "called": [
             "Irq"
           ]
@@ -12680,29 +12680,29 @@
         {
           "kind": "namespace",
           "name": "Irq",
-          "line": 204,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ofNat",
-          "line": 207,
-          "called": [
-            "Irq"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "toNat",
-          "line": 210,
-          "called": [
-            "Irq"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:212>",
           "line": 212,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ofNat",
+          "line": 215,
+          "called": [
+            "Irq"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "toNat",
+          "line": 218,
+          "called": [
+            "Irq"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:220>",
+          "line": 220,
           "called": [
             "Irq"
           ]
@@ -12710,13 +12710,13 @@
         {
           "kind": "structure",
           "name": "ServiceId",
-          "line": 218,
+          "line": 226,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:224>",
-          "line": 224,
+          "name": "<anonymous:instance:232>",
+          "line": 232,
           "called": [
             "ServiceId"
           ]
@@ -12724,13 +12724,13 @@
         {
           "kind": "namespace",
           "name": "ServiceId",
-          "line": 227,
+          "line": 235,
           "called": []
         },
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 230,
+          "line": 238,
           "called": [
             "ServiceId"
           ]
@@ -12738,15 +12738,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 233,
+          "line": 241,
           "called": [
             "ServiceId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:235>",
-          "line": 235,
+          "name": "<anonymous:instance:243>",
+          "line": 243,
           "called": [
             "ServiceId"
           ]
@@ -12754,7 +12754,7 @@
         {
           "kind": "def",
           "name": "isReserved",
-          "line": 239,
+          "line": 247,
           "called": [
             "ServiceId"
           ]
@@ -12762,7 +12762,7 @@
         {
           "kind": "def",
           "name": "sentinel",
-          "line": 242,
+          "line": 250,
           "called": [
             "ServiceId"
           ]
@@ -12770,13 +12770,13 @@
         {
           "kind": "structure",
           "name": "CPtr",
-          "line": 247,
+          "line": 255,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:253>",
-          "line": 253,
+          "name": "<anonymous:instance:261>",
+          "line": 261,
           "called": [
             "CPtr"
           ]
@@ -12784,13 +12784,13 @@
         {
           "kind": "namespace",
           "name": "CPtr",
-          "line": 256,
+          "line": 264,
           "called": []
         },
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 259,
+          "line": 267,
           "called": [
             "CPtr"
           ]
@@ -12798,15 +12798,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 262,
+          "line": 270,
           "called": [
             "CPtr"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:264>",
-          "line": 264,
+          "name": "<anonymous:instance:272>",
+          "line": 272,
           "called": [
             "CPtr"
           ]
@@ -12814,7 +12814,7 @@
         {
           "kind": "def",
           "name": "isReserved",
-          "line": 269,
+          "line": 277,
           "called": [
             "CPtr"
           ]
@@ -12822,7 +12822,7 @@
         {
           "kind": "def",
           "name": "sentinel",
-          "line": 272,
+          "line": 280,
           "called": [
             "CPtr"
           ]
@@ -12830,7 +12830,7 @@
         {
           "kind": "theorem",
           "name": "default_eq_sentinel",
-          "line": 274,
+          "line": 282,
           "called": [
             "CPtr"
           ]
@@ -12838,7 +12838,7 @@
         {
           "kind": "theorem",
           "name": "sentinel_isReserved",
-          "line": 276,
+          "line": 284,
           "called": [
             "CPtr"
           ]
@@ -12846,13 +12846,13 @@
         {
           "kind": "structure",
           "name": "Slot",
-          "line": 281,
+          "line": 289,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:287>",
-          "line": 287,
+          "name": "<anonymous:instance:295>",
+          "line": 295,
           "called": [
             "Slot"
           ]
@@ -12860,29 +12860,29 @@
         {
           "kind": "namespace",
           "name": "Slot",
-          "line": 290,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ofNat",
-          "line": 293,
-          "called": [
-            "Slot"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "toNat",
-          "line": 296,
-          "called": [
-            "Slot"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:298>",
           "line": 298,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ofNat",
+          "line": 301,
+          "called": [
+            "Slot"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "toNat",
+          "line": 304,
+          "called": [
+            "Slot"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:306>",
+          "line": 306,
           "called": [
             "Slot"
           ]
@@ -12890,13 +12890,13 @@
         {
           "kind": "structure",
           "name": "Badge",
-          "line": 304,
+          "line": 312,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:310>",
-          "line": 310,
+          "name": "<anonymous:instance:318>",
+          "line": 318,
           "called": [
             "Badge"
           ]
@@ -12904,29 +12904,29 @@
         {
           "kind": "namespace",
           "name": "Badge",
-          "line": 313,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ofNat",
-          "line": 316,
-          "called": [
-            "Badge"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "toNat",
-          "line": 319,
-          "called": [
-            "Badge"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:321>",
           "line": 321,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ofNat",
+          "line": 324,
+          "called": [
+            "Badge"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "toNat",
+          "line": 327,
+          "called": [
+            "Badge"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:329>",
+          "line": 329,
           "called": [
             "Badge"
           ]
@@ -12934,13 +12934,13 @@
         {
           "kind": "structure",
           "name": "ASID",
-          "line": 327,
+          "line": 335,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:333>",
-          "line": 333,
+          "name": "<anonymous:instance:341>",
+          "line": 341,
           "called": [
             "ASID"
           ]
@@ -12948,29 +12948,29 @@
         {
           "kind": "namespace",
           "name": "ASID",
-          "line": 336,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "ofNat",
-          "line": 339,
-          "called": [
-            "ASID"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "toNat",
-          "line": 342,
-          "called": [
-            "ASID"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:344>",
           "line": 344,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "ofNat",
+          "line": 347,
+          "called": [
+            "ASID"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "toNat",
+          "line": 350,
+          "called": [
+            "ASID"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:352>",
+          "line": 352,
           "called": [
             "ASID"
           ]
@@ -12978,13 +12978,13 @@
         {
           "kind": "structure",
           "name": "VAddr",
-          "line": 350,
+          "line": 358,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:356>",
-          "line": 356,
+          "name": "<anonymous:instance:364>",
+          "line": 364,
           "called": [
             "VAddr"
           ]
@@ -12992,13 +12992,13 @@
         {
           "kind": "namespace",
           "name": "VAddr",
-          "line": 359,
+          "line": 367,
           "called": []
         },
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 362,
+          "line": 370,
           "called": [
             "VAddr"
           ]
@@ -13006,15 +13006,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 365,
+          "line": 373,
           "called": [
             "VAddr"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:367>",
-          "line": 367,
+          "name": "<anonymous:instance:375>",
+          "line": 375,
           "called": [
             "VAddr"
           ]
@@ -13022,13 +13022,13 @@
         {
           "kind": "structure",
           "name": "PAddr",
-          "line": 373,
+          "line": 381,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:379>",
-          "line": 379,
+          "name": "<anonymous:instance:387>",
+          "line": 387,
           "called": [
             "PAddr"
           ]
@@ -13036,13 +13036,13 @@
         {
           "kind": "namespace",
           "name": "PAddr",
-          "line": 382,
+          "line": 390,
           "called": []
         },
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 385,
+          "line": 393,
           "called": [
             "PAddr"
           ]
@@ -13050,15 +13050,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 388,
+          "line": 396,
           "called": [
             "PAddr"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:390>",
-          "line": 390,
+          "name": "<anonymous:instance:398>",
+          "line": 398,
           "called": [
             "PAddr"
           ]
@@ -13066,19 +13066,19 @@
         {
           "kind": "abbrev",
           "name": "KernelM",
-          "line": 396,
+          "line": 404,
           "called": []
         },
         {
           "kind": "namespace",
           "name": "KernelM",
-          "line": 398,
+          "line": 406,
           "called": []
         },
         {
           "kind": "def",
           "name": "pure",
-          "line": 400,
+          "line": 408,
           "called": [
             "KernelM"
           ]
@@ -13086,15 +13086,15 @@
         {
           "kind": "def",
           "name": "bind",
-          "line": 403,
+          "line": 411,
           "called": [
             "KernelM"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:409>",
-          "line": 409,
+          "name": "<anonymous:instance:417>",
+          "line": 417,
           "called": [
             "KernelM",
             "bind",
@@ -13104,28 +13104,12 @@
         {
           "kind": "namespace",
           "name": "KernelM",
-          "line": 419,
+          "line": 427,
           "called": []
         },
         {
           "kind": "def",
           "name": "get",
-          "line": 422,
-          "called": [
-            "KernelM"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "set",
-          "line": 426,
-          "called": [
-            "KernelM"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "modify",
           "line": 430,
           "called": [
             "KernelM"
@@ -13133,7 +13117,7 @@
         },
         {
           "kind": "def",
-          "name": "liftExcept",
+          "name": "set",
           "line": 434,
           "called": [
             "KernelM"
@@ -13141,8 +13125,24 @@
         },
         {
           "kind": "def",
+          "name": "modify",
+          "line": 438,
+          "called": [
+            "KernelM"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "liftExcept",
+          "line": 442,
+          "called": [
+            "KernelM"
+          ]
+        },
+        {
+          "kind": "def",
           "name": "throw",
-          "line": 441,
+          "line": 449,
           "called": [
             "KernelM"
           ]
@@ -13150,7 +13150,7 @@
         {
           "kind": "theorem",
           "name": "get_returns_state",
-          "line": 446,
+          "line": 454,
           "called": [
             "get"
           ]
@@ -13158,7 +13158,7 @@
         {
           "kind": "theorem",
           "name": "set_replaces_state",
-          "line": 449,
+          "line": 457,
           "called": [
             "set"
           ]
@@ -13166,7 +13166,7 @@
         {
           "kind": "theorem",
           "name": "modify_applies_function",
-          "line": 452,
+          "line": 460,
           "called": [
             "modify"
           ]
@@ -13174,7 +13174,7 @@
         {
           "kind": "theorem",
           "name": "liftExcept_ok",
-          "line": 455,
+          "line": 463,
           "called": [
             "liftExcept"
           ]
@@ -13182,7 +13182,7 @@
         {
           "kind": "theorem",
           "name": "liftExcept_error",
-          "line": 458,
+          "line": 466,
           "called": [
             "liftExcept"
           ]
@@ -13190,13 +13190,13 @@
         {
           "kind": "theorem",
           "name": "throw_errors",
-          "line": 461,
+          "line": 469,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "pure_bind_law",
-          "line": 467,
+          "line": 475,
           "called": [
             "KernelM",
             "bind",
@@ -13206,7 +13206,7 @@
         {
           "kind": "theorem",
           "name": "bind_pure_law",
-          "line": 471,
+          "line": 479,
           "called": [
             "KernelM",
             "bind",
@@ -13216,7 +13216,7 @@
         {
           "kind": "theorem",
           "name": "bind_assoc_law",
-          "line": 480,
+          "line": 488,
           "called": [
             "KernelM",
             "bind"
@@ -13225,7 +13225,7 @@
         {
           "kind": "instance",
           "name": "instLawfulMonad",
-          "line": 489,
+          "line": 497,
           "called": [
             "KernelM",
             "bind",
@@ -13236,114 +13236,98 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:520>",
-          "line": 520,
+          "name": "<anonymous:instance:528>",
+          "line": 528,
           "called": [
             "ObjId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:523>",
-          "line": 523,
+          "name": "<anonymous:instance:531>",
+          "line": 531,
           "called": [
             "ThreadId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:526>",
-          "line": 526,
+          "name": "<anonymous:instance:534>",
+          "line": 534,
           "called": [
             "DomainId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:529>",
-          "line": 529,
+          "name": "<anonymous:instance:537>",
+          "line": 537,
           "called": [
             "Priority"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:532>",
-          "line": 532,
+          "name": "<anonymous:instance:540>",
+          "line": 540,
           "called": [
             "Deadline"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:535>",
-          "line": 535,
+          "name": "<anonymous:instance:543>",
+          "line": 543,
           "called": [
             "Irq"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:538>",
-          "line": 538,
+          "name": "<anonymous:instance:546>",
+          "line": 546,
           "called": [
             "ServiceId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:541>",
-          "line": 541,
+          "name": "<anonymous:instance:549>",
+          "line": 549,
           "called": [
             "CPtr"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:544>",
-          "line": 544,
+          "name": "<anonymous:instance:552>",
+          "line": 552,
           "called": [
             "Slot"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:547>",
-          "line": 547,
+          "name": "<anonymous:instance:555>",
+          "line": 555,
           "called": [
             "Badge"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:550>",
-          "line": 550,
+          "name": "<anonymous:instance:558>",
+          "line": 558,
           "called": [
             "ASID"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:553>",
-          "line": 553,
+          "name": "<anonymous:instance:561>",
+          "line": 561,
           "called": [
             "VAddr"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:556>",
-          "line": 556,
-          "called": [
-            "PAddr"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:563>",
-          "line": 563,
-          "called": [
-            "ObjId"
           ]
         },
         {
@@ -13351,55 +13335,7 @@
           "name": "<anonymous:instance:564>",
           "line": 564,
           "called": [
-            "ThreadId"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:565>",
-          "line": 565,
-          "called": [
-            "DomainId"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:566>",
-          "line": 566,
-          "called": [
-            "Priority"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:567>",
-          "line": 567,
-          "called": [
-            "Deadline"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:568>",
-          "line": 568,
-          "called": [
-            "Irq"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:569>",
-          "line": 569,
-          "called": [
-            "ServiceId"
-          ]
-        },
-        {
-          "kind": "instance",
-          "name": "<anonymous:instance:570>",
-          "line": 570,
-          "called": [
-            "CPtr"
+            "PAddr"
           ]
         },
         {
@@ -13407,7 +13343,7 @@
           "name": "<anonymous:instance:571>",
           "line": 571,
           "called": [
-            "Slot"
+            "ObjId"
           ]
         },
         {
@@ -13415,7 +13351,7 @@
           "name": "<anonymous:instance:572>",
           "line": 572,
           "called": [
-            "Badge"
+            "ThreadId"
           ]
         },
         {
@@ -13423,7 +13359,7 @@
           "name": "<anonymous:instance:573>",
           "line": 573,
           "called": [
-            "ASID"
+            "DomainId"
           ]
         },
         {
@@ -13431,7 +13367,7 @@
           "name": "<anonymous:instance:574>",
           "line": 574,
           "called": [
-            "VAddr"
+            "Priority"
           ]
         },
         {
@@ -13439,7 +13375,15 @@
           "name": "<anonymous:instance:575>",
           "line": 575,
           "called": [
-            "PAddr"
+            "Deadline"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:576>",
+          "line": 576,
+          "called": [
+            "Irq"
           ]
         },
         {
@@ -13447,7 +13391,23 @@
           "name": "<anonymous:instance:577>",
           "line": 577,
           "called": [
-            "ObjId"
+            "ServiceId"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:578>",
+          "line": 578,
+          "called": [
+            "CPtr"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:579>",
+          "line": 579,
+          "called": [
+            "Slot"
           ]
         },
         {
@@ -13455,7 +13415,23 @@
           "name": "<anonymous:instance:580>",
           "line": 580,
           "called": [
-            "ThreadId"
+            "Badge"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:581>",
+          "line": 581,
+          "called": [
+            "ASID"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:582>",
+          "line": 582,
+          "called": [
+            "VAddr"
           ]
         },
         {
@@ -13463,85 +13439,109 @@
           "name": "<anonymous:instance:583>",
           "line": 583,
           "called": [
+            "PAddr"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:585>",
+          "line": 585,
+          "called": [
+            "ObjId"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:588>",
+          "line": 588,
+          "called": [
+            "ThreadId"
+          ]
+        },
+        {
+          "kind": "instance",
+          "name": "<anonymous:instance:591>",
+          "line": 591,
+          "called": [
             "DomainId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:586>",
-          "line": 586,
+          "name": "<anonymous:instance:594>",
+          "line": 594,
           "called": [
             "Priority"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:589>",
-          "line": 589,
+          "name": "<anonymous:instance:597>",
+          "line": 597,
           "called": [
             "Deadline"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:592>",
-          "line": 592,
+          "name": "<anonymous:instance:600>",
+          "line": 600,
           "called": [
             "Irq"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:595>",
-          "line": 595,
+          "name": "<anonymous:instance:603>",
+          "line": 603,
           "called": [
             "ServiceId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:598>",
-          "line": 598,
+          "name": "<anonymous:instance:606>",
+          "line": 606,
           "called": [
             "CPtr"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:601>",
-          "line": 601,
+          "name": "<anonymous:instance:609>",
+          "line": 609,
           "called": [
             "Slot"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:604>",
-          "line": 604,
+          "name": "<anonymous:instance:612>",
+          "line": 612,
           "called": [
             "Badge"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:607>",
-          "line": 607,
+          "name": "<anonymous:instance:615>",
+          "line": 615,
           "called": [
             "ASID"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:610>",
-          "line": 610,
+          "name": "<anonymous:instance:618>",
+          "line": 618,
           "called": [
             "VAddr"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:613>",
-          "line": 613,
+          "name": "<anonymous:instance:621>",
+          "line": 621,
           "called": [
             "PAddr"
           ]
@@ -13549,7 +13549,7 @@
         {
           "kind": "theorem",
           "name": "HashMap_get",
-          "line": 623,
+          "line": 631,
           "called": [
             "get"
           ]
@@ -13557,7 +13557,7 @@
         {
           "kind": "theorem",
           "name": "HashMap_get",
-          "line": 629,
+          "line": 637,
           "called": [
             "get",
             "none"
@@ -13566,7 +13566,7 @@
         {
           "kind": "theorem",
           "name": "HashMap_get",
-          "line": 634,
+          "line": 642,
           "called": [
             "get",
             "none"
@@ -13575,13 +13575,13 @@
         {
           "kind": "theorem",
           "name": "HashMap_getElem",
-          "line": 641,
+          "line": 649,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashMap_getElem",
-          "line": 647,
+          "line": 655,
           "called": [
             "none"
           ]
@@ -13589,7 +13589,7 @@
         {
           "kind": "theorem",
           "name": "HashMap_getElem",
-          "line": 652,
+          "line": 660,
           "called": [
             "none"
           ]
@@ -13597,19 +13597,19 @@
         {
           "kind": "theorem",
           "name": "HashMap_getElem",
-          "line": 659,
+          "line": 667,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashMap_get",
-          "line": 663,
+          "line": 671,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashMap_filter_preserves_key",
-          "line": 673,
+          "line": 681,
           "called": [
             "none"
           ]
@@ -13617,55 +13617,55 @@
         {
           "kind": "theorem",
           "name": "HashMap_filter_filter_getElem",
-          "line": 697,
+          "line": 705,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashSet_contains_empty",
-          "line": 723,
+          "line": 731,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashSet_contains_insert_iff",
-          "line": 729,
+          "line": 737,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashSet_not_contains_insert",
-          "line": 743,
+          "line": 751,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "HashSet_contains_insert_self",
-          "line": 758,
+          "line": 766,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "List.foldl_preserves_contains",
-          "line": 769,
+          "line": 777,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "List.foldl_not_contains_when_absent",
-          "line": 783,
+          "line": 791,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "List.foldl_preserves_when_pred_false",
-          "line": 803,
+          "line": 811,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ObjId.default_eq_sentinel",
-          "line": 831,
+          "line": 839,
           "called": [
             "ObjId"
           ]
@@ -13673,7 +13673,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.default_eq_sentinel",
-          "line": 834,
+          "line": 842,
           "called": [
             "ThreadId"
           ]
@@ -13681,19 +13681,19 @@
         {
           "kind": "theorem",
           "name": "ObjId.sentinel_isReserved",
-          "line": 837,
+          "line": 845,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ThreadId.sentinel_isReserved",
-          "line": 840,
+          "line": 848,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ObjId.valid_iff_not_reserved",
-          "line": 843,
+          "line": 851,
           "called": [
             "ObjId"
           ]
@@ -13701,7 +13701,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.default_eq_sentinel",
-          "line": 848,
+          "line": 856,
           "called": [
             "ServiceId"
           ]
@@ -13709,13 +13709,13 @@
         {
           "kind": "theorem",
           "name": "ServiceId.sentinel_isReserved",
-          "line": 851,
+          "line": 859,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ObjId.toNat_ofNat",
-          "line": 858,
+          "line": 866,
           "called": [
             "toNat"
           ]
@@ -13723,7 +13723,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.ofNat_toNat",
-          "line": 860,
+          "line": 868,
           "called": [
             "ObjId"
           ]
@@ -13731,13 +13731,13 @@
         {
           "kind": "theorem",
           "name": "ObjId.ofNat_injective",
-          "line": 862,
+          "line": 870,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ObjId.ext",
-          "line": 865,
+          "line": 873,
           "called": [
             "ObjId"
           ]
@@ -13745,28 +13745,6 @@
         {
           "kind": "theorem",
           "name": "ThreadId.toNat_ofNat",
-          "line": 869,
-          "called": [
-            "toNat"
-          ]
-        },
-        {
-          "kind": "theorem",
-          "name": "ThreadId.ofNat_toNat",
-          "line": 871,
-          "called": [
-            "ThreadId"
-          ]
-        },
-        {
-          "kind": "theorem",
-          "name": "ThreadId.ofNat_injective",
-          "line": 873,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "DomainId.toNat_ofNat",
           "line": 877,
           "called": [
             "toNat"
@@ -13774,8 +13752,30 @@
         },
         {
           "kind": "theorem",
-          "name": "DomainId.ofNat_toNat",
+          "name": "ThreadId.ofNat_toNat",
           "line": 879,
+          "called": [
+            "ThreadId"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "ThreadId.ofNat_injective",
+          "line": 881,
+          "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "DomainId.toNat_ofNat",
+          "line": 885,
+          "called": [
+            "toNat"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "DomainId.ofNat_toNat",
+          "line": 887,
           "called": [
             "DomainId"
           ]
@@ -13783,13 +13783,13 @@
         {
           "kind": "theorem",
           "name": "DomainId.ofNat_injective",
-          "line": 881,
+          "line": 889,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "DomainId.ext",
-          "line": 884,
+          "line": 892,
           "called": [
             "DomainId"
           ]
@@ -13797,7 +13797,7 @@
         {
           "kind": "theorem",
           "name": "Priority.toNat_ofNat",
-          "line": 888,
+          "line": 896,
           "called": [
             "toNat"
           ]
@@ -13805,7 +13805,7 @@
         {
           "kind": "theorem",
           "name": "Priority.ofNat_toNat",
-          "line": 890,
+          "line": 898,
           "called": [
             "Priority"
           ]
@@ -13813,13 +13813,13 @@
         {
           "kind": "theorem",
           "name": "Priority.ofNat_injective",
-          "line": 892,
+          "line": 900,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "Priority.ext",
-          "line": 895,
+          "line": 903,
           "called": [
             "Priority"
           ]
@@ -13827,7 +13827,7 @@
         {
           "kind": "theorem",
           "name": "Deadline.toNat_ofNat",
-          "line": 899,
+          "line": 907,
           "called": [
             "toNat"
           ]
@@ -13835,7 +13835,7 @@
         {
           "kind": "theorem",
           "name": "Deadline.ofNat_toNat",
-          "line": 901,
+          "line": 909,
           "called": [
             "Deadline"
           ]
@@ -13843,13 +13843,13 @@
         {
           "kind": "theorem",
           "name": "Deadline.ofNat_injective",
-          "line": 903,
+          "line": 911,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "Deadline.ext",
-          "line": 906,
+          "line": 914,
           "called": [
             "Deadline"
           ]
@@ -13857,7 +13857,7 @@
         {
           "kind": "theorem",
           "name": "Irq.toNat_ofNat",
-          "line": 910,
+          "line": 918,
           "called": [
             "toNat"
           ]
@@ -13865,7 +13865,7 @@
         {
           "kind": "theorem",
           "name": "Irq.ofNat_toNat",
-          "line": 912,
+          "line": 920,
           "called": [
             "Irq"
           ]
@@ -13873,13 +13873,13 @@
         {
           "kind": "theorem",
           "name": "Irq.ofNat_injective",
-          "line": 914,
+          "line": 922,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "Irq.ext",
-          "line": 917,
+          "line": 925,
           "called": [
             "Irq"
           ]
@@ -13887,7 +13887,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.toNat_ofNat",
-          "line": 921,
+          "line": 929,
           "called": [
             "toNat"
           ]
@@ -13895,7 +13895,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.ofNat_toNat",
-          "line": 923,
+          "line": 931,
           "called": [
             "ServiceId"
           ]
@@ -13903,13 +13903,13 @@
         {
           "kind": "theorem",
           "name": "ServiceId.ofNat_injective",
-          "line": 925,
+          "line": 933,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ServiceId.ext",
-          "line": 928,
+          "line": 936,
           "called": [
             "ServiceId"
           ]
@@ -13917,7 +13917,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.toNat_ofNat",
-          "line": 932,
+          "line": 940,
           "called": [
             "toNat"
           ]
@@ -13925,7 +13925,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.ofNat_toNat",
-          "line": 934,
+          "line": 942,
           "called": [
             "CPtr"
           ]
@@ -13933,13 +13933,13 @@
         {
           "kind": "theorem",
           "name": "CPtr.ofNat_injective",
-          "line": 936,
+          "line": 944,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "CPtr.ext",
-          "line": 939,
+          "line": 947,
           "called": [
             "CPtr"
           ]
@@ -13947,7 +13947,7 @@
         {
           "kind": "theorem",
           "name": "Slot.toNat_ofNat",
-          "line": 943,
+          "line": 951,
           "called": [
             "toNat"
           ]
@@ -13955,7 +13955,7 @@
         {
           "kind": "theorem",
           "name": "Slot.ofNat_toNat",
-          "line": 945,
+          "line": 953,
           "called": [
             "Slot"
           ]
@@ -13963,13 +13963,13 @@
         {
           "kind": "theorem",
           "name": "Slot.ofNat_injective",
-          "line": 947,
+          "line": 955,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "Slot.ext",
-          "line": 950,
+          "line": 958,
           "called": [
             "Slot"
           ]
@@ -13977,7 +13977,7 @@
         {
           "kind": "theorem",
           "name": "Badge.toNat_ofNat",
-          "line": 954,
+          "line": 962,
           "called": [
             "toNat"
           ]
@@ -13985,7 +13985,7 @@
         {
           "kind": "theorem",
           "name": "Badge.ofNat_toNat",
-          "line": 956,
+          "line": 964,
           "called": [
             "Badge"
           ]
@@ -13993,13 +13993,13 @@
         {
           "kind": "theorem",
           "name": "Badge.ofNat_injective",
-          "line": 958,
+          "line": 966,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "Badge.ext",
-          "line": 961,
+          "line": 969,
           "called": [
             "Badge"
           ]
@@ -14007,7 +14007,7 @@
         {
           "kind": "theorem",
           "name": "ASID.toNat_ofNat",
-          "line": 965,
+          "line": 973,
           "called": [
             "toNat"
           ]
@@ -14015,7 +14015,7 @@
         {
           "kind": "theorem",
           "name": "ASID.ofNat_toNat",
-          "line": 967,
+          "line": 975,
           "called": [
             "ASID"
           ]
@@ -14023,13 +14023,13 @@
         {
           "kind": "theorem",
           "name": "ASID.ofNat_injective",
-          "line": 969,
+          "line": 977,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ASID.ext",
-          "line": 972,
+          "line": 980,
           "called": [
             "ASID"
           ]
@@ -14037,7 +14037,7 @@
         {
           "kind": "theorem",
           "name": "VAddr.toNat_ofNat",
-          "line": 976,
+          "line": 984,
           "called": [
             "toNat"
           ]
@@ -14045,7 +14045,7 @@
         {
           "kind": "theorem",
           "name": "VAddr.ofNat_toNat",
-          "line": 978,
+          "line": 986,
           "called": [
             "VAddr"
           ]
@@ -14053,13 +14053,13 @@
         {
           "kind": "theorem",
           "name": "VAddr.ofNat_injective",
-          "line": 980,
+          "line": 988,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "VAddr.ext",
-          "line": 983,
+          "line": 991,
           "called": [
             "VAddr"
           ]
@@ -14067,7 +14067,7 @@
         {
           "kind": "theorem",
           "name": "PAddr.toNat_ofNat",
-          "line": 987,
+          "line": 995,
           "called": [
             "toNat"
           ]
@@ -14075,7 +14075,7 @@
         {
           "kind": "theorem",
           "name": "PAddr.ofNat_toNat",
-          "line": 989,
+          "line": 997,
           "called": [
             "PAddr"
           ]
@@ -14083,13 +14083,13 @@
         {
           "kind": "theorem",
           "name": "PAddr.ofNat_injective",
-          "line": 991,
+          "line": 999,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "PAddr.ext",
-          "line": 994,
+          "line": 1002,
           "called": [
             "PAddr"
           ]
@@ -14097,7 +14097,7 @@
         {
           "kind": "def",
           "name": "ThreadId.valid",
-          "line": 1002,
+          "line": 1010,
           "called": [
             "ThreadId"
           ]
@@ -14105,7 +14105,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.valid_iff_not_reserved",
-          "line": 1005,
+          "line": 1013,
           "called": [
             "ThreadId",
             "ThreadId.valid"
@@ -14114,7 +14114,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.sentinel_not_valid",
-          "line": 1010,
+          "line": 1018,
           "called": [
             "ThreadId.valid"
           ]
@@ -14122,7 +14122,7 @@
         {
           "kind": "def",
           "name": "ServiceId.valid",
-          "line": 1014,
+          "line": 1022,
           "called": [
             "ServiceId"
           ]
@@ -14130,7 +14130,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.valid_iff_not_reserved",
-          "line": 1017,
+          "line": 1025,
           "called": [
             "ServiceId",
             "ServiceId.valid"
@@ -14139,7 +14139,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.sentinel_not_valid",
-          "line": 1022,
+          "line": 1030,
           "called": [
             "ServiceId.valid"
           ]
@@ -14147,7 +14147,7 @@
         {
           "kind": "def",
           "name": "CPtr.valid",
-          "line": 1026,
+          "line": 1034,
           "called": [
             "CPtr"
           ]
@@ -14155,7 +14155,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.valid_iff_not_reserved",
-          "line": 1029,
+          "line": 1037,
           "called": [
             "CPtr",
             "CPtr.valid"
@@ -14164,7 +14164,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.sentinel_not_valid",
-          "line": 1034,
+          "line": 1042,
           "called": [
             "CPtr.valid"
           ]
@@ -14172,7 +14172,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.sentinel_not_valid",
-          "line": 1038,
+          "line": 1046,
           "called": []
         }
       ]
@@ -14185,19 +14185,19 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Testing",
-          "line": 5,
+          "line": 13,
           "called": []
         },
         {
           "kind": "def",
           "name": "lookupQueueTcbB",
-          "line": 7,
+          "line": 15,
           "called": []
         },
         {
           "kind": "def",
           "name": "intrusiveQueueReachable",
-          "line": 12,
+          "line": 20,
           "called": [
             "lookupQueueTcbB"
           ]
@@ -14205,7 +14205,7 @@
         {
           "kind": "def",
           "name": "intrusiveQueueWellFormedB",
-          "line": 42,
+          "line": 50,
           "called": [
             "intrusiveQueueReachable",
             "lookupQueueTcbB"
@@ -14214,7 +14214,7 @@
         {
           "kind": "def",
           "name": "endpointDualQueueWellFormedB",
-          "line": 57,
+          "line": 65,
           "called": [
             "intrusiveQueueWellFormedB"
           ]
@@ -14222,91 +14222,91 @@
         {
           "kind": "def",
           "name": "notificationQueueWellFormedB",
-          "line": 60,
+          "line": 68,
           "called": []
         },
         {
           "kind": "def",
           "name": "schedulerQueueCurrentConsistentB",
-          "line": 66,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "schedulerRunQueueUniqueB",
-          "line": 71,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "currentThreadValidB",
           "line": 74,
           "called": []
         },
         {
           "kind": "def",
+          "name": "schedulerRunQueueUniqueB",
+          "line": 79,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "currentThreadValidB",
+          "line": 82,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "cspaceSlotCoherencyChecks",
-          "line": 84,
+          "line": 92,
           "called": []
         },
         {
           "kind": "def",
           "name": "capabilityRightsStructuralChecks",
-          "line": 100,
+          "line": 108,
           "called": []
         },
         {
           "kind": "def",
           "name": "lifecycleMetadataChecks",
-          "line": 113,
+          "line": 121,
           "called": []
         },
         {
           "kind": "def",
           "name": "serviceGraphAcyclicityChecks",
-          "line": 122,
+          "line": 130,
           "called": []
         },
         {
           "kind": "def",
           "name": "vspaceAsidUniquenessChecks",
-          "line": 132,
+          "line": 140,
           "called": []
         },
         {
           "kind": "def",
           "name": "asidTableConsistencyChecks",
-          "line": 143,
+          "line": 151,
           "called": []
         },
         {
           "kind": "def",
           "name": "untypedWatermarkChecks",
-          "line": 166,
+          "line": 174,
           "called": []
         },
         {
           "kind": "def",
           "name": "notificationWaiterConsistentChecks",
-          "line": 178,
+          "line": 186,
           "called": []
         },
         {
           "kind": "def",
           "name": "runQueueThreadPriorityConsistentB",
-          "line": 193,
+          "line": 201,
           "called": []
         },
         {
           "kind": "def",
           "name": "cdtChildMapConsistentCheck",
-          "line": 202,
+          "line": 210,
           "called": []
         },
         {
           "kind": "def",
           "name": "stateInvariantChecksFor",
-          "line": 217,
+          "line": 225,
           "called": [
             "asidTableConsistencyChecks",
             "capabilityRightsStructuralChecks",
@@ -14329,7 +14329,7 @@
         {
           "kind": "def",
           "name": "stateInvariantChecks",
-          "line": 261,
+          "line": 269,
           "called": [
             "stateInvariantChecksFor"
           ]
@@ -14337,13 +14337,13 @@
         {
           "kind": "def",
           "name": "failedChecks",
-          "line": 264,
+          "line": 272,
           "called": []
         },
         {
           "kind": "def",
           "name": "assertStateInvariantsFor",
-          "line": 267,
+          "line": 275,
           "called": [
             "failedChecks",
             "stateInvariantChecksFor"
@@ -14352,7 +14352,7 @@
         {
           "kind": "def",
           "name": "assertStateInvariants",
-          "line": 275,
+          "line": 283,
           "called": [
             "assertStateInvariantsFor"
           ]
@@ -14367,121 +14367,121 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Testing",
-          "line": 8,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "mkRunQueue",
-          "line": 11,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "rootSlot",
-          "line": 14,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "rootPath",
-          "line": 15,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "rootPathAlias",
           "line": 16,
           "called": []
         },
         {
           "kind": "def",
-          "name": "lifecycleAuthSlot",
-          "line": 17,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "mintedSlot",
-          "line": 18,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "siblingSlot",
+          "name": "mkRunQueue",
           "line": 19,
           "called": []
         },
         {
           "kind": "def",
-          "name": "demoEndpoint",
-          "line": 20,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "demoNotification",
-          "line": 21,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "demoUntyped",
+          "name": "rootSlot",
           "line": 22,
           "called": []
         },
         {
           "kind": "def",
-          "name": "untypedAuthSlot",
+          "name": "rootPath",
           "line": 23,
           "called": []
         },
         {
           "kind": "def",
-          "name": "svcDb",
+          "name": "rootPathAlias",
+          "line": 24,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "lifecycleAuthSlot",
           "line": 25,
           "called": []
         },
         {
           "kind": "def",
-          "name": "svcApi",
+          "name": "mintedSlot",
           "line": 26,
           "called": []
         },
         {
           "kind": "def",
-          "name": "svcDenied",
+          "name": "siblingSlot",
           "line": 27,
           "called": []
         },
         {
           "kind": "def",
-          "name": "svcBroken",
+          "name": "demoEndpoint",
           "line": 28,
           "called": []
         },
         {
           "kind": "def",
-          "name": "svcRestart",
+          "name": "demoNotification",
           "line": 29,
           "called": []
         },
         {
           "kind": "def",
-          "name": "svcRestartBroken",
+          "name": "demoUntyped",
           "line": 30,
           "called": []
         },
         {
           "kind": "def",
-          "name": "svcMissingBacking",
+          "name": "untypedAuthSlot",
           "line": 31,
           "called": []
         },
         {
           "kind": "def",
-          "name": "bootstrapInvariantObjectIds",
+          "name": "svcDb",
           "line": 33,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "svcApi",
+          "line": 34,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "svcDenied",
+          "line": 35,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "svcBroken",
+          "line": 36,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "svcRestart",
+          "line": 37,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "svcRestartBroken",
+          "line": 38,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "svcMissingBacking",
+          "line": 39,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "bootstrapInvariantObjectIds",
+          "line": 41,
           "called": [
             "demoEndpoint",
             "demoNotification",
@@ -14491,7 +14491,7 @@
         {
           "kind": "def",
           "name": "bootstrapServiceIds",
-          "line": 36,
+          "line": 44,
           "called": [
             "svcApi",
             "svcBroken",
@@ -14505,7 +14505,7 @@
         {
           "kind": "def",
           "name": "bootstrapState",
-          "line": 39,
+          "line": 47,
           "called": [
             "demoEndpoint",
             "demoNotification",
@@ -14525,13 +14525,13 @@
         {
           "kind": "def",
           "name": "runCapabilityAndArchitectureTrace",
-          "line": 148,
+          "line": 156,
           "called": []
         },
         {
           "kind": "def",
           "name": "runServiceAndStressTrace",
-          "line": 218,
+          "line": 226,
           "called": [
             "demoEndpoint",
             "mkRunQueue",
@@ -14547,7 +14547,7 @@
         {
           "kind": "def",
           "name": "runLifecycleAndEndpointTrace",
-          "line": 390,
+          "line": 398,
           "called": [
             "demoEndpoint",
             "demoNotification",
@@ -14560,7 +14560,7 @@
         {
           "kind": "def",
           "name": "runCapabilityIpcTrace",
-          "line": 495,
+          "line": 503,
           "called": [
             "demoEndpoint",
             "rootSlot"
@@ -14569,7 +14569,7 @@
         {
           "kind": "def",
           "name": "runSchedulerTimingDomainTrace",
-          "line": 546,
+          "line": 554,
           "called": [
             "mkRunQueue"
           ]
@@ -14577,7 +14577,7 @@
         {
           "kind": "def",
           "name": "runIpcMessageTransferTrace",
-          "line": 616,
+          "line": 624,
           "called": [
             "demoEndpoint"
           ]
@@ -14585,7 +14585,7 @@
         {
           "kind": "def",
           "name": "runIpcMessageBoundsTrace",
-          "line": 777,
+          "line": 785,
           "called": [
             "demoEndpoint"
           ]
@@ -14593,7 +14593,7 @@
         {
           "kind": "def",
           "name": "runUntypedMemoryTrace",
-          "line": 850,
+          "line": 858,
           "called": [
             "demoUntyped",
             "lifecycleAuthSlot",
@@ -14604,19 +14604,19 @@
         {
           "kind": "def",
           "name": "runDequeueOnDispatchTrace",
-          "line": 937,
+          "line": 945,
           "called": []
         },
         {
           "kind": "def",
           "name": "runInlineContextSwitchTrace",
-          "line": 994,
+          "line": 1002,
           "called": []
         },
         {
           "kind": "def",
           "name": "runBoundedMessageExtendedTrace",
-          "line": 1037,
+          "line": 1045,
           "called": [
             "demoEndpoint"
           ]
@@ -14624,7 +14624,7 @@
         {
           "kind": "def",
           "name": "runMainTraceFrom",
-          "line": 1073,
+          "line": 1081,
           "called": [
             "bootstrapInvariantObjectIds",
             "bootstrapServiceIds",
@@ -14647,13 +14647,13 @@
         {
           "kind": "def",
           "name": "buildParameterizedTopology",
-          "line": 1105,
+          "line": 1113,
           "called": []
         },
         {
           "kind": "def",
           "name": "runParameterizedTopologyCheck",
-          "line": 1156,
+          "line": 1164,
           "called": [
             "buildParameterizedTopology"
           ]
@@ -14661,7 +14661,7 @@
         {
           "kind": "def",
           "name": "runParameterizedTopologies",
-          "line": 1170,
+          "line": 1178,
           "called": [
             "runParameterizedTopologyCheck"
           ]
@@ -14669,7 +14669,7 @@
         {
           "kind": "def",
           "name": "runMainTrace",
-          "line": 1178,
+          "line": 1186,
           "called": [
             "bootstrapInvariantObjectIds",
             "bootstrapServiceIds",
@@ -14688,31 +14688,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Testing",
-          "line": 5,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "runtimeContractAcceptAll",
           "line": 13,
           "called": []
         },
         {
           "kind": "def",
+          "name": "runtimeContractAcceptAll",
+          "line": 21,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "runtimeContractDenyAll",
-          "line": 35,
+          "line": 43,
           "called": []
         },
         {
           "kind": "def",
           "name": "runtimeContractTimerOnly",
-          "line": 58,
+          "line": 66,
           "called": []
         },
         {
           "kind": "def",
           "name": "runtimeContractReadOnlyMemory",
-          "line": 81,
+          "line": 89,
           "called": []
         }
       ]
@@ -14725,31 +14725,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Testing",
-          "line": 5,
+          "line": 13,
           "called": []
         },
         {
           "kind": "def",
           "name": "listLookup",
-          "line": 8,
+          "line": 16,
           "called": []
         },
         {
           "kind": "structure",
           "name": "BootstrapBuilder",
-          "line": 16,
+          "line": 24,
           "called": []
         },
         {
           "kind": "namespace",
           "name": "BootstrapBuilder",
-          "line": 26,
+          "line": 34,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 28,
+          "line": 36,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14757,7 +14757,7 @@
         {
           "kind": "def",
           "name": "withObject",
-          "line": 30,
+          "line": 38,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14765,7 +14765,7 @@
         {
           "kind": "def",
           "name": "withService",
-          "line": 33,
+          "line": 41,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14773,7 +14773,7 @@
         {
           "kind": "def",
           "name": "withRunnable",
-          "line": 39,
+          "line": 47,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14781,7 +14781,7 @@
         {
           "kind": "def",
           "name": "withCurrent",
-          "line": 42,
+          "line": 50,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14789,7 +14789,7 @@
         {
           "kind": "def",
           "name": "withIrqHandler",
-          "line": 45,
+          "line": 53,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14797,7 +14797,7 @@
         {
           "kind": "def",
           "name": "withLifecycleObjectType",
-          "line": 51,
+          "line": 59,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14805,7 +14805,7 @@
         {
           "kind": "def",
           "name": "withLifecycleCapabilityRef",
-          "line": 57,
+          "line": 65,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14813,7 +14813,7 @@
         {
           "kind": "def",
           "name": "withMachine",
-          "line": 63,
+          "line": 71,
           "called": [
             "BootstrapBuilder"
           ]
@@ -14821,13 +14821,13 @@
         {
           "kind": "def",
           "name": "lookupThreadPriority",
-          "line": 68,
+          "line": 76,
           "called": []
         },
         {
           "kind": "def",
           "name": "build",
-          "line": 74,
+          "line": 82,
           "called": [
             "BootstrapBuilder",
             "lookupThreadPriority"
@@ -14843,7 +14843,7 @@
         {
           "kind": "def",
           "name": "main",
-          "line": 4,
+          "line": 12,
           "called": []
         }
       ]
@@ -14856,31 +14856,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Testing",
-          "line": 8,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "expect",
-          "line": 10,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "publicLabel",
           "line": 16,
           "called": []
         },
         {
           "kind": "def",
+          "name": "expect",
+          "line": 18,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "publicLabel",
+          "line": 24,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "secretLabel",
-          "line": 19,
+          "line": 27,
           "called": []
         },
         {
           "kind": "def",
           "name": "reviewer",
-          "line": 22,
+          "line": 30,
           "called": [
             "publicLabel"
           ]
@@ -14888,7 +14888,7 @@
         {
           "kind": "def",
           "name": "admin",
-          "line": 25,
+          "line": 33,
           "called": [
             "secretLabel"
           ]
@@ -14896,19 +14896,19 @@
         {
           "kind": "def",
           "name": "sampleServiceEntry",
-          "line": 28,
+          "line": 36,
           "called": []
         },
         {
           "kind": "def",
           "name": "publicServiceEntry",
-          "line": 37,
+          "line": 45,
           "called": []
         },
         {
           "kind": "def",
           "name": "sampleState",
-          "line": 45,
+          "line": 53,
           "called": [
             "publicServiceEntry",
             "sampleServiceEntry"
@@ -14917,7 +14917,7 @@
         {
           "kind": "def",
           "name": "sampleLabeling",
-          "line": 55,
+          "line": 63,
           "called": [
             "publicLabel",
             "secretLabel"
@@ -14926,7 +14926,7 @@
         {
           "kind": "def",
           "name": "altState",
-          "line": 72,
+          "line": 80,
           "called": [
             "publicServiceEntry",
             "sampleServiceEntry"
@@ -14935,7 +14935,7 @@
         {
           "kind": "def",
           "name": "runInformationFlowChecks",
-          "line": 85,
+          "line": 93,
           "called": [
             "admin",
             "altState",
@@ -14950,7 +14950,7 @@
         {
           "kind": "def",
           "name": "main",
-          "line": 807,
+          "line": 815,
           "called": []
         }
       ]
@@ -14963,67 +14963,67 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Testing",
-          "line": 9,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "endpointId",
-          "line": 11,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "cnodeId",
-          "line": 12,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "wrongTypeId",
-          "line": 13,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "guardedCnodeId",
-          "line": 14,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "sendEmptyEndpointId",
-          "line": 15,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "notificationId",
-          "line": 16,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "asidPrimary",
           "line": 17,
           "called": []
         },
         {
           "kind": "def",
-          "name": "vaddrPrimary",
-          "line": 18,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "paddrPrimary",
+          "name": "endpointId",
           "line": 19,
           "called": []
         },
         {
           "kind": "def",
-          "name": "slot0",
+          "name": "cnodeId",
+          "line": 20,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "wrongTypeId",
           "line": 21,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "guardedCnodeId",
+          "line": 22,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "sendEmptyEndpointId",
+          "line": 23,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "notificationId",
+          "line": 24,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "asidPrimary",
+          "line": 25,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "vaddrPrimary",
+          "line": 26,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "paddrPrimary",
+          "line": 27,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "slot0",
+          "line": 29,
           "called": [
             "cnodeId"
           ]
@@ -15031,7 +15031,7 @@
         {
           "kind": "def",
           "name": "slot0Path",
-          "line": 22,
+          "line": 30,
           "called": [
             "cnodeId"
           ]
@@ -15039,7 +15039,7 @@
         {
           "kind": "def",
           "name": "guardedPathBadDepth",
-          "line": 23,
+          "line": 31,
           "called": [
             "guardedCnodeId"
           ]
@@ -15047,7 +15047,7 @@
         {
           "kind": "def",
           "name": "badSlot",
-          "line": 24,
+          "line": 32,
           "called": [
             "wrongTypeId"
           ]
@@ -15055,7 +15055,7 @@
         {
           "kind": "def",
           "name": "guardedPathBadGuard",
-          "line": 25,
+          "line": 33,
           "called": [
             "guardedCnodeId"
           ]
@@ -15063,7 +15063,7 @@
         {
           "kind": "def",
           "name": "baseState",
-          "line": 27,
+          "line": 35,
           "called": [
             "asidPrimary",
             "cnodeId",
@@ -15077,7 +15077,7 @@
         {
           "kind": "def",
           "name": "invariantObjectIds",
-          "line": 109,
+          "line": 117,
           "called": [
             "cnodeId",
             "endpointId",
@@ -15089,7 +15089,7 @@
         {
           "kind": "def",
           "name": "sendEmptyEndpointState",
-          "line": 112,
+          "line": 120,
           "called": [
             "baseState",
             "sendEmptyEndpointId"
@@ -15098,13 +15098,13 @@
         {
           "kind": "def",
           "name": "expectError",
-          "line": 118,
+          "line": 126,
           "called": []
         },
         {
           "kind": "def",
           "name": "expectOkState",
-          "line": 131,
+          "line": 139,
           "called": [
             "invariantObjectIds"
           ]
@@ -15112,43 +15112,43 @@
         {
           "kind": "def",
           "name": "expectOk",
-          "line": 143,
+          "line": 151,
           "called": []
         },
         {
           "kind": "def",
           "name": "expectThreadQueueLinks",
-          "line": 153,
+          "line": 161,
           "called": []
         },
         {
           "kind": "def",
           "name": "corruptThreadQueueLinks",
-          "line": 170,
+          "line": 178,
           "called": []
         },
         {
           "kind": "def",
           "name": "f2UntypedObjId",
-          "line": 186,
+          "line": 194,
           "called": []
         },
         {
           "kind": "def",
           "name": "f2UntypedChildId",
-          "line": 187,
+          "line": 195,
           "called": []
         },
         {
           "kind": "def",
           "name": "f2UntypedAuthCnode",
-          "line": 188,
+          "line": 196,
           "called": []
         },
         {
           "kind": "def",
           "name": "f2UntypedAuthSlot",
-          "line": 189,
+          "line": 197,
           "called": [
             "f2UntypedAuthCnode"
           ]
@@ -15156,7 +15156,7 @@
         {
           "kind": "def",
           "name": "f2UntypedState",
-          "line": 192,
+          "line": 200,
           "called": [
             "f2UntypedAuthCnode",
             "f2UntypedAuthSlot",
@@ -15166,13 +15166,13 @@
         {
           "kind": "def",
           "name": "f2DeviceUntypedId",
-          "line": 219,
+          "line": 227,
           "called": []
         },
         {
           "kind": "def",
           "name": "f2DeviceState",
-          "line": 221,
+          "line": 229,
           "called": [
             "f2DeviceUntypedId",
             "f2UntypedAuthCnode",
@@ -15182,7 +15182,7 @@
         {
           "kind": "def",
           "name": "runNegativeChecks",
-          "line": 248,
+          "line": 256,
           "called": [
             "asidPrimary",
             "badSlot",
@@ -15214,7 +15214,7 @@
         {
           "kind": "def",
           "name": "runH2NegativeChecks",
-          "line": 1002,
+          "line": 1010,
           "called": [
             "expectError",
             "f2UntypedAuthCnode",
@@ -15226,7 +15226,7 @@
         {
           "kind": "def",
           "name": "runAuditCoverageChecks",
-          "line": 1051,
+          "line": 1059,
           "called": [
             "baseState",
             "endpointId",
@@ -15238,7 +15238,7 @@
         {
           "kind": "def",
           "name": "runWSH7Checks",
-          "line": 1134,
+          "line": 1142,
           "called": [
             "baseState",
             "endpointId",
@@ -15248,7 +15248,7 @@
         {
           "kind": "def",
           "name": "runWSH11Checks",
-          "line": 1191,
+          "line": 1199,
           "called": [
             "expectError",
             "expectOkState"
@@ -15257,7 +15257,7 @@
         {
           "kind": "def",
           "name": "runWSH13Checks",
-          "line": 1378,
+          "line": 1386,
           "called": [
             "expectError"
           ]
@@ -15265,7 +15265,7 @@
         {
           "kind": "def",
           "name": "main",
-          "line": 1419,
+          "line": 1427,
           "called": []
         }
       ]
@@ -15278,31 +15278,31 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Testing",
-          "line": 6,
+          "line": 14,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "ProbeOp",
-          "line": 8,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "probeEndpointId",
-          "line": 14,
-          "called": []
-        },
-        {
-          "kind": "def",
-          "name": "probeThreadIds",
           "line": 16,
           "called": []
         },
         {
           "kind": "def",
+          "name": "probeEndpointId",
+          "line": 22,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "probeThreadIds",
+          "line": 24,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "probeBaseState",
-          "line": 19,
+          "line": 27,
           "called": [
             "probeEndpointId"
           ]
@@ -15310,13 +15310,13 @@
         {
           "kind": "def",
           "name": "nextRand",
-          "line": 34,
+          "line": 42,
           "called": []
         },
         {
           "kind": "def",
           "name": "pickOp",
-          "line": 37,
+          "line": 45,
           "called": [
             "ProbeOp"
           ]
@@ -15324,19 +15324,19 @@
         {
           "kind": "def",
           "name": "pickThreadId",
-          "line": 43,
+          "line": 51,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointConsistencyHolds",
-          "line": 48,
+          "line": 56,
           "called": []
         },
         {
           "kind": "def",
           "name": "probeInvariantObjectIds",
-          "line": 53,
+          "line": 61,
           "called": [
             "probeEndpointId",
             "probeThreadIds"
@@ -15345,7 +15345,7 @@
         {
           "kind": "def",
           "name": "checkStateInvariants",
-          "line": 56,
+          "line": 64,
           "called": [
             "probeInvariantObjectIds"
           ]
@@ -15353,7 +15353,7 @@
         {
           "kind": "def",
           "name": "checkEndpointConsistency",
-          "line": 63,
+          "line": 71,
           "called": [
             "endpointConsistencyHolds",
             "probeEndpointId"
@@ -15362,13 +15362,13 @@
         {
           "kind": "inductive",
           "name": "StepOutcome",
-          "line": 75,
+          "line": 83,
           "called": []
         },
         {
           "kind": "def",
           "name": "classifyError",
-          "line": 87,
+          "line": 95,
           "called": [
             "ProbeOp",
             "StepOutcome",
@@ -15378,7 +15378,7 @@
         {
           "kind": "def",
           "name": "stepOp",
-          "line": 102,
+          "line": 110,
           "called": [
             "ProbeOp",
             "StepOutcome",
@@ -15389,13 +15389,13 @@
         {
           "kind": "structure",
           "name": "ProbeStats",
-          "line": 119,
+          "line": 127,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:126>",
-          "line": 126,
+          "name": "<anonymous:instance:134>",
+          "line": 134,
           "called": [
             "ProbeStats"
           ]
@@ -15403,7 +15403,7 @@
         {
           "kind": "def",
           "name": "runProbeLoop",
-          "line": 129,
+          "line": 137,
           "called": [
             "ProbeStats",
             "checkEndpointConsistency",
@@ -15417,13 +15417,13 @@
         {
           "kind": "def",
           "name": "pickThreadCount",
-          "line": 153,
+          "line": 161,
           "called": []
         },
         {
           "kind": "def",
           "name": "runProbe",
-          "line": 156,
+          "line": 164,
           "called": [
             "ProbeStats",
             "pickThreadCount",
@@ -15434,13 +15434,13 @@
         {
           "kind": "def",
           "name": "parseNatArg",
-          "line": 167,
+          "line": 175,
           "called": []
         },
         {
           "kind": "def",
           "name": "main",
-          "line": 172,
+          "line": 180,
           "called": [
             "parseNatArg"
           ]

--- a/docs/gitbook/01-project-overview.md
+++ b/docs/gitbook/01-project-overview.md
@@ -19,8 +19,8 @@ works forward: executable semantics and proofs are developed together, and the
 kernel *is* the specification. This eliminates the verification gap between
 specification and implementation.
 
-Current state: 31,268 lines of production Lean across 41 modules, 2,413 lines across 3 Lean test suites,
-958 theorem/lemma declarations, zero unsound constructs, 1,777 total declarations across 44 modules.
+Current state: 32,120 lines of production Lean across 65 files, 2,436 lines across 3 Lean test suites,
+1,034 theorem/lemma declarations, zero unsound constructs, 1,890 total declarations across 68 modules.
 Metrics source: [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key).
 
 ## 3. Architectural improvements over seL4

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -15,8 +15,8 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 |-----------|-------|
 | Version | `0.14.6` |
 | Lean toolchain | `v4.28.0` |
-| Production LoC | 31,600 across 65 files |
-| Test LoC | 2,412 across 3 suites |
+| Production LoC | 32,120 across 65 files |
+| Test LoC | 2,436 across 3 suites |
 | Proved declarations | 1,034 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 1,890 across 68 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |

--- a/docs/gitbook/22-next-slice-development-path.md
+++ b/docs/gitbook/22-next-slice-development-path.md
@@ -5,8 +5,8 @@
 **Version:** 0.14.6 (Lean v4.28.0)
 
 **Verified metrics snapshot (from [`docs/codebase_map.json`](../../docs/codebase_map.json) `readme_sync`):**
-- Production LoC: 31,600 across 65 files
-- Test LoC: 2,412 across 3 suites
+- Production LoC: 32,120 across 65 files
+- Test LoC: 2,436 across 3 suites
 - Proved declarations: 1,034 theorem/lemma declarations (zero sorry/axiom)
 - Total declarations: 1,890 across 68 modules
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -6,7 +6,7 @@ This GitBook is the long-form guide for seLe4n — a production-oriented microke
 
 ## Current project state
 - **Version:** 0.14.6 (Lean v4.28.0).
-- **Codebase metrics:** 31,600 production LoC across 65 files; 2,412 test LoC across 3 suites; 1,034 theorem/lemma declarations (zero sorry/axiom); 1,890 total declarations across 68 modules.
+- **Codebase metrics:** 32,120 production LoC across 65 files; 2,436 test LoC across 3 suites; 1,034 theorem/lemma declarations (zero sorry/axiom); 1,890 total declarations across 68 modules.
 - **Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.
 - **Next workstreams:** WS-H15..H16 (remaining v0.12.15 audit remediation) and WS-F5..F8 (remaining v0.12.2 audit remediation).
 - **Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -2,7 +2,7 @@
   "description": "This GitBook is the long-form guide for seLe4n \u2014 a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.",
   "current_state_bullets": [
     "**Version:** 0.14.6 (Lean v4.28.0).",
-    "**Codebase metrics:** 31,600 production LoC across 65 files; 2,412 test LoC across 3 suites; 1,034 theorem/lemma declarations (zero sorry/axiom); 1,890 total declarations across 68 modules.",
+    "**Codebase metrics:** 32,120 production LoC across 65 files; 2,436 test LoC across 3 suites; 1,034 theorem/lemma declarations (zero sorry/axiom); 1,890 total declarations across 68 modules.",
     "**Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.",
     "**Next workstreams:** WS-H15..H16 (remaining v0.12.15 audit remediation) and WS-F5..F8 (remaining v0.12.2 audit remediation).",
     "**Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.",

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -50,8 +50,8 @@ enforcement, and scheduling.
 |-----------|-------|
 | **Package version** | `0.14.6` (`lakefile.toml`) |
 | **Lean toolchain** | `v4.28.0` (`lean-toolchain`) |
-| **Production LoC** | 31,600 across 65 Lean files |
-| **Test LoC** | 2,412 across 3 Lean test suites |
+| **Production LoC** | 32,120 across 65 Lean files |
+| **Test LoC** | 2,436 across 3 Lean test suites |
 | **Proved declarations** | 1,034 theorem/lemma declarations (zero sorry/axiom) |
 | **Total declarations** | 1,890 across 68 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,13 @@
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+
 name = "seLe4n"
 version = "0.14.6"
+keywords = ["microkernel", "lean4", "formal-verification", "seL4"]
+license = "GPL-3.0-or-later"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/scripts/audit_testing_framework.sh
+++ b/scripts/audit_testing_framework.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/check_website_links.sh
+++ b/scripts/check_website_links.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 # check_website_links.sh — verify that all paths referenced by the seLe4n
 # project website (sele4n.org / hatter6822.github.io) still exist in the repo.
 #

--- a/scripts/ci_capture_timing.sh
+++ b/scripts/ci_capture_timing.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 if [[ "$#" -lt 2 ]]; then

--- a/scripts/ci_flake_probe.sh
+++ b/scripts/ci_flake_probe.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 if [[ "$#" -lt 2 ]]; then

--- a/scripts/setup_lean_env.sh
+++ b/scripts/setup_lean_env.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/test_docs_sync.sh
+++ b/scripts/test_docs_sync.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_fast.sh
+++ b/scripts/test_fast.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_full.sh
+++ b/scripts/test_full.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 TEST_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_nightly.sh
+++ b/scripts/test_nightly.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_smoke.sh
+++ b/scripts/test_smoke.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_tier0_hygiene.sh
+++ b/scripts/test_tier0_hygiene.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_tier1_build.sh
+++ b/scripts/test_tier1_build.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_tier2_negative.sh
+++ b/scripts/test_tier2_negative.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_tier2_trace.sh
+++ b/scripts/test_tier2_trace.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_tier3_invariant_surface.sh
+++ b/scripts/test_tier3_invariant_surface.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_tier4_nightly_candidates.sh
+++ b/scripts/test_tier4_nightly_candidates.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# seLe4n  - A Lean Microkernel
+# Copyright (C) 2026  Adam Hall
+# This program comes with ABSOLUTELY NO WARRANTY.
+# This is free software, and you are welcome to redistribute it
+# under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/InformationFlowSuite.lean
+++ b/tests/InformationFlowSuite.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 import SeLe4n.Testing.StateBuilder
 

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 import SeLe4n.Testing.StateBuilder
 import SeLe4n.Testing.InvariantChecks

--- a/tests/TraceSequenceProbe.lean
+++ b/tests/TraceSequenceProbe.lean
@@ -1,3 +1,11 @@
+/-
+  seLe4n  - A Lean Microkernel
+  Copyright (C) 2026  Adam Hall
+  This program comes with ABSOLUTELY NO WARRANTY.
+  This is free software, and you are welcome to redistribute it
+  under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
+-/
+
 import SeLe4n
 import SeLe4n.Testing.InvariantChecks
 


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: Project governance & licensing
- Recommendation IDs closed: N/A
- Scope notes: Comprehensive addition of GPL-3.0 license headers across the entire codebase

## Changes

This PR adds GPL-3.0 license headers to all source files in the seLe4n project:

- **Lean source files** (`.lean`): Added 8-line GPL-3.0 header block in Lean comment syntax
- **Configuration files** (`lakefile.toml`, `.gitleaks.toml`): Added GPL-3.0 header in shell comment syntax
- **GitHub workflow files** (`.yml`): Added GPL-3.0 header in YAML comment syntax
- **Shell scripts** (`.sh`): Added GPL-3.0 header after shebang line
- **Documentation files** (`CONTRIBUTING.md`, `README.md`, `.md` files): Added or updated license section
- **Build metadata** (`docs/codebase_map.json`): Regenerated with updated file headers

All headers follow the standard format:
```
seLe4n  - A Lean Microkernel
Copyright (C) 2026  Adam Hall
This program comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it
under certain conditions; see LICENSE file for details.
```

## Validation evidence

- [ ] `./scripts/test_smoke.sh`
- [ ] `./scripts/test_full.sh`
- [ ] `./scripts/test_nightly.sh` (or justify omission)
- [ ] Targeted `rg -n` checks for new docs/anchors

## Documentation synchronization checklist (required)

- [x] Canonical source docs updated first (`docs/*`, `docs/audits/*`)
- [x] GitBook mirrors synchronized in the same PR (`docs/gitbook/*`)
- [x] Generated navigation files refreshed (`scripts/generate_doc_navigation.py`)
- [x] Markdown-link automation passed (`scripts/test_docs_sync.sh`)
- [x] Active slice/workstream status synchronized across `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`
- [x] Any deferrals explicitly linked to owning workstream

## Risks / follow-ups

- Residual risks: None—this is a non-functional change adding licensing metadata
- Deferred items + owning workstream: None

https://claude.ai/code/session_018hqNNHcF2gMA9KoD8qVRfF