### PR TITLE
docs: sync workstream status across canonical docs and GitBook mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ tests/                           Negative-state suite, information-flow suite, t
 Current priorities and the full workstream history are maintained in
 [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md). Summary:
 
-- **WS-I5** — Remaining WS-I documentation/code-quality polish (Low priority). WS-I4 (subsystem coverage expansion) completed in v0.15.3, adding VSpace multi-ASID sharing tests, IPC interleaved-send ordering checks, and lifecycle cascading revoke/authority-degradation chains in `OperationChainSuite`.
+- **WS-I5** — Remaining WS-I documentation/code-quality polish (Low priority). WS-I1..WS-I4 are completed (v0.15.0–v0.15.3), including mandatory determinism checks, proof-validation depth upgrades, operation-chain coverage expansion, VSpace multi-ASID sharing tests, IPC interleaved-send ordering checks, and lifecycle cascading revoke/authority-degradation chains.
 - **Raspberry Pi 5 hardware binding** — ARMv8 page table walk, GIC-400 interrupt routing, boot sequence (RPi5 platform contracts now substantive via WS-H15)
 
 Prior audits (v0.8.0-v0.9.32), milestone closeouts, and legacy GitBook chapters

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,10 +36,10 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 ## 3) Next workstreams
 
 The WS-F portfolio (v0.12.2 audit) is fully complete — all 33 findings closed.
-The active improvement portfolio is WS-I (v0.14.10). WS-I1 and WS-I2 are completed;
-remaining follow-up workstreams are WS-I4..WS-I5.
+The active improvement portfolio is WS-I (v0.14.10). WS-I1..WS-I4 are completed;
+remaining follow-up workstream is WS-I5.
 
-### 3.1 WS-H11..H16 — Remaining v0.12.15 audit remediation
+### 3.1 WS-H11..H16 — v0.12.15 audit remediation status (completed)
 
 See [`docs/audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md)
 for the full execution plan.
@@ -123,7 +123,7 @@ Every milestone-moving PR should include:
 
 ## 5) Daily contributor loop
 
-1. Sync branch and choose one coherent slice from the active plans (WS-H11..H16 or WS-F5..F8; prefer the highest-priority pending item).
+1. Sync branch and choose one coherent slice from the active plans (currently WS-I5 documentation/code-quality polish or Raspberry Pi 5 binding prep).
 2. Implement the minimal semantic/proof/doc delta.
 3. Run smallest relevant check first, then higher tiers.
 4. Update docs in the same commit range.

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -43,10 +43,10 @@ full details.
 | ID | Focus | Priority |
 |----|-------|----------|
 | **WS-I1** | Test infrastructure hardening (inter-transition assertions, determinism promotion, scenario ID traceability) | HIGH — **COMPLETED** (v0.15.0) |
-| **WS-I2** | Proof & hygiene strengthening (L-08 regex upgrade, HashMap.fold migration, NI CDT frame lemmas, VSpace memory projection) | HIGH — pending |
-| **WS-I3** | Documentation completeness (codebase map automation, GitBook Tier 3 chapter, claim-evidence gap closure) | MEDIUM — pending |
-| **WS-I4** | Code quality refinement (RuntimeContract documentation, Service subsystem docstring expansion) | LOW — pending |
-| **WS-I5** | Coverage expansion (scheduler edge-case scenarios, information-flow declassification tests, platform contract stress tests) | LOW — pending |
+| **WS-I2** | Proof & hygiene strengthening (semantic L-08 validation, Tier 3 correctness anchors, VSpace memory ownership projection) | HIGH — **COMPLETED** (v0.15.1) |
+| **WS-I3** | Operations coverage expansion (multi-operation chains, scheduler stress, declassification checks) | MEDIUM — **COMPLETED** (v0.15.2) |
+| **WS-I4** | Subsystem coverage expansion (VSpace multi-ASID, IPC interleaving, lifecycle cascading revoke chains) | LOW — **COMPLETED** (v0.15.3) |
+| **WS-I5** | Documentation and code-quality polish (remaining low-priority recommendations) | LOW — pending |
 
 ### Raspberry Pi 5 hardware binding
 

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -20,7 +20,7 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 | Proved declarations | 1,086 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 2,006 across 70 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| Next workstreams | WS-I4+ (v0.14.10 improvement portfolio; WS-I1/WS-I3 completed); Raspberry Pi 5 hardware binding |
+| Next workstreams | WS-I5 (v0.14.10 improvement portfolio; WS-I1..WS-I4 completed); Raspberry Pi 5 hardware binding |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | Metrics source of truth | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 
@@ -224,38 +224,19 @@ re-verified — zero sorry/axiom.
 See [Kernel Performance Optimization (WS-G)](08-kernel-performance-optimization.md)
 for the full technical breakdown.
 
-## Next: WS-H11..H16 and WS-F5..F8 (WS-F5 completed)
+## Next: WS-I5 and Raspberry Pi 5 hardware binding
 
-### Remaining v0.12.15 audit remediation (WS-H11..H16)
+All WS-F and WS-H remediation workstreams are completed. The active remaining
+improvement workstream is **WS-I5** (documentation and code-quality polish).
 
-WS-H1..H11 are completed. The remaining workstreams address Phases 4–5:
-scheduler/IPC alignment (H12), CSpace/service
-enrichment (H13), type safety (H14), platform hardening (H15), and
-testing/docs expansion (H16). WS-H11 added `PagePermissions` with W^X enforcement,
-abstract TLB model, bounded address translation checks, and extended
-`vspaceInvariantBundle` to 5 conjuncts.
-
-See [`AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md)
+See [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md),
+[`docs/audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md),
 and [Next Development Path](22-next-slice-development-path.md).
-
-### Remaining v0.12.2 audit remediation (WS-F7..F8)
-
-WS-F1..F6 (critical/high/medium priority) are completed. The remaining workstreams
-address low findings from the v0.12.2 audits:
-
-| ID | Focus | Priority |
-|----|-------|----------|
-| **WS-F5** | Model fidelity (word-bounded badge, order-independent rights, deferred ops) | Medium — **COMPLETED** (v0.14.9) |
-| **WS-F6** | Invariant quality (tautology reclassification, adapter proof hooks) | Medium — **COMPLETED** (v0.14.9) |
-| **WS-F7** | Testing expansion (oracle, probe, fixtures) | Low — **COMPLETED** |
-| **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low |
-
-See [v0.12.2 Audit Remediation (WS-F)](24-comprehensive-audit-2026-workstream-planning.md).
 
 ## Hardware roadmap
 
 H0 (neutral semantics, complete) → H1 (boundary interfaces, complete) →
-H2 (proof deepening, WS-F remaining) → H3 (Raspberry Pi 5 binding) →
+H2 (proof deepening, complete) → H3 (Raspberry Pi 5 binding) →
 H4 (evidence convergence).
 
 See [Path to Real Hardware](10-path-to-real-hardware-mobile-first.md).

--- a/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
+++ b/docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md
@@ -20,7 +20,7 @@ Two independent audits of the v0.12.2 codebase:
 | **WS-F5** | Model fidelity (badge bitmask, per-thread regs, multi-level CSpace) | Medium | **Completed** |
 | **WS-F6** | Invariant quality (tautology reclassification, adapter hooks) | Medium | **Completed** |
 | **WS-F7** | Testing expansion (oracle, probe, fixtures) | Low | **Completed** |
-| **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low | Planned |
+| **WS-F8** | Cleanup (dead code, legacy/dual-queue resolution) | Low | **Completed** |
 
 ## Execution phases
 
@@ -30,12 +30,12 @@ Two independent audits of the v0.12.2 codebase:
 | ~~**P1**~~ | WS-F1, WS-F2, WS-F4 | Critical IPC/memory + proof gaps | **Completed** |
 | ~~**P2**~~ | WS-F3 | Info-flow completeness | **Completed** |
 | ~~**P3**~~ | ~~WS-F5, WS-F6~~ | ~~Model fidelity + invariant quality~~ | **Completed** |
-| **P4** | WS-F7, WS-F8 | Testing + cleanup | WS-F7 **Done**, WS-F8 Planned |
+| **P4** | WS-F7, WS-F8 | Testing + cleanup | **Completed** |
 
 ## Related: WS-G (completed)
 
 The WS-G kernel performance optimization portfolio (v0.12.6–v0.12.15) was
-completed between WS-F1..F4 and the remaining WS-F8 workstream.
+completed between WS-F1..F4 and WS-F8 closeout.
 See [Kernel Performance Optimization (WS-G)](08-kernel-performance-optimization.md).
 
 ## Prior completed portfolios

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -8,7 +8,7 @@ This GitBook is the long-form guide for seLe4n — a production-oriented microke
 - **Version:** 0.14.10 (Lean v4.28.0).
 - **Codebase metrics:** 34,171 production LoC across 67 files; 2,886 test LoC across 3 suites; 1,086 theorem/lemma declarations (zero sorry/axiom); 2,006 total declarations across 70 modules.
 - **Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.
-- **Next workstreams:** Raspberry Pi 5 hardware binding (all WS-F and WS-H portfolios completed).
+- **Next workstreams:** WS-I5 documentation/code-quality polish, then Raspberry Pi 5 hardware binding (WS-F/WS-H and WS-I1..WS-I4 completed).
 - **Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.
 - **Hardware target:** Raspberry Pi 5 (ARM64).
 - **Metrics source of truth:** [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key). Cross-check with `./scripts/report_current_state.py`.

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -4,7 +4,7 @@
     "**Version:** 0.14.10 (Lean v4.28.0).",
     "**Codebase metrics:** 34,171 production LoC across 67 files; 2,886 test LoC across 3 suites; 1,086 theorem/lemma declarations (zero sorry/axiom); 2,006 total declarations across 70 modules.",
     "**Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.",
-    "**Next workstreams:** Raspberry Pi 5 hardware binding (all WS-F and WS-H portfolios completed).",
+    "**Next workstreams:** WS-I5 documentation/code-quality polish, then Raspberry Pi 5 hardware binding (WS-F/WS-H and WS-I1..WS-I4 completed).",
     "**Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.",
     "**Hardware target:** Raspberry Pi 5 (ARM64).",
     "**Metrics source of truth:** [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key). Cross-check with `./scripts/report_current_state.py`.",

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -56,7 +56,7 @@ enforcement, and scheduling.
 | **Total declarations** | 2,006 across 70 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| **Next workstreams** | WS-I5+ (v0.14.10 improvement portfolio; WS-I1/WS-I4 completed) |
+| **Next workstreams** | WS-I5 (v0.14.10 improvement portfolio; WS-I1..WS-I4 completed) + Raspberry Pi 5 hardware binding |
 | **Workstream history** | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | **Metrics source of truth** | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 | **Codebase map** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`) |
@@ -288,7 +288,7 @@ The first production hardware target is **Raspberry Pi 5** (ARM64, BCM2712).
 |-------|-------------|--------|
 | **H0** | Architecture-neutral semantics and proofs | Complete (M1–M7, WS-B..E) |
 | **H1** | Architecture-boundary interfaces and adapters | Complete (M6) |
-| **H2** | Audit-driven proof deepening (close critical gaps) | Active (WS-F) |
+| **H2** | Audit-driven proof deepening (close critical gaps) | Complete (WS-F and WS-H portfolios) |
 | **H3** | Platform binding — map interfaces to Raspberry Pi 5 hardware | **H3-prep complete** |
 | **H4** | Evidence convergence — connect proofs to platform assumptions | Planned |
 


### PR DESCRIPTION
### Motivation

- The public documentation and GitBook mirrors contained inconsistent workstream status for the WS-I portfolio and WS-F/WS-H completion state, which risks confusing contributors and auditors.  
- Canonical docs that feed onboarding, acceptance criteria, and CI assertions needed to reflect the implemented state (WS-I1..WS-I4 completed, WS-I5 remaining) and the updated hardware roadmap.  

### Description

- Updated the canonical project docs to reflect the current workstream state by editing `README.md`, `docs/WORKSTREAM_HISTORY.md`, `docs/DEVELOPMENT.md`, and `docs/spec/SELE4N_SPEC.md` to mark `WS-I2`/`WS-I3`/`WS-I4` completed and `WS-I5` as the remaining follow-up.  
- Synchronized GitBook mirrors and navigation by editing `docs/gitbook/05-specification-and-roadmap.md`, `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`, and `docs/gitbook/navigation_manifest.json`, and regenerated `docs/gitbook/README.md`.  
- Cleaned up wording in the daily contributor loop and hardware roadmap (H2/H3 status) to match completed portfolios.  
- Changes were committed as a single docs synchronization update and include the regenerated GitBook README produced by the docs sync script.  

### Testing

- Ran the full smoke validation gate via `./scripts/test_smoke.sh`, which executed hygiene checks, `lake build`, trace fixture validation, determinism checks, the negative-state suite, and docs sync checks.  
- All automated checks in the smoke gate passed successfully (hygiene PASS, build PASS, trace fixture comparison 121/121 matched, determinism PASS, negative and information-flow suites PASS, docs sync PASS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b483517a90832b88e6c6bf2b5c7d7d)