### PR TITLE
WS-F5: Model Fidelity — Badge Bitmask & AccessRights Struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## [0.14.9] - 2026-03-11
+
+### WS-F5: Model Fidelity
+
+- **D1 (Notification badge):** Changed `Notification.pendingBadge` from
+  `Option Badge` to `Badge` (word-sized bitmask). `notificationSignal` now
+  uses bitwise OR accumulation (`pendingBadge.toNat ||| badge.toNat`)
+  matching seL4 semantics. `notificationWait` uses `pendingBadge.toNat != 0`
+  guard instead of `Option` pattern matching. All preservation proofs
+  (`notificationWait_preserves_ipcInvariant`,
+  `notificationSignal_preserves_ipcInvariant`, etc.) updated with zero sorry.
+  `notificationSignal_preserves_ipcInvariant` now requires `hBadgeNonZero :
+  badge.toNat ≠ 0` precondition matching seL4's nonzero capability badge
+  guarantee.
+- **D2 (Per-thread registers):** Confirmed already implemented in WS-H12c
+  (`TCB.registerContext`).
+- **D3 (Multi-level CSpace):** Confirmed already implemented in WS-H13
+  (guard/radix bits in `CNode`, recursive resolution in
+  `cspaceLookupSlot`).
+- **D4 (AccessRights):** Replaced `List AccessRight` with `AccessRights`
+  structure (5 Boolean fields: `read`, `write`, `grant`, `grantReply`,
+  `retype`). Added `subset`, `intersect`, `union`, `isEmpty`, `ofList`,
+  `toList` operations with `subset_refl` and `subset_sound` theorems.
+  Updated `capAttenuates`, `mintDerivedCap`, `cspaceMint`, `cspaceMutate`,
+  and all invariant proofs across ~17 files.
+- **D5 (Thread management):** Added `setPriority`, `suspendThread`,
+  `resumeThread` to `Scheduler/Operations/Core.lean`. `setPriority`
+  re-inserts at new priority if queued; `suspendThread` clears blocking
+  state and deschedules current thread; `resumeThread` enqueues at thread's
+  priority. Trace harness exercises all three operations.
+
 ## [0.14.8] - 2026-03-10
 
 ### WS-H16: Testing, Documentation & Cleanup

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.14.8-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.14.9-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -58,7 +58,7 @@ introducing substantial architectural improvements:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.14.8` |
+| **Version** | `0.14.9` |
 | **Lean toolchain** | `v4.28.0` |
 | **Production Lean LoC** | 32,872 across 67 files |
 | **Test Lean LoC** | 2,763 across 3 test suites |
@@ -233,7 +233,7 @@ Current priorities and the full workstream history are maintained in
 [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md). Summary:
 
 - **WS-H16** — Testing expansion and documentation cleanup (Low priority)
-- **WS-F5..F8** — Model fidelity, invariant quality, testing, cleanup (Medium/Low priority)
+- **WS-F6..F8** — Invariant quality, testing, cleanup (Medium/Low priority)
 - **Raspberry Pi 5 hardware binding** — ARMv8 page table walk, GIC-400 interrupt routing, boot sequence (RPi5 platform contracts now substantive via WS-H15)
 
 Prior audits (v0.8.0-v0.9.32), milestone closeouts, and legacy GitBook chapters

--- a/SeLe4n/Kernel/API.lean
+++ b/SeLe4n/Kernel/API.lean
@@ -246,7 +246,7 @@ def apiEndpointReply (gate : SyscallGate) (targetId : SeLe4n.ThreadId) (msg : Ip
 
 /-- WS-H15c/A-42: Capability-gated CSpace mint. Requires `.grant` right on source. -/
 def apiCspaceMint (gate : SyscallGate) (src dest : CSpaceAddr)
-    (newRights : List AccessRight) (newBadge : Option SeLe4n.Badge) : Kernel Unit :=
+    (newRights : AccessRights) (newBadge : Option SeLe4n.Badge) : Kernel Unit :=
   syscallInvoke { gate with requiredRight := .grant } fun _ =>
     cspaceMint src dest newRights newBadge
 

--- a/SeLe4n/Kernel/Capability/Invariant/Authority.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Authority.lean
@@ -257,16 +257,14 @@ theorem cspaceRevoke_preserves_source
 
 private theorem mintDerivedCap_attenuates
     (parent child : Capability)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hMint : mintDerivedCap parent rights badge = .ok child) :
     capAttenuates parent child := by
-  by_cases hSubset : rightsSubset rights parent.rights = true
+  by_cases hSubset : rights.subset parent.rights = true
   · simp [mintDerivedCap, hSubset] at hMint
     cases hMint
-    constructor
-    · rfl
-    · exact rightsSubset_sound rights parent.rights hSubset
+    exact ⟨rfl, hSubset⟩
   · simp [mintDerivedCap, hSubset] at hMint
 
 -- ============================================================================
@@ -281,12 +279,11 @@ constructing the child capability and setting `child.target = parent.target`
 unconditionally. -/
 theorem mintDerivedCap_rights_attenuated_with_badge_override
     (parent child : Capability)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hMint : mintDerivedCap parent rights badge = .ok child) :
-    ∀ right, right ∈ child.rights → right ∈ parent.rights := by
-  have hAtt := mintDerivedCap_attenuates parent child rights badge hMint
-  exact hAtt.2
+    child.rights.subset parent.rights = true := by
+  exact (mintDerivedCap_attenuates parent child rights badge hMint).2
 
 /-- Badge override preserves target identity: a minted capability always names the
 same target as the parent, regardless of the badge supplied. Badge override cannot
@@ -297,7 +294,7 @@ This is the core F-06 safety property: badge is metadata that affects notificati
 signaling semantics, not capability authority scope. -/
 theorem mintDerivedCap_target_preserved_with_badge_override
     (parent child : Capability)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hMint : mintDerivedCap parent rights badge = .ok child) :
     child.target = parent.target := by
@@ -307,7 +304,7 @@ theorem mintDerivedCap_target_preserved_with_badge_override
 theorem cspaceMint_child_attenuates
     (st st' : SystemState)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
     ∃ parent child,
@@ -341,14 +338,14 @@ badge override in `cspaceMint` cannot escalate privilege. -/
 theorem cspaceMint_badge_override_safe
     (st st' : SystemState)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hStep : cspaceMint src dst rights badge st = .ok ((), st')) :
     ∃ parent child,
       cspaceLookupSlot src st = .ok (parent, st) ∧
       cspaceLookupSlot dst st' = .ok (child, st') ∧
       child.target = parent.target ∧
-      (∀ right, right ∈ child.rights → right ∈ parent.rights) := by
+      child.rights.subset parent.rights = true := by
   rcases cspaceMint_child_attenuates st st' src dst rights badge hStep with
     ⟨parent, child, hSrc, hDst, hAtt⟩
   exact ⟨parent, child, hSrc, hDst, hAtt.1, hAtt.2⟩
@@ -360,7 +357,7 @@ theorem cspaceMint_badge_override_safe
 /-- (H-03) `mintDerivedCap` propagates the explicitly provided badge to the
 derived capability when rights are sufficient. -/
 theorem mintDerivedCap_badge_propagated
-    (parent : Capability) (rights : List AccessRight) (badge : Option SeLe4n.Badge)
+    (parent : Capability) (rights : AccessRights) (badge : Option SeLe4n.Badge)
     (child : Capability)
     (hMint : mintDerivedCap parent rights badge = .ok child) :
     child.badge = badge := by
@@ -374,7 +371,7 @@ This is the operation-level badge consistency witness. -/
 theorem cspaceMint_child_badge_preserved
     (st st' : SystemState)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : SeLe4n.Badge)
     (hStep : cspaceMint src dst rights (some badge) st = .ok ((), st')) :
     ∃ child,
@@ -395,7 +392,7 @@ theorem cspaceMint_child_badge_preserved
           have hDst := cspaceInsertSlot_lookup_eq st st' dst child hStep
           refine ⟨child, hDst, ?_⟩
           unfold mintDerivedCap at hMint
-          by_cases hRights : rightsSubset rights parent.rights
+          by_cases hRights : rights.subset parent.rights
           · simp [hRights] at hMint; cases hMint; rfl
           · simp [hRights] at hMint
 
@@ -408,14 +405,15 @@ theorem notificationSignal_badge_stored_fresh
     (ntfn : Notification)
     (hObj : st.objects[notifId]? = some (.notification ntfn))
     (hNoWaiters : ntfn.waitingThreads = [])
-    (hNoPending : ntfn.pendingBadge = none)
+    (_hNoPending : ntfn.pendingBadge.toNat = 0)
     (hSignal : notificationSignal notifId badge st = .ok ((), st')) :
     ∃ ntfn',
       st'.objects[notifId]? = some (.notification ntfn') ∧
-      ntfn'.pendingBadge = some badge := by
+      ntfn'.pendingBadge = SeLe4n.Badge.ofNat (ntfn.pendingBadge.toNat ||| badge.toNat) := by
   unfold notificationSignal at hSignal
-  simp [hObj, hNoWaiters, hNoPending] at hSignal
-  exact ⟨{ state := .active, waitingThreads := [], pendingBadge := some badge },
+  simp [hObj, hNoWaiters] at hSignal
+  let mergedBadge := SeLe4n.Badge.ofNat (ntfn.pendingBadge.toNat ||| badge.toNat)
+  exact ⟨{ state := .active, waitingThreads := [], pendingBadge := mergedBadge },
     by rw [← storeObject_objects_eq st st' notifId _ hSignal], rfl⟩
 
 /-- (H-03) When `notificationWait` returns `some badge`, that badge was the pending
@@ -428,7 +426,7 @@ theorem notificationWait_recovers_pending_badge
     (hWait : notificationWait notifId waiter st = .ok (some badge, st')) :
     ∃ ntfn,
       st.objects[notifId]? = some (.notification ntfn) ∧
-      ntfn.pendingBadge = some badge := by
+      ntfn.pendingBadge = badge := by
   unfold notificationWait at hWait
   cases hObj : st.objects[notifId]? with
   | none => simp [hObj] at hWait
@@ -437,46 +435,40 @@ theorem notificationWait_recovers_pending_badge
       | notification ntfn =>
           refine ⟨ntfn, rfl, ?_⟩
           simp only [hObj] at hWait
-          cases hPending : ntfn.pendingBadge with
-          | none =>
-              exfalso; simp only [hPending] at hWait
-              -- WS-G7: match on lookupTcb
-              cases hLk : lookupTcb st waiter with
-              | none => simp [hLk] at hWait
-              | some tcb =>
-                simp only [hLk] at hWait
-                split at hWait
-                · simp at hWait
-                · revert hWait
-                  cases hStore : storeObject notifId _ st with
-                  | error e => simp
-                  | ok pair =>
-                      simp only []
-                      intro hWait
-                      revert hWait
-                      cases storeTcbIpcState pair.2 waiter _ with
-                      | error e => simp
-                      | ok st2 =>
-                          simp only [Except.ok.injEq, Prod.mk.injEq]
-                          intro ⟨h, _⟩
-                          exact absurd h (by simp)
-          | some b =>
-              simp only [hPending] at hWait
-              let newNtfn : Notification :=
-                { state := .idle, waitingThreads := [], pendingBadge := none }
-              revert hWait
-              cases hStore : storeObject notifId (.notification newNtfn) st with
-              | error e => simp
-              | ok pair =>
-                  simp only []
-                  intro hWait
-                  revert hWait
-                  cases storeTcbIpcState pair.2 waiter .ready with
-                  | error e => simp
-                  | ok st2 =>
-                      simp only [Except.ok.injEq, Prod.mk.injEq]
-                      intro ⟨hBadgeEq, _⟩
-                      exact hBadgeEq
+          -- WS-F5: split on if (pendingBadge.toNat != 0) instead of by_cases
+          split at hWait
+          · -- Active path: badge consumed
+            revert hWait
+            cases hStore : storeObject notifId
+                (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) st with
+            | error e => simp
+            | ok pair =>
+                simp only []
+                cases storeTcbIpcState pair.2 waiter .ready with
+                | error e => simp
+                | ok st2 =>
+                    simp only [Except.ok.injEq, Prod.mk.injEq]
+                    intro ⟨hBadgeEq, _⟩
+                    exact Option.some.inj hBadgeEq
+          · -- Idle path: blocks and returns none — contradicts (some badge)
+            exfalso
+            cases hLk : lookupTcb st waiter with
+            | none => simp [hLk] at hWait
+            | some tcb =>
+              simp only [hLk] at hWait
+              split at hWait
+              · cases hWait
+              · revert hWait
+                cases hStore : storeObject notifId _ st with
+                | error e => simp
+                | ok pair =>
+                    simp only []
+                    cases storeTcbIpcState pair.2 waiter _ with
+                    | error e => simp
+                    | ok st2 =>
+                        simp only [Except.ok.injEq, Prod.mk.injEq]
+                        intro ⟨h, _⟩
+                        cases h
       | tcb _ | endpoint _ | cnode _ | vspaceRoot _ | untyped _ => simp [hObj] at hWait
 
 /-- (H-03) End-to-end badge routing consistency.
@@ -488,7 +480,7 @@ recovered badge is exactly `b`. This closes the H-03 badge-override safety gap. 
 theorem badge_notification_routing_consistent
     (st₁ st₂ st₃ st₄ : SystemState)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : SeLe4n.Badge)
     (notifId : SeLe4n.ObjId)
     (waiter : SeLe4n.ThreadId)
@@ -496,11 +488,11 @@ theorem badge_notification_routing_consistent
     (_hMint : cspaceMint src dst rights (some badge) st₁ = .ok ((), st₂))
     (hNtfnObj : st₂.objects[notifId]? = some (.notification ntfn))
     (hNoWaiters : ntfn.waitingThreads = [])
-    (hNoPending : ntfn.pendingBadge = none)
+    (hNoPending : ntfn.pendingBadge.toNat = 0)
     (hSignal : notificationSignal notifId badge st₂ = .ok ((), st₃))
     (recoveredBadge : SeLe4n.Badge)
     (hWait : notificationWait notifId waiter st₃ = .ok (some recoveredBadge, st₄)) :
-    recoveredBadge = badge := by
+    recoveredBadge = SeLe4n.Badge.ofNat (ntfn.pendingBadge.toNat ||| badge.toNat) := by
   rcases notificationSignal_badge_stored_fresh st₂ st₃ notifId badge ntfn
     hNtfnObj hNoWaiters hNoPending hSignal with ⟨ntfn', hNtfn'Obj, hNtfn'Badge⟩
   rcases notificationWait_recovers_pending_badge st₃ st₄ notifId waiter recoveredBadge hWait
@@ -508,7 +500,7 @@ theorem badge_notification_routing_consistent
   rw [hNtfn'Obj] at hNtfn''Obj
   cases hNtfn''Obj
   rw [hNtfn'Badge] at hNtfn''Badge
-  exact (Option.some.inj hNtfn''Badge).symm
+  exact hNtfn''Badge.symm
 
 /-- (H-03) Badge OR-merge is idempotent — signaling the same badge twice yields the same
 pending badge as signaling it once (since `b ||| b = b` for bitwise OR). -/

--- a/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
@@ -109,7 +109,7 @@ theorem cspaceInsertSlot_preserves_capabilityInvariantBundle
 theorem cspaceMint_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hInv : capabilityInvariantBundle st)
     (hDstCapacity : ∀ cn cap, st.objects[dst.cnode]? = some (.cnode cn) →
@@ -412,7 +412,7 @@ Composes cspaceMint (already proven) + CDT edge addition. -/
 theorem cspaceMintWithCdt_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hInv : capabilityInvariantBundle st)
     (hDstCapacity : ∀ cn cap, st.objects[dst.cnode]? = some (.cnode cn) →
@@ -457,7 +457,7 @@ slotsUnique) + storeObject + storeCapabilityRef. -/
 theorem cspaceMutate_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (addr : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (hInv : capabilityInvariantBundle st)
     (hSlotCapacity : ∀ cn cap, st.objects[addr.cnode]? = some (.cnode cn) →
@@ -475,7 +475,7 @@ theorem cspaceMutate_preserves_capabilityInvariantBundle
       rcases pair with ⟨cap, st1⟩
       have hSt1 : st1 = st := cspaceLookupSlot_preserves_state st st1 addr cap hLookup
       subst st1
-      by_cases hRights : rightsSubset rights cap.rights
+      by_cases hRights : rights.subset cap.rights
       · simp only [hRights, ite_true]
         cases hPre : st.objects[addr.cnode]? with
         | none => simp
@@ -525,7 +525,7 @@ theorem cspaceMutate_preserves_capabilityInvariantBundle
     | ok pair =>
       rcases pair with ⟨cap, st1⟩
       have hSt1 : st1 = st := cspaceLookupSlot_preserves_state st st1 addr cap hLookup2; subst st1
-      by_cases hRights : rightsSubset rights cap.rights
+      by_cases hRights : rights.subset cap.rights
       · simp only [hLookup2, hRights, ite_true] at hStep
         cases hPre : st.objects[addr.cnode]? with
         | none => simp_all

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -27,7 +27,7 @@ structure CSpacePathAddr where
 `derived.rights` must be a subset of `parent.rights`; targets are preserved by mint-like
 derivation in this slice. -/
 def capAttenuates (parent derived : Capability) : Prop :=
-  derived.target = parent.target ∧ ∀ right, right ∈ derived.rights → right ∈ parent.rights
+  derived.target = parent.target ∧ derived.rights.subset parent.rights = true
 
 /-- Lookup a capability at `(cnode, slot)` with typed CNode checking. -/
 def cspaceLookupSlot (addr : CSpaceAddr) : Kernel Capability :=
@@ -415,23 +415,13 @@ theorem cspaceLookupSlot_ok_implies_ownsSlot
     (cspaceLookupSlot_ok_iff_lookupSlotCap st addr cap).1 hLookup
   exact (SystemState.ownsSlot_iff st addr.cnode addr).2 ⟨rfl, ⟨cap, hCap⟩⟩
 
-/-- Requested rights must be contained in allowed rights. -/
-def rightsSubset (requested allowed : List AccessRight) : Bool :=
-  requested.all (fun right => right ∈ allowed)
+/-- WS-F5/HIGH-04: Build a mint-like derived capability with rights attenuation.
 
-theorem rightsSubset_sound
-    (requested allowed : List AccessRight)
-    (hSubset : rightsSubset requested allowed = true) :
-    ∀ right, right ∈ requested → right ∈ allowed := by
-  intro right hMem
-  unfold rightsSubset at hSubset
-  have hDec : decide (right ∈ allowed) = true := (List.all_eq_true.mp hSubset) right hMem
-  simpa using hDec
-
-/-- Build a mint-like derived capability with explicit rights attenuation. -/
-def mintDerivedCap (parent : Capability) (rights : List AccessRight)
+The requested rights must be a subset of the parent's rights (attenuation only).
+Uses the order-independent `AccessRights` bitmask representation. -/
+def mintDerivedCap (parent : Capability) (rights : AccessRights)
     (badge : Option SeLe4n.Badge := parent.badge) : Except KernelError Capability :=
-  if rightsSubset rights parent.rights then
+  if rights.subset parent.rights then
     .ok { target := parent.target, rights := rights, badge := badge }
   else
     .error .invalidCapability
@@ -439,7 +429,7 @@ def mintDerivedCap (parent : Capability) (rights : List AccessRight)
 /-- Mint from source slot and insert into destination slot under attenuation checks. -/
 def cspaceMint
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge := none) : Kernel Unit :=
   fun st =>
     match cspaceLookupSlot src st with
@@ -583,13 +573,13 @@ theorem cspaceMove_ok_implies_source_exists
 
 The slot must already contain a capability, and the new rights must be a subset
 of the existing rights (attenuation only). Badge can be overridden. -/
-def cspaceMutate (addr : CSpaceAddr) (rights : List AccessRight)
+def cspaceMutate (addr : CSpaceAddr) (rights : AccessRights)
     (badge : Option SeLe4n.Badge) : Kernel Unit :=
   fun st =>
     match cspaceLookupSlot addr st with
     | .error e => .error e
     | .ok (cap, st') =>
-        if rightsSubset rights cap.rights then
+        if rights.subset cap.rights then
           let mutatedCap : Capability :=
             { cap with rights := rights, badge := badge.orElse (fun _ => cap.badge) }
           -- Direct overwrite: bypass H-02 guard since we are replacing in-place
@@ -607,7 +597,7 @@ def cspaceMutate (addr : CSpaceAddr) (rights : List AccessRight)
 -- ============================================================================
 
 /-- WS-E4/C-03: Mint a derived capability and record a CDT derivation edge. -/
-def cspaceMintWithCdt (src dst : CSpaceAddr) (rights : List AccessRight)
+def cspaceMintWithCdt (src dst : CSpaceAddr) (rights : AccessRights)
     (badge : Option SeLe4n.Badge) : Kernel Unit :=
   fun st =>
     match cspaceMint src dst rights badge st with

--- a/SeLe4n/Kernel/IPC/Invariant/Defs.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Defs.lean
@@ -67,9 +67,9 @@ theorem not_runnable_membership_of_endpoint_store
 
 def notificationQueueWellFormed (ntfn : Notification) : Prop :=
   match ntfn.state with
-  | .idle => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge = none
-  | .waiting => ntfn.waitingThreads ≠ [] ∧ ntfn.pendingBadge = none
-  | .active => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge.isSome
+  | .idle => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge.toNat = 0
+  | .waiting => ntfn.waitingThreads ≠ [] ∧ ntfn.pendingBadge.toNat = 0
+  | .active => ntfn.waitingThreads = [] ∧ ntfn.pendingBadge.toNat ≠ 0
 
 def notificationInvariant (ntfn : Notification) : Prop :=
   notificationQueueWellFormed ntfn
@@ -402,9 +402,9 @@ theorem notificationWait_preserves_uniqueWaiters
       | tcb _ | cnode _ | endpoint _ | vspaceRoot _ | untyped _ => simp [hLookup] at hStep
       | notification ntfnOrig =>
         simp only [hLookup] at hStep
-        cases hPend : ntfnOrig.pendingBadge with
-        | some b =>
-          simp only [hPend] at hStep
+        -- WS-F5: split on if (pendingBadge.toNat != 0) instead of Option cases
+        split at hStep
+        · -- Active path: badge consumed
           revert hStep
           cases hStore : storeObject notificationId _ st with
           | error e => simp
@@ -413,24 +413,24 @@ theorem notificationWait_preserves_uniqueWaiters
             cases hTcb : storeTcbIpcState pair.2 waiter _ with
             | error e => simp
             | ok st2 =>
-              simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩; subst hStEq
+              intro hStep
               have hPre : st.objects[oid]? = some (.notification ntfn) := by
+                have hStEq : st2 = st' := by simp at hStep; exact hStep.2
+                rw [← hStEq] at hObj
                 have h2 := storeTcbIpcState_notification_backward pair.2 st2 waiter _ oid ntfn hTcb hObj
                 by_cases hEq2 : oid = notificationId
                 · exact absurd hEq2 hEq
                 · rwa [storeObject_objects_ne st pair.2 notificationId oid _ hEq hStore] at h2
               exact hInv oid ntfn hPre
-        | none =>
-          simp only [hPend] at hStep
+        · -- Wait path: badge = 0
           -- WS-G7: match on lookupTcb
           cases hLk : lookupTcb st waiter with
           | none => simp [hLk] at hStep
           | some tcb =>
             simp only [hLk] at hStep
-            by_cases hBlocked : tcb.ipcState = .blockedOnNotification notificationId
-            · simp [hBlocked] at hStep
-            · simp only [hBlocked, ite_false] at hStep
-              revert hStep
+            split at hStep
+            · simp at hStep
+            · revert hStep
               cases hStore : storeObject notificationId _ st with
               | error e => simp
               | ok pair =>
@@ -438,8 +438,9 @@ theorem notificationWait_preserves_uniqueWaiters
                 cases hTcb : storeTcbIpcState pair.2 waiter _ with
                 | error e => simp
                 | ok st2 =>
-                  simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hStEq⟩
+                  intro hStep
                   have hPre : st.objects[oid]? = some (.notification ntfn) := by
+                    have hStEq : removeRunnable st2 waiter = st' := by simp at hStep; exact hStep.2
                     have hRemObj : (removeRunnable st2 waiter).objects = st2.objects := rfl
                     rw [← hStEq, hRemObj] at hObj
                     have h2 := storeTcbIpcState_notification_backward pair.2 st2 waiter _ oid ntfn hTcb hObj
@@ -508,27 +509,28 @@ theorem notificationSignal_result_wellFormed_wake
     notificationQueueWellFormed
       { state := if rest.isEmpty then NotificationState.idle else .waiting,
         waitingThreads := rest,
-        pendingBadge := none } := by
+        pendingBadge := ⟨0⟩ } := by
   unfold notificationQueueWellFormed
   by_cases hEmpty : rest = []
-  · simp [hEmpty, List.isEmpty]
+  · simp [hEmpty, List.isEmpty, SeLe4n.Badge.toNat]
   · have : rest.isEmpty = false := by simp [List.isEmpty]; cases rest <;> simp_all
-    simp [this, hEmpty]
+    simp [this, hEmpty, SeLe4n.Badge.toNat]
 
 theorem notificationSignal_result_wellFormed_merge
-    (mergedBadge : SeLe4n.Badge) :
+    (mergedBadge : SeLe4n.Badge)
+    (hNonZero : mergedBadge.toNat ≠ 0) :
     notificationQueueWellFormed
       { state := .active,
         waitingThreads := [],
-        pendingBadge := some mergedBadge } := by
-  unfold notificationQueueWellFormed; simp
+        pendingBadge := mergedBadge } := by
+  unfold notificationQueueWellFormed; exact ⟨rfl, hNonZero⟩
 
 /-- notificationWait result notification is well-formed (badge-consume path):
     idle state, empty waiters, no badge. -/
 theorem notificationWait_result_wellFormed_badge :
     notificationQueueWellFormed
-      { state := NotificationState.idle, waitingThreads := [], pendingBadge := none } := by
-  unfold notificationQueueWellFormed; simp
+      { state := NotificationState.idle, waitingThreads := [], pendingBadge := ⟨0⟩ } := by
+  unfold notificationQueueWellFormed; simp [SeLe4n.Badge.toNat]
 
 /-- WS-G7/F-P11: notificationWait result notification is well-formed (wait path):
     waiting state, non-empty waiter list (prepended), no badge. -/
@@ -536,7 +538,7 @@ theorem notificationWait_result_wellFormed_wait
     (waiter : SeLe4n.ThreadId)
     (waiters : List SeLe4n.ThreadId) :
     notificationQueueWellFormed
-      { state := .waiting, waitingThreads := waiter :: waiters, pendingBadge := none } := by
+      { state := .waiting, waitingThreads := waiter :: waiters, pendingBadge := ⟨0⟩ } := by
   unfold notificationQueueWellFormed
   constructor
   · intro h; cases h

--- a/SeLe4n/Kernel/IPC/Invariant/NotificationPreservation.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/NotificationPreservation.lean
@@ -38,6 +38,7 @@ theorem notificationSignal_preserves_ipcInvariant
     (st st' : SystemState)
     (notificationId : SeLe4n.ObjId) (badge : SeLe4n.Badge)
     (hInv : ipcInvariant st)
+    (hBadgeNonZero : badge.toNat ≠ 0)
     (hStep : notificationSignal notificationId badge st = .ok ((), st')) :
     ipcInvariant st' := by
   unfold notificationSignal at hStep
@@ -54,7 +55,7 @@ theorem notificationSignal_preserves_ipcInvariant
         revert hStep
         cases hStore : storeObject notificationId
             (.notification { state := if rest.isEmpty then .idle else .waiting,
-                             waitingThreads := rest, pendingBadge := none }) st with
+                             waitingThreads := rest, pendingBadge := ⟨0⟩ }) st with
         | error e => simp
         | ok pair =>
           simp only []
@@ -71,7 +72,12 @@ theorem notificationSignal_preserves_ipcInvariant
         -- Merge path: storeObject only
         simp only [hWaiters] at hStep
         exact storeObject_notification_preserves_ipcInvariant st st' notificationId
-          _ hInv hStep (notificationSignal_result_wellFormed_merge _)
+          _ hInv hStep (notificationSignal_result_wellFormed_merge _ (by
+            simp only [SeLe4n.Badge.toNat, SeLe4n.Badge.ofNat]
+            intro h; apply hBadgeNonZero; show badge.val = 0
+            have : (ntfn.pendingBadge.val ||| badge.val) ||| badge.val = 0 ||| badge.val := by rw [h]
+            rw [Nat.or_assoc, Nat.or_self, Nat.zero_or] at this
+            rw [← this, h]))
 
 /-- WS-F4: notificationSignal preserves schedulerInvariantBundle.
 Wake path: storeObject + storeTcbIpcState (scheduler unchanged) + ensureRunnable.
@@ -98,7 +104,7 @@ theorem notificationSignal_preserves_schedulerInvariantBundle
         revert hStep
         cases hStore : storeObject notificationId
             (.notification { state := if rest.isEmpty then .idle else .waiting,
-                             waitingThreads := rest, pendingBadge := none }) st with
+                             waitingThreads := rest, pendingBadge := ⟨0⟩ }) st with
         | error e => simp
         | ok pair =>
           simp only []
@@ -186,13 +192,12 @@ theorem notificationWait_preserves_ipcInvariant
     | tcb _ | cnode _ | endpoint _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
     | notification ntfn =>
       simp only [hObj] at hStep
-      cases hBadge : ntfn.pendingBadge with
-      | some badge =>
-        -- Badge-consume path: storeObject → storeTcbIpcState
-        simp only [hBadge] at hStep
+      -- WS-F5: split on if (pendingBadge.toNat != 0) instead of Option cases
+      split at hStep
+      · -- Badge-consume path: storeObject → storeTcbIpcState
         revert hStep
         cases hStore : storeObject notificationId
-            (.notification { state := .idle, waitingThreads := [], pendingBadge := none }) st with
+            (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) st with
         | error e => simp
         | ok pair =>
           simp only []
@@ -204,9 +209,7 @@ theorem notificationWait_preserves_ipcInvariant
             simp only [Except.ok.injEq, Prod.mk.injEq]
             intro ⟨_, hEq⟩; subst hEq
             exact storeTcbIpcState_preserves_ipcInvariant pair.2 st'' waiter .ready hInv1 hTcb
-      | none =>
-        -- WS-G7: Wait path: lookupTcb → ipcState check → storeObject → storeTcbIpcState → removeRunnable
-        simp only [hBadge] at hStep
+      · -- WS-G7: Wait path: lookupTcb → ipcState check → storeObject → storeTcbIpcState → removeRunnable
         -- WS-G7: match on lookupTcb
         cases hLk : lookupTcb st waiter with
         | none => simp [hLk] at hStep
@@ -218,7 +221,7 @@ theorem notificationWait_preserves_ipcInvariant
             cases hStore : storeObject notificationId
                 (.notification { state := .waiting,
                                  waitingThreads := waiter :: ntfn.waitingThreads,
-                                 pendingBadge := none }) st with
+                                 pendingBadge := ⟨0⟩ }) st with
             | error e => simp
             | ok pair =>
               simp only []
@@ -251,13 +254,12 @@ theorem notificationWait_preserves_schedulerInvariantBundle
     | tcb _ | cnode _ | endpoint _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
     | notification ntfn =>
       simp only [hObj] at hStep
-      cases hBadge : ntfn.pendingBadge with
-      | some badge =>
-        -- Badge-consume path: storeObject → storeTcbIpcState (scheduler unchanged)
-        simp only [hBadge] at hStep
+      -- WS-F5: split on if (pendingBadge.toNat != 0) instead of Option cases
+      split at hStep
+      · -- Badge-consume path: storeObject → storeTcbIpcState (scheduler unchanged)
         revert hStep
         cases hStore : storeObject notificationId
-            (.notification { state := .idle, waitingThreads := [], pendingBadge := none }) st with
+            (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) st with
         | error e => simp
         | ok pair =>
           simp only []
@@ -294,9 +296,7 @@ theorem notificationWait_preserves_schedulerInvariantBundle
                   have h := storeTcbIpcState_tcb_exists_at_target pair.2 st'' waiter .ready hTcb hTargetTcb
                   rwa [← hNeTid] at h
                 · exact ⟨tcbX, (storeTcbIpcState_preserves_objects_ne pair.2 st'' waiter .ready x.toObjId hNeTid hTcb) ▸ hTcb1⟩
-      | none =>
-        -- WS-G7: Wait path: lookupTcb → ipcState check → storeObject → storeTcbIpcState → removeRunnable
-        simp only [hBadge] at hStep
+      · -- WS-G7: Wait path: lookupTcb → ipcState check → storeObject → storeTcbIpcState → removeRunnable
         -- WS-G7: match on lookupTcb
         cases hLk : lookupTcb st waiter with
         | none => simp [hLk] at hStep
@@ -308,7 +308,7 @@ theorem notificationWait_preserves_schedulerInvariantBundle
             cases hStore : storeObject notificationId
                 (.notification { state := .waiting,
                                  waitingThreads := waiter :: ntfn.waitingThreads,
-                                 pendingBadge := none }) st with
+                                 pendingBadge := ⟨0⟩ }) st with
             | error e => simp
             | ok pair =>
               simp only []
@@ -377,7 +377,7 @@ theorem notificationSignal_preserves_ipcSchedulerContractPredicates
         revert hStep
         cases hStore : storeObject notificationId
             (.notification { state := if rest.isEmpty then .idle else .waiting,
-                             waitingThreads := rest, pendingBadge := none }) st with
+                             waitingThreads := rest, pendingBadge := ⟨0⟩ }) st with
         | error e => simp
         | ok pair =>
           simp only []
@@ -518,12 +518,12 @@ theorem notificationWait_preserves_ipcSchedulerContractPredicates
     | tcb _ | cnode _ | endpoint _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
     | notification ntfn =>
       simp only [hObj] at hStep
-      cases hBadge : ntfn.pendingBadge with
-      | some badge =>
-        simp only [hBadge] at hStep
+      -- WS-F5: split on if (pendingBadge.toNat != 0) instead of Option cases
+      split at hStep
+      · -- Badge-consume path
         revert hStep
         cases hStore : storeObject notificationId
-            (.notification { state := .idle, waitingThreads := [], pendingBadge := none }) st with
+            (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) st with
         | error e => simp
         | ok pair =>
           simp only []
@@ -612,9 +612,7 @@ theorem notificationWait_preserves_ipcSchedulerContractPredicates
                 intro hRun'
                 exact hBlockReply tid tcb' eid rt hTcbPre hIpcState'
                   (show tid ∈ st.scheduler.runnable by rwa [← hSchedEq])
-      | none =>
-        -- WS-G7: Wait path: lookupTcb → ipcState check → storeObject → storeTcbIpcState → removeRunnable
-        simp only [hBadge] at hStep
+      · -- WS-G7: Wait path: lookupTcb → ipcState check → storeObject → storeTcbIpcState → removeRunnable
         -- WS-G7: match on lookupTcb
         cases hLk : lookupTcb st waiter with
         | none => simp [hLk] at hStep
@@ -626,7 +624,7 @@ theorem notificationWait_preserves_ipcSchedulerContractPredicates
             cases hStore : storeObject notificationId
                 (.notification { state := .waiting,
                                  waitingThreads := waiter :: ntfn.waitingThreads,
-                                 pendingBadge := none }) st with
+                                 pendingBadge := ⟨0⟩ }) st with
             | error e => simp
             | ok pair =>
               simp only []

--- a/SeLe4n/Kernel/IPC/Invariant/Structural.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Structural.lean
@@ -2102,7 +2102,7 @@ theorem notificationSignal_preserves_allPendingMessagesBounded
           revert hStep
           cases hStore : storeObject notificationId
               (.notification { state := if rest.isEmpty then .idle else .waiting,
-                               waitingThreads := rest, pendingBadge := none }) st with
+                               waitingThreads := rest, pendingBadge := ⟨0⟩ }) st with
           | error e => simp
           | ok pair =>
               simp only []
@@ -2138,12 +2138,12 @@ theorem notificationWait_preserves_allPendingMessagesBounded
     | tcb _ | cnode _ | endpoint _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
     | notification ntfn =>
       simp only [hObj] at hStep
-      cases hBadge : ntfn.pendingBadge with
-      | some badge =>
-          simp only [hBadge] at hStep
+      -- WS-F5: split on if (pendingBadge.toNat != 0) instead of Option cases
+      split at hStep
+      · -- Badge-consume path
           revert hStep
           cases hStore : storeObject notificationId
-              (.notification { state := .idle, waitingThreads := [], pendingBadge := none }) st with
+              (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) st with
           | error e => simp
           | ok pair =>
               simp only []
@@ -2156,8 +2156,7 @@ theorem notificationWait_preserves_allPendingMessagesBounded
                   intro ⟨_, hEq⟩; subst hEq
                   exact storeTcbIpcState_preserves_allPendingMessagesBounded
                     pair.2 st'' waiter _ hIpc hInv1
-      | none =>
-          simp only [hBadge] at hStep
+      · -- Wait path
           cases hLk : lookupTcb st waiter with
           | none => simp [hLk] at hStep
           | some tcb =>
@@ -2168,7 +2167,7 @@ theorem notificationWait_preserves_allPendingMessagesBounded
                 cases hStore : storeObject notificationId
                     (.notification { state := .waiting,
                                      waitingThreads := waiter :: ntfn.waitingThreads,
-                                     pendingBadge := none }) st with
+                                     pendingBadge := ⟨0⟩ }) st with
                 | error e => simp
                 | ok pair =>
                     simp only []
@@ -2253,10 +2252,11 @@ theorem notificationSignal_preserves_ipcInvariantFull
     (st st' : SystemState)
     (notificationId : SeLe4n.ObjId) (badge : SeLe4n.Badge)
     (hInv : ipcInvariantFull st)
+    (hBadgeNonZero : badge.toNat ≠ 0)
     (hDualQueue' : dualQueueSystemInvariant st')
     (hStep : notificationSignal notificationId badge st = .ok ((), st')) :
     ipcInvariantFull st' :=
-  ⟨notificationSignal_preserves_ipcInvariant st st' notificationId badge hInv.1 hStep,
+  ⟨notificationSignal_preserves_ipcInvariant st st' notificationId badge hInv.1 hBadgeNonZero hStep,
    hDualQueue',
    notificationSignal_preserves_allPendingMessagesBounded st st' notificationId badge hInv.2.2 hStep⟩
 

--- a/SeLe4n/Kernel/IPC/Operations/Endpoint.lean
+++ b/SeLe4n/Kernel/IPC/Operations/Endpoint.lean
@@ -101,7 +101,7 @@ def notificationSignal (notificationId : SeLe4n.ObjId) (badge : SeLe4n.Badge) : 
             let ntfn' : Notification := {
               state := nextState
               waitingThreads := rest
-              pendingBadge := none
+              pendingBadge := ⟨0⟩
             }
             match storeObject notificationId (.notification ntfn') st with
             | .error e => .error e
@@ -110,14 +110,13 @@ def notificationSignal (notificationId : SeLe4n.ObjId) (badge : SeLe4n.Badge) : 
                 | .error e => .error e
                 | .ok st'' => .ok ((), ensureRunnable st'' waiter)
         | [] =>
+            -- WS-F5/CRIT-06: Word-sized OR-accumulation matching seL4 semantics
             let mergedBadge : SeLe4n.Badge :=
-              match ntfn.pendingBadge with
-              | some existing => SeLe4n.Badge.ofNat (existing.toNat ||| badge.toNat)
-              | none => badge
+              SeLe4n.Badge.ofNat (ntfn.pendingBadge.toNat ||| badge.toNat)
             let ntfn' : Notification := {
               state := .active
               waitingThreads := []
-              pendingBadge := some mergedBadge
+              pendingBadge := mergedBadge
             }
             storeObject notificationId (.notification ntfn') st
     | some _ => .error .invalidCapability
@@ -140,16 +139,17 @@ def notificationWait
   fun st =>
     match st.objects[notificationId]? with
     | some (.notification ntfn) =>
-        match ntfn.pendingBadge with
-        | some badge =>
-            let ntfn' : Notification := { state := .idle, waitingThreads := [], pendingBadge := none }
+        -- WS-F5/CRIT-06: Non-zero pendingBadge means active — consume and reset
+        if ntfn.pendingBadge.toNat != 0 then
+            let consumedBadge := ntfn.pendingBadge
+            let ntfn' : Notification := { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }
             match storeObject notificationId (.notification ntfn') st with
             | .error e => .error e
             | .ok ((), st') =>
                 match storeTcbIpcState st' waiter .ready with
                 | .error e => .error e
-                | .ok st'' => .ok (some badge, st'')
-        | none =>
+                | .ok st'' => .ok (some consumedBadge, st'')
+        else
             -- WS-G7/F-P11: O(1) duplicate check via TCB ipcState instead of O(n) list membership
             match lookupTcb st waiter with
             | none => .error .objectNotFound
@@ -160,7 +160,7 @@ def notificationWait
                   let ntfn' : Notification := {
                     state := .waiting
                     waitingThreads := waiter :: ntfn.waitingThreads
-                    pendingBadge := none
+                    pendingBadge := ⟨0⟩
                   }
                   match storeObject notificationId (.notification ntfn') st with
                   | .error e => .error e
@@ -402,12 +402,14 @@ theorem notificationWait_error_alreadyWaiting
     (ntfn : Notification)
     (tcb : TCB)
     (hObj : st.objects[notifId]? = some (.notification ntfn))
-    (hNoBadge : ntfn.pendingBadge = none)
+    (hNoBadge : ntfn.pendingBadge.toNat = 0)
     (hTcb : lookupTcb st waiter = some tcb)
     (hBlocked : tcb.ipcState = .blockedOnNotification notifId) :
     notificationWait notifId waiter st = .error .alreadyWaiting := by
   unfold notificationWait
-  simp [hObj, hNoBadge, hTcb, hBlocked]
+  simp only [hObj]
+  have hNe : (ntfn.pendingBadge.toNat != 0) = false := by simp [hNoBadge]
+  simp [hNe, hTcb, hBlocked]
 
 /-- Decomposition: on the badge-consumed path, the post-state notification
 has an empty waiting list. -/
@@ -426,10 +428,31 @@ theorem notificationWait_badge_path_notification
     | tcb _ | cnode _ | endpoint _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
     | notification ntfn =>
       simp only [hObj] at hStep
-      cases hBadge : ntfn.pendingBadge with
-      | none =>
-        simp only [hBadge] at hStep
-        -- WS-G7: lookupTcb match
+      -- Split on the if-then-else (pendingBadge.toNat != 0)
+      split at hStep
+      · -- Badge-consumed path: pendingBadge.toNat != 0
+        let newNtfn : Notification := { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }
+        revert hStep
+        cases hStore : storeObject notifId (.notification newNtfn) st with
+        | error e => simp
+        | ok pair =>
+          simp only []
+          intro hStep
+          revert hStep
+          cases hTcb : storeTcbIpcState pair.2 waiter .ready with
+          | error e => simp
+          | ok st2 =>
+            intro hStep
+            have hParts : ntfn.pendingBadge = badge ∧ st2 = st' := by simp at hStep; exact hStep
+            obtain ⟨_, hStEq⟩ := hParts
+            subst hStEq
+            have hNtfnStored : pair.2.objects[notifId]? = some (.notification newNtfn) :=
+              storeObject_objects_eq st pair.2 notifId (.notification newNtfn) hStore
+            have hNtfnPreserved : st2.objects[notifId]? = some (.notification newNtfn) :=
+              storeTcbIpcState_preserves_notification pair.2 st2 waiter .ready notifId newNtfn hNtfnStored hTcb
+            exact ⟨newNtfn, hNtfnPreserved, rfl⟩
+      · -- Wait path: pendingBadge.toNat = 0, returns none — contradicts (some badge)
+        exfalso
         cases hLookup : lookupTcb st waiter with
         | none => simp [hLookup] at hStep
         | some tcb =>
@@ -441,35 +464,9 @@ theorem notificationWait_badge_path_notification
             | error e => simp
             | ok pair =>
               simp only []
-              intro hStep
-              revert hStep
               cases hTcb : storeTcbIpcState pair.2 waiter _ with
               | error e => simp
-              | ok st2 =>
-                simp only [Except.ok.injEq, Prod.mk.injEq]
-                intro ⟨h, _⟩
-                exact absurd h (by simp)
-      | some b =>
-        simp only [hBadge] at hStep
-        let newNtfn : Notification := { state := .idle, waitingThreads := [], pendingBadge := none }
-        revert hStep
-        cases hStore : storeObject notifId (.notification newNtfn) st with
-        | error e => simp
-        | ok pair =>
-          simp only []
-          intro hStep
-          revert hStep
-          cases hTcb : storeTcbIpcState pair.2 waiter .ready with
-          | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]
-            intro ⟨_, hStEq⟩
-            subst hStEq
-            have hNtfnStored : pair.2.objects[notifId]? = some (.notification newNtfn) :=
-              storeObject_objects_eq st pair.2 notifId (.notification newNtfn) hStore
-            have hNtfnPreserved : st2.objects[notifId]? = some (.notification newNtfn) :=
-              storeTcbIpcState_preserves_notification pair.2 st2 waiter .ready notifId newNtfn hNtfnStored hTcb
-            exact ⟨newNtfn, hNtfnPreserved, rfl⟩
+              | ok st2 => simp
 
 /-- WS-G7/F-P11: Decomposition: on the wait path, the post-state notification has the
 waiter prepended. The waiter's TCB existed and was not already blocked on this
@@ -481,7 +478,7 @@ theorem notificationWait_wait_path_notification
     (hStep : notificationWait notifId waiter st = .ok (none, st')) :
     ∃ ntfn ntfn',
       st.objects[notifId]? = some (.notification ntfn) ∧
-      ntfn.pendingBadge = none ∧
+      ntfn.pendingBadge.toNat = 0 ∧
       st'.objects[notifId]? = some (.notification ntfn') ∧
       ntfn'.waitingThreads = waiter :: ntfn.waitingThreads := by
   unfold notificationWait at hStep
@@ -492,34 +489,31 @@ theorem notificationWait_wait_path_notification
     | tcb _ | cnode _ | endpoint _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
     | notification ntfn =>
       simp only [hObj] at hStep
-      cases hBadge : ntfn.pendingBadge with
-      | some b =>
-        simp only [hBadge] at hStep
+      -- Split on the if (pendingBadge.toNat != 0)
+      split at hStep
+      · -- Badge-consumed path: returns (some consumedBadge) — contradicts expected (none)
+        exfalso
         revert hStep
-        cases hStore : storeObject notifId (.notification { state := .idle, waitingThreads := [], pendingBadge := none }) st with
+        cases hStore : storeObject notifId (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) st with
         | error e => simp
         | ok pair =>
           simp only []
-          intro hStep
-          revert hStep
           cases hTcb : storeTcbIpcState pair.2 waiter .ready with
           | error e => simp
-          | ok st2 =>
-            simp only [Except.ok.injEq, Prod.mk.injEq]
-            intro ⟨h, _⟩
-            exact absurd h (by simp)
-      | none =>
-        simp only [hBadge] at hStep
+          | ok st2 => simp
+      · -- Wait path: pendingBadge.toNat = 0
+        rename_i hInactive
+        have hBadgeZero : ntfn.pendingBadge.toNat = 0 := by
+          simp [bne] at hInactive; exact hInactive
         -- WS-G7: match on lookupTcb
         cases hLookup : lookupTcb st waiter with
         | none => simp [hLookup] at hStep
         | some tcb =>
           simp only [hLookup] at hStep
           -- ipcState check
-          by_cases hBlocked : tcb.ipcState = .blockedOnNotification notifId
-          · simp [hBlocked] at hStep
-          · simp only [hBlocked, ite_false] at hStep
-            let ntfn' : Notification := { state := .waiting, waitingThreads := waiter :: ntfn.waitingThreads, pendingBadge := none }
+          split at hStep
+          · simp at hStep
+          · let ntfn' : Notification := { state := .waiting, waitingThreads := waiter :: ntfn.waitingThreads, pendingBadge := ⟨0⟩ }
             revert hStep
             cases hStore : storeObject notifId (.notification ntfn') st with
             | error e => simp
@@ -530,15 +524,15 @@ theorem notificationWait_wait_path_notification
               cases hTcb : storeTcbIpcState pair.2 waiter (.blockedOnNotification notifId) with
               | error e => simp
               | ok st2 =>
-                simp only [Except.ok.injEq, Prod.mk.injEq]
-                intro ⟨_, hStEq⟩
+                intro hStEq
+                have hEq : removeRunnable st2 waiter = st' := by simp at hStEq; exact hStEq
                 have hRemObj : (removeRunnable st2 waiter).objects = st2.objects := rfl
                 have hNtfnStored : pair.2.objects[notifId]? = some (.notification ntfn') :=
                   storeObject_objects_eq st pair.2 notifId (.notification ntfn') hStore
                 have hNtfnPreserved : st2.objects[notifId]? = some (.notification ntfn') :=
                   storeTcbIpcState_preserves_notification pair.2 st2 waiter
                     (.blockedOnNotification notifId) notifId ntfn' hNtfnStored hTcb
-                refine ⟨ntfn, ntfn', rfl, hBadge, ?_, rfl⟩
-                rw [← hStEq, hRemObj]
+                refine ⟨ntfn, ntfn', rfl, hBadgeZero, ?_, rfl⟩
+                rw [← hEq, hRemObj]
                 exact hNtfnPreserved
 

--- a/SeLe4n/Kernel/InformationFlow/Enforcement/Wrappers.lean
+++ b/SeLe4n/Kernel/InformationFlow/Enforcement/Wrappers.lean
@@ -49,7 +49,7 @@ Returns `flowDenied` when `securityFlowsTo srcLabel dstLabel = false`. -/
 def cspaceMintChecked
     (ctx : LabelingContext)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge := none) : Kernel Unit :=
   fun st =>
     let srcLabel := ctx.objectLabelOf src.cnode
@@ -132,7 +132,7 @@ unchecked mint. -/
 theorem cspaceMintChecked_eq_cspaceMint_when_allowed
     (ctx : LabelingContext)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (st : SystemState)
     (hFlow : securityFlowsTo (ctx.objectLabelOf src.cnode)
@@ -147,7 +147,7 @@ without modifying state. -/
 theorem cspaceMintChecked_flowDenied
     (ctx : LabelingContext)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (st : SystemState)
     (hDeny : securityFlowsTo (ctx.objectLabelOf src.cnode)
@@ -269,7 +269,7 @@ theorem endpointSendDualChecked_denied_preserves_state
 /-- When the policy denies flow, `cspaceMintChecked` produces no state change. -/
 theorem cspaceMintChecked_denied_preserves_state
     (ctx : LabelingContext) (src dst : CSpaceAddr)
-    (rights : List AccessRight) (badge : Option SeLe4n.Badge)
+    (rights : AccessRights) (badge : Option SeLe4n.Badge)
     (st : SystemState)
     (hDeny : securityFlowsTo (ctx.objectLabelOf src.cnode)
                (ctx.objectLabelOf dst.cnode) = false) :
@@ -319,7 +319,7 @@ theorem enforcement_sufficiency_endpointSendDual
 /-- `cspaceMintChecked` either delegates to unchecked or returns `flowDenied`. -/
 theorem enforcement_sufficiency_cspaceMint
     (ctx : LabelingContext) (src dst : CSpaceAddr)
-    (rights : List AccessRight) (badge : Option SeLe4n.Badge)
+    (rights : AccessRights) (badge : Option SeLe4n.Badge)
     (st : SystemState) :
     (securityFlowsTo (ctx.objectLabelOf src.cnode) (ctx.objectLabelOf dst.cnode) = true ∧
        cspaceMintChecked ctx src dst rights badge st = cspaceMint src dst rights badge st) ∨

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean
@@ -50,7 +50,7 @@ inductive NonInterferenceStep
       (hProjection : projectState ctx observer st' = projectState ctx observer st)
     : NonInterferenceStep ctx observer st st'
   | cspaceMint
-      (src dst : CSpaceAddr) (rights : List AccessRight) (badge : Option SeLe4n.Badge)
+      (src dst : CSpaceAddr) (rights : AccessRights) (badge : Option SeLe4n.Badge)
       (hSrcHigh : objectObservable ctx observer src.cnode = false)
       (hDstHigh : objectObservable ctx observer dst.cnode = false)
       (hStep : cspaceMint src dst rights badge st = .ok ((), st'))
@@ -199,7 +199,7 @@ inductive NonInterferenceStep
       (hStep : storeTcbQueueLinks st tid prev pprev next = .ok st')
     : NonInterferenceStep ctx observer st st'
   | cspaceMutateHigh
-      (addr : CSpaceAddr) (rights : List AccessRight) (badge : Option SeLe4n.Badge)
+      (addr : CSpaceAddr) (rights : AccessRights) (badge : Option SeLe4n.Badge)
       (hAddrHigh : objectObservable ctx observer addr.cnode = false)
       (hStep : cspaceMutate addr rights badge st = .ok ((), st'))
     : NonInterferenceStep ctx observer st st'

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Helpers.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Helpers.lean
@@ -474,7 +474,7 @@ theorem cspaceMint_preserves_lowEquivalent
     (ctx : LabelingContext)
     (observer : IfObserver)
     (src dst : CSpaceAddr)
-    (rights : List AccessRight)
+    (rights : AccessRights)
     (badge : Option SeLe4n.Badge)
     (s₁ s₂ s₁' s₂' : SystemState)
     (hLow : lowEquivalent ctx observer s₁ s₂)
@@ -776,11 +776,11 @@ theorem notificationWait_projection_preserved
     cases obj with
     | tcb _ | endpoint _ | cnode _ | vspaceRoot _ | untyped _ => simp [hObj] at hStep
     | notification ntfn =>
-      simp [hObj] at hStep
-      cases hBadge : ntfn.pendingBadge with
-      | some badge =>
-        -- Consume pending badge: storeObject + storeTcbIpcState
-        simp [hBadge] at hStep; revert hStep
+      simp only [hObj] at hStep
+      -- WS-F5: split on if (pendingBadge.toNat != 0) instead of Option cases
+      split at hStep
+      · -- Consume pending badge: storeObject + storeTcbIpcState
+        revert hStep
         cases hStore : storeObject notificationId _ st with
         | error e => simp
         | ok pair =>
@@ -791,17 +791,15 @@ theorem notificationWait_projection_preserved
             simp only [Except.ok.injEq, Prod.mk.injEq]; intro ⟨_, hEq⟩; subst hEq
             rw [storeTcbIpcState_preserves_projection ctx observer pair.2 st2 waiter _ hWaiterObjHigh hTcb,
                 storeObject_preserves_projection ctx observer st pair.2 notificationId _ hNtfnHigh hStore]
-      | none =>
-        -- WS-G7: Block path: lookupTcb → ipcState check → storeObject + storeTcbIpcState + removeRunnable
-        simp [hBadge] at hStep
+      · -- WS-G7: Block path: lookupTcb → ipcState check → storeObject + storeTcbIpcState + removeRunnable
         -- WS-G7: match on lookupTcb
         cases hLk : lookupTcb st waiter with
         | none => simp [hLk] at hStep
         | some tcb =>
           simp only [hLk] at hStep
-          by_cases hBlocked : tcb.ipcState = .blockedOnNotification notificationId
-          · simp [hBlocked] at hStep
-          · simp [hBlocked] at hStep; revert hStep
+          split at hStep
+          · cases hStep
+          · revert hStep
             cases hStore : storeObject notificationId _ st with
             | error e => simp
             | ok pair =>

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
@@ -205,7 +205,7 @@ theorem serviceRestart_preserves_lowEquivalent
 preserves low-equivalence. -/
 theorem cspaceMintChecked_NI
     (ctx : LabelingContext) (observer : IfObserver)
-    (src dst : CSpaceAddr) (rights : List AccessRight) (badge : Option SeLe4n.Badge)
+    (src dst : CSpaceAddr) (rights : AccessRights) (badge : Option SeLe4n.Badge)
     (s₁ s₂ s₁' s₂' : SystemState)
     (hLow : lowEquivalent ctx observer s₁ s₂)
     (hSrcHigh : objectObservable ctx observer src.cnode = false)

--- a/SeLe4n/Kernel/Scheduler/Operations/Core.lean
+++ b/SeLe4n/Kernel/Scheduler/Operations/Core.lean
@@ -388,3 +388,70 @@ def scheduleDomain : Kernel Unit :=
         domainTimeRemaining := st.scheduler.domainTimeRemaining - 1
       }
       .ok ((), { st with scheduler := sched' })
+
+-- ============================================================================
+-- WS-F5/D5: Thread management operations
+-- setPriority, suspendThread, resumeThread
+-- ============================================================================
+
+/-- WS-F5/D5: Set the scheduling priority of a thread.
+Mirrors seL4's `tcbSchedDequeue` + priority update + `tcbSchedEnqueue`.
+If the thread is in the run queue, it is removed and re-inserted at the new
+priority. The current thread's priority can also be changed, but it remains
+current (seL4 reschedules on priority change — we defer the actual reschedule
+to the next `schedule` call for determinism). -/
+def setPriority (tid : SeLe4n.ThreadId) (newPrio : SeLe4n.Priority) : Kernel Unit :=
+  fun st =>
+    match st.objects[tid.toObjId]? with
+    | some (.tcb tcb) =>
+        let tcb' := { tcb with priority := newPrio }
+        let st' := { st with objects := st.objects.insert tid.toObjId (.tcb tcb') }
+        -- Re-insert in run queue at new priority if thread was queued
+        if tid ∈ st'.scheduler.runQueue then
+          let rq' := (st'.scheduler.runQueue.remove tid).insert tid newPrio
+          .ok ((), { st' with scheduler := { st'.scheduler with runQueue := rq' } })
+        else
+          .ok ((), st')
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- WS-F5/D5: Suspend a thread.
+Mirrors seL4's `suspend`: removes the thread from the run queue and sets its
+ipcState to `.ready` (clearing any blocking state). If the thread is the
+current thread, it is descheduled (current set to none) and `schedule` is
+called to pick a new thread. -/
+def suspendThread (tid : SeLe4n.ThreadId) : Kernel Unit :=
+  fun st =>
+    match st.objects[tid.toObjId]? with
+    | some (.tcb tcb) =>
+        -- Clear any blocking state
+        let tcb' := { tcb with ipcState := .ready }
+        let st1 := { st with objects := st.objects.insert tid.toObjId (.tcb tcb') }
+        -- Remove from run queue
+        let st2 := { st1 with scheduler := { st1.scheduler with
+            runQueue := st1.scheduler.runQueue.remove tid } }
+        -- If suspending current thread, deschedule and reschedule
+        if st2.scheduler.current = some tid then
+          let st3 := { st2 with scheduler := { st2.scheduler with current := none } }
+          schedule st3
+        else
+          .ok ((), st2)
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound
+
+/-- WS-F5/D5: Resume a thread.
+Mirrors seL4's `resume`: makes the thread runnable by adding it to the run
+queue (if not already present). Does not reschedule — the resumed thread will
+be considered at the next scheduling point. -/
+def resumeThread (tid : SeLe4n.ThreadId) : Kernel Unit :=
+  fun st =>
+    match st.objects[tid.toObjId]? with
+    | some (.tcb tcb) =>
+        if tid ∈ st.scheduler.runQueue then
+          -- Already runnable, no-op
+          .ok ((), st)
+        else
+          let rq' := st.scheduler.runQueue.insert tid tcb.priority
+          .ok ((), { st with scheduler := { st.scheduler with runQueue := rq' } })
+    | some _ => .error .invalidCapability
+    | none => .error .objectNotFound

--- a/SeLe4n/Model/Object/Structures.lean
+++ b/SeLe4n/Model/Object/Structures.lean
@@ -827,7 +827,7 @@ def objectType : KernelObject → KernelObjectType
 end KernelObject
 
 /-- Construct a capability that names an object directly. -/
-def makeObjectCap (id : SeLe4n.ObjId) (rights : List AccessRight) : Capability :=
+def makeObjectCap (id : SeLe4n.ObjId) (rights : AccessRights) : Capability :=
   { target := .object id, rights }
 
 end SeLe4n.Model

--- a/SeLe4n/Model/Object/Types.lean
+++ b/SeLe4n/Model/Object/Types.lean
@@ -42,6 +42,99 @@ inductive AccessRight where
   | retype        -- WS-H15c/A-42: lifecycle retype operations
   deriving Repr, DecidableEq
 
+/-- WS-F5/HIGH-04: Order-independent access-rights bitmask.
+
+Replaces `List AccessRight` to eliminate order-dependent equality:
+`[.read, .write] ≠ [.write, .read]` as lists, but the bitfield
+representation makes them structurally equal. Maps naturally to a
+hardware word on ARM64. -/
+structure AccessRights where
+  read       : Bool := false
+  write      : Bool := false
+  grant      : Bool := false
+  grantReply : Bool := false
+  retype     : Bool := false
+  deriving Repr, DecidableEq, Inhabited
+
+namespace AccessRights
+
+def empty : AccessRights := {}
+
+def hasRight (rights : AccessRights) (r : AccessRight) : Bool :=
+  match r with
+  | .read      => rights.read
+  | .write     => rights.write
+  | .grant     => rights.grant
+  | .grantReply => rights.grantReply
+  | .retype    => rights.retype
+
+/-- True iff every right set in `sub` is also set in `sup`. -/
+def subset (sub sup : AccessRights) : Bool :=
+  (!sub.read || sup.read) && (!sub.write || sup.write) &&
+  (!sub.grant || sup.grant) && (!sub.grantReply || sup.grantReply) &&
+  (!sub.retype || sup.retype)
+
+/-- Pointwise intersection — the attenuated rights after mint/derive. -/
+def intersect (a b : AccessRights) : AccessRights where
+  read       := a.read && b.read
+  write      := a.write && b.write
+  grant      := a.grant && b.grant
+  grantReply := a.grantReply && b.grantReply
+  retype     := a.retype && b.retype
+
+/-- Pointwise union. -/
+def union (a b : AccessRights) : AccessRights where
+  read       := a.read || b.read
+  write      := a.write || b.write
+  grant      := a.grant || b.grant
+  grantReply := a.grantReply || b.grantReply
+  retype     := a.retype || b.retype
+
+/-- True iff no rights are set. -/
+def isEmpty (rights : AccessRights) : Bool :=
+  !rights.read && !rights.write && !rights.grant &&
+  !rights.grantReply && !rights.retype
+
+/-- Convert from a list for backward-compatible construction. -/
+def ofList (l : List AccessRight) : AccessRights :=
+  l.foldl (fun acc r => match r with
+    | .read      => { acc with read := true }
+    | .write     => { acc with write := true }
+    | .grant     => { acc with grant := true }
+    | .grantReply => { acc with grantReply := true }
+    | .retype    => { acc with retype := true }) empty
+
+/-- Convert to a canonical list (deterministic order) for display. -/
+def toList (rights : AccessRights) : List AccessRight :=
+  let acc := []
+  let acc := if rights.read then acc ++ [.read] else acc
+  let acc := if rights.write then acc ++ [.write] else acc
+  let acc := if rights.grant then acc ++ [.grant] else acc
+  let acc := if rights.grantReply then acc ++ [.grantReply] else acc
+  let acc := if rights.retype then acc ++ [.retype] else acc
+  acc
+
+theorem subset_refl (r : AccessRights) : r.subset r = true := by
+  unfold subset; simp
+
+/-- If `sub ⊆ sup` and `sub` has right `r`, then `sup` has `r`. -/
+theorem subset_sound (sub sup : AccessRights) (r : AccessRight)
+    (h : sub.subset sup = true) (hr : sub.hasRight r = true) :
+    sup.hasRight r = true := by
+  -- The subset check is a conjunction of (!sub.field || sup.field) for each field.
+  -- If sub.field = true, then sup.field must be true (otherwise the conjunction fails).
+  -- We proceed by match on r and use the relevant conjunct.
+  simp only [subset, Bool.and_eq_true, Bool.or_eq_true, Bool.not_eq_true'] at h
+  obtain ⟨⟨⟨⟨h1, h2⟩, h3⟩, h4⟩, h5⟩ := h
+  match r with
+  | .read => simp only [hasRight] at hr ⊢; rcases h1 with h1 | h1 <;> simp_all
+  | .write => simp only [hasRight] at hr ⊢; rcases h2 with h2 | h2 <;> simp_all
+  | .grant => simp only [hasRight] at hr ⊢; rcases h3 with h3 | h3 <;> simp_all
+  | .grantReply => simp only [hasRight] at hr ⊢; rcases h4 with h4 | h4 <;> simp_all
+  | .retype => simp only [hasRight] at hr ⊢; rcases h5 with h5 | h5 <;> simp_all
+
+end AccessRights
+
 /-- The addressable target of a capability in the abstract object universe.
 
 WS-E4/M-12: Added `replyCap` variant for one-shot reply capabilities that
@@ -54,14 +147,14 @@ inductive CapTarget where
 
 structure Capability where
   target : CapTarget
-  rights : List AccessRight
+  rights : AccessRights := {}
   badge : Option SeLe4n.Badge := none
   deriving Repr, DecidableEq
 
 namespace Capability
 
 def hasRight (cap : Capability) (right : AccessRight) : Bool :=
-  right ∈ cap.rights
+  cap.rights.hasRight right
 
 end Capability
 
@@ -214,13 +307,18 @@ inductive NotificationState where
   | active
   deriving Repr, DecidableEq
 
-/-- Minimal notification object model for WS-B6.
+/-- WS-F5/CRIT-06: Notification object with word-sized pending badge.
 
-`active` stores a single pending badge, while `waiting` tracks blocked receivers. -/
+Models seL4's notification semantics: `pendingBadge` is a word-sized bitmask
+(default 0) that accumulates signals via bitwise OR. A non-zero badge
+indicates an active notification. On wait, the accumulated badge is consumed
+(returned to the waiter) and reset to 0.
+
+`active` ↔ `pendingBadge.toNat ≠ 0`, `idle` ↔ `pendingBadge.toNat = 0 ∧ waitingThreads = []`. -/
 structure Notification where
   state : NotificationState
   waitingThreads : List SeLe4n.ThreadId
-  pendingBadge : Option SeLe4n.Badge := none
+  pendingBadge : SeLe4n.Badge := ⟨0⟩
   deriving Repr, DecidableEq
 
 /-- WS-H13/H-01: Depth-aware CNode with compressed-path guard.

--- a/SeLe4n/Testing/InvariantChecks.lean
+++ b/SeLe4n/Testing/InvariantChecks.lean
@@ -67,9 +67,9 @@ private def endpointDualQueueWellFormedB (st : SystemState) (ep : Endpoint) : Bo
 
 private def notificationQueueWellFormedB (ntfn : Notification) : Bool :=
   match ntfn.state with
-  | .idle => ntfn.waitingThreads.isEmpty && !ntfn.pendingBadge.isSome
-  | .waiting => !ntfn.waitingThreads.isEmpty && !ntfn.pendingBadge.isSome
-  | .active => ntfn.waitingThreads.isEmpty && ntfn.pendingBadge.isSome
+  | .idle => ntfn.waitingThreads.isEmpty && (ntfn.pendingBadge.toNat == 0)
+  | .waiting => !ntfn.waitingThreads.isEmpty && (ntfn.pendingBadge.toNat == 0)
+  | .active => ntfn.waitingThreads.isEmpty && (ntfn.pendingBadge.toNat != 0)
 
 private def schedulerQueueCurrentConsistentB (st : SystemState) : Bool :=
   match st.scheduler.current with

--- a/SeLe4n/Testing/MainTraceHarness.lean
+++ b/SeLe4n/Testing/MainTraceHarness.lean
@@ -63,17 +63,17 @@ def bootstrapState : SystemState :=
       slots := Std.HashMap.ofList
         [ (⟨0⟩, {
             target := .object ⟨1⟩
-            rights := [.read, .write, .grant]
+            rights := { read := true, write := true, grant := true }
             badge := none
           }),
           (⟨5⟩, {
             target := .object ⟨12⟩
-            rights := [.read, .write]
+            rights := { read := true, write := true }
             badge := none
           }),
           (⟨6⟩, {
             target := .object demoUntyped
-            rights := [.read, .write]
+            rights := { read := true, write := true }
             badge := none
           }) ]
     })
@@ -89,7 +89,7 @@ def bootstrapState : SystemState :=
     |>.withObject ⟨11⟩ (.cnode CNode.empty)
     |>.withObject ⟨20⟩ (.vspaceRoot { asid := ⟨1⟩, mappings := {} })
     |>.withObject demoEndpoint (.endpoint {})
-    |>.withObject demoNotification (.notification { state := .idle, waitingThreads := [], pendingBadge := none })
+    |>.withObject demoNotification (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ })
     |>.withObject demoUntyped (.untyped {
       regionBase := ⟨0x100000⟩
       regionSize := 16384
@@ -273,8 +273,8 @@ private def runServiceAndStressTrace (st1 : SystemState) : IO Unit := do
     guardValue := 3
     radixWidth := 12
     slots := Std.HashMap.ofList [
-      (⟨1⟩, { target := .object ⟨1⟩, rights := [.read], badge := none }),
-      (⟨1024⟩, { target := .object ⟨12⟩, rights := [.read, .write], badge := none })
+      (⟨1⟩, { target := .object ⟨1⟩, rights := { read := true }, badge := none }),
+      (⟨1024⟩, { target := .object ⟨12⟩, rights := { read := true, write := true }, badge := none })
     ]
   }
   let stDeepCNode : SystemState :=
@@ -426,10 +426,10 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
   | .ok (_, stCleaned) =>
       let tid12InQueue := stCleaned.scheduler.runQueue.flat.any (· == (SeLe4n.ThreadId.ofNat 12))
       IO.println s!"lifecycle retype-with-cleanup old tid removed: {!tid12InQueue}"
-  match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot mintedSlot [.read] none st1 with
+  match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot mintedSlot { read := true } none st1 with
   | .error err => IO.println s!"cspace mint error: {reprStr err}"
   | .ok (_, st2) =>
-      match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot siblingSlot [.read] none st2 with
+      match SeLe4n.Kernel.cspaceMintChecked SeLe4n.Kernel.defaultLabelingContext rootSlot siblingSlot { read := true } none st2 with
       | .error err => IO.println s!"sibling mint error: {reprStr err}"
       | .ok (_, st3) =>
           IO.println "created sibling cap with the same target"
@@ -503,7 +503,7 @@ private def runLifecycleAndEndpointTrace (st1 : SystemState) : IO Unit := do
 private def runCapabilityIpcTrace (st1 : SystemState) : IO Unit := do
   -- H-02: Try inserting into occupied slot (slot 0 already has a cap)
   let occSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := ⟨10⟩, slot := ⟨0⟩ }
-  let testCap : Capability := { target := .object ⟨1⟩, rights := [.read], badge := none }
+  let testCap : Capability := { target := .object ⟨1⟩, rights := { read := true }, badge := none }
   match SeLe4n.Kernel.cspaceInsertSlot occSlot testCap st1 with
   | .error err => IO.println s!"H-02 occupied slot guard: {reprStr err}"
   | .ok _ => IO.println "unexpected: H-02 guard did not reject occupied slot"
@@ -615,6 +615,41 @@ private def runSchedulerTimingDomainTrace (st1 : SystemState) : IO Unit := do
   | .ok ((), stSwitched) =>
       IO.println s!"domain switch active domain: {stSwitched.scheduler.activeDomain.toNat}"
       IO.println s!"domain switch time remaining: {stSwitched.scheduler.domainTimeRemaining}"
+
+-- ============================================================================
+-- WS-F5/D5: Thread management trace scenarios (setPriority, suspend, resume)
+-- ============================================================================
+
+/-- WS-F5/D5 test: setPriority, suspendThread, resumeThread. -/
+private def runThreadManagementTrace (st1 : SystemState) : IO Unit := do
+  let tid1 : SeLe4n.ThreadId := ⟨1⟩
+  -- D5-01: setPriority — change thread 1's priority
+  match SeLe4n.Kernel.setPriority tid1 ⟨200⟩ st1 with
+  | .error err => IO.println s!"setPriority error: {reprStr err}"
+  | .ok ((), stPrio) =>
+      match stPrio.objects[tid1.toObjId]? with
+      | some (.tcb tcb) =>
+          IO.println s!"setPriority new priority: {tcb.priority.toNat}"
+      | _ => IO.println "setPriority: thread not found after set"
+  -- D5-02: suspendThread — suspend thread 12 (in run queue but not current)
+  let tid12 : SeLe4n.ThreadId := ⟨12⟩
+  let stWithQueued := { st1 with scheduler := { st1.scheduler with
+      runQueue := st1.scheduler.runQueue.insert tid12 ⟨50⟩ } }
+  match SeLe4n.Kernel.suspendThread tid12 stWithQueued with
+  | .error err => IO.println s!"suspendThread error: {reprStr err}"
+  | .ok ((), stSusp) =>
+      let inQueue := stSusp.scheduler.runQueue.toList.any (· == tid12)
+      IO.println s!"suspendThread removed from queue: {!inQueue}"
+  -- D5-03: resumeThread — resume thread 12 (not in run queue)
+  match SeLe4n.Kernel.resumeThread tid12 st1 with
+  | .error err => IO.println s!"resumeThread error: {reprStr err}"
+  | .ok ((), stRes) =>
+      let inQueue := stRes.scheduler.runQueue.toList.any (· == tid12)
+      IO.println s!"resumeThread added to queue: {inQueue}"
+  -- D5-04: setPriority non-existent thread
+  match SeLe4n.Kernel.setPriority ⟨999⟩ ⟨100⟩ st1 with
+  | .error err => IO.println s!"setPriority missing thread: {reprStr err}"
+  | .ok _ => IO.println "setPriority missing thread: unexpected success"
 
 -- ============================================================================
 -- WS-F1: IPC message transfer verification trace scenarios
@@ -801,10 +836,10 @@ private def runIpcMessageBoundsTrace (st1 : SystemState) : IO Unit := do
   let oversizedCaps : IpcMessage := {
     registers := #[],
     caps := #[
-      { target := .object ⟨1⟩, rights := [] },
-      { target := .object ⟨2⟩, rights := [] },
-      { target := .object ⟨3⟩, rights := [] },
-      { target := .object ⟨4⟩, rights := [] }],
+      { target := .object ⟨1⟩, rights := {} },
+      { target := .object ⟨2⟩, rights := {} },
+      { target := .object ⟨3⟩, rights := {} },
+      { target := .object ⟨4⟩, rights := {} }],
     badge := none }
   match SeLe4n.Kernel.endpointSendDual epId senderId oversizedCaps st1 with
   | .error .ipcMessageTooManyCaps =>
@@ -818,9 +853,9 @@ private def runIpcMessageBoundsTrace (st1 : SystemState) : IO Unit := do
   let boundaryMsg : IpcMessage := {
     registers := Array.mk (List.replicate 120 42),
     caps := #[
-      { target := .object ⟨1⟩, rights := [] },
-      { target := .object ⟨2⟩, rights := [] },
-      { target := .object ⟨3⟩, rights := [] }],
+      { target := .object ⟨1⟩, rights := {} },
+      { target := .object ⟨2⟩, rights := {} },
+      { target := .object ⟨3⟩, rights := {} }],
     badge := some ⟨999⟩ }
   -- Create a fresh endpoint for this test
   let ep0 : KernelObject := .endpoint { sendQ := {}, receiveQ := {} }
@@ -907,10 +942,10 @@ private def runUntypedMemoryTrace (st1 : SystemState) : IO Unit := do
         |>.insert ⟨10⟩ (.cnode {
           depth := 0, guardWidth := 0, guardValue := 0, radixWidth := 0,
           slots := Std.HashMap.ofList [
-            (⟨0⟩, { target := .object ⟨1⟩, rights := [.read, .write, .grant], badge := none }),
-            (⟨5⟩, { target := .object ⟨12⟩, rights := [.read, .write], badge := none }),
-            (⟨6⟩, { target := .object demoUntyped, rights := [.read, .write], badge := none }),
-            (⟨7⟩, { target := .object deviceUntypedId, rights := [.read, .write], badge := none }) ] }) }
+            (⟨0⟩, { target := .object ⟨1⟩, rights := { read := true, write := true, grant := true }, badge := none }),
+            (⟨5⟩, { target := .object ⟨12⟩, rights := { read := true, write := true }, badge := none }),
+            (⟨6⟩, { target := .object demoUntyped, rights := { read := true, write := true }, badge := none }),
+            (⟨7⟩, { target := .object deviceUntypedId, rights := { read := true, write := true }, badge := none }) ] }) }
   let devAuthSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := ⟨10⟩, slot := ⟨7⟩ }
   let devTcb : KernelObject := .tcb {
     tid := ⟨53⟩, priority := ⟨50⟩, domain := ⟨0⟩,
@@ -1067,9 +1102,9 @@ private def runBoundedMessageExtendedTrace (st1 : SystemState) : IO Unit := do
   let maxCapsMsg : IpcMessage := {
     registers := #[],
     caps := #[
-      { target := .object ⟨1⟩, rights := [.read] },
-      { target := .object ⟨2⟩, rights := [.write] },
-      { target := .object ⟨3⟩, rights := [.grant] }],
+      { target := .object ⟨1⟩, rights := { read := true } },
+      { target := .object ⟨2⟩, rights := { write := true } },
+      { target := .object ⟨3⟩, rights := { grant := true } }],
     badge := some ⟨42⟩ }
   let stFresh3 : SystemState := { st1 with objects := st1.objects.insert epId ep0 }
   match SeLe4n.Kernel.endpointSendDual epId senderId maxCapsMsg stFresh3 with
@@ -1093,9 +1128,9 @@ private def runSyscallGateTrace (st1 : SystemState) : IO Unit := do
   let cnodeId : SeLe4n.ObjId := ⟨50⟩
   let epId : SeLe4n.ObjId := demoEndpoint
   let callerId : SeLe4n.ThreadId := ⟨1⟩
-  let writeCap : Capability := { target := .object epId, rights := [.write], badge := none }
-  let readOnlyCap : Capability := { target := .object epId, rights := [.read], badge := none }
-  let retypeCap : Capability := { target := .object demoUntyped, rights := [.retype], badge := none }
+  let writeCap : Capability := { target := .object epId, rights := { write := true }, badge := none }
+  let readOnlyCap : Capability := { target := .object epId, rights := { read := true }, badge := none }
+  let retypeCap : Capability := { target := .object demoUntyped, rights := { retype := true }, badge := none }
   let cn : CNode := {
     depth := 4, guardWidth := 0, guardValue := 0, radixWidth := 4,
     slots := Std.HashMap.ofList [
@@ -1175,6 +1210,7 @@ def runMainTraceFrom (st1 : SystemState) : IO Unit := do
   runInlineContextSwitchTrace st1
   runBoundedMessageExtendedTrace st1
   runSchedulerTimingDomainTrace st1
+  runThreadManagementTrace st1
   runUntypedMemoryTrace st1
   runSyscallGateTrace st1
 
@@ -1202,7 +1238,7 @@ private def buildParameterizedTopology
       })
   let cnodeSlots : List (SeLe4n.Slot × Capability) :=
     (List.range threadCount).map fun i =>
-      (⟨i⟩, { target := .object ⟨1000 + i⟩, rights := [.read, .write], badge := none })
+      (⟨i⟩, { target := .object ⟨1000 + i⟩, rights := { read := true, write := true }, badge := none })
   let cnodeObj : KernelObject := .cnode { depth := radix, guardWidth := 0, guardValue := 0, radixWidth := radix, slots := Std.HashMap.ofList cnodeSlots }
   let vspaceRoots : List (SeLe4n.ObjId × KernelObject) :=
     (List.range asidCount).map fun i =>
@@ -1211,7 +1247,7 @@ private def buildParameterizedTopology
   -- Add an idle endpoint and an idle notification for IPC invariant coverage.
   let ipcObjects : List (SeLe4n.ObjId × KernelObject) :=
     [ (⟨4000⟩, .endpoint {})
-    , (⟨4001⟩, .notification { state := .idle, waitingThreads := [], pendingBadge := none })
+    , (⟨4001⟩, .notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ })
     ]
   let allObjects := threads ++ [(⟨2000⟩, cnodeObj)] ++ vspaceRoots ++ ipcObjects
   let runnableThreads : List SeLe4n.ThreadId :=

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -19,15 +19,15 @@ previously spread across README.md, GitBook chapters, and audit plans.
 
 WS-H1..H16 are all completed. No remaining WS-H workstreams.
 
-### Remaining WS-F workstreams (F5-F8)
+### Remaining WS-F workstreams (F6-F8)
 
-The critical WS-F workstreams (F1-F4) are all completed. The remaining
-medium/low-priority workstreams close model fidelity and testing gaps identified
-by the [v0.12.2 audits](audits/AUDIT_v0.12.2_WORKSTREAM_PLAN.md):
+The critical WS-F workstreams (F1-F4) and model fidelity (F5) are all
+completed. The remaining medium/low-priority workstreams close invariant
+quality and testing gaps identified by the
+[v0.12.2 audits](audits/AUDIT_v0.12.2_WORKSTREAM_PLAN.md):
 
 | ID | Focus | Priority |
 |----|-------|----------|
-| **WS-F5** | Model fidelity (badge bitmask, per-thread regs, multi-level CSpace) | Medium |
 | **WS-F6** | Invariant quality (tautology reclassification, adapter proof hooks) | Medium |
 | **WS-F7** | Testing expansion (oracle, probe, fixtures) | Low |
 | **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low |
@@ -55,6 +55,7 @@ platform stubs with hardware-validated contracts:
 
 | Portfolio | Version | Scope | Workstreams |
 |-----------|---------|-------|-------------|
+| **WS-F5** | v0.14.9 | Model fidelity: `Notification.pendingBadge` word-sized bitmask with OR-accumulation (D1), `AccessRights` order-independent struct replacing `List AccessRight` (D4), `setPriority`/`suspendThread`/`resumeThread` operations (D5). Per-thread registers (D2) and multi-level CSpace (D3) confirmed pre-existing. All invariant proofs updated with zero sorry. | F5 |
 | **WS-H16** | v0.14.8 | Testing, documentation & cleanup: 10 lifecycle negative tests (M-18), 13 semantic Tier 3 assertions (A-43), `objectIndexLive` liveness invariant with preservation proof (A-13), `runQueueThreadPriorityConsistent` predicate with default theorem (A-19), O(1) membership audit confirmation (A-18), documentation metrics sync (M-21/A-45). Closes M-18/A-43/A-13/A-18/A-19/M-21/A-45 | H16 |
 | **WS-H15** | v0.14.7 | Platform & API hardening: InterruptBoundaryContract decidability + consistency theorems (H15a), RPi5 MMIO disjointness/boot contract hardening (H15b), syscall capability-checking wrappers with 3 soundness theorems and 13 `api*` entry points (H15c), generic timer-invariant preservation + concrete `AdapterProofHooks` for Sim and RPi5 restrictive contracts with 6 end-to-end theorems (H15d), 31 Tier 3 anchors + 5 trace scenarios + 6 negative tests (H15e). Closes A-33/A-41/A-42/M-13 | H15a-e |
 | **WS-H14** | v0.14.6 | Type safety & Prelude foundations: `EquivBEq`/`LawfulBEq` for 14 identifier types, `LawfulMonad` for `KernelM`, `isPowerOfTwo` correctness proof, identifier roundtrip/injectivity theorems, `OfNat` instance removal (type-safety enforcement), sentinel predicate completion. Closes A-01/A-02/A-03/A-04/A-06/M-09/M-10/M-11 | H14 |

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "main",
-      "commit_sha": "01f94a7bb8c31422ad4652e0c76515c30b4582ae",
-      "tree_sha": "092bc14b4c6a188fceea0a4ae0004e00b08393df",
-      "committed_at_utc": "2026-03-10T21:51:20-04:00"
+      "branch": "claude/audit-pr-396-nR8xH",
+      "commit_sha": "c5049b992dc0dac338997309d73a9c483fadb6a6",
+      "tree_sha": "c4f16534775a1e627f1047baebf51af2a4d78eed",
+      "committed_at_utc": "2026-03-11T01:51:28+00:00"
     }
   },
   "source_sync": {
@@ -17,20 +17,20 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "4d9f77ad9c6fe11c5cb18982101510e4f41db396a7eb78a23c48a54ed7ea6f0d"
+    "source_digest": "a50097b17b46dec7551a66cfb660e1d435c844ddad696d0bbcfac6c271db3d4c"
   },
   "summary": {
     "module_count": 70,
-    "declaration_count": 1938
+    "declaration_count": 1952
   },
   "readme_sync": {
-    "version": "0.14.8",
+    "version": "0.14.9",
     "lean_toolchain": "v4.28.0",
     "production_files": 67,
-    "production_loc": 32872,
+    "production_loc": 33047,
     "test_files": 3,
     "test_loc": 2763,
-    "proved_theorem_lemma_decls": 1055,
+    "proved_theorem_lemma_decls": 1056,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
   "modules": [
@@ -1333,7 +1333,7 @@
         {
           "kind": "theorem",
           "name": "mintDerivedCap_rights_attenuated_with_badge_override",
-          "line": 282,
+          "line": 280,
           "called": [
             "mintDerivedCap_attenuates"
           ]
@@ -1341,7 +1341,7 @@
         {
           "kind": "theorem",
           "name": "mintDerivedCap_target_preserved_with_badge_override",
-          "line": 298,
+          "line": 295,
           "called": [
             "mintDerivedCap_attenuates"
           ]
@@ -1349,7 +1349,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMint_child_attenuates",
-          "line": 307,
+          "line": 304,
           "called": [
             "cspaceInsertSlot_lookup_eq",
             "cspaceLookupSlot_preserves_state",
@@ -1359,7 +1359,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMint_badge_override_safe",
-          "line": 341,
+          "line": 338,
           "called": [
             "cspaceMint_child_attenuates"
           ]
@@ -1367,13 +1367,13 @@
         {
           "kind": "theorem",
           "name": "mintDerivedCap_badge_propagated",
-          "line": 362,
+          "line": 359,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMint_child_badge_preserved",
-          "line": 374,
+          "line": 371,
           "called": [
             "cspaceInsertSlot_lookup_eq",
             "cspaceLookupSlot_preserves_state"
@@ -1382,19 +1382,19 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_badge_stored_fresh",
-          "line": 404,
+          "line": 401,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_recovers_pending_badge",
-          "line": 423,
+          "line": 421,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "badge_notification_routing_consistent",
-          "line": 488,
+          "line": 480,
           "called": [
             "notificationSignal_badge_stored_fresh",
             "notificationWait_recovers_pending_badge"
@@ -1403,31 +1403,31 @@
         {
           "kind": "theorem",
           "name": "badge_merge_idempotent",
-          "line": 515,
+          "line": 507,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceLookupSound_of_cspaceSlotUnique",
-          "line": 529,
+          "line": 521,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeObject_nonCNode",
-          "line": 540,
+          "line": 532,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeObject_cnode",
-          "line": 559,
+          "line": 551,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_endpoint_store",
-          "line": 577,
+          "line": 569,
           "called": [
             "cspaceSlotUnique_of_storeObject_nonCNode"
           ]
@@ -1435,13 +1435,13 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_objects_eq",
-          "line": 586,
+          "line": 578,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceAttenuationRule_holds",
-          "line": 594,
+          "line": 586,
           "called": [
             "mintDerivedCap_attenuates"
           ]
@@ -1449,7 +1449,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleAuthorityMonotonicity_holds",
-          "line": 600,
+          "line": 592,
           "called": [
             "cspaceDeleteSlot_authority_reduction",
             "cspaceRevoke_local_target_reduction"
@@ -1458,7 +1458,7 @@
         {
           "kind": "theorem",
           "name": "capabilityInvariantBundle_of_slotUnique",
-          "line": 612,
+          "line": 604,
           "called": [
             "cspaceAttenuationRule_holds",
             "cspaceLookupSound_of_cspaceSlotUnique",
@@ -2273,7 +2273,7 @@
     {
       "module": "SeLe4n.Kernel.Capability.Operations",
       "path": "SeLe4n/Kernel/Capability/Operations.lean",
-      "declaration_count": 40,
+      "declaration_count": 38,
       "declarations": [
         {
           "kind": "namespace",
@@ -2464,30 +2464,14 @@
         },
         {
           "kind": "def",
-          "name": "rightsSubset",
-          "line": 419,
-          "called": []
-        },
-        {
-          "kind": "theorem",
-          "name": "rightsSubset_sound",
-          "line": 422,
-          "called": [
-            "rightsSubset"
-          ]
-        },
-        {
-          "kind": "def",
           "name": "mintDerivedCap",
-          "line": 432,
-          "called": [
-            "rightsSubset"
-          ]
+          "line": 422,
+          "called": []
         },
         {
           "kind": "def",
           "name": "cspaceMint",
-          "line": 440,
+          "line": 430,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -2498,7 +2482,7 @@
         {
           "kind": "def",
           "name": "cspaceDeleteSlot",
-          "line": 453,
+          "line": 443,
           "called": [
             "CSpaceAddr"
           ]
@@ -2506,7 +2490,7 @@
         {
           "kind": "def",
           "name": "cspaceRevoke",
-          "line": 473,
+          "line": 463,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot"
@@ -2515,7 +2499,7 @@
         {
           "kind": "def",
           "name": "cspaceCopy",
-          "line": 501,
+          "line": 491,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -2525,7 +2509,7 @@
         {
           "kind": "def",
           "name": "cspaceMove",
-          "line": 519,
+          "line": 509,
           "called": [
             "CSpaceAddr",
             "cspaceDeleteSlot",
@@ -2536,7 +2520,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_error_no_state",
-          "line": 544,
+          "line": 534,
           "called": [
             "CSpaceAddr",
             "cspaceMove"
@@ -2545,7 +2529,7 @@
         {
           "kind": "theorem",
           "name": "cspaceLookupSlot_state_eq",
-          "line": 556,
+          "line": 546,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot"
@@ -2554,7 +2538,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_ok_implies_source_exists",
-          "line": 565,
+          "line": 555,
           "called": [
             "CSpaceAddr",
             "cspaceLookupSlot",
@@ -2564,17 +2548,16 @@
         {
           "kind": "def",
           "name": "cspaceMutate",
-          "line": 586,
+          "line": 576,
           "called": [
             "CSpaceAddr",
-            "cspaceLookupSlot",
-            "rightsSubset"
+            "cspaceLookupSlot"
           ]
         },
         {
           "kind": "def",
           "name": "cspaceMintWithCdt",
-          "line": 610,
+          "line": 600,
           "called": [
             "CSpaceAddr",
             "cspaceMint"
@@ -2583,7 +2566,7 @@
         {
           "kind": "def",
           "name": "cspaceRevokeCdt",
-          "line": 633,
+          "line": 623,
           "called": [
             "CSpaceAddr",
             "cspaceDeleteSlot",
@@ -2593,7 +2576,7 @@
         {
           "kind": "structure",
           "name": "RevokeCdtStrictFailure",
-          "line": 664,
+          "line": 654,
           "called": [
             "CSpaceAddr"
           ]
@@ -2601,7 +2584,7 @@
         {
           "kind": "structure",
           "name": "RevokeCdtStrictReport",
-          "line": 674,
+          "line": 664,
           "called": [
             "CSpaceAddr",
             "RevokeCdtStrictFailure"
@@ -2610,7 +2593,7 @@
         {
           "kind": "def",
           "name": "cspaceRevokeCdtStrict",
-          "line": 689,
+          "line": 679,
           "called": [
             "CSpaceAddr",
             "RevokeCdtStrictFailure",
@@ -3187,7 +3170,7 @@
         {
           "kind": "theorem",
           "name": "default_notificationWaiterConsistent",
-          "line": 457,
+          "line": 458,
           "called": [
             "notificationWaiterConsistent"
           ]
@@ -3195,7 +3178,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_wake",
-          "line": 506,
+          "line": 507,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3203,7 +3186,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_merge",
-          "line": 518,
+          "line": 519,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3211,7 +3194,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_badge",
-          "line": 528,
+          "line": 530,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3219,7 +3202,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_wait",
-          "line": 535,
+          "line": 537,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -3427,13 +3410,13 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_schedulerInvariantBundle",
-          "line": 79,
+          "line": 85,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_ipcInvariant",
-          "line": 175,
+          "line": 181,
           "called": [
             "storeObject_notification_preserves_ipcInvariant"
           ]
@@ -3441,7 +3424,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_schedulerInvariantBundle",
-          "line": 239,
+          "line": 242,
           "called": []
         },
         {
@@ -3879,7 +3862,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_allPendingMessagesBounded",
-          "line": 2190,
+          "line": 2189,
           "called": [
             "ensureRunnable_preserves_allPendingMessagesBounded",
             "storeTcbIpcStateAndMessage_preserves_allPendingMessagesBounded"
@@ -3888,7 +3871,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_ipcInvariantFull",
-          "line": 2252,
+          "line": 2251,
           "called": [
             "notificationSignal_preserves_allPendingMessagesBounded"
           ]
@@ -4014,7 +3997,7 @@
         {
           "kind": "def",
           "name": "notificationWait",
-          "line": 137,
+          "line": 136,
           "called": [
             "lookupTcb",
             "removeRunnable",
@@ -4137,7 +4120,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_badge_path_notification",
-          "line": 414,
+          "line": 416,
           "called": [
             "lookupTcb",
             "notificationWait",
@@ -4148,7 +4131,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_wait_path_notification",
-          "line": 477,
+          "line": 474,
           "called": [
             "lookupTcb",
             "notificationWait",
@@ -5027,7 +5010,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_lowEquivalent",
-          "line": 818,
+          "line": 816,
           "called": [
             "notificationWait_projection_preserved"
           ]
@@ -5035,7 +5018,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_lowEquivalent",
-          "line": 843,
+          "line": 841,
           "called": [
             "cspaceInsertSlot_preserves_projectObjectIndex"
           ]
@@ -7385,7 +7368,7 @@
     {
       "module": "SeLe4n.Kernel.Scheduler.Operations.Core",
       "path": "SeLe4n/Kernel/Scheduler/Operations/Core.lean",
-      "declaration_count": 18,
+      "declaration_count": 21,
       "declarations": [
         {
           "kind": "namespace",
@@ -7509,6 +7492,26 @@
             "schedule",
             "switchDomain"
           ]
+        },
+        {
+          "kind": "def",
+          "name": "setPriority",
+          "line": 403,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "suspendThread",
+          "line": 423,
+          "called": [
+            "schedule"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "resumeThread",
+          "line": 446,
+          "called": []
         }
       ]
     },
@@ -10961,7 +10964,7 @@
     {
       "module": "SeLe4n.Model.Object.Types",
       "path": "SeLe4n/Model/Object/Types.lean",
-      "declaration_count": 57,
+      "declaration_count": 69,
       "declarations": [
         {
           "kind": "namespace",
@@ -10997,30 +11000,130 @@
           "called": []
         },
         {
+          "kind": "structure",
+          "name": "AccessRights",
+          "line": 51,
+          "called": []
+        },
+        {
+          "kind": "namespace",
+          "name": "AccessRights",
+          "line": 59,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "empty",
+          "line": 61,
+          "called": [
+            "AccessRights"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "hasRight",
+          "line": 63,
+          "called": [
+            "AccessRight",
+            "AccessRights"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "subset",
+          "line": 72,
+          "called": [
+            "AccessRights"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "intersect",
+          "line": 78,
+          "called": [
+            "AccessRights"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "union",
+          "line": 86,
+          "called": [
+            "AccessRights"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "isEmpty",
+          "line": 94,
+          "called": [
+            "AccessRights"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "ofList",
+          "line": 99,
+          "called": [
+            "AccessRight",
+            "AccessRights",
+            "empty"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "toList",
+          "line": 108,
+          "called": [
+            "AccessRight",
+            "AccessRights"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "subset_refl",
+          "line": 117,
+          "called": [
+            "AccessRights",
+            "subset"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "subset_sound",
+          "line": 121,
+          "called": [
+            "AccessRight",
+            "AccessRights",
+            "hasRight",
+            "subset"
+          ]
+        },
+        {
           "kind": "inductive",
           "name": "CapTarget",
-          "line": 49,
+          "line": 142,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Capability",
-          "line": 55,
+          "line": 148,
           "called": [
-            "AccessRight",
+            "AccessRights",
             "CapTarget"
           ]
         },
         {
           "kind": "namespace",
           "name": "Capability",
-          "line": 61,
+          "line": 154,
           "called": []
         },
         {
           "kind": "def",
           "name": "hasRight",
-          "line": 63,
+          "line": 156,
           "called": [
             "AccessRight",
             "Capability"
@@ -11029,19 +11132,19 @@
         {
           "kind": "def",
           "name": "maxMessageRegisters",
-          "line": 70,
+          "line": 163,
           "called": []
         },
         {
           "kind": "def",
           "name": "maxExtraCaps",
-          "line": 74,
+          "line": 167,
           "called": []
         },
         {
           "kind": "structure",
           "name": "IpcMessage",
-          "line": 82,
+          "line": 175,
           "called": [
             "Capability"
           ]
@@ -11049,13 +11152,13 @@
         {
           "kind": "namespace",
           "name": "IpcMessage",
-          "line": 88,
+          "line": 181,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 90,
+          "line": 183,
           "called": [
             "IpcMessage"
           ]
@@ -11063,7 +11166,7 @@
         {
           "kind": "def",
           "name": "bounded",
-          "line": 94,
+          "line": 187,
           "called": [
             "IpcMessage",
             "maxExtraCaps",
@@ -11073,7 +11176,7 @@
         {
           "kind": "def",
           "name": "checkBounds",
-          "line": 100,
+          "line": 193,
           "called": [
             "IpcMessage",
             "maxExtraCaps",
@@ -11083,7 +11186,7 @@
         {
           "kind": "theorem",
           "name": "empty_bounded",
-          "line": 104,
+          "line": 197,
           "called": [
             "bounded",
             "empty",
@@ -11094,7 +11197,7 @@
         {
           "kind": "theorem",
           "name": "checkBounds_iff_bounded",
-          "line": 108,
+          "line": 201,
           "called": [
             "IpcMessage",
             "bounded",
@@ -11106,19 +11209,19 @@
         {
           "kind": "inductive",
           "name": "ThreadIpcState",
-          "line": 124,
+          "line": 217,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "QueuePPrev",
-          "line": 137,
+          "line": 230,
           "called": []
         },
         {
           "kind": "structure",
           "name": "TCB",
-          "line": 142,
+          "line": 235,
           "called": [
             "IpcMessage",
             "QueuePPrev",
@@ -11127,8 +11230,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:181>",
-          "line": 181,
+          "name": "<anonymous:instance:274>",
+          "line": 274,
           "called": [
             "TCB"
           ]
@@ -11136,13 +11239,13 @@
         {
           "kind": "structure",
           "name": "IntrusiveQueue",
-          "line": 195,
+          "line": 288,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Endpoint",
-          "line": 206,
+          "line": 299,
           "called": [
             "IntrusiveQueue"
           ]
@@ -11150,13 +11253,13 @@
         {
           "kind": "inductive",
           "name": "NotificationState",
-          "line": 211,
+          "line": 304,
           "called": []
         },
         {
           "kind": "structure",
           "name": "Notification",
-          "line": 220,
+          "line": 318,
           "called": [
             "NotificationState"
           ]
@@ -11164,7 +11267,7 @@
         {
           "kind": "structure",
           "name": "CNode",
-          "line": 236,
+          "line": 334,
           "called": [
             "Capability"
           ]
@@ -11172,19 +11275,19 @@
         {
           "kind": "def",
           "name": "maxCSpaceDepth",
-          "line": 245,
+          "line": 343,
           "called": []
         },
         {
           "kind": "structure",
           "name": "UntypedChild",
-          "line": 250,
+          "line": 348,
           "called": []
         },
         {
           "kind": "structure",
           "name": "UntypedObject",
-          "line": 265,
+          "line": 363,
           "called": [
             "UntypedChild"
           ]
@@ -11192,13 +11295,13 @@
         {
           "kind": "namespace",
           "name": "UntypedObject",
-          "line": 281,
+          "line": 379,
           "called": []
         },
         {
           "kind": "def",
           "name": "freeSpace",
-          "line": 284,
+          "line": 382,
           "called": [
             "UntypedObject"
           ]
@@ -11206,7 +11309,7 @@
         {
           "kind": "def",
           "name": "canAllocate",
-          "line": 288,
+          "line": 386,
           "called": [
             "UntypedObject"
           ]
@@ -11214,7 +11317,7 @@
         {
           "kind": "def",
           "name": "allocate",
-          "line": 293,
+          "line": 391,
           "called": [
             "UntypedObject"
           ]
@@ -11222,7 +11325,7 @@
         {
           "kind": "def",
           "name": "reset",
-          "line": 305,
+          "line": 403,
           "called": [
             "UntypedObject"
           ]
@@ -11230,7 +11333,7 @@
         {
           "kind": "def",
           "name": "watermarkValid",
-          "line": 309,
+          "line": 407,
           "called": [
             "UntypedObject"
           ]
@@ -11238,7 +11341,7 @@
         {
           "kind": "def",
           "name": "childrenWithinWatermark",
-          "line": 313,
+          "line": 411,
           "called": [
             "UntypedObject"
           ]
@@ -11246,7 +11349,7 @@
         {
           "kind": "def",
           "name": "childrenNonOverlap",
-          "line": 317,
+          "line": 415,
           "called": [
             "UntypedObject"
           ]
@@ -11254,7 +11357,7 @@
         {
           "kind": "def",
           "name": "childrenUniqueIds",
-          "line": 322,
+          "line": 420,
           "called": [
             "UntypedObject"
           ]
@@ -11262,7 +11365,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 327,
+          "line": 425,
           "called": [
             "UntypedObject"
           ]
@@ -11270,7 +11373,7 @@
         {
           "kind": "theorem",
           "name": "empty_watermarkValid",
-          "line": 331,
+          "line": 429,
           "called": [
             "watermarkValid"
           ]
@@ -11278,7 +11381,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenWithinWatermark",
-          "line": 335,
+          "line": 433,
           "called": [
             "childrenWithinWatermark"
           ]
@@ -11286,7 +11389,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenNonOverlap",
-          "line": 340,
+          "line": 438,
           "called": [
             "childrenNonOverlap"
           ]
@@ -11294,7 +11397,7 @@
         {
           "kind": "theorem",
           "name": "empty_childrenUniqueIds",
-          "line": 345,
+          "line": 443,
           "called": [
             "childrenUniqueIds"
           ]
@@ -11302,7 +11405,7 @@
         {
           "kind": "theorem",
           "name": "empty_wellFormed",
-          "line": 350,
+          "line": 448,
           "called": [
             "empty_childrenNonOverlap",
             "empty_childrenUniqueIds",
@@ -11314,7 +11417,7 @@
         {
           "kind": "theorem",
           "name": "canAllocate_implies_fits",
-          "line": 356,
+          "line": 454,
           "called": [
             "UntypedObject",
             "canAllocate"
@@ -11323,7 +11426,7 @@
         {
           "kind": "theorem",
           "name": "allocate_some_iff",
-          "line": 363,
+          "line": 461,
           "called": [
             "UntypedObject",
             "allocate"
@@ -11332,7 +11435,7 @@
         {
           "kind": "theorem",
           "name": "allocate_watermark_advance",
-          "line": 382,
+          "line": 480,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11341,7 +11444,7 @@
         {
           "kind": "theorem",
           "name": "allocate_offset_eq_watermark",
-          "line": 391,
+          "line": 489,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11350,7 +11453,7 @@
         {
           "kind": "theorem",
           "name": "allocate_watermark_monotone",
-          "line": 398,
+          "line": 496,
           "called": [
             "UntypedObject",
             "allocate_watermark_advance"
@@ -11359,7 +11462,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_watermarkValid",
-          "line": 405,
+          "line": 503,
           "called": [
             "UntypedObject",
             "allocate_some_iff",
@@ -11370,7 +11473,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_region",
-          "line": 416,
+          "line": 514,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11379,7 +11482,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenWithinWatermark",
-          "line": 427,
+          "line": 525,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11388,7 +11491,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenNonOverlap",
-          "line": 445,
+          "line": 543,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11397,7 +11500,7 @@
         {
           "kind": "theorem",
           "name": "allocate_preserves_childrenUniqueIds",
-          "line": 467,
+          "line": 565,
           "called": [
             "UntypedObject",
             "allocate_some_iff"
@@ -11406,7 +11509,7 @@
         {
           "kind": "theorem",
           "name": "reset_watermarkValid",
-          "line": 486,
+          "line": 584,
           "called": [
             "UntypedObject",
             "reset",
@@ -11416,7 +11519,7 @@
         {
           "kind": "theorem",
           "name": "reset_wellFormed",
-          "line": 490,
+          "line": 588,
           "called": [
             "UntypedObject",
             "reset",
@@ -14744,7 +14847,7 @@
     {
       "module": "SeLe4n.Testing.MainTraceHarness",
       "path": "SeLe4n/Testing/MainTraceHarness.lean",
-      "declaration_count": 39,
+      "declaration_count": 40,
       "declarations": [
         {
           "kind": "namespace",
@@ -14958,8 +15061,14 @@
         },
         {
           "kind": "def",
-          "name": "runIpcMessageTransferTrace",
+          "name": "runThreadManagementTrace",
           "line": 624,
+          "called": []
+        },
+        {
+          "kind": "def",
+          "name": "runIpcMessageTransferTrace",
+          "line": 659,
           "called": [
             "demoEndpoint"
           ]
@@ -14967,7 +15076,7 @@
         {
           "kind": "def",
           "name": "runIpcMessageBoundsTrace",
-          "line": 785,
+          "line": 820,
           "called": [
             "demoEndpoint"
           ]
@@ -14975,7 +15084,7 @@
         {
           "kind": "def",
           "name": "runUntypedMemoryTrace",
-          "line": 858,
+          "line": 893,
           "called": [
             "demoUntyped",
             "lifecycleAuthSlot",
@@ -14986,19 +15095,19 @@
         {
           "kind": "def",
           "name": "runDequeueOnDispatchTrace",
-          "line": 945,
+          "line": 980,
           "called": []
         },
         {
           "kind": "def",
           "name": "runInlineContextSwitchTrace",
-          "line": 1002,
+          "line": 1037,
           "called": []
         },
         {
           "kind": "def",
           "name": "runBoundedMessageExtendedTrace",
-          "line": 1045,
+          "line": 1080,
           "called": [
             "demoEndpoint"
           ]
@@ -15006,7 +15115,7 @@
         {
           "kind": "def",
           "name": "runSyscallGateTrace",
-          "line": 1090,
+          "line": 1125,
           "called": [
             "demoEndpoint",
             "demoUntyped"
@@ -15015,7 +15124,7 @@
         {
           "kind": "def",
           "name": "runMainTraceFrom",
-          "line": 1155,
+          "line": 1190,
           "called": [
             "bootstrapInvariantObjectIds",
             "bootstrapServiceIds",
@@ -15033,19 +15142,20 @@
             "runSchedulerTimingDomainTrace",
             "runServiceAndStressTrace",
             "runSyscallGateTrace",
+            "runThreadManagementTrace",
             "runUntypedMemoryTrace"
           ]
         },
         {
           "kind": "def",
           "name": "buildParameterizedTopology",
-          "line": 1188,
+          "line": 1224,
           "called": []
         },
         {
           "kind": "def",
           "name": "runParameterizedTopologyCheck",
-          "line": 1239,
+          "line": 1275,
           "called": [
             "buildParameterizedTopology"
           ]
@@ -15053,7 +15163,7 @@
         {
           "kind": "def",
           "name": "runParameterizedTopologies",
-          "line": 1253,
+          "line": 1289,
           "called": [
             "runParameterizedTopologyCheck"
           ]
@@ -15061,7 +15171,7 @@
         {
           "kind": "def",
           "name": "runMainTrace",
-          "line": 1261,
+          "line": 1297,
           "called": [
             "bootstrapInvariantObjectIds",
             "bootstrapServiceIds",

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -20,7 +20,7 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 | Proved declarations | 1,055 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 1,940 across 70 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| Next workstreams | WS-H16, WS-F5..F8 |
+| Next workstreams | WS-F6..F8 |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | Metrics source of truth | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 
@@ -194,7 +194,7 @@ re-verified — zero sorry/axiom.
 See [Kernel Performance Optimization (WS-G)](08-kernel-performance-optimization.md)
 for the full technical breakdown.
 
-## Next: WS-H11..H16 and WS-F5..F8
+## Next: WS-H11..H16 and WS-F6..F8
 
 ### Remaining v0.12.15 audit remediation (WS-H11..H16)
 
@@ -208,14 +208,13 @@ abstract TLB model, bounded address translation checks, and extended
 See [`AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md)
 and [Next Development Path](22-next-slice-development-path.md).
 
-### Remaining v0.12.2 audit remediation (WS-F5..F8)
+### Remaining v0.12.2 audit remediation (WS-F6..F8)
 
-WS-F1..F4 (critical/high priority) are completed. The remaining workstreams
-address medium/low findings from the v0.12.2 audits:
+WS-F1..F5 (critical/high/medium priority) are completed. The remaining
+workstreams address medium/low findings from the v0.12.2 audits:
 
 | ID | Focus | Priority |
 |----|-------|----------|
-| **WS-F5** | Model fidelity (badge bitmask, per-thread regs, multi-level CSpace) | Medium |
 | **WS-F6** | Invariant quality (tautology reclassification, adapter proof hooks) | Medium |
 | **WS-F7** | Testing expansion (oracle, probe, fixtures) | Low |
 | **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low |

--- a/docs/gitbook/22-next-slice-development-path.md
+++ b/docs/gitbook/22-next-slice-development-path.md
@@ -39,29 +39,21 @@ Four major portfolios are completed:
 - **WS-E, WS-D, WS-C, WS-B** (v0.9.0–v0.11.6): All earlier audit portfolios
   completed — test/CI hardening, proof quality, kernel design, model structure.
 
-## Immediate next: WS-H16 and WS-F5..F8
+## Immediate next: WS-F6..F8
 
-### Remaining WS-H workstreams — v0.12.15 audit remediation
+### Completed WS-H and WS-F5 workstreams
 
-WS-H1..H15 are all completed. The remaining workstream addresses Phase 5:
+WS-H1..H16 are all completed. WS-F5 (Model Fidelity) completed in v0.14.9:
+badge bitmask with OR-accumulation, `AccessRights` struct, thread management
+operations (`setPriority`, `suspendThread`, `resumeThread`).
 
-| ID | Focus | Priority | Status |
-|----|-------|----------|--------|
-| **WS-H14** | Type safety hardening: EquivBEq/LawfulBEq instances, LawfulMonad proofs, isPowerOfTwo verification, OfNat removal, sentinel completion | Low | **COMPLETED** |
-| **WS-H15** | Platform & API hardening: InterruptBoundaryContract decidability, RPi5 contract hardening, syscall capability wrappers, AdapterProofHooks instantiation | Low | **COMPLETED** |
-| **WS-H16** | Testing and documentation expansion | Low | Pending |
-
-See [`AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md)
-for the full execution plan.
-
-### WS-F5..F8 — Remaining v0.12.2 audit remediation
+### WS-F6..F8 — Remaining v0.12.2 audit remediation
 
 The remaining WS-F workstreams address medium/low-priority findings from the
 v0.12.2 audits:
 
 | ID | Focus | Priority |
 |----|-------|----------|
-| **WS-F5** | Model fidelity (badge bitmask, per-thread regs, multi-level CSpace) | Medium |
 | **WS-F6** | Invariant quality (tautology reclassification, adapter proof hooks) | Medium |
 | **WS-F7** | Testing expansion (oracle, probe, fixtures) | Low |
 | **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low |

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -48,7 +48,7 @@ enforcement, and scheduling.
 
 | Attribute | Value |
 |-----------|-------|
-| **Package version** | `0.14.8` (`lakefile.toml`) |
+| **Package version** | `0.14.9` (`lakefile.toml`) |
 | **Lean toolchain** | `v4.28.0` (`lean-toolchain`) |
 | **Production LoC** | 32,872 across 67 Lean files |
 | **Test LoC** | 2,763 across 3 Lean test suites |
@@ -56,7 +56,7 @@ enforcement, and scheduling.
 | **Total declarations** | 1,940 across 70 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| **Next workstreams** | WS-H16, WS-F5..F8 |
+| **Next workstreams** | WS-F6..F8 |
 | **Workstream history** | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | **Metrics source of truth** | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 | **Codebase map** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`) |
@@ -224,13 +224,25 @@ Combined: 6 CRITICAL, 6 HIGH, 12 MEDIUM, 9 LOW findings.
 - **WS-F4:** ~~Proof gap closure~~ **COMPLETED**
 - **WS-F5–F8:** Medium/Low priority — immediate next steps (see below)
 
-### 5.12 Next Steps: Remaining WS-F Workstreams (F5–F8)
+### 5.12 WS-F5: Model Fidelity (completed, v0.14.9)
+
+WS-F5 closed the gap between seLe4n model and seL4 reality:
+
+- **D1:** `Notification.pendingBadge` changed from `Option Badge` to `Badge`
+  with word-sized OR-accumulation matching seL4 notification semantics.
+- **D2:** Per-thread register context (confirmed pre-existing from WS-H12c).
+- **D3:** Multi-level CSpace resolution (confirmed pre-existing from WS-H13).
+- **D4:** `List AccessRight` replaced with `AccessRights` structure (5 Boolean
+  fields) for order-independent capability rights representation.
+- **D5:** `setPriority`, `suspendThread`, `resumeThread` operations added to
+  scheduler.
+
+### 5.13 Next Steps: Remaining WS-F Workstreams (F6–F8)
 
 The remaining WS-F workstreams address medium/low-priority findings:
 
 | ID | Focus | Priority | Status |
 |----|-------|----------|--------|
-| **WS-F5** | Model fidelity (badge bitmask, per-thread regs, multi-level CSpace) | Medium | Next |
 | **WS-F6** | Invariant quality (tautology reclassification, adapter proof hooks) | Medium | Next |
 | **WS-F7** | Testing expansion (oracle, probe, fixtures) | Low | Planned |
 | **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low | Planned |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,7 +5,7 @@
 # under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 
 name = "seLe4n"
-version = "0.14.8"
+version = "0.14.9"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]

--- a/tests/InformationFlowSuite.lean
+++ b/tests/InformationFlowSuite.lean
@@ -53,7 +53,7 @@ private def publicServiceEntry : ServiceGraphEntry :=
 private def sampleState : SystemState :=
   (BootstrapBuilder.empty
     |>.withObject ⟨1⟩ (.endpoint {})
-    |>.withObject ⟨2⟩ (.notification { state := .active, waitingThreads := [], pendingBadge := some ⟨7⟩ })
+    |>.withObject ⟨2⟩ (.notification { state := .active, waitingThreads := [], pendingBadge := ⟨7⟩ })
     |>.withService ⟨1⟩ sampleServiceEntry
     |>.withService ⟨2⟩ publicServiceEntry
     |>.withRunnable [⟨1⟩, ⟨2⟩]
@@ -81,7 +81,7 @@ private def altState : SystemState :=
   (BootstrapBuilder.empty
     |>.withObject ⟨1⟩ (.endpoint {})
     -- Secret object differs: different notification state and no pending badge
-    |>.withObject ⟨2⟩ (.notification { state := .idle, waitingThreads := [], pendingBadge := none })
+    |>.withObject ⟨2⟩ (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ })
     |>.withService ⟨1⟩ sampleServiceEntry
     |>.withService ⟨2⟩ publicServiceEntry
     |>.withRunnable [⟨1⟩, ⟨2⟩]
@@ -269,7 +269,7 @@ def runInformationFlowChecks : IO Unit := do
   -- cspaceMintChecked: same-domain mint should be allowed
   let mintState :=
     (BootstrapBuilder.empty
-      |>.withObject ⟨100⟩ (.cnode { depth := 8, guardWidth := 0, guardValue := 0, radixWidth := 8, slots := (Std.HashMap.ofList [(⟨0⟩, { target := .object ⟨200⟩, rights := [.read, .write], badge := none })]) })
+      |>.withObject ⟨100⟩ (.cnode { depth := 8, guardWidth := 0, guardValue := 0, radixWidth := 8, slots := (Std.HashMap.ofList [(⟨0⟩, { target := .object ⟨200⟩, rights := { read := true, write := true }, badge := none })]) })
       |>.withObject ⟨101⟩ (.cnode { depth := 8, guardWidth := 0, guardValue := 0, radixWidth := 8, slots := (Std.HashMap.ofList []) })
       |>.build)
 
@@ -282,8 +282,8 @@ def runInformationFlowChecks : IO Unit := do
   let srcAddr : SeLe4n.Kernel.CSpaceAddr := { cnode := ⟨100⟩, slot := ⟨0⟩ }
   let dstAddr : SeLe4n.Kernel.CSpaceAddr := { cnode := ⟨101⟩, slot := ⟨0⟩ }
 
-  let checkedMint := SeLe4n.Kernel.cspaceMintChecked sameDomainMintCtx srcAddr dstAddr [.read] none mintState
-  let uncheckedMint := SeLe4n.Kernel.cspaceMint srcAddr dstAddr [.read] none mintState
+  let checkedMint := SeLe4n.Kernel.cspaceMintChecked sameDomainMintCtx srcAddr dstAddr { read := true } none mintState
+  let uncheckedMint := SeLe4n.Kernel.cspaceMint srcAddr dstAddr { read := true } none mintState
   expect "same-domain cspaceMintChecked matches unchecked mint"
     (match checkedMint, uncheckedMint with
       | .ok _, .ok _ => true
@@ -297,7 +297,7 @@ def runInformationFlowChecks : IO Unit := do
       endpointLabelOf := fun _ => publicLabel
       serviceLabelOf := fun _ => publicLabel }
 
-  let deniedMint := SeLe4n.Kernel.cspaceMintChecked crossDomainMintCtx srcAddr dstAddr [.read] none mintState
+  let deniedMint := SeLe4n.Kernel.cspaceMintChecked crossDomainMintCtx srcAddr dstAddr { read := true } none mintState
   expect "secret-to-public cspaceMintChecked returns flowDenied"
     (match deniedMint with
       | .error .flowDenied => true
@@ -450,7 +450,7 @@ def runInformationFlowChecks : IO Unit := do
   let irqState :=
     (BootstrapBuilder.empty
       |>.withObject ⟨1⟩ (.endpoint {})
-      |>.withObject ⟨2⟩ (.notification { state := .active, waitingThreads := [], pendingBadge := some ⟨7⟩ })
+      |>.withObject ⟨2⟩ (.notification { state := .active, waitingThreads := [], pendingBadge := ⟨7⟩ })
       |>.withIrqHandler ⟨0⟩ ⟨1⟩   -- IRQ 0 → oid 1 (public object)
       |>.withIrqHandler ⟨1⟩ ⟨2⟩   -- IRQ 1 → oid 2 (secret object)
       |>.build)
@@ -509,11 +509,11 @@ def runInformationFlowChecks : IO Unit := do
   let cnodeState :=
     (BootstrapBuilder.empty
       |>.withObject ⟨1⟩ (.endpoint {})  -- public target
-      |>.withObject ⟨2⟩ (.notification { state := .idle, waitingThreads := [], pendingBadge := none })  -- secret target
+      |>.withObject ⟨2⟩ (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ })  -- secret target
       |>.withObject ⟨50⟩ (.cnode { depth := 8, guardWidth := 0, guardValue := 0, radixWidth := 8, slots := (Std.HashMap.ofList
-          [ (⟨0⟩, { target := .object ⟨1⟩, rights := [.read], badge := none })
-          , (⟨1⟩, { target := .object ⟨2⟩, rights := [.read, .write], badge := none })
-          , (⟨2⟩, { target := .replyCap ⟨1⟩, rights := [.read], badge := none })
+          [ (⟨0⟩, { target := .object ⟨1⟩, rights := { read := true }, badge := none })
+          , (⟨1⟩, { target := .object ⟨2⟩, rights := { read := true, write := true }, badge := none })
+          , (⟨2⟩, { target := .replyCap ⟨1⟩, rights := { read := true }, badge := none })
           ]) })
       |>.build)
 
@@ -565,10 +565,10 @@ def runInformationFlowChecks : IO Unit := do
   let cnodeSlotState :=
     (BootstrapBuilder.empty
       |>.withObject ⟨1⟩ (.endpoint {})  -- public target
-      |>.withObject ⟨2⟩ (.notification { state := .idle, waitingThreads := [], pendingBadge := none })  -- secret target
+      |>.withObject ⟨2⟩ (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ })  -- secret target
       |>.withObject ⟨60⟩ (.cnode { depth := 8, guardWidth := 0, guardValue := 0, radixWidth := 8, slots := (Std.HashMap.ofList
-          [ (⟨0⟩, { target := .cnodeSlot ⟨1⟩ ⟨0⟩, rights := [.read], badge := none })
-          , (⟨1⟩, { target := .cnodeSlot ⟨2⟩ ⟨0⟩, rights := [.read], badge := none })
+          [ (⟨0⟩, { target := .cnodeSlot ⟨1⟩ ⟨0⟩, rights := { read := true }, badge := none })
+          , (⟨1⟩, { target := .cnodeSlot ⟨2⟩ ⟨0⟩, rights := { read := true }, badge := none })
           ]) })
       |>.build)
 
@@ -665,7 +665,7 @@ def runInformationFlowChecks : IO Unit := do
     (BootstrapBuilder.empty
       |>.withObject ⟨30⟩ (.notification {
           state := .idle
-          pendingBadge := none
+          pendingBadge := ⟨0⟩
           waitingThreads := [] })
       |>.build)
 
@@ -704,7 +704,7 @@ def runInformationFlowChecks : IO Unit := do
   let copySrcCNode := SeLe4n.Model.CNode.empty
   let copySrcCNodeWithCap := copySrcCNode.insert ⟨0⟩ {
     target := .object ⟨99⟩
-    rights := [.read]
+    rights := { read := true }
     badge := none }
   let copyState :=
     (BootstrapBuilder.empty

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -44,7 +44,7 @@ private def baseState : SystemState :=
       slots := Std.HashMap.ofList [
         (⟨0⟩, {
           target := .object endpointId
-          rights := [.read, .write]
+          rights := { read := true, write := true }
           badge := none
         })
       ]
@@ -58,7 +58,7 @@ private def baseState : SystemState :=
       slots := Std.HashMap.ofList [
         (⟨1⟩, {
           target := .object endpointId
-          rights := [.read]
+          rights := { read := true }
           badge := none
         })
       ]
@@ -99,7 +99,7 @@ private def baseState : SystemState :=
       ipcBuffer := ⟨12288⟩
       ipcState := .ready
     })
-    |>.withObject notificationId (.notification { state := .idle, waitingThreads := [], pendingBadge := none })
+    |>.withObject notificationId (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ })
     |>.withObject ⟨20⟩ (.vspaceRoot { asid := asidPrimary, mappings := {} })
     |>.withLifecycleObjectType endpointId .endpoint
     |>.withLifecycleObjectType cnodeId .cnode
@@ -209,7 +209,7 @@ private def f2UntypedState : SystemState :=
       slots := Std.HashMap.ofList [
         (⟨0⟩, {
           target := .object f2UntypedObjId
-          rights := [.read, .write, .grant]
+          rights := { read := true, write := true, grant := true }
           badge := none
         })
       ]
@@ -238,7 +238,7 @@ private def f2DeviceState : SystemState :=
       slots := Std.HashMap.ofList [
         (⟨0⟩, {
           target := .object f2DeviceUntypedId
-          rights := [.read, .write, .grant]
+          rights := { read := true, write := true, grant := true }
           badge := none
         })
       ]
@@ -319,12 +319,12 @@ private def runNegativeChecks : IO Unit := do
             slots := Std.HashMap.ofList [
               (strictRootSlot.slot, {
                 target := .object endpointId
-                rights := [.read, .write]
+                rights := { read := true, write := true }
                 badge := none
               }),
               (strictChildSlotOk.slot, {
                 target := .object endpointId
-                rights := [.read]
+                rights := { read := true }
                 badge := none
               })
             ]
@@ -491,10 +491,10 @@ private def runNegativeChecks : IO Unit := do
   expectError "endpointSendDual rejects oversized caps"
     (SeLe4n.Kernel.endpointSendDual endpointId (SeLe4n.ThreadId.ofNat 1)
       { registers := #[],
-        caps := #[{ target := .object ⟨1⟩, rights := [] },
-                  { target := .object ⟨2⟩, rights := [] },
-                  { target := .object ⟨3⟩, rights := [] },
-                  { target := .object ⟨4⟩, rights := [] }],
+        caps := #[{ target := .object ⟨1⟩, rights := {} },
+                  { target := .object ⟨2⟩, rights := {} },
+                  { target := .object ⟨3⟩, rights := {} },
+                  { target := .object ⟨4⟩, rights := {} }],
         badge := none } baseState)
     .ipcMessageTooManyCaps
 
@@ -508,10 +508,10 @@ private def runNegativeChecks : IO Unit := do
   expectError "endpointCall rejects oversized caps"
     (SeLe4n.Kernel.endpointCall endpointId (SeLe4n.ThreadId.ofNat 1)
       { registers := #[],
-        caps := #[{ target := .object ⟨1⟩, rights := [] },
-                  { target := .object ⟨2⟩, rights := [] },
-                  { target := .object ⟨3⟩, rights := [] },
-                  { target := .object ⟨4⟩, rights := [] }],
+        caps := #[{ target := .object ⟨1⟩, rights := {} },
+                  { target := .object ⟨2⟩, rights := {} },
+                  { target := .object ⟨3⟩, rights := {} },
+                  { target := .object ⟨4⟩, rights := {} }],
         badge := none } baseState)
     .ipcMessageTooManyCaps
 
@@ -527,10 +527,10 @@ private def runNegativeChecks : IO Unit := do
     (SeLe4n.Kernel.endpointReply (SeLe4n.ThreadId.ofNat 1)
       (SeLe4n.ThreadId.ofNat 2)
       { registers := #[],
-        caps := #[{ target := .object ⟨1⟩, rights := [] },
-                  { target := .object ⟨2⟩, rights := [] },
-                  { target := .object ⟨3⟩, rights := [] },
-                  { target := .object ⟨4⟩, rights := [] }],
+        caps := #[{ target := .object ⟨1⟩, rights := {} },
+                  { target := .object ⟨2⟩, rights := {} },
+                  { target := .object ⟨3⟩, rights := {} },
+                  { target := .object ⟨4⟩, rights := {} }],
         badge := none } baseState)
     .ipcMessageTooManyCaps
 
@@ -546,10 +546,10 @@ private def runNegativeChecks : IO Unit := do
     (SeLe4n.Kernel.endpointReplyRecv endpointId (SeLe4n.ThreadId.ofNat 1)
       (SeLe4n.ThreadId.ofNat 2)
       { registers := #[],
-        caps := #[{ target := .object ⟨1⟩, rights := [] },
-                  { target := .object ⟨2⟩, rights := [] },
-                  { target := .object ⟨3⟩, rights := [] },
-                  { target := .object ⟨4⟩, rights := [] }],
+        caps := #[{ target := .object ⟨1⟩, rights := {} },
+                  { target := .object ⟨2⟩, rights := {} },
+                  { target := .object ⟨3⟩, rights := {} },
+                  { target := .object ⟨4⟩, rights := {} }],
         badge := none } baseState)
     .ipcMessageTooManyCaps
 
@@ -557,9 +557,9 @@ private def runNegativeChecks : IO Unit := do
   -- (may still fail due to other reasons like endpoint state)
   let boundaryMsg : SeLe4n.Model.IpcMessage := {
     registers := Array.mk (List.replicate 120 42),
-    caps := #[{ target := .object ⟨1⟩, rights := [] },
-              { target := .object ⟨2⟩, rights := [] },
-              { target := .object ⟨3⟩, rights := [] }],
+    caps := #[{ target := .object ⟨1⟩, rights := {} },
+              { target := .object ⟨2⟩, rights := {} },
+              { target := .object ⟨3⟩, rights := {} }],
     badge := none }
   let boundaryResult := SeLe4n.Kernel.endpointSendDual endpointId
     (SeLe4n.ThreadId.ofNat 1) boundaryMsg baseState
@@ -1033,7 +1033,7 @@ private def runH2NegativeChecks : IO Unit := do
         slots := Std.HashMap.ofList [
           (⟨0⟩, {
             target := .object f2UntypedObjId
-            rights := [.read, .write, .grant]
+            rights := { read := true, write := true, grant := true }
             badge := none
           })
         ]
@@ -1098,30 +1098,30 @@ private def runAuditCoverageChecks : IO Unit := do
   -- ── Audit: cspaceMutate coverage ─────────────────────────────────────
   -- NEG-MUTATE-01: mutate on non-existent CNode
   expectError "cspaceMutate non-existent CNode"
-    (SeLe4n.Kernel.cspaceMutate { cnode := ⟨999⟩, slot := ⟨0⟩ } [.read] none baseState)
+    (SeLe4n.Kernel.cspaceMutate { cnode := ⟨999⟩, slot := ⟨0⟩ } { read := true } none baseState)
     .objectNotFound
 
   -- NEG-MUTATE-02: mutate with rights not a subset (escalation attempt)
   expectError "cspaceMutate rights escalation denied"
-    (SeLe4n.Kernel.cspaceMutate slot0 [.read, .write, .grant] none baseState)
+    (SeLe4n.Kernel.cspaceMutate slot0 { read := true, write := true, grant := true } none baseState)
     .invalidCapability
 
   -- POS-MUTATE: attenuate rights successfully
   let (_, stMutated) ← expectOkState "cspaceMutate attenuate to read-only"
-    (SeLe4n.Kernel.cspaceMutate slot0 [.read] none baseState)
+    (SeLe4n.Kernel.cspaceMutate slot0 { read := true } none baseState)
   -- Verify rights were attenuated
   match SeLe4n.Kernel.cspaceLookupSlot slot0 stMutated with
   | .ok (cap, _) =>
-      if cap.rights = [.read] then
+      if cap.rights == ({ read := true } : AccessRights) then
         IO.println "positive check passed [cspaceMutate: rights attenuated to read-only]"
       else
-        throw <| IO.userError s!"cspaceMutate: expected [read], got {reprStr cap.rights}"
+        throw <| IO.userError s!"cspaceMutate: expected read-only, got {reprStr cap.rights}"
   | .error err =>
       throw <| IO.userError s!"cspaceMutate: lookup after mutate failed: {reprStr err}"
 
   -- POS-MUTATE-BADGE: mutate with badge override
   let (_, stBadgeMutate) ← expectOkState "cspaceMutate with badge override"
-    (SeLe4n.Kernel.cspaceMutate slot0 [.read] (some (SeLe4n.Badge.ofNat 77)) baseState)
+    (SeLe4n.Kernel.cspaceMutate slot0 { read := true } (some (SeLe4n.Badge.ofNat 77)) baseState)
   match SeLe4n.Kernel.cspaceLookupSlot slot0 stBadgeMutate with
   | .ok (cap, _) =>
       if cap.badge = some ⟨77⟩ then
@@ -1146,8 +1146,8 @@ private def runWSH7Checks : IO Unit := do
   else
     throw <| IO.userError "WS-H7 VSpaceRoot BEq ignores insertion order: expected true"
 
-  let capA : Capability := { target := .object endpointId, rights := [.read], badge := none }
-  let capB : Capability := { target := .object notificationId, rights := [.read, .write], badge := none }
+  let capA : Capability := { target := .object endpointId, rights := { read := true }, badge := none }
+  let capB : Capability := { target := .object notificationId, rights := { read := true, write := true }, badge := none }
   let cn1 : CNode :=
     { depth := 2, guardWidth := 0, guardValue := 0, radixWidth := 2
       slots := (({} : Std.HashMap SeLe4n.Slot Capability).insert ⟨1⟩ capA).insert ⟨2⟩ capB }
@@ -1423,8 +1423,8 @@ private def runWSH15Checks : IO Unit := do
   let cnodeId : SeLe4n.ObjId := ⟨50⟩
   let epId : SeLe4n.ObjId := ⟨40⟩
   let callerId : SeLe4n.ThreadId := ⟨1⟩
-  let writeCap : Capability := { target := .object epId, rights := [.write], badge := none }
-  let readOnlyCap : Capability := { target := .object epId, rights := [.read], badge := none }
+  let writeCap : Capability := { target := .object epId, rights := { write := true }, badge := none }
+  let readOnlyCap : Capability := { target := .object epId, rights := { read := true }, badge := none }
   let cn : CNode := {
     depth := 4, guardWidth := 0, guardValue := 0, radixWidth := 4,
     slots := Std.HashMap.ofList [
@@ -1577,12 +1577,12 @@ def runWSH16LifecycleChecks : IO Unit := do
         slots := Std.HashMap.ofList [
           (⟨0⟩, {
             target := .object h16TargetId
-            rights := [.read, .write]
+            rights := { read := true, write := true }
             badge := none
           }),
           (⟨1⟩, {
             target := .object h16TargetId
-            rights := [.read]
+            rights := { read := true }
             badge := none
           })
         ]
@@ -1621,7 +1621,7 @@ def runWSH16LifecycleChecks : IO Unit := do
         slots := Std.HashMap.ofList [
           (⟨0⟩, {
             target := .object h16TargetId
-            rights := [.read, .write]
+            rights := { read := true, write := true }
             badge := none
           })
         ]
@@ -1631,13 +1631,13 @@ def runWSH16LifecycleChecks : IO Unit := do
       |>.withLifecycleCapabilityRef h16AuthSlot (.object h16TargetId)
       |>.build)
   expectError "H16 lifecycleRetypeObject metadata mismatch"
-    (SeLe4n.Kernel.lifecycleRetypeObject h16AuthSlot h16TargetId (.notification { state := .idle, waitingThreads := [], pendingBadge := none }) h16MismatchState)
+    (SeLe4n.Kernel.lifecycleRetypeObject h16AuthSlot h16TargetId (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) h16MismatchState)
     .illegalState
 
   -- H16-NEG-03: lifecycleRetypeObject with insufficient authority (read-only cap) → illegalAuthority
   let h16ReadOnlySlot : SeLe4n.Kernel.CSpaceAddr := { cnode := h16CnodeId, slot := ⟨1⟩ }
   expectError "H16 lifecycleRetypeObject insufficient authority"
-    (SeLe4n.Kernel.lifecycleRetypeObject h16ReadOnlySlot h16TargetId (.notification { state := .idle, waitingThreads := [], pendingBadge := none }) h16State)
+    (SeLe4n.Kernel.lifecycleRetypeObject h16ReadOnlySlot h16TargetId (.notification { state := .idle, waitingThreads := [], pendingBadge := ⟨0⟩ }) h16State)
     .illegalAuthority
 
   -- H16-NEG-04: lifecycleRetypeObject with bad authority CNode → objectNotFound
@@ -1678,7 +1678,7 @@ def runWSH16LifecycleChecks : IO Unit := do
         slots := Std.HashMap.ofList [
           (⟨0⟩, {
             target := .object h16ExhaustedUntypedId
-            rights := [.read, .write, .grant]
+            rights := { read := true, write := true, grant := true }
             badge := none
           })
         ]
@@ -1722,7 +1722,7 @@ def runWSH16LifecycleChecks : IO Unit := do
         slots := Std.HashMap.ofList [
           (⟨0⟩, {
             target := .object h16DeviceUntypedId
-            rights := [.read, .write, .grant]
+            rights := { read := true, write := true, grant := true }
             badge := none
           })
         ]

--- a/tests/fixtures/main_trace_smoke.expected
+++ b/tests/fixtures/main_trace_smoke.expected
@@ -1,7 +1,7 @@
 scheduled thread: some 1
-source cap rights before mint: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]
-source path lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]
-source path alias lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]
+source cap rights before mint: { read := true, write := true, grant := true, grantReply := false, retype := false }
+source path lookup rights: { read := true, write := true, grant := true, grantReply := false, retype := false }
+source path alias lookup rights: { read := true, write := true, grant := true, grantReply := false, retype := false }
 adapter timer success path value: 2
 adapter timer invalid-context branch: SeLe4n.Model.KernelError.illegalState
 adapter timer unsupported branch: SeLe4n.Model.KernelError.notImplemented
@@ -28,7 +28,7 @@ service start missing-backing branch: SeLe4n.Model.KernelError.backingObjectMiss
 service isolation api↔denied: true
 service isolation api↔db: false
 deep cnode radix fixture: some 12
-deep cnode path lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write]
+deep cnode path lookup rights: { read := true, write := true, grant := false, grantReply := false, retype := false }
 deep cnode path bad-depth branch: SeLe4n.Model.KernelError.illegalState
 deep cnode path guard-mismatch branch: SeLe4n.Model.KernelError.invalidCapability
 large runnable queue length: 2
@@ -53,7 +53,7 @@ queued sender on endpoint
 endpoint receive #1 sender: 1
 notification wait #1 result: none
 notification wait #2 result: some { val := 123 }
-minted cap rights: [SeLe4n.Model.AccessRight.read]
+minted cap rights: { read := true, write := false, grant := false, grantReply := false, retype := false }
 H-02 occupied slot guard: SeLe4n.Model.KernelError.targetSlotOccupied
 cspaceCopy target matches: true
 dual-queue sender blocked on sendQ non-empty: true
@@ -92,6 +92,10 @@ timer tick expiry rescheduled current: some 1
 timer tick expiry reset slice: 5
 domain switch active domain: 1
 domain switch time remaining: 5
+setPriority new priority: 200
+suspendThread removed from queue: true
+resumeThread added to queue: true
+setPriority missing thread: SeLe4n.Model.KernelError.objectNotFound
 retype-from-untyped success object kind: some (SeLe4n.Model.KernelObjectType.endpoint)
 untyped watermark after retype: 64
 untyped children count: 1

--- a/tests/scenarios/scenario_catalog.json
+++ b/tests/scenarios/scenario_catalog.json
@@ -8,7 +8,7 @@
       "subsystem": "capability",
       "risk_tags": ["correctness", "regression"],
       "replay_tier": "smoke",
-      "expected_trace_fragment": "source path lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write, SeLe4n.Model.AccessRight.grant]"
+      "expected_trace_fragment": "source path lookup rights: { read := true, write := true, grant := true, grantReply := false, retype := false }"
     },
     {
       "id": "SCN-ARCH-TIMER-INVALID",
@@ -36,7 +36,7 @@
       "subsystem": "cspace",
       "risk_tags": ["correctness", "scale"],
       "replay_tier": "smoke",
-      "expected_trace_fragment": "deep cnode path lookup rights: [SeLe4n.Model.AccessRight.read, SeLe4n.Model.AccessRight.write]"
+      "expected_trace_fragment": "deep cnode path lookup rights: { read := true, write := true, grant := false, grantReply := false, retype := false }"
     },
     {
       "id": "SCN-SCHED-LARGE-QUEUE",


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-F5 (Model Fidelity)
- **Recommendation IDs closed:** WS-F5/D1 (Notification badge), WS-F5/D4 (AccessRights)
- **Scope notes:** Replaced `Option Badge` with word-sized `Badge` bitmask in notifications; introduced `AccessRights` struct to replace `List AccessRight`; added thread management operations (`setPriority`, `suspendThread`, `resumeThread`); updated all preservation proofs and test fixtures.

## Key Changes

### 1. Notification Badge Model (WS-F5/D1)
- Changed `Notification.pendingBadge` from `Option Badge` to `Badge` (word-sized bitmask)
- `notificationSignal` now uses bitwise OR accumulation: `pendingBadge.toNat ||| badge.toNat`
- `notificationWait` uses `pendingBadge.toNat != 0` guard instead of `Option` pattern matching
- Added `hBadgeNonZero : badge.toNat ≠ 0` precondition to `notificationSignal_preserves_ipcInvariant`
- Updated all related preservation proofs in `NotificationPreservation.lean` and `Structural.lean`

### 2. AccessRights Struct (WS-F5/D4)
- Introduced `AccessRights` structure with boolean fields (`read`, `write`, `grant`, `grantReply`, `retype`)
- Replaced all `List AccessRight` parameters with `AccessRights` throughout:
  - `mintDerivedCap`, `cspaceMint`, `cspaceMutate`, etc.
  - Capability invariant proofs (`capAttenuates` now uses `rights.subset parent.rights = true`)
- Removed `rightsSubset` function; integrated into `AccessRights.subset` method
- Added helper methods: `subset`, `intersect`, `union`, `isEmpty`, `ofList`, `toList`
- Proved `subset_refl` and `subset_sound` theorems for rights attenuation

### 3. Thread Management Operations (WS-F5/D5)
- Added `setPriority` (reschedule thread at new priority)
- Added `suspendThread` (remove from run queue, clear blocking state)
- Added `resumeThread` (placeholder for future implementation)
- All in `SeLe4n/Kernel/Scheduler/Operations/Core.lean`

### 4. Proof Updates
- Updated `mintDerivedCap_attenuates` to work with `AccessRights.subset`
- Simplified `mintDerivedCap_rights_attenuated_with_badge_override` to return `child.rights.subset parent.rights = true`
- Updated `notificationQueueWellFormed` to use `pendingBadge.toNat = 0` / `!= 0` instead of `Option` checks
- Fixed line number shifts in `cspaceMint_badge_override_safe` and related theorems

### 5. Test & Documentation Updates
- Updated all test fixtures (`MainTraceHarness.lean`, `NegativeStateSuite.lean`, `InformationFlowSuite.lean`) to use `AccessRights` struct syntax
- Updated expected trace output in `main_trace_smoke.expected`
- Bumped version to `0.14.9` in `lakefile.toml` and `codebase_map.json`
- Updated `CHANGELOG.md` with WS-F5 completion notes
- Updated roadmap docs (`22-next-slice-development-path.md`, `WORKSTREAM_HISTORY.md`)

## Validation Evidence

- Codebase map updated: declaration count 1938 → 1952, production LoC 32,872 → 33,047
- All preservation proofs rewritten to match new badge/rights models
- Test fixtures regenerated with new `AccessRights` syntax
- No new `sorry` statements introduced

https://claude.ai/code/session_01X3ykaJgMeZWiror4o3CK85