### PR TITLE
Bump patch version to 0.14.10 and synchronize docs/gitbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
 - **Build jobs:** 138. Zero sorry/axiom. Zero warnings.
 - **Recommendations closed:** R-01, R-02, R-03.
 
+## [0.14.10] - 2026-03-13
+
+### Documentation & version sync
+
+- Bumped package version from `0.14.9` to `0.14.10` in `lakefile.toml`.
+- Synchronized canonical documentation version markers (`README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/codebase_map.json`).
+- Updated GitBook mirror version markers (`docs/gitbook/README.md`, `docs/gitbook/navigation_manifest.json`, `docs/gitbook/05-specification-and-roadmap.md`, and `docs/gitbook/22-next-slice-development-path.md`).
+
 ## [0.14.9] - 2026-03-11
 
 ### WS-F5: Model Fidelity

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.14.9-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.14.10-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -57,7 +57,7 @@ architectural improvements compared to other microkernels:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.14.9` |
+| **Version** | `0.14.10` |
 | **Lean toolchain** | `v4.28.0` |
 | **Production Lean LoC** | 34,171 across 67 files |
 | **Test Lean LoC** | 2,886 across 3 test suites |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,7 +36,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 ## 3) Next workstreams
 
 The WS-F portfolio (v0.12.2 audit) is fully complete — all 33 findings closed.
-The active improvement portfolio is WS-I (v0.14.9). WS-I1 and WS-I2 are completed;
+The active improvement portfolio is WS-I (v0.14.10). WS-I1 and WS-I2 are completed;
 remaining follow-up workstreams are WS-I4..WS-I5.
 
 ### 3.1 WS-H11..H16 — Remaining v0.12.15 audit remediation

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -24,7 +24,7 @@
     "declaration_count": 2031
   },
   "readme_sync": {
-    "version": "0.14.9",
+    "version": "0.14.10",
     "lean_toolchain": "v4.28.0",
     "production_files": 67,
     "production_loc": 34286,

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -13,14 +13,14 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 
 | Attribute | Value |
 |-----------|-------|
-| Version | `0.14.9` |
+| Version | `0.14.10` |
 | Lean toolchain | `v4.28.0` |
 | Production LoC | 34,171 across 67 files |
 | Test LoC | 2,886 across 3 suites |
 | Proved declarations | 1,086 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 2,006 across 70 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| Next workstreams | WS-I4+ (v0.14.9 improvement portfolio; WS-I1/WS-I3 completed); Raspberry Pi 5 hardware binding |
+| Next workstreams | WS-I4+ (v0.14.10 improvement portfolio; WS-I1/WS-I3 completed); Raspberry Pi 5 hardware binding |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | Metrics source of truth | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 

--- a/docs/gitbook/22-next-slice-development-path.md
+++ b/docs/gitbook/22-next-slice-development-path.md
@@ -2,7 +2,7 @@
 
 ## Current state
 
-**Version:** 0.14.9 (Lean v4.28.0)
+**Version:** 0.14.10 (Lean v4.28.0)
 
 **Verified metrics snapshot (from [`docs/codebase_map.json`](../../docs/codebase_map.json) `readme_sync`):**
 - Production LoC: 34,171 across 67 files

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -5,7 +5,7 @@
 This GitBook is the long-form guide for seLe4n — a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.
 
 ## Current project state
-- **Version:** 0.14.9 (Lean v4.28.0).
+- **Version:** 0.14.10 (Lean v4.28.0).
 - **Codebase metrics:** 34,171 production LoC across 67 files; 2,886 test LoC across 3 suites; 1,086 theorem/lemma declarations (zero sorry/axiom); 2,006 total declarations across 70 modules.
 - **Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.
 - **Next workstreams:** Raspberry Pi 5 hardware binding (all WS-F and WS-H portfolios completed).

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -1,7 +1,7 @@
 {
   "description": "This GitBook is the long-form guide for seLe4n \u2014 a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.",
   "current_state_bullets": [
-    "**Version:** 0.14.9 (Lean v4.28.0).",
+    "**Version:** 0.14.10 (Lean v4.28.0).",
     "**Codebase metrics:** 34,171 production LoC across 67 files; 2,886 test LoC across 3 suites; 1,086 theorem/lemma declarations (zero sorry/axiom); 2,006 total declarations across 70 modules.",
     "**Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.",
     "**Next workstreams:** Raspberry Pi 5 hardware binding (all WS-F and WS-H portfolios completed).",

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -48,7 +48,7 @@ enforcement, and scheduling.
 
 | Attribute | Value |
 |-----------|-------|
-| **Package version** | `0.14.9` (`lakefile.toml`) |
+| **Package version** | `0.14.10` (`lakefile.toml`) |
 | **Lean toolchain** | `v4.28.0` (`lean-toolchain`) |
 | **Production LoC** | 34,171 across 67 Lean files |
 | **Test LoC** | 2,886 across 3 Lean test suites |
@@ -56,7 +56,7 @@ enforcement, and scheduling.
 | **Total declarations** | 2,006 across 70 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| **Next workstreams** | WS-I4+ (v0.14.9 improvement portfolio; WS-I1/WS-I3 completed) |
+| **Next workstreams** | WS-I4+ (v0.14.10 improvement portfolio; WS-I1/WS-I3 completed) |
 | **Workstream history** | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | **Metrics source of truth** | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 | **Codebase map** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`) |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,7 +5,7 @@
 # under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 
 name = "seLe4n"
-version = "0.14.9"
+version = "0.14.10"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
### Motivation

- Ensure the package and published documentation reflect the new patch release and keep the canonical and GitBook mirrors in sync after the recent workstream/documentation updates. 

### Description

- Bumped package version to `0.14.10` in `lakefile.toml` and updated version markers in `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/codebase_map.json`.
- Updated the GitBook mirror and navigation markers in `docs/gitbook/README.md`, `docs/gitbook/navigation_manifest.json`, `docs/gitbook/05-specification-and-roadmap.md`, and `docs/gitbook/22-next-slice-development-path.md`.
- Added a `0.14.10` entry in `CHANGELOG.md` documenting the version bump and documentation synchronization.

### Testing

- Ran `./scripts/test_smoke.sh` (hygiene + build + trace + determinism + negative-state + docs sync); an initial `clang` frontend crash occurred during a transient compile step, but a subsequent full run completed successfully and all smoke-tier checks passed.
- Confirmed `lake build` completed and the trace fixture comparison passed (fixture lines matched), and the docs generation/sync steps executed without errors as part of the smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b37e9280bc832b82ba5b2a24d3d521)