### PR TITLE
Fix WS-J1 planning doc links after audit filename rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ tests/                           Negative-state suite, information-flow suite, t
 Current priorities and the full workstream history are maintained in
 [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md). Summary:
 
-- **WS-J1** — Register-indexed authoritative kernel namespaces (High priority planning slice). This supersedes WS-I5 Part A’s documentation-only treatment of `RegName`/`RegValue` and defines a staged migration from raw register `Nat` payloads to typed namespace references resolved against authoritative state registries (plan: `docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`).
+- **WS-J1** — Register-indexed authoritative kernel namespaces (High priority planning slice). This supersedes WS-I5 Part A’s documentation-only treatment of `RegName`/`RegValue` and defines a staged migration from raw register `Nat` payloads to typed namespace references resolved against authoritative state registries (plan: `docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`).
 - **Raspberry Pi 5 hardware binding** — ARMv8 page table walk, GIC-400 interrupt routing, boot sequence (RPi5 platform contracts now substantive via WS-H15)
 
 Prior audits (v0.8.0-v0.9.32), milestone closeouts, and legacy GitBook chapters

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -125,4 +125,4 @@ When a claim changes:
 4. run at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).
 
 
-| Next major planning slice is WS-J1: register-indexed authoritative namespace migration superseding WS-I5 Part A for authority-resolution paths. | `docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`, `docs/WORKSTREAM_HISTORY.md`, `README.md` | `./scripts/test_smoke.sh` | Documentation planning update: defines phased delivery (WS-J1-A..E), risk register, validation gates, and file impact map. |
+| Next major planning slice is WS-J1: register-indexed authoritative namespace migration superseding WS-I5 Part A for authority-resolution paths. | `docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`, `docs/WORKSTREAM_HISTORY.md`, `README.md` | `./scripts/test_smoke.sh` | Documentation planning update: defines phased delivery (WS-J1-A..E), risk register, validation gates, and file impact map. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,14 +7,14 @@ production-oriented microkernel written in Lean 4 with machine-checked proofs.
 
 It is aligned to the **current project state**:
 
-- **next workstream:** WS-J1 (v0.15.4 register-indexed authoritative namespace migration plan). WS-F portfolio fully completed (F1..F8),
+- **next workstream:** WS-J1 (v0.14.10 register-indexed authoritative namespace migration plan). WS-F portfolio fully completed (F1..F8),
 - **recently completed:** WS-H15 (v0.14.7, platform & API hardening — `InterruptBoundaryContract` decidability, RPi5 contract hardening with substantive predicates, 13 capability-gated syscall wrappers, `AdapterProofHooks` concrete instantiation for Sim/RPi5, MMIO disjointness proof; closes A-33, A-41, A-42, M-13), WS-H14 (v0.14.6, type safety & Prelude foundations — `EquivBEq`/`LawfulBEq` for 14 identifier types, `LawfulMonad` for `KernelM`, `isPowerOfTwo` correctness proof, identifier roundtrip/injectivity theorems, `OfNat` instance removal for type-safety enforcement, sentinel predicate completion), Module restructuring (v0.14.5, decomposed 9 monolithic files into 24 focused submodules via re-export hub pattern; zero code loss, 50 new helper theorems extracted, 209 Tier 3 anchor checks updated), WS-H13 (v0.14.4, CSpace/service model enrichment — `cspaceDepthConsistent` invariant, `resolveCapAddress` theorems, `serviceStop` backing-object verification, `serviceGraphInvariant` preservation, `cspaceMove` atomicity; addresses H-01, A-21, A-29, A-30, M-17/A-31), WS-H12f (v0.14.3, test harness update & documentation sync — dequeue-on-dispatch, context switch, and bounded message trace scenarios; legacy `endpointInvariant` comment cleanup; expected fixture updated; Tier 3 anchors added; documentation synchronized), WS-H12e (v0.14.2, cross-subsystem invariant reconciliation), WS-H12d (v0.14.1, IPC message payload bounds — A-09 closed), WS-H12c (v0.14.0, per-TCB register context with inline context switch — H-03 closed), WS-H12b (v0.13.9, dequeue-on-dispatch scheduler semantics — H-04 closed), WS-H12a (v0.13.8, legacy endpoint removal), WS-H11 (v0.13.7, VSpace & architecture enrichment), End-to-end audit (v0.13.6), WS-H10 (v0.13.6, security model foundations), WS-H7/H8/H9 gaps closed (v0.13.5), WS-H9 (v0.13.4, NI coverage >80%), WS-H8 (v0.13.2, enforcement-NI bridge), WS-H6 (v0.13.1, scheduler proof completion), WS-H5 (v0.12.19, IPC dual-queue invariant), WS-H4 (v0.12.18, capability invariant redesign), WS-H3 (v0.12.17, build/CI), WS-H2 (v0.12.16, lifecycle safety), WS-H1 (v0.12.16, IPC call-path fix), WS-G (v0.12.15, kernel performance), WS-F1..F4 (critical audit remediation),
 - **findings baseline:** [`AUDIT_CODEBASE_v0.12.2_v1.md`](audits/AUDIT_CODEBASE_v0.12.2_v1.md), [`v2`](audits/AUDIT_CODEBASE_v0.12.2_v2.md),
 - **latest audit:** [`AUDIT_CODEBASE_v0.13.6.md`](audits/AUDIT_CODEBASE_v0.13.6.md) — comprehensive end-to-end audit, zero critical issues,
 - **hardware target:** Raspberry Pi 5 (ARM64).
 
 Canonical planning sources:
-[`docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md) for WS-J1 and
+[`docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md) for WS-J1 and
 [`docs/audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md`](./audits/AUDIT_v0.12.15_WORKSTREAM_PLAN.md) for completed WS-H remediation lineage.
 
 ---
@@ -37,7 +37,7 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 ## 3) Next workstreams
 
 The WS-F portfolio (v0.12.2 audit) is fully complete — all 33 findings closed.
-The active near-term portfolio is WS-J1 (v0.15.4): register-indexed authoritative
+The active near-term portfolio is WS-J1 (v0.14.10): register-indexed authoritative
 namespace migration. WS-I1..WS-I4 are completed; WS-I5 Part A remains documented
 for historical rationale but is superseded for authority-resolution paths.
 

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -52,7 +52,7 @@ full details.
 
 A new planning slice supersedes the WS-I5 Part A documentation-only treatment of
 `RegName`/`RegValue` for authority-bearing register paths. See
-[`AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md).
+[`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md).
 
 | ID | Focus | Priority |
 |----|-------|----------|

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -13,7 +13,7 @@ moved to [`docs/dev_history/audits/`](../dev_history/audits/).
 6. [`AUDIT_v0.12.2_WORKSTREAM_PLAN.md`](./AUDIT_v0.12.2_WORKSTREAM_PLAN.md) — WS-F execution plan (**WS-F1..F4 completed; WS-F5..F8 remaining**).
 7. [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](./KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) — v0.12.5 performance audit (**all 14 findings closed by WS-G**).
 8. [`KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md`](./KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md) — WS-G execution plan (**all 9 workstreams completed**).
-9. [`AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](./AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md) — WS-J1 planning document for typed register-indexed authoritative namespace migration.
+9. [`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](./AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md) — WS-J1 planning document for typed register-indexed authoritative namespace migration.
 
 ## Planning guidance
 
@@ -22,7 +22,7 @@ For current planning, use:
 - **active workstream (WS-H11..H16):** `AUDIT_v0.12.15_WORKSTREAM_PLAN.md`
 - **remaining WS-F (WS-F5..F8):** `AUDIT_v0.12.2_WORKSTREAM_PLAN.md`
 - **completed performance portfolio (WS-G):** `KERNEL_PERFORMANCE_WORKSTREAM_PLAN.md`
-- **next planned architecture/model migration (WS-J1):** `AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`
+- **next planned architecture/model migration (WS-J1):** `AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`
 - **audit findings:** `AUDIT_CODEBASE_v0.12.2_v1.md` + `v2`, `AUDIT_CODEBASE_v0.12.15_v1.md` + `v2`
 
 ## Audit lineage

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -20,7 +20,7 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 | Proved declarations | 1,086 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 2,006 across 70 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| Next workstreams | WS-J1 register-indexed authoritative namespaces (v0.15.4 plan); Raspberry Pi 5 hardware binding |
+| Next workstreams | WS-J1 register-indexed authoritative namespaces (v0.14.10 plan); Raspberry Pi 5 hardware binding |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | Metrics source of truth | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 
@@ -231,7 +231,7 @@ workstream is **WS-J1** (register-indexed authoritative namespace migration;
 plan-first, then staged implementation).
 
 See [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md),
-[`docs/audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md),
+[`docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md),
 and [Next Development Path](22-next-slice-development-path.md).
 
 ## Hardware roadmap

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -56,7 +56,7 @@ enforcement, and scheduling.
 | **Total declarations** | 2,006 across 70 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| **Next workstreams** | WS-J1 register-indexed authoritative namespaces (v0.15.4 plan) + Raspberry Pi 5 hardware binding |
+| **Next workstreams** | WS-J1 register-indexed authoritative namespaces (v0.14.10 plan) + Raspberry Pi 5 hardware binding |
 | **Workstream history** | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | **Metrics source of truth** | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 | **Codebase map** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`) |


### PR DESCRIPTION
### Motivation
- The docs-sync CI was failing due to stale markdown links referencing a renamed WS-J1 planning document (`AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`) that no longer exists. 
- Restore canonical documentation and GitBook mirror link integrity so automated doc-generation/link checks succeed.

### Description
- Replaced all references to `AUDIT_v0.15.4_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md` / `v0.15.4` with `AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md` / `v0.14.10` in the canonical docs and GitBook mirror. 
- Files updated: `README.md`, `docs/audits/README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, `docs/WORKSTREAM_HISTORY.md`, `docs/gitbook/05-specification-and-roadmap.md`, and `docs/CLAIM_EVIDENCE_INDEX.md`. 
- This is a documentation-only change and does not alter kernel code, proofs, or behavior. 

### Testing
- Ran `./scripts/test_docs_sync.sh`, which generated the GitBook artifacts and reported "markdown link check passed". 
- Ran `./scripts/test_smoke.sh`, which executed the Tiered Tests / Smoke suite and completed successfully (all automated checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4968e7c7c832b94f1f79cb710ff36)