### PR TITLE
WS-I4: Add subsystem tests (VSpace multi-ASID, IPC interleaving, lifecycle chains) and sync docs

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,8 +36,8 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 ## 3) Next workstreams
 
 The WS-F portfolio (v0.12.2 audit) is fully complete — all 33 findings closed.
-The active improvement portfolio is WS-I (v0.14.10). WS-I1 and WS-I2 are completed;
-remaining follow-up workstreams are WS-I4..WS-I5.
+The active improvement portfolio is WS-I (v0.14.10). WS-I1 through WS-I4 are completed;
+remaining follow-up workstream is WS-I5.
 
 ### 3.1 WS-H11..H16 — Remaining v0.12.15 audit remediation
 
@@ -73,6 +73,7 @@ for the full execution plan.
 ### 3.3 Completed portfolios
 
 - **WS-I3:** completed (v0.15.2). Test coverage expansion — new `tests/OperationChainSuite.lean` adds 6 multi-operation chain tests (retype→mint→revoke, send/send/receive FIFO, map/lookup/unmap/lookup, service start/stop dependency sequencing, copy/move/delete, notification badge accumulation), scheduler stress coverage (16-thread repeated scheduling, same-priority determinism, multi-domain isolation), and Tier 2 integration via `scripts/test_tier2_negative.sh`; `tests/InformationFlowSuite.lean` now includes declassification runtime checks for authorized downgrade, normal-flow rejection, policy-denied rejection, and 3-domain lattice behavior. Closes R-06/R-07/R-08 Declassification policy denial now reports a distinct `declassificationDenied` error in `declassifyStore` and suite expectations.
+- **WS-I4:** completed (v0.15.3). Subsystem coverage expansion — `tests/OperationChainSuite.lean` now includes dedicated WS-I4 sections for (R-09) VSpace multi-ASID shared-page coverage (shared PAddr persistence across ASID-local unmap + per-ASID permission divergence via `vspaceLookupFull`), (R-10) IPC interleaved sender/receiver ordering checks (3-sender FIFO and alternating send/receive), and (R-11) lifecycle transaction chains (authority attenuation root→child→grandchild, syscall-gated no-grant mint denial, and cascading `cspaceRevokeCdtStrict` descendant cleanup with CDT detachment assertions). Closes R-09/R-10/R-11.
 - **WS-I1:** completed (v0.15.0). Critical testing infrastructure — 17 inter-transition invariant assertions across all 13 trace functions (R-01), mandatory Tier 2 determinism validation (R-02), scenario ID traceability with 121 tagged trace lines, pipe-delimited fixture format, scenario registry YAML with Tier 0 validation (R-03). Phase 1 of the WS-I improvement portfolio. Closes R-01/R-02/R-03.
 - **WS-F8:** completed. Cleanup — removed dead `ServiceStatus.failed`/`isolated` constructors, labeled Service subsystem as seLe4n extension with module docstrings (MED-17), closed F-14 (endpointInvariant already removed in WS-H12a), closed F-01 (legacy endpoint fields already removed in WS-H12a), closed MED-04 (domain lattice alive and exercised — finding misidentified). Completes 100% of v0.12.2 audit findings (33/33). Closes MED-04, MED-17, F-01, F-14, F-19.
 - **WS-F7:** completed. Testing expansion — 4 new runtime invariant checks (`blockedOnSendNotRunnable`, `blockedOnReceiveNotRunnable`, `currentThreadInActiveDomain`, `uniqueWaiters`) added to `InvariantChecks.lean`; `TraceSequenceProbe` extended from 3 to 7 operation families (+ notification signal/wait, schedule, capability lookup) with blocked-thread guard; `runtimeContractTimerOnly` and `runtimeContractReadOnlyMemory` fixtures exercised in `MainTraceHarness` with 6 deterministic trace assertions; CDT `childMapConsistentCheck` confirmed already delivered. Zero sorry, zero axiom. Closes MED-08, F-24, F-25, F-26.

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -43,10 +43,10 @@ full details.
 | ID | Focus | Priority |
 |----|-------|----------|
 | **WS-I1** | Test infrastructure hardening (inter-transition assertions, determinism promotion, scenario ID traceability) | HIGH — **COMPLETED** (v0.15.0) |
-| **WS-I2** | Proof & hygiene strengthening (L-08 regex upgrade, HashMap.fold migration, NI CDT frame lemmas, VSpace memory projection) | HIGH — pending |
-| **WS-I3** | Documentation completeness (codebase map automation, GitBook Tier 3 chapter, claim-evidence gap closure) | MEDIUM — pending |
-| **WS-I4** | Code quality refinement (RuntimeContract documentation, Service subsystem docstring expansion) | LOW — pending |
-| **WS-I5** | Coverage expansion (scheduler edge-case scenarios, information-flow declassification tests, platform contract stress tests) | LOW — pending |
+| **WS-I2** | Proof & validation depth (semantic L-08 validation, Tier 3 property anchors, CDT decomposition lemmas, VSpace memory projection ownership) | HIGH — **COMPLETED** (v0.15.1) |
+| **WS-I3** | Operations coverage expansion (multi-operation chains, scheduler stress, declassification checks) | MEDIUM — **COMPLETED** (v0.15.2) |
+| **WS-I4** | Subsystem coverage expansion (VSpace multi-ASID sharing, IPC interleaving, lifecycle chain tests) | LOW — **COMPLETED** (v0.15.3) |
+| **WS-I5** | Documentation & code quality polish (RegName/RegValue docs, IF readers' guide, fixture process, HashMap.fold migration, metrics automation) | LOW — pending |
 
 ### Raspberry Pi 5 hardware binding
 
@@ -71,6 +71,7 @@ platform stubs with hardware-validated contracts:
 
 | Portfolio | Version | Scope | Workstreams |
 |-----------|---------|-------|-------------|
+| **WS-I4** | v0.15.3 | Subsystem coverage expansion: `tests/OperationChainSuite.lean` now includes VSpace multi-ASID shared-page tests (cross-ASID shared PAddr coherence under ASID-local unmap and per-ASID permission divergence), IPC interleaved send/receive tests (three-sender FIFO plus alternating send/receive queue-integrity checks), and lifecycle transaction chains (authority attenuation root→child→grandchild with no-grant mint denial and strict cascading CDT revoke assertions). Tier 2 smoke now exercises these via `tests/OperationChainSuite.lean`. Closes R-09/R-10/R-11 | I4 |
 | **WS-I1** | v0.15.0 | Critical testing infrastructure: 17 inter-transition invariant assertions across all 13 trace functions (R-01), mandatory Tier 2 determinism validation via `test_tier2_determinism.sh` (R-02), scenario ID traceability with 121 tagged trace lines in pipe-delimited format, scenario registry YAML with Tier 0 validation (R-03). Zero sorry/axiom. Closes R-01/R-02/R-03 | I1 |
 | **WS-F8** | v0.14.9 | Cleanup: removed dead `ServiceStatus.failed`/`isolated` constructors (D1), labeled Service subsystem as seLe4n extension with module docstrings (D2/MED-17), closed F-14 (endpointInvariant already removed in WS-H12a), closed F-01 (legacy endpoint fields already removed in WS-H12a), closed MED-04 (domain lattice alive and exercised, finding misidentified). Completes 100% of v0.12.2 audit findings (33/33). Closes MED-04/MED-17/F-01/F-14/F-19 | F8 |
 | **WS-F5** | v0.14.9 | Model fidelity: word-bounded `Badge` with `ofNatMasked`/`bor`/validity theorems (F5-D1/CRIT-06), order-independent `AccessRightSet` bitmask replacing list-based rights (F5-D2/HIGH-04), deferred operations documented with rationale (F5-D3/MED-03), `badgeWellFormed` invariant with `notificationBadgesWellFormed`/`capabilityBadgesWellFormed` predicates and preservation proofs for `notificationSignal`/`notificationWait`/`cspaceMint`/`cspaceMutate`. Closes CRIT-06/HIGH-04/MED-03 | F5 |

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "main",
-      "commit_sha": "93ba8562f4c528965675a5e043c93bd9acdef894",
-      "tree_sha": "1c132150f4b6874df134bd8bd82b0efd558c03cf",
-      "committed_at_utc": "2026-03-12T23:26:05-04:00"
+      "branch": "work",
+      "commit_sha": "3e114512f3bdc49b1d3afe7f23f579ccf95c6fa4",
+      "tree_sha": "183951798e144413d93c7dd9038974547952e9f9",
+      "committed_at_utc": "2026-03-13T03:26:12+00:00"
     }
   },
   "source_sync": {
@@ -17,11 +17,11 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "4da02426be772ec22275b8bad556ad98873a6ed057992fa6cd1ff5c4e6eb73c0"
+    "source_digest": "ea1182df55f7adf01fa05bca5a6e5aa1dfeb058b98f7a90b1139b51ffaa3e8d2"
   },
   "summary": {
     "module_count": 71,
-    "declaration_count": 2031
+    "declaration_count": 2034
   },
   "readme_sync": {
     "version": "0.14.10",
@@ -29,7 +29,7 @@
     "production_files": 67,
     "production_loc": 34286,
     "test_files": 4,
-    "test_loc": 3293,
+    "test_loc": 3448,
     "proved_theorem_lemma_decls": 1089,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
@@ -16279,7 +16279,7 @@
     {
       "module": "tests.OperationChainSuite",
       "path": "tests/OperationChainSuite.lean",
-      "declaration_count": 18,
+      "declaration_count": 21,
       "declarations": [
         {
           "kind": "namespace",
@@ -16385,14 +16385,46 @@
         },
         {
           "kind": "def",
-          "name": "buildParameterizedTopology",
+          "name": "wsI4VspaceMultiAsidSharing",
           "line": 210,
+          "called": [
+            "assertInvariants",
+            "expect",
+            "expectError",
+            "expectOkState"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "wsI4IpcInterleavedSends",
+          "line": 257,
+          "called": [
+            "assertInvariants",
+            "expect",
+            "expectOkState"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "wsI4LifecycleTransactionChains",
+          "line": 301,
+          "called": [
+            "assertInvariants",
+            "expect",
+            "expectError",
+            "expectOkState"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "buildParameterizedTopology",
+          "line": 362,
           "called": []
         },
         {
           "kind": "def",
           "name": "scheduleNTimes",
-          "line": 243,
+          "line": 395,
           "called": [
             "assertInvariants",
             "runKernelState"
@@ -16401,7 +16433,7 @@
         {
           "kind": "def",
           "name": "schedulerStressChecks",
-          "line": 253,
+          "line": 405,
           "called": [
             "assertInvariants",
             "buildParameterizedTopology",
@@ -16414,7 +16446,7 @@
         {
           "kind": "def",
           "name": "runOperationChainSuite",
-          "line": 335,
+          "line": 487,
           "called": [
             "chain1RetypeMintRevoke",
             "chain2SendSendReceiveFifo",
@@ -16422,13 +16454,16 @@
             "chain4ServiceStartDependentStop",
             "chain5CopyMoveDelete",
             "chain6NotificationBadgeAccumulation",
-            "schedulerStressChecks"
+            "schedulerStressChecks",
+            "wsI4IpcInterleavedSends",
+            "wsI4LifecycleTransactionChains",
+            "wsI4VspaceMultiAsidSharing"
           ]
         },
         {
           "kind": "def",
           "name": "main",
-          "line": 347,
+          "line": 502,
           "called": []
         }
       ]

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -20,7 +20,7 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 | Proved declarations | 1,086 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 2,006 across 70 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| Next workstreams | WS-I4+ (v0.14.10 improvement portfolio; WS-I1/WS-I3 completed); Raspberry Pi 5 hardware binding |
+| Next workstreams | WS-I5+ (v0.14.10 improvement portfolio; WS-I1..WS-I4 completed); Raspberry Pi 5 hardware binding |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | Metrics source of truth | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 
@@ -74,6 +74,14 @@ boundaries (`endpointSendDual`/`endpointCall`/`endpointReply`/`endpointReplyRecv
 integrated into `ipcInvariantFull` 3-conjunct bundle. `checkBounds_iff_bounded`
 decidability bridge. Information-flow enforcement updated with bounds-before-flow
 ordering. Closes A-09 (HIGH).
+
+## Completed: WS-I4 Subsystem Coverage Expansion (v0.15.3)
+
+Phase 3 (subsystem-focused) of the WS-I improvement portfolio:
+
+- `tests/OperationChainSuite.lean` now includes VSpace multi-ASID sharing coverage: one physical page mapped into two ASIDs, ASID-local unmap isolation, and per-ASID permission divergence validated with `vspaceLookupFull`.
+- IPC interleaving coverage validates three-sender FIFO ordering and alternating send/receive sequencing on a shared endpoint without queue corruption.
+- Lifecycle chain coverage validates authority attenuation (`{read,write,grant}` → `{read,write}` → `{read}`), syscall-gated no-grant mint denial, and strict cascading `cspaceRevokeCdtStrict` descendant cleanup with CDT detachment assertions.
 
 ## Completed: WS-I3 Operations Coverage Expansion (v0.15.2)
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -56,7 +56,7 @@ enforcement, and scheduling.
 | **Total declarations** | 2,006 across 70 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| **Next workstreams** | WS-I4+ (v0.14.10 improvement portfolio; WS-I1/WS-I3 completed) |
+| **Next workstreams** | WS-I5+ (v0.14.10 improvement portfolio; WS-I1..WS-I4 completed) |
 | **Workstream history** | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | **Metrics source of truth** | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 | **Codebase map** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`) |
@@ -237,6 +237,7 @@ The remaining WS-F workstreams address medium/low-priority findings:
 | **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low | **Completed** (v0.14.9) |
 | **WS-I1** | Critical testing infrastructure (inter-transition assertions, mandatory determinism, scenario ID traceability) | High | **Completed** (v0.15.0) |
 | **WS-I3** | Test coverage expansion — operations (multi-operation chains, scheduler stress, declassification checks) | Medium | **Completed** (v0.15.2) |
+| **WS-I4** | Test coverage expansion — subsystems (VSpace multi-ASID sharing, IPC interleaving, lifecycle transaction chains) | Low | **Completed** (v0.15.3) |
 
 After WS-F/WS-I1: Raspberry Pi 5 hardware binding (H3).
 
@@ -250,6 +251,7 @@ critical testing infrastructure recommendations from the v0.14.9 audit.
 - **Part C (R-03 — Scenario ID traceability):** All 121 trace output lines tagged with unique scenario IDs (15 prefix families: ENT, CAT, SST, LEP, CIC, IMT, IMB, DDT, ICS, BME, STD, UMT, SGT, RCF, ITR, PTY). Fixture format upgraded to pipe-delimited (`SCENARIO_ID | SUBSYSTEM | expected_trace_fragment`). `tests/fixtures/scenario_registry.yaml` maps all 121 IDs to source functions and subsystems. `scripts/scenario_catalog.py validate-registry` checks bidirectional fixture↔registry consistency. Tier 0 hygiene validates registry on every PR.
 - **WS-I2 (v0.15.1):** proof/validation depth completed: Tier 0 now runs semantic L-08 theorem-body analysis (`scripts/check_proof_depth.py` with regex fallback), Tier 3 now runs Lean `#check` correctness anchors across scheduler/capability/IPC/lifecycle/service/VSpace/IF preservation theorems, and IF projection now supports optional memory-domain ownership (`memoryOwnership`) with backward-compatible default (`none`).
 - **WS-I3 (v0.15.2):** operations coverage expansion completed: new `tests/OperationChainSuite.lean` adds six multi-operation chain tests and scheduler stress coverage (16-thread repeated schedule/yield, same-priority determinism, multi-domain domain-switch isolation); Tier 2 now executes this suite via `scripts/test_tier2_negative.sh`; `tests/InformationFlowSuite.lean` adds declassification runtime checks for authorized downgrade, normal-flow rejection, policy-denied rejection, and three-domain lattice behavior. The declassification policy-denied branch is represented explicitly as `KernelError.declassificationDenied` for clearer failure-mode discrimination.
+- **WS-I4 (v0.15.3):** subsystem coverage expansion completed in `tests/OperationChainSuite.lean`: VSpace multi-ASID shared-page scenarios validate ASID-local unmap isolation and per-ASID permission divergence via `vspaceLookupFull`; IPC interleaving scenarios validate three-sender FIFO and alternating send/receive queue integrity; lifecycle transaction scenarios validate authority attenuation and strict cascading `cspaceRevokeCdtStrict` cleanup with CDT detachment checks.
 
 ### 5.14 Deferred Operations (WS-F5/D3)
 

--- a/tests/OperationChainSuite.lean
+++ b/tests/OperationChainSuite.lean
@@ -207,6 +207,158 @@ private def chain6NotificationBadgeAccumulation : IO Unit := do
     (received = some (SeLe4n.Badge.ofNat 0x11))
   assertInvariants "chain6: signal→signal→wait" st3
 
+private def wsI4VspaceMultiAsidSharing : IO Unit := do
+  let asid1 : SeLe4n.ASID := ⟨1⟩
+  let asid2 : SeLe4n.ASID := ⟨2⟩
+  let sharedPaddr : SeLe4n.PAddr := ⟨0x1000⟩
+  let vaddr1 : SeLe4n.VAddr := ⟨0x2000⟩
+  let vaddr2 : SeLe4n.VAddr := ⟨0x3000⟩
+  let st0 :=
+    (BootstrapBuilder.empty
+      |>.withObject ⟨270⟩ (.vspaceRoot { asid := asid1, mappings := {} })
+      |>.withObject ⟨271⟩ (.vspaceRoot { asid := asid2, mappings := {} })
+      |>.build)
+
+  let (_, st1) ← expectOkState "ws-i4 vspace: map shared page ASID1"
+    (SeLe4n.Kernel.Architecture.vspaceMapPage asid1 vaddr1 sharedPaddr default st0)
+  let (_, st2) ← expectOkState "ws-i4 vspace: map shared page ASID2"
+    (SeLe4n.Kernel.Architecture.vspaceMapPage asid2 vaddr2 sharedPaddr default st1)
+  let (lookupAsid1, st3) ← expectOkState "ws-i4 vspace: lookup ASID1 shared mapping"
+    (SeLe4n.Kernel.Architecture.vspaceLookup asid1 vaddr1 st2)
+  let (lookupAsid2, st4) ← expectOkState "ws-i4 vspace: lookup ASID2 shared mapping"
+    (SeLe4n.Kernel.Architecture.vspaceLookup asid2 vaddr2 st3)
+  expect "ws-i4 vspace: shared paddr visible in ASID1" (lookupAsid1 = sharedPaddr)
+  expect "ws-i4 vspace: shared paddr visible in ASID2" (lookupAsid2 = sharedPaddr)
+
+  let (_, st5) ← expectOkState "ws-i4 vspace: unmap ASID1 only"
+    (SeLe4n.Kernel.Architecture.vspaceUnmapPage asid1 vaddr1 st4)
+  expectError "ws-i4 vspace: ASID1 unmapped lookup faults"
+    (SeLe4n.Kernel.Architecture.vspaceLookup asid1 vaddr1 st5) .translationFault
+  let (stillMappedAsid2, st6) ← expectOkState "ws-i4 vspace: ASID2 remains mapped"
+    (SeLe4n.Kernel.Architecture.vspaceLookup asid2 vaddr2 st5)
+  expect "ws-i4 vspace: ASID2 mapping survives ASID1 unmap" (stillMappedAsid2 = sharedPaddr)
+
+  let readOnly : PagePermissions := { read := true, write := false, execute := false, user := false, cacheable := true }
+  let readWrite : PagePermissions := { read := true, write := true, execute := false, user := false, cacheable := true }
+  let (_, st7) ← expectOkState "ws-i4 vspace: map read-only in ASID1"
+    (SeLe4n.Kernel.Architecture.vspaceMapPage asid1 vaddr1 sharedPaddr readOnly st6)
+  let (_, st8) ← expectOkState "ws-i4 vspace: map read-write in ASID2"
+    (SeLe4n.Kernel.Architecture.vspaceMapPage asid2 ⟨0x3100⟩ sharedPaddr readWrite st7)
+  let ((_, permsAsid1), st9) ← expectOkState "ws-i4 vspace: lookupFull ASID1 perms"
+    (SeLe4n.Kernel.Architecture.vspaceLookupFull asid1 vaddr1 st8)
+  let ((_, permsAsid2), st10) ← expectOkState "ws-i4 vspace: lookupFull ASID2 perms"
+    (SeLe4n.Kernel.Architecture.vspaceLookupFull asid2 ⟨0x3100⟩ st9)
+  expect "ws-i4 vspace: ASID1 keeps read-only permissions" (permsAsid1 = readOnly)
+  expect "ws-i4 vspace: ASID2 keeps read-write permissions" (permsAsid2 = readWrite)
+  expect "ws-i4 vspace: ASID1 mapping remains W^X compliant" permsAsid1.wxCompliant
+  expect "ws-i4 vspace: ASID2 mapping remains W^X compliant" permsAsid2.wxCompliant
+  assertInvariants "ws-i4 vspace: multi-asid sharing" st10
+
+private def wsI4IpcInterleavedSends : IO Unit := do
+  let epId : SeLe4n.ObjId := ⟨280⟩
+  let senderA : SeLe4n.ThreadId := ⟨2801⟩
+  let senderB : SeLe4n.ThreadId := ⟨2802⟩
+  let senderC : SeLe4n.ThreadId := ⟨2803⟩
+  let receiver : SeLe4n.ThreadId := ⟨2804⟩
+  let st0 :=
+    (BootstrapBuilder.empty
+      |>.withObject epId (.endpoint {})
+      |>.withObject senderA.toObjId (.tcb { tid := senderA, priority := ⟨50⟩, domain := ⟨0⟩, cspaceRoot := ⟨3800⟩, vspaceRoot := ⟨3900⟩, ipcBuffer := ⟨0x1000⟩, ipcState := .ready })
+      |>.withObject senderB.toObjId (.tcb { tid := senderB, priority := ⟨49⟩, domain := ⟨0⟩, cspaceRoot := ⟨3800⟩, vspaceRoot := ⟨3900⟩, ipcBuffer := ⟨0x2000⟩, ipcState := .ready })
+      |>.withObject senderC.toObjId (.tcb { tid := senderC, priority := ⟨48⟩, domain := ⟨0⟩, cspaceRoot := ⟨3800⟩, vspaceRoot := ⟨3900⟩, ipcBuffer := ⟨0x3000⟩, ipcState := .ready })
+      |>.withObject receiver.toObjId (.tcb { tid := receiver, priority := ⟨47⟩, domain := ⟨0⟩, cspaceRoot := ⟨3800⟩, vspaceRoot := ⟨3900⟩, ipcBuffer := ⟨0x4000⟩, ipcState := .ready })
+      |>.withRunnable [senderA, senderB, senderC, receiver]
+      |>.build)
+
+  let (_, st1) ← expectOkState "ws-i4 ipc: sender A enqueues"
+    (SeLe4n.Kernel.endpointSendDual epId senderA .empty st0)
+  let (_, st2) ← expectOkState "ws-i4 ipc: sender B enqueues"
+    (SeLe4n.Kernel.endpointSendDual epId senderB .empty st1)
+  let (_, st3) ← expectOkState "ws-i4 ipc: sender C enqueues"
+    (SeLe4n.Kernel.endpointSendDual epId senderC .empty st2)
+  let (firstSender, st4) ← expectOkState "ws-i4 ipc: first receive"
+    (SeLe4n.Kernel.endpointReceiveDual epId receiver st3)
+  let (secondSender, st5) ← expectOkState "ws-i4 ipc: second receive"
+    (SeLe4n.Kernel.endpointReceiveDual epId receiver st4)
+  let (thirdSender, st6) ← expectOkState "ws-i4 ipc: third receive"
+    (SeLe4n.Kernel.endpointReceiveDual epId receiver st5)
+  expect "ws-i4 ipc: FIFO first sender" (firstSender = senderA)
+  expect "ws-i4 ipc: FIFO second sender" (secondSender = senderB)
+  expect "ws-i4 ipc: FIFO third sender" (thirdSender = senderC)
+
+  let (_, st7) ← expectOkState "ws-i4 ipc: interleaved send A"
+    (SeLe4n.Kernel.endpointSendDual epId senderA .empty st6)
+  let (senderAfterA, st8) ← expectOkState "ws-i4 ipc: interleaved receive after A"
+    (SeLe4n.Kernel.endpointReceiveDual epId receiver st7)
+  expect "ws-i4 ipc: interleaved receive returns A" (senderAfterA = senderA)
+  let (_, st9) ← expectOkState "ws-i4 ipc: interleaved send B"
+    (SeLe4n.Kernel.endpointSendDual epId senderB .empty st8)
+  let (senderAfterB, st10) ← expectOkState "ws-i4 ipc: interleaved receive after B"
+    (SeLe4n.Kernel.endpointReceiveDual epId receiver st9)
+  expect "ws-i4 ipc: interleaved receive returns B" (senderAfterB = senderB)
+  assertInvariants "ws-i4 ipc: interleaved send/receive" st10
+
+private def wsI4LifecycleTransactionChains : IO Unit := do
+  let cnodeId : SeLe4n.ObjId := ⟨290⟩
+  let endpointId : SeLe4n.ObjId := ⟨291⟩
+  let rootSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := cnodeId, slot := ⟨0⟩ }
+  let childSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := cnodeId, slot := ⟨1⟩ }
+  let grandchildSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := cnodeId, slot := ⟨2⟩ }
+  let extraSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := cnodeId, slot := ⟨3⟩ }
+  let st0 :=
+    (BootstrapBuilder.empty
+      |>.withObject endpointId (.endpoint {})
+      |>.withObject cnodeId (.cnode {
+          depth := 0
+          guardWidth := 0
+          guardValue := 0
+          radixWidth := 4
+          slots := Std.HashMap.ofList [
+            (⟨0⟩, { target := .object endpointId, rights := AccessRightSet.ofList [.read, .write, .grant], badge := none })
+          ]
+        })
+      |>.build)
+
+  let (_, st1) ← expectOkState "ws-i4 lifecycle: mint root→child (attenuate grant)"
+    (SeLe4n.Kernel.cspaceMintWithCdt rootSlot childSlot (AccessRightSet.ofList [.read, .write]) none st0)
+  let (_, st2) ← expectOkState "ws-i4 lifecycle: mint child→grandchild (read-only)"
+    (SeLe4n.Kernel.cspaceMintWithCdt childSlot grandchildSlot (AccessRightSet.ofList [.read]) none st1)
+  let grandchildCap := SeLe4n.Model.SystemState.lookupSlotCap st2 grandchildSlot
+  expect "ws-i4 lifecycle: grandchild rights are read-only"
+    (grandchildCap.map (fun cap => cap.rights) = some (AccessRightSet.ofList [.read]))
+
+  let grantGate : SeLe4n.Kernel.SyscallGate := {
+    callerId := ⟨99⟩
+    cspaceRoot := cnodeId
+    capAddr := ⟨2⟩
+    capDepth := 4
+    requiredRight := .grant
+  }
+  expectError "ws-i4 lifecycle: grandchild cannot mint without grant"
+    (SeLe4n.Kernel.apiCspaceMint grantGate grandchildSlot extraSlot
+      (AccessRightSet.ofList [.read]) none st2)
+    .illegalAuthority
+
+  let (revokeReport, st3) ← expectOkState "ws-i4 lifecycle: strict revoke root"
+    (SeLe4n.Kernel.cspaceRevokeCdtStrict rootSlot st2)
+  expect "ws-i4 lifecycle: strict revoke has no descendant deletion failures"
+    (revokeReport.firstFailure = none)
+  expect "ws-i4 lifecycle: strict revoke deleted exactly two descendants"
+    (revokeReport.deletedSlots.length = 2)
+  expect "ws-i4 lifecycle: strict revoke deleted child slot"
+    (childSlot ∈ revokeReport.deletedSlots)
+  expect "ws-i4 lifecycle: strict revoke deleted grandchild slot"
+    (grandchildSlot ∈ revokeReport.deletedSlots)
+  expect "ws-i4 lifecycle: child slot removed"
+    (SeLe4n.Model.SystemState.lookupSlotCap st3 childSlot = none)
+  expect "ws-i4 lifecycle: grandchild slot removed"
+    (SeLe4n.Model.SystemState.lookupSlotCap st3 grandchildSlot = none)
+  expect "ws-i4 lifecycle: child detached from CDT"
+    (SeLe4n.Model.SystemState.lookupCdtNodeOfSlot st3 childSlot = none)
+  expect "ws-i4 lifecycle: grandchild detached from CDT"
+    (SeLe4n.Model.SystemState.lookupCdtNodeOfSlot st3 grandchildSlot = none)
+  assertInvariants "ws-i4 lifecycle: cascading revoke" st3
+
 private def buildParameterizedTopology
     (threadCount : Nat) (basePriority : Nat) (radix : Nat) (asidCount : Nat) : SystemState :=
   let threads : List (SeLe4n.ObjId × KernelObject) :=
@@ -339,8 +491,11 @@ private def runOperationChainSuite : IO Unit := do
   chain4ServiceStartDependentStop
   chain5CopyMoveDelete
   chain6NotificationBadgeAccumulation
+  wsI4VspaceMultiAsidSharing
+  wsI4IpcInterleavedSends
+  wsI4LifecycleTransactionChains
   schedulerStressChecks
-  IO.println "all WS-I3 operation-chain checks passed"
+  IO.println "all WS-I3/WS-I4 operation-chain checks passed"
 
 end SeLe4n.Testing
 


### PR DESCRIPTION
### Motivation
- Close WS-I4 recommendations (R-09, R-10, R-11) by adding focused subsystem tests that exercise cross-ASID VSpace sharing, IPC interleaved send/receive order, and cascading lifecycle/CDT behaviors. 
- Increase confidence in cross-subsystem coherence (VSpace, IPC, lifecycle/CDT) through compositional operation-chain tests that assert both return values and resulting state. 
- Keep project documentation and metrics in sync with the new tests so CI/Tier checks remain authoritative. 

### Description
- Added three WS-I4 test blocks to `tests/OperationChainSuite.lean`: `wsI4VspaceMultiAsidSharing`, `wsI4IpcInterleavedSends`, and `wsI4LifecycleTransactionChains`, and wired them into `runOperationChainSuite`. 
- The new tests exercise `Architecture.vspaceMapPage`/`vspaceLookupFull` (multi-ASID shared mappings and per-ASID permissions), `endpointSendDual`/`endpointReceiveDual` (FIFO and interleaved sender/receiver sequences), and `cspaceMintWithCdt`/`cspaceRevokeCdtStrict` (authority attenuation and strict cascading revoke + CDT detachment assertions). 
- Synchronized documentation and mirrors to record WS-I4 completion by updating `docs/DEVELOPMENT.md`, `docs/WORKSTREAM_HISTORY.md`, `docs/spec/SELE4N_SPEC.md`, and `docs/gitbook/05-specification-and-roadmap.md`. 
- Regenerated `docs/codebase_map.json` to reflect the added test declarations and keep docs-sync checks consistent. 

### Testing
- Built the project and ran the suite test with `lake env lean --run tests/OperationChainSuite.lean`, and the operation-chain suite completed successfully with all added WS-I4 checks passing. 
- Executed documentation sync with `./scripts/test_docs_sync.sh` and the docs automation checks passed after regenerating `docs/codebase_map.json`. 
- Ran the smoke gate via `./scripts/test_smoke.sh` (Tier 0–2), which includes the trace, determinism, negative, and documentation checks, and it completed with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b386fb8f68832bb1053e35986782e1)