### PR TITLE
docs: add WS-J1 register-namespace migration workstream plan and sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ tests/                           Negative-state suite, information-flow suite, t
 Current priorities and the full workstream history are maintained in
 [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md). Summary:
 
-- **WS-I5** — Remaining WS-I documentation/code-quality polish (Low priority). WS-I1..WS-I4 are completed (v0.15.0–v0.15.3), including mandatory determinism checks, proof-validation depth upgrades, operation-chain coverage expansion, VSpace multi-ASID sharing tests, IPC interleaved-send ordering checks, and lifecycle cascading revoke/authority-degradation chains.
+- **WS-J1** — Register-indexed authoritative kernel namespaces (High priority planning slice). This supersedes WS-I5 Part A’s documentation-only treatment of `RegName`/`RegValue` and defines a staged migration from raw register `Nat` payloads to typed namespace references resolved against authoritative state registries (plan: `docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`).
 - **Raspberry Pi 5 hardware binding** — ARMv8 page table walk, GIC-400 interrupt routing, boot sequence (RPi5 platform contracts now substantive via WS-H15)
 
 Prior audits (v0.8.0-v0.9.32), milestone closeouts, and legacy GitBook chapters

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -124,3 +124,5 @@ When a claim changes:
 3. refresh this table row(s) for changed claims,
 4. run at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).
 
+
+| Next major planning slice is WS-J1: register-indexed authoritative namespace migration superseding WS-I5 Part A for authority-resolution paths. | `docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`, `docs/WORKSTREAM_HISTORY.md`, `README.md` | `./scripts/test_smoke.sh` | Documentation planning update: defines phased delivery (WS-J1-A..E), risk register, validation gates, and file impact map. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,14 +7,15 @@ production-oriented microkernel written in Lean 4 with machine-checked proofs.
 
 It is aligned to the **current project state**:
 
-- **next workstream:** WS-I5 (v0.14.10 improvement portfolio documentation/code-quality polish). WS-F portfolio fully completed (F1..F8),
+- **next workstream:** WS-J1 (v0.15.4 register-indexed authoritative namespace migration plan). WS-F portfolio fully completed (F1..F8),
 - **recently completed:** WS-H15 (v0.14.7, platform & API hardening — `InterruptBoundaryContract` decidability, RPi5 contract hardening with substantive predicates, 13 capability-gated syscall wrappers, `AdapterProofHooks` concrete instantiation for Sim/RPi5, MMIO disjointness proof; closes A-33, A-41, A-42, M-13), WS-H14 (v0.14.6, type safety & Prelude foundations — `EquivBEq`/`LawfulBEq` for 14 identifier types, `LawfulMonad` for `KernelM`, `isPowerOfTwo` correctness proof, identifier roundtrip/injectivity theorems, `OfNat` instance removal for type-safety enforcement, sentinel predicate completion), Module restructuring (v0.14.5, decomposed 9 monolithic files into 24 focused submodules via re-export hub pattern; zero code loss, 50 new helper theorems extracted, 209 Tier 3 anchor checks updated), WS-H13 (v0.14.4, CSpace/service model enrichment — `cspaceDepthConsistent` invariant, `resolveCapAddress` theorems, `serviceStop` backing-object verification, `serviceGraphInvariant` preservation, `cspaceMove` atomicity; addresses H-01, A-21, A-29, A-30, M-17/A-31), WS-H12f (v0.14.3, test harness update & documentation sync — dequeue-on-dispatch, context switch, and bounded message trace scenarios; legacy `endpointInvariant` comment cleanup; expected fixture updated; Tier 3 anchors added; documentation synchronized), WS-H12e (v0.14.2, cross-subsystem invariant reconciliation), WS-H12d (v0.14.1, IPC message payload bounds — A-09 closed), WS-H12c (v0.14.0, per-TCB register context with inline context switch — H-03 closed), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics — H-04 closed), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), End-to-end audit (v0.13.6), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (v0.13.4, NI coverage >80%), WS-H8 (v0.13.2, enforcement-NI bridge), WS-H6 (v0.13.1, scheduler proof completion), WS-H5 (v0.12.19, IPC dual-queue invariant), WS-H4 (v0.12.18, capability invariant redesign), WS-H3 (v0.12.17, build/CI), WS-H2 (v0.12.16, lifecycle safety), WS-H1 (v0.12.16, IPC call-path fix), WS-G (v0.12.15, kernel performance), WS-F1..F4 (critical audit remediation),
 - **findings baseline:** [`AUDIT_CODEBASE_v0.12.2_v1.md`](audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](audits/AUDIT_CODEBASE_v0.12.2_v2.md),
 - **latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](audits/AUDIT_CODEBASE_v0.13.6.md) — comprehensive end-to-end audit, zero critical issues,
 - **hardware target:** Raspberry Pi 5 (ARM64).
 
-Canonical planning source:
-[`docs/audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md).
+Canonical planning sources:
+[`docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md) for WS-J1 and
+[`docs/audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md) for completed WS-H remediation lineage.
 
 ---
 
@@ -36,8 +37,9 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 ## 3) Next workstreams
 
 The WS-F portfolio (v0.12.2 audit) is fully complete — all 33 findings closed.
-The active improvement portfolio is WS-I (v0.14.10). WS-I1..WS-I4 are completed;
-remaining follow-up workstream is WS-I5.
+The active near-term portfolio is WS-J1 (v0.15.4): register-indexed authoritative
+namespace migration. WS-I1..WS-I4 are completed; WS-I5 Part A remains documented
+for historical rationale but is superseded for authority-resolution paths.
 
 ### 3.1 WS-H11..H16 — v0.12.15 audit remediation status (completed)
 
@@ -123,7 +125,7 @@ Every milestone-moving PR should include:
 
 ## 5) Daily contributor loop
 
-1. Sync branch and choose one coherent slice from the active plans (currently WS-I5 documentation/code-quality polish or Raspberry Pi 5 binding prep).
+1. Sync branch and choose one coherent slice from the active plans (currently WS-J1 register-namespace migration planning/implementation or Raspberry Pi 5 binding prep).
 2. Implement the minimal semantic/proof/doc delta.
 3. Run smallest relevant check first, then higher tiers.
 4. Update docs in the same commit range.

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -48,6 +48,16 @@ full details.
 | **WS-I4** | Subsystem coverage expansion (VSpace multi-ASID, IPC interleaving, lifecycle cascading revoke chains) | LOW — **COMPLETED** (v0.15.3) |
 | **WS-I5** | Documentation and code-quality polish (remaining low-priority recommendations) | LOW — pending |
 
+### WS-J1 workstream (register namespace authority modeling)
+
+A new planning slice supersedes the WS-I5 Part A documentation-only treatment of
+`RegName`/`RegValue` for authority-bearing register paths. See
+[`AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md).
+
+| ID | Focus | Priority |
+|----|-------|----------|
+| **WS-J1** | Allow register values to index authoritative kernel namespaces directly through typed decode/resolve paths, preserving determinism and proof obligations | HIGH — planned |
+
 ### Raspberry Pi 5 hardware binding
 
 After the remaining workstreams, the next major milestone is populating the RPi5

--- a/docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md
@@ -1,0 +1,271 @@
+# seLe4n Workstream Plan — Register-Indexed Authoritative Namespaces (WS-J1)
+
+**Version target:** v0.15.4+
+**Status:** Planned
+**Priority:** High
+**Estimated effort:** 3–5 days
+**Dependencies:** WS-I1..WS-I5 complete baseline, no additional blockers
+**Primary scope:** Replace the current `RegName := Nat` / `RegValue := Nat` modeling path for namespace references with a typed, authoritative register-namespace indexing model.
+
+---
+
+## 1. Executive summary
+
+`SeLe4n/Machine.lean` currently models register names/values with `abbrev Nat`.
+That decision kept the abstract machine lightweight, but it limits the model’s
+ability to express hardware-mediated authority transfer where register payloads
+index kernel namespaces directly (e.g., CSpace roots, endpoint IDs, ASID roots,
+or service handles).
+
+This workstream introduces a **typed register namespace index layer** so register
+values can carry and resolve **authoritative namespace references** with explicit
+validation rules, deterministic error outcomes, and preservation proofs.
+
+The migration is split into small, reviewable units to reduce proof breakage and
+keep CI feedback fast.
+
+---
+
+## 2. Problem statement and design goal
+
+### 2.1 Current limitation
+
+WS-I5 Part A documented why `RegName` / `RegValue` were left as bare `Nat` in
+the abstract machine model. That is acceptable for local read/write lemmas, but
+it is too weak for upcoming hardware-binding and syscall-gate realism:
+
+1. Register payloads that represent authority remain untyped until deep in API
+   wrappers.
+2. Namespace confusion (wrong identifier class in a register channel) is
+   prevented by conventions rather than type-level structure.
+3. Proof obligations about authority resolution are duplicated across subsystem
+   wrappers instead of concentrated in one decode/resolve layer.
+
+### 2.2 Target capability
+
+Add a register-namespace mechanism where:
+
+- Register values can be decoded as **typed namespace indices**.
+- Resolution against authoritative maps is total and deterministic (`ok/error`).
+- Authority-bearing operations consume resolved typed references, not raw `Nat`.
+- Existing abstract-machine lemmas remain available via compatibility shims.
+
+---
+
+## 3. Scope and non-goals
+
+### In scope
+
+- New typed structures and decoding APIs for register namespace references.
+- Authoritative namespace registries in kernel state (minimal initial set).
+- API/adapter integration for capability-gated operations that consume register
+  references.
+- Invariant and non-interference updates for the new resolution path.
+- Tiered tests and trace fixtures for successful and failing decode/resolve paths.
+- Documentation and GitBook synchronization.
+
+### Out of scope (this workstream)
+
+- Full hardware MMU/register-file implementation for Raspberry Pi 5.
+- ISA-level binary encoding fidelity for all ARM64 registers.
+- Multi-core register-bank semantics.
+
+---
+
+## 4. Architecture proposal
+
+### 4.1 New core types
+
+Introduce (names indicative; final names should remain semantics-first):
+
+- `RegRefKind` — namespace discriminator (e.g., cspace, endpoint, notification,
+  asidRoot, service).
+- `RegNamespaceIndex` — typed payload containing kind + bounded index token.
+- `RegPayload` — register value algebra (`word`, `namespaceRef`, future variants).
+- `RegisterFile` update path preserving deterministic semantics.
+
+### 4.2 Authoritative namespace layer
+
+Add a state-owned registry for resolvable namespace references, e.g.:
+
+- `NamespaceRegistry` in `Model.State` (or subsystem-owned projections),
+- total resolver: `resolveRegNamespace : KernelState → RegNamespaceIndex → Except KernelError ResolvedRef`.
+
+### 4.3 Determinism and safety contract
+
+Every decode/resolve function must:
+
+- return explicit errors on malformed/unknown/stale references,
+- preserve no-`sorry` / no-`axiom` policy,
+- avoid partial functions and non-deterministic branches.
+
+---
+
+## 5. Work breakdown structure (small execution units)
+
+## WS-J1-A — Type introduction and compatibility bridge
+
+**Goal:** Add new types without changing behavior of existing call paths.
+
+Tasks:
+1. Add `RegRefKind`, `RegNamespaceIndex`, and `RegPayload` in machine/model layer.
+2. Keep `readReg`/`writeReg` behavior stable via compatibility conversion APIs.
+3. Prove bridge lemmas showing legacy `Nat` paths remain observationally equivalent for plain word registers.
+
+Exit criteria:
+- `lake build` passes.
+- Existing smoke suite unchanged.
+
+---
+
+## WS-J1-B — Authoritative namespace registry foundations
+
+**Goal:** Introduce canonical namespace ownership and resolver.
+
+Tasks:
+1. Add `NamespaceRegistry` structure and initialization defaults.
+2. Implement total resolver with explicit `KernelError` mapping.
+3. Add preservation lemmas for unaffected subsystems.
+
+Exit criteria:
+- Resolver round-trip/uniqueness lemmas proved.
+- Negative tests for unknown index and kind mismatch.
+
+---
+
+## WS-J1-C — API and transition-path adoption
+
+**Goal:** Move authority-bearing transitions from raw register `Nat` decode to typed resolution.
+
+Tasks:
+1. Update syscall boundary wrappers that pull IDs from registers.
+2. Route capability and IPC entry points through typed resolver.
+3. Preserve determinism and capability checks in the same transition step.
+
+Exit criteria:
+- Existing API soundness theorems re-proved.
+- Trace harness includes successful + denied resolution scenarios.
+
+---
+
+## WS-J1-D — Invariant and information-flow integration
+
+**Goal:** Make namespace indexing first-class in proof surfaces.
+
+Tasks:
+1. Add/extend invariants for namespace registry well-formedness.
+2. Extend NI bridge lemmas for resolver-observable behavior.
+3. Add composition coverage for new step variants.
+
+Exit criteria:
+- `test_full.sh` passes.
+- NI theorem surface remains sorry-free.
+
+---
+
+## WS-J1-E — Evidence, migration cleanup, and docs sync
+
+**Goal:** Finalize migration and documentation coherence.
+
+Tasks:
+1. Remove temporary compatibility shims that are no longer needed.
+2. Update fixtures (if trace output changes) with rationale.
+3. Synchronize canonical docs + GitBook mirror + claim/evidence links.
+
+Exit criteria:
+- `test_smoke.sh` (minimum) and `test_full.sh` pass.
+- Documentation index references WS-J1 and its evidence.
+
+---
+
+## 6. File impact map (expected)
+
+### Core model and machine
+- `SeLe4n/Machine.lean`
+- `SeLe4n/Model/State.lean`
+- `SeLe4n/Prelude.lean` (if additional typed wrappers are needed)
+
+### Kernel transition surfaces (expected first adopters)
+- `SeLe4n/Kernel/API.lean`
+- `SeLe4n/Kernel/Capability/*`
+- `SeLe4n/Kernel/IPC/*`
+- `SeLe4n/Kernel/Architecture/*` (if ASID/VSpace references are register-fed)
+
+### Proof/test surfaces
+- `SeLe4n/Kernel/*/Invariant*.lean`
+- `SeLe4n/Kernel/InformationFlow/*`
+- `SeLe4n/Testing/MainTraceHarness.lean`
+- `tests/OperationChainSuite.lean`
+- `tests/NegativeStateSuite.lean`
+
+### Documentation surfaces
+- `README.md`
+- `docs/DEVELOPMENT.md`
+- `docs/spec/SELE4N_SPEC.md`
+- `docs/WORKSTREAM_HISTORY.md`
+- `docs/CLAIM_EVIDENCE_INDEX.md`
+- `docs/gitbook/*` roadmap pages
+
+---
+
+## 7. Risk register and mitigations
+
+1. **Proof churn in large invariant files** (High)
+   - Mitigation: adopt WS-J1-A/B first with compatibility bridge; only then migrate call paths.
+2. **Namespace/model over-coupling** (Medium)
+   - Mitigation: keep resolver interface minimal and subsystem-neutral.
+3. **Trace fixture instability** (Medium)
+   - Mitigation: stage fixture updates in WS-J1-E with diff rationale.
+4. **Performance regressions in hot paths** (Low/Medium)
+   - Mitigation: use O(1) map lookup structures and avoid repeated decode passes.
+
+---
+
+## 8. Validation plan
+
+Minimum gate per slice:
+
+```bash
+./scripts/test_smoke.sh
+```
+
+Required for theorem/invariant slices:
+
+```bash
+./scripts/test_full.sh
+```
+
+Nightly confidence (optional when touching NI composition broadly):
+
+```bash
+NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh
+```
+
+Additionally for this workstream:
+- Resolver property tests (success/failure determinism).
+- Cross-subsystem negative tests for namespace mismatch.
+- Trace scenario IDs for decode/resolve failures.
+
+---
+
+## 9. Completion evidence checklist
+
+- [ ] Typed register-namespace model merged with no `sorry`/`axiom`.
+- [ ] All authority-bearing register decode sites migrated.
+- [ ] Invariant and NI surfaces updated and passing.
+- [ ] Fixture updates (if any) justified and reviewed.
+- [ ] Canonical docs and GitBook mirrors synchronized.
+
+---
+
+## 10. Relationship to WS-I5 Part A
+
+WS-I5 Part A intentionally documented the prior `abbrev Nat` choice as a
+low-risk simplification. WS-J1 supersedes that simplification for authority
+resolution paths by introducing typed, authoritative register namespace
+indexing while preserving deterministic semantics and proof ergonomics.
+
+Both statements remain consistent:
+- WS-I5 Part A explains why the old model was reasonable at that stage.
+- WS-J1 defines the migration path now that deeper hardware-binding realism and
+  namespace authority modeling are priority.

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -13,6 +13,7 @@ moved to [`docs/dev_history/audits/`](../dev_history/audits/).
 6. [`AUDIT_v0.12.2_WORKSTREAM_PLAN.md`](./AUDIT_v0.12.2_WORKSTREAM_PLAN.md) — WS-F execution plan (**WS-F1..F4 completed; WS-F5..F8 remaining**).
 7. [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](./KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) — v0.12.5 performance audit (**all 14 findings closed by WS-G**).
 8. [`KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md`](./KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md) — WS-G execution plan (**all 9 workstreams completed**).
+9. [`AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](./AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md) — WS-J1 planning document for typed register-indexed authoritative namespace migration.
 
 ## Planning guidance
 
@@ -21,6 +22,7 @@ For current planning, use:
 - **active workstream (WS-H11..H16):** `AUDIT_v0.12.15_WORKSTREAM_PLAN.md`
 - **remaining WS-F (WS-F5..F8):** `AUDIT_v0.12.2_WORKSTREAM_PLAN.md`
 - **completed performance portfolio (WS-G):** `KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md`
+- **next planned architecture/model migration (WS-J1):** `AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`
 - **audit findings:** `AUDIT_CODEBASE_v0.12.2_v1.md` + `v2`, `AUDIT_CODEBASE_v0.12.15_v1.md` + `v2`
 
 ## Audit lineage

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -20,7 +20,7 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 | Proved declarations | 1,086 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 2,006 across 70 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| Next workstreams | WS-I5 (v0.14.10 improvement portfolio; WS-I1..WS-I4 completed); Raspberry Pi 5 hardware binding |
+| Next workstreams | WS-J1 register-indexed authoritative namespaces (v0.15.4 plan); Raspberry Pi 5 hardware binding |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | Metrics source of truth | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 
@@ -224,13 +224,14 @@ re-verified — zero sorry/axiom.
 See [Kernel Performance Optimization (WS-G)](08-kernel-performance-optimization.md)
 for the full technical breakdown.
 
-## Next: WS-I5 and Raspberry Pi 5 hardware binding
+## Next: WS-J1 and Raspberry Pi 5 hardware binding
 
-All WS-F and WS-H remediation workstreams are completed. The active remaining
-improvement workstream is **WS-I5** (documentation and code-quality polish).
+All WS-F and WS-H remediation workstreams are completed. The active next
+workstream is **WS-J1** (register-indexed authoritative namespace migration;
+plan-first, then staged implementation).
 
 See [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md),
-[`docs/audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md),
+[`docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md),
 and [Next Development Path](22-next-slice-development-path.md).
 
 ## Hardware roadmap

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -8,7 +8,7 @@ This GitBook is the long-form guide for seLe4n — a production-oriented microke
 - **Version:** 0.14.10 (Lean v4.28.0).
 - **Codebase metrics:** 34,171 production LoC across 67 files; 2,886 test LoC across 3 suites; 1,086 theorem/lemma declarations (zero sorry/axiom); 2,006 total declarations across 70 modules.
 - **Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.
-- **Next workstreams:** WS-I5 documentation/code-quality polish, then Raspberry Pi 5 hardware binding (WS-F/WS-H and WS-I1..WS-I4 completed).
+- **Next workstreams:** WS-J1 register-indexed authoritative namespaces, then Raspberry Pi 5 hardware binding (WS-F/WS-H complete; WS-I1..WS-I4 completed).
 - **Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.
 - **Hardware target:** Raspberry Pi 5 (ARM64).
 - **Metrics source of truth:** [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key). Cross-check with `./scripts/report_current_state.py`.

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -4,7 +4,7 @@
     "**Version:** 0.14.10 (Lean v4.28.0).",
     "**Codebase metrics:** 34,171 production LoC across 67 files; 2,886 test LoC across 3 suites; 1,086 theorem/lemma declarations (zero sorry/axiom); 2,006 total declarations across 70 modules.",
     "**Latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues.",
-    "**Next workstreams:** WS-I5 documentation/code-quality polish, then Raspberry Pi 5 hardware binding (WS-F/WS-H and WS-I1..WS-I4 completed).",
+    "**Next workstreams:** WS-J1 register-indexed authoritative namespaces, then Raspberry Pi 5 hardware binding (WS-F/WS-H complete; WS-I1..WS-I4 completed).",
     "**Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.",
     "**Hardware target:** Raspberry Pi 5 (ARM64).",
     "**Metrics source of truth:** [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key). Cross-check with `./scripts/report_current_state.py`.",

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -56,7 +56,7 @@ enforcement, and scheduling.
 | **Total declarations** | 2,006 across 70 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| **Next workstreams** | WS-I5 (v0.14.10 improvement portfolio; WS-I1..WS-I4 completed) + Raspberry Pi 5 hardware binding |
+| **Next workstreams** | WS-J1 register-indexed authoritative namespaces (v0.15.4 plan) + Raspberry Pi 5 hardware binding |
 | **Workstream history** | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | **Metrics source of truth** | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 | **Codebase map** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`) |


### PR DESCRIPTION
### Motivation
- The existing WS-I5 Part A documented why `RegName/RegValue` are `abbrev Nat` but left authority-bearing register paths underspecified for upcoming hardware-binding and syscall-gate realism. 
- A staged migration to typed, register-indexed authoritative namespace references reduces duplication of decode/resolve proofs, prevents namespace-class confusion, and centralizes authority resolution.
- The change is documentation and planning only: it defines a concrete, incremental execution plan to implement the migration while minimising proof churn.

### Description
- Add a new comprehensive planning document `docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md` that defines WS-J1 and breaks work into five slices (WS-J1-A..E) with goals, exit criteria, risk register, validation gates, and file-impact map. 
- Update canonical project docs and roadmap references to make WS-J1 the active next workstream and link the new plan across `README.md`, `docs/DEVELOPMENT.md`, `docs/spec/SELE4N_SPEC.md`, `docs/WORKSTREAM_HISTORY.md`, `docs/audits/README.md`, `docs/CLAIM_EVIDENCE_INDEX.md`, and the GitBook mirror. 
- Sync the GitBook navigation manifest and generated GitBook files so mirrors and navigation reflect the new plan. 
- This PR is docs/planning-only and does not modify any Lean kernel implementation or proofs.

### Testing
- Ran `./scripts/test_smoke.sh`, which includes hygiene checks, `lake build`, trace fixture comparison, determinism checks and relevant unit suites, and this run passed. 
- Ran `./scripts/test_docs_sync.sh` to regenerate GitBook artifacts and verify markdown links, and this run passed. 
- Per the plan's exit criteria, the change is limited to documentation and roadmap updates and did not introduce any proof or build regressions in automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4887e3448832b9c0df8863a9b37ea)