### PR TITLE
WS-J1 planning: register-indexed authoritative namespace audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ tests/                           Negative-state suite, information-flow suite, t
 Current priorities and the full workstream history are maintained in
 [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md). Summary:
 
-- **WS-J1** — Register-indexed authoritative kernel namespaces (High priority planning slice). This supersedes WS-I5 Part A’s documentation-only treatment of `RegName`/`RegValue` and defines a staged migration from raw register `Nat` payloads to typed namespace references resolved against authoritative state registries (plan: `docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`).
+- **WS-J1** — Register-indexed authoritative namespaces (High priority, 6 phases). Replaces `RegName`/`RegValue` bare `Nat` aliases with typed wrapper structures, introduces a `RegisterDecode.lean` module with total decode functions from raw register words to typed kernel references, adds `syscallEntry` as a register-sourced syscall dispatch path closing the gap between the model and real ARM64 hardware, wraps `CdtNodeId` for consistency, and proves decode correctness, invariant preservation, and NI properties (plan: [`docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md)).
 - **Raspberry Pi 5 hardware binding** — ARMv8 page table walk, GIC-400 interrupt routing, boot sequence (RPi5 platform contracts now substantive via WS-H15)
 
 Prior audits (v0.8.0-v0.9.32), milestone closeouts, and legacy GitBook chapters

--- a/docs/CLAIM_EVIDENCE_INDEX.md
+++ b/docs/CLAIM_EVIDENCE_INDEX.md
@@ -125,4 +125,4 @@ When a claim changes:
 4. run at least `./scripts/test_smoke.sh` (`./scripts/test_full.sh` when Tier-3 anchors/policies changed).
 
 
-| Next major planning slice is WS-J1: register-indexed authoritative namespace migration superseding WS-I5 Part A for authority-resolution paths. | `docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`, `docs/WORKSTREAM_HISTORY.md`, `README.md` | `./scripts/test_smoke.sh` | Documentation planning update: defines phased delivery (WS-J1-A..E), risk register, validation gates, and file impact map. |
+| WS-J1: Register-indexed authoritative namespaces with typed register wrappers, syscall decode layer, and CdtNodeId cleanup. Supersedes WS-I5 Part A. | `docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`, `docs/WORKSTREAM_HISTORY.md`, `README.md` | `./scripts/test_smoke.sh` | Redesigned workstream plan: 6 phases (J1-A..F), typed `RegName`/`RegValue` wrappers, `RegisterDecode.lean` module with round-trip/determinism lemmas, `syscallEntry` register-sourced dispatch, `CdtNodeId` typed wrapper, NI composition, risk register with 6 items, comprehensive file impact map. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -38,8 +38,11 @@ Unless a PR explicitly proposes spec-level change control, preserve:
 
 The WS-F portfolio (v0.12.2 audit) is fully complete — all 33 findings closed.
 The active near-term portfolio is WS-J1 (v0.14.10): register-indexed authoritative
-namespace migration. WS-I1..WS-I4 are completed; WS-I5 Part A remains documented
-for historical rationale but is superseded for authority-resolution paths.
+namespace migration with typed register wrappers, syscall argument decode layer,
+and `CdtNodeId` cleanup (6 phases: J1-A through J1-F). WS-I1..WS-I4 are completed;
+WS-I5 Part A (R-12) is superseded by WS-J1, which replaces `RegName`/`RegValue`
+`abbrev Nat` definitions with typed wrapper structures and introduces a
+`RegisterDecode.lean` module to close the syscall argument decode gap.
 
 ### 3.1 WS-H11..H16 — v0.12.15 audit remediation status (completed)
 

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -48,15 +48,27 @@ full details.
 | **WS-I4** | Subsystem coverage expansion (VSpace multi-ASID, IPC interleaving, lifecycle cascading revoke chains) | LOW — **COMPLETED** (v0.15.3) |
 | **WS-I5** | Documentation and code-quality polish (remaining low-priority recommendations) | LOW — pending |
 
-### WS-J1 workstream (register namespace authority modeling)
+### WS-J1 workstream (register-indexed authoritative namespaces)
 
-A new planning slice supersedes the WS-I5 Part A documentation-only treatment of
-`RegName`/`RegValue` for authority-bearing register paths. See
-[`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md).
+WS-J1 supersedes the WS-I5 Part A documentation-only treatment of
+`RegName`/`RegValue`. A comprehensive audit revealed that bare `Nat`
+abbreviations are insufficient: the syscall API bypasses the machine register
+file entirely, omitting the decode path where untrusted user-space register
+values become trusted kernel references. WS-J1 addresses this by:
+
+1. Replacing `RegName`/`RegValue` with typed wrapper structures.
+2. Introducing a `RegisterDecode.lean` module with total, deterministic decode
+   functions from raw register words to typed kernel identifiers.
+3. Adding `syscallEntry` as a register-sourced syscall dispatch path.
+4. Wrapping `CdtNodeId` (secondary bare-Nat alias) for consistency.
+5. Proving decode correctness, invariant preservation, and NI properties.
+
+See [`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md)
+for the full workstream plan (6 phases: J1-A through J1-F).
 
 | ID | Focus | Priority |
 |----|-------|----------|
-| **WS-J1** | Allow register values to index authoritative kernel namespaces directly through typed decode/resolve paths, preserving determinism and proof obligations | HIGH — planned |
+| **WS-J1** | Replace `abbrev Nat` register types with typed wrappers, add syscall argument decode layer bridging machine registers to typed kernel operations, wrap `CdtNodeId`, prove decode correctness and NI | HIGH — planned |
 
 ### Raspberry Pi 5 hardware binding
 
@@ -127,3 +139,4 @@ are archived in [`docs/dev_history/`](dev_history/README.md).
 | [`KERNEL_PERFORMANCE_AUDIT_v0.12.5.md`](audits/KERNEL_PERFORMANCE_AUDIT_v0.12.5.md) | Performance audit baseline |
 | [`AUDIT_CODEBASE_v0.13.6.md`](audits/AUDIT_CODEBASE_v0.13.6.md) | Prior end-to-end audit (v0.13.6) |
 | [`AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md) | WS-I portfolio (v0.14.9 improvement recommendations) |
+| [`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md) | WS-J1 register-indexed authoritative namespaces (6 phases) |

--- a/docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md
@@ -3,269 +3,765 @@
 **Version target:** v0.14.10+
 **Status:** Planned
 **Priority:** High
-**Estimated effort:** 3–5 days
-**Dependencies:** WS-I1..WS-I5 complete baseline, no additional blockers
-**Primary scope:** Replace the current `RegName := Nat` / `RegValue := Nat` modeling path for namespace references with a typed, authoritative register-namespace indexing model.
+**Estimated effort:** 5–8 days
+**Dependencies:** WS-I1..WS-I4 complete baseline, no additional blockers
+**Primary scope:** Replace `RegName := Nat` / `RegValue := Nat` with typed
+register identifiers that index authoritative kernel namespaces directly,
+close the syscall-argument decode gap between the model and real hardware,
+and integrate with the existing proof surface.
 
 ---
 
 ## 1. Executive summary
 
-`SeLe4n/Machine.lean` currently models register names/values with `abbrev Nat`.
-That decision kept the abstract machine lightweight, but it limits the model’s
-ability to express hardware-mediated authority transfer where register payloads
-index kernel namespaces directly (e.g., CSpace roots, endpoint IDs, ASID roots,
-or service handles).
+`SeLe4n/Machine.lean` currently defines register names and values as bare
+`Nat` abbreviations (`abbrev RegName := Nat`, `abbrev RegValue := Nat`).
+The syscall API layer (`Kernel/API.lean`) accepts pre-typed Lean parameters
+(`ObjId`, `CPtr`, `ThreadId`) directly — it never extracts these identifiers
+from the machine register file. This means the model omits the entire
+**syscall argument decode path** that real hardware mandates: on ARM64, syscall
+arguments arrive in general-purpose registers x0–x7, and the kernel must
+decode raw register words into typed kernel references before any authority
+check can proceed.
 
-This workstream introduces a **typed register namespace index layer** so register
-values can carry and resolve **authoritative namespace references** with explicit
-validation rules, deterministic error outcomes, and preservation proofs.
+This workstream closes that gap by:
 
-The migration is split into small, reviewable units to reduce proof breakage and
-keep CI feedback fast.
+1. Replacing `RegName` and `RegValue` with typed wrapper structures that
+   carry namespace semantics at the type level.
+2. Introducing a **register decode layer** that converts raw register words
+   into typed kernel identifiers with total, deterministic error handling.
+3. Wiring the syscall API wrappers (`api*` functions) through the decode
+   layer so that authority flows from machine registers through decode into
+   typed kernel operations.
+4. Proving decode correctness, invariant preservation, and non-interference
+   properties for the new path.
 
----
-
-## 2. Problem statement and design goal
-
-### 2.1 Current limitation
-
-WS-I5 Part A documented why `RegName` / `RegValue` were left as bare `Nat` in
-the abstract machine model. That is acceptable for local read/write lemmas, but
-it is too weak for upcoming hardware-binding and syscall-gate realism:
-
-1. Register payloads that represent authority remain untyped until deep in API
-   wrappers.
-2. Namespace confusion (wrong identifier class in a register channel) is
-   prevented by conventions rather than type-level structure.
-3. Proof obligations about authority resolution are duplicated across subsystem
-   wrappers instead of concentrated in one decode/resolve layer.
-
-### 2.2 Target capability
-
-Add a register-namespace mechanism where:
-
-- Register values can be decoded as **typed namespace indices**.
-- Resolution against authoritative maps is total and deterministic (`ok/error`).
-- Authority-bearing operations consume resolved typed references, not raw `Nat`.
-- Existing abstract-machine lemmas remain available via compatibility shims.
+The migration is staged into six small, independently reviewable units (A–F)
+to limit proof churn and keep CI feedback fast at every step.
 
 ---
 
-## 3. Scope and non-goals
+## 2. Problem analysis (code-level audit findings)
+
+### 2.1 Finding: bare `Nat` aliases bypass type safety
+
+**Location:** `SeLe4n/Machine.lean:14–17`
+
+```lean
+abbrev RegName := Nat    -- line 14
+abbrev RegValue := Nat   -- line 17
+```
+
+Every other kernel-facing identifier in the codebase is a typed wrapper
+structure with `DecidableEq`, `Hashable`, `LawfulHashable`, `Repr`,
+`ToString`, and sentinel support (`ObjId`, `ThreadId`, `CPtr`, `DomainId`,
+`Priority`, `Deadline`, `Irq`, `ServiceId`, `Slot`, `Badge`, `ASID`,
+`VAddr`, `PAddr` — 13 types defined in `Prelude.lean:29–448`).
+
+`RegName` and `RegValue` are the **only** `abbrev Nat` types that flow into
+authority-sensitive operations. While `CdtNodeId := Nat` also exists
+(`Model/Object/Structures.lean:554`), it is internal to CDT bookkeeping
+and never crosses a trust boundary.
+
+**Consequence:** A `Nat` value intended as a `RegName` can be silently used
+as a `RegValue` or as an index into any other `Nat`-typed field. The type
+checker provides no defense against namespace confusion.
+
+### 2.2 Finding: syscall arguments bypass the register file
+
+**Location:** `SeLe4n/Kernel/API.lean:138–149` (`SyscallGate` structure)
+
+```lean
+structure SyscallGate where
+  callerId     : SeLe4n.ThreadId
+  cspaceRoot   : SeLe4n.ObjId
+  capAddr      : SeLe4n.CPtr
+  capDepth     : Nat
+  requiredRight : AccessRight
+```
+
+In real seL4 (and on real ARM64 hardware), these fields come from machine
+registers:
+- `x0` carries the destination capability pointer
+- `x1` carries the message info word (encodes message length, extra caps,
+  label)
+- `x2–x5` carry inline message registers
+- `x7` carries the syscall number
+
+The seLe4n model passes `SyscallGate` fields as direct Lean function
+arguments. The machine register file (`MachineState.regs`) is only used for
+context save/restore during thread switching (`saveOutgoingContext`/
+`restoreIncomingContext` in `Kernel/Scheduler/Operations/Core.lean:215–233`).
+No operation ever *reads* a syscall argument from the register file.
+
+**Consequence:** The model cannot express or prove properties about the
+decode path — the moment where untrusted user-space register values become
+trusted kernel references. This is exactly the boundary where real-world
+confusion attacks (wrong register, truncated value, stale capability pointer)
+occur.
+
+### 2.3 Finding: `CdtNodeId` also lacks typed wrapping
+
+**Location:** `SeLe4n/Model/Object/Structures.lean:554`
+
+```lean
+abbrev CdtNodeId := Nat
+```
+
+Used as a `HashMap` key in `SystemState` (`cdtSlotNode`, `cdtNodeSlot`,
+`cdtNextNode` at `Model/State.lean:141–143`). While it inherits `Nat`'s
+`Hashable`, it lacks explicit `Hashable`, `LawfulHashable`, `EquivBEq`,
+and `LawfulBEq` instances — inconsistent with every other HashMap key type
+in the codebase. This workstream wraps `CdtNodeId` as a secondary cleanup
+item (WS-J1-F).
+
+### 2.4 Finding: `RegisterFile.gpr` is unbounded
+
+**Location:** `SeLe4n/Machine.lean:40–58`
+
+```lean
+structure RegisterFile where
+  pc : RegValue
+  sp : RegValue
+  gpr : RegName → RegValue
+```
+
+The `gpr` field is a total function `Nat → Nat` — conceptually infinite
+registers. The `BEq` instance compares only the first 32 GPRs (ARM64
+convention), but nothing in the type system prevents reading `gpr 999`.
+
+**Consequence:** Proofs about register operations do not carry architectural
+bounds. The read-after-write lemmas (`readReg_writeReg_eq/ne`) are correct
+but apply to an unbounded register space, which is strictly weaker than the
+bounded 31-register space (x0–x30) of real ARM64.
+
+### 2.5 Summary of gaps
+
+| Gap | Location | Severity | Impact |
+|-----|----------|----------|--------|
+| Bare `Nat` register types | `Machine.lean:14–17` | Medium | Type confusion possible |
+| No syscall decode path | `API.lean:138–149` | High | Authority boundary unmodeled |
+| Unbounded register space | `Machine.lean:43` | Low | Proofs weaker than hardware |
+| `CdtNodeId` inconsistency | `Structures.lean:554` | Low | Missing type-safety instances |
+
+---
+
+## 3. Design: typed register namespace indexing
+
+### 3.1 Design principles
+
+1. **Register values are the authoritative source.** Syscall arguments must
+   originate from the current thread's register file, not from direct Lean
+   parameters.
+2. **Decode is total and deterministic.** Every decode from register word to
+   typed reference returns `ok` or an explicit `KernelError`.
+3. **Typed identifiers at every boundary.** `RegName` and `RegValue` become
+   wrapper structures consistent with the 13 existing typed identifiers.
+4. **Backward compatibility via shims.** Existing `readReg`/`writeReg`
+   lemmas continue to work through compatibility conversions during the
+   migration period.
+5. **Bounded register space.** `RegName` carries a proof-relevant bound
+   (`n < 32` for ARM64 GPRs), eliminating the infinite-register fiction.
+
+### 3.2 New core types
+
+All names are semantics-first (no workstream IDs in identifiers).
+
+#### 3.2.1 `RegName` — bounded register index
+
+```lean
+/-- Bounded general-purpose register index.
+    ARM64: 31 GPRs (x0–x30), plus pc and sp as separate fields. -/
+structure RegName where
+  val : Nat
+  deriving DecidableEq, Repr, Hashable
+```
+
+The `MachineConfig.registerCount` field (new) provides the architectural
+bound. Syscall decode operations that reference out-of-bounds register
+names return `KernelError.invalidRegister` (new error variant).
+
+#### 3.2.2 `RegValue` — machine word with namespace decode
+
+```lean
+/-- Register-width machine word. Carries the raw numeric value from which
+    typed kernel references are decoded at syscall boundaries. -/
+structure RegValue where
+  val : Nat
+  deriving DecidableEq, Repr, Hashable
+```
+
+#### 3.2.3 `SyscallRegisterLayout` — register-to-argument mapping
+
+```lean
+/-- Mapping from ARM64 syscall convention registers to typed arguments.
+    Encodes the real hardware convention:
+    - x0: destination capability pointer (CPtr)
+    - x1: message info word (length, extra caps, label)
+    - x2–x5: inline message registers
+    - x7: syscall number -/
+structure SyscallRegisterLayout where
+  capPtrReg      : RegName   -- x0
+  msgInfoReg     : RegName   -- x1
+  msgRegs        : Array RegName  -- x2–x5
+  syscallNumReg  : RegName   -- x7
+```
+
+A default ARM64 layout is provided as a constant. The platform
+`MachineConfig` can override for alternative ABI conventions.
+
+#### 3.2.4 `SyscallDecodeResult` — decoded syscall arguments
+
+```lean
+/-- Result of decoding raw register values into typed syscall arguments.
+    Total: always returns either a valid decode or a specific error. -/
+structure SyscallDecodeResult where
+  capAddr   : CPtr
+  msgInfo   : MessageInfo
+  syscallId : SyscallId
+```
+
+The `MessageInfo` and `SyscallId` types are new, lightweight structures
+encoding the seL4 message-info word layout and syscall numbering.
+
+### 3.3 Register decode layer
+
+A new module `SeLe4n/Kernel/Architecture/RegisterDecode.lean` provides:
+
+```lean
+/-- Decode a raw register value into a capability pointer.
+    Returns illegalArgument if the value exceeds the CPtr address space. -/
+def decodeCapPtr (rv : RegValue) : Except KernelError CPtr
+
+/-- Decode a raw register value into a message info word.
+    Extracts length, extra caps count, and label from bit fields. -/
+def decodeMsgInfo (rv : RegValue) : Except KernelError MessageInfo
+
+/-- Decode the syscall number register into a typed syscall identifier. -/
+def decodeSyscallId (rv : RegValue) : Except KernelError SyscallId
+
+/-- Extract typed syscall arguments from the current thread's register file
+    using the platform's register layout convention.
+    This is the single authoritative decode entry point. -/
+def decodeSyscallArgs
+    (layout : SyscallRegisterLayout)
+    (regs : RegisterFile) : Except KernelError SyscallDecodeResult
+```
+
+Each decode function is total with explicit error returns. The module also
+provides:
+
+- **Round-trip lemmas:** `decodeCapPtr (encodeCapPtr c) = .ok c`
+- **Determinism theorem:** decode of the same register values always
+  produces the same result.
+- **Error exclusivity:** each error variant maps to exactly one failure mode.
+
+### 3.4 Syscall gate integration
+
+The existing `SyscallGate` structure is preserved but its construction
+changes. Today, callers pass typed arguments directly:
+
+```lean
+-- Current (bypasses registers):
+apiEndpointSend gate epId msg
+```
+
+After WS-J1, the canonical syscall entry point reads from the current
+thread's register context:
+
+```lean
+/-- Decode syscall arguments from the current thread's register file
+    and dispatch to the appropriate kernel operation. -/
+def syscallEntry (layout : SyscallRegisterLayout) : Kernel Unit :=
+  fun st =>
+    match st.scheduler.current with
+    | none => .error .illegalState
+    | some tid =>
+      match lookupThreadRegisterContext tid st with
+      | .error e => .error e
+      | .ok regs =>
+        match decodeSyscallArgs layout regs with
+        | .error e => .error e
+        | .ok decoded =>
+          -- Route to the appropriate api* wrapper based on decoded.syscallId
+          dispatchSyscall decoded tid st
+```
+
+The existing `api*` functions remain as the **internal kernel API** (typed
+arguments, no decode). `syscallEntry` is the **new user-space entry point**
+that models the real hardware decode path. This preserves backward
+compatibility: all existing tests and proofs that call `api*` directly
+continue to work unchanged.
+
+### 3.5 `CdtNodeId` typed wrapper (secondary)
+
+Replace:
+```lean
+abbrev CdtNodeId := Nat
+```
+
+With:
+```lean
+structure CdtNodeId where
+  val : Nat
+  deriving DecidableEq, Repr, Hashable
+```
+
+Add `LawfulHashable`, `EquivBEq`, `LawfulBEq`, `ToString`, `ofNat`/`toNat`
+instances matching the pattern in `Prelude.lean`.
+
+### 3.6 Architecture diagram
+
+```
+User space
+    │
+    ▼ (hardware trap: arguments in x0–x7)
+┌────────────────────────────────────────────┐
+│  RegisterDecode.decodeSyscallArgs          │
+│  ┌─────────────────────────────────────┐   │
+│  │ raw RegValue → CPtr                │   │
+│  │ raw RegValue → MessageInfo          │   │
+│  │ raw RegValue → SyscallId            │   │
+│  └─────────────────────────────────────┘   │
+│            │ typed decode result            │
+│            ▼                                │
+│  syscallEntry: route to api* wrapper       │
+│            │                                │
+│            ▼                                │
+│  SyscallGate: capability resolution        │
+│  (resolveCapAddress → lookupSlotCap)       │
+│            │                                │
+│            ▼                                │
+│  api* wrapper: authority + operation       │
+│  (apiEndpointSend, apiCspaceMint, ...)     │
+│            │                                │
+│            ▼                                │
+│  Internal kernel operation                 │
+│  (endpointSendDual, cspaceMint, ...)       │
+└────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Scope and non-goals
 
 ### In scope
 
-- New typed structures and decoding APIs for register namespace references.
-- Authoritative namespace registries in kernel state (minimal initial set).
-- API/adapter integration for capability-gated operations that consume register
-  references.
-- Invariant and non-interference updates for the new resolution path.
-- Tiered tests and trace fixtures for successful and failing decode/resolve paths.
-- Documentation and GitBook synchronization.
+- `RegName` and `RegValue` as typed wrapper structures with full instance
+  suite (`DecidableEq`, `Hashable`, `LawfulHashable`, `EquivBEq`,
+  `LawfulBEq`, `Repr`, `ToString`, `ofNat`/`toNat`).
+- `SyscallRegisterLayout`, `SyscallDecodeResult`, `MessageInfo`, `SyscallId`.
+- `RegisterDecode.lean` module with total decode functions and round-trip
+  lemmas.
+- `syscallEntry` as the register-sourced syscall dispatch path.
+- `CdtNodeId` typed wrapper with full instance suite.
+- New `KernelError` variants: `invalidRegister`, `invalidSyscallNumber`,
+  `invalidMessageInfo`.
+- Invariant updates for decode path preservation.
+- NI bridge lemmas for register-observable decode behavior.
+- Negative tests for every decode error path.
+- Trace scenarios for register-sourced syscall execution.
+- Documentation sync across all canonical sources and GitBook.
 
 ### Out of scope (this workstream)
 
-- Full hardware MMU/register-file implementation for Raspberry Pi 5.
-- ISA-level binary encoding fidelity for all ARM64 registers.
-- Multi-core register-bank semantics.
+- Full ARM64 ISA binary encoding for all system registers (SPSR, ESR, etc.).
+- Multi-core per-CPU register banks.
+- Floating-point / SIMD register state (D0–D31, V0–V31).
+- Hardware MMU page-table register integration (TTBR0/TTBR1).
+- MCS scheduling context register usage.
 
 ---
 
-## 4. Architecture proposal
+## 5. Work breakdown structure
 
-### 4.1 New core types
+### WS-J1-A — Typed register wrappers and compatibility bridge
 
-Introduce (names indicative; final names should remain semantics-first):
+**Goal:** Replace `abbrev Nat` with wrapper structures. Zero behavior change.
 
-- `RegRefKind` — namespace discriminator (e.g., cspace, endpoint, notification,
-  asidRoot, service).
-- `RegNamespaceIndex` — typed payload containing kind + bounded index token.
-- `RegPayload` — register value algebra (`word`, `namespaceRef`, future variants).
-- `RegisterFile` update path preserving deterministic semantics.
+**Tasks:**
 
-### 4.2 Authoritative namespace layer
+1. Define `RegName` and `RegValue` as wrapper structures in `Machine.lean`.
+   Add `DecidableEq`, `Hashable`, `Repr`, `ToString`, `ofNat`/`toNat`.
+2. Add `LawfulHashable`, `EquivBEq`, `LawfulBEq` instances in
+   `Prelude.lean` following the existing pattern for the 13 typed identifiers.
+3. Update `RegisterFile.gpr` signature: `RegName → RegValue`.
+4. Update `readReg`/`writeReg` to use wrapper types.
+5. Re-prove all 10 existing machine lemmas (`readReg_writeReg_eq/ne`,
+   `writeReg_preserves_pc/sp`, `writeMem_preserves_regs/timer`,
+   `setPC_preserves_memory/timer`, `tick_preserves_regs/memory`,
+   `tick_timer_succ`).
+6. Add compatibility conversion functions: `RegName.ofNat`/`.toNat`,
+   `RegValue.ofNat`/`.toNat`.
+7. Fix all downstream compilation errors from the type change (systematic:
+   grep for `RegName` and `RegValue` usage across 18 files).
 
-Add a state-owned registry for resolvable namespace references, e.g.:
+**Exit criteria:**
+- `lake build` passes with zero errors.
+- `./scripts/test_smoke.sh` passes (existing tests unchanged).
+- Zero `sorry`/`axiom` introduced.
 
-- `NamespaceRegistry` in `Model.State` (or subsystem-owned projections),
-- total resolver: `resolveRegNamespace : KernelState → RegNamespaceIndex → Except KernelError ResolvedRef`.
-
-### 4.3 Determinism and safety contract
-
-Every decode/resolve function must:
-
-- return explicit errors on malformed/unknown/stale references,
-- preserve no-`sorry` / no-`axiom` policy,
-- avoid partial functions and non-deterministic branches.
+**Files modified:**
+- `SeLe4n/Machine.lean` — type definitions, operations, lemmas
+- `SeLe4n/Prelude.lean` — lawful instances
+- `SeLe4n/Kernel/Architecture/Adapter.lean` — type annotations
+- `SeLe4n/Kernel/Architecture/Assumptions.lean` — contract signatures
+- `SeLe4n/Kernel/Scheduler/Operations/Selection.lean` — context switch
+- `SeLe4n/Kernel/Scheduler/Operations/Core.lean` — save/restore
+- `SeLe4n/Platform/Sim/RuntimeContract.lean` — contract predicates
+- `SeLe4n/Platform/RPi5/RuntimeContract.lean` — contract predicates
+- `SeLe4n/Testing/MainTraceHarness.lean` — trace construction
 
 ---
 
-## 5. Work breakdown structure (small execution units)
+### WS-J1-B — Register decode layer
 
-## WS-J1-A — Type introduction and compatibility bridge
+**Goal:** Introduce the decode module that converts raw register words into
+typed kernel references.
 
-**Goal:** Add new types without changing behavior of existing call paths.
+**Tasks:**
 
-Tasks:
-1. Add `RegRefKind`, `RegNamespaceIndex`, and `RegPayload` in machine/model layer.
-2. Keep `readReg`/`writeReg` behavior stable via compatibility conversion APIs.
-3. Prove bridge lemmas showing legacy `Nat` paths remain observationally equivalent for plain word registers.
+1. Add `SyscallId` inductive in `Model/Object/Types.lean` covering the
+   modeled syscall set (send, receive, call, reply, cspaceMint, cspaceCopy,
+   cspaceMove, cspaceDelete, lifecycleRetype, vspaceMap, vspaceUnmap,
+   serviceStart, serviceStop).
+2. Add `MessageInfo` structure encoding seL4 message-info word layout
+   (length, extraCaps, label fields).
+3. Add `SyscallRegisterLayout` structure and `arm64DefaultLayout` constant.
+4. Create `SeLe4n/Kernel/Architecture/RegisterDecode.lean`:
+   - `decodeCapPtr : RegValue → Except KernelError CPtr`
+   - `decodeMsgInfo : RegValue → Except KernelError MessageInfo`
+   - `decodeSyscallId : RegValue → Except KernelError SyscallId`
+   - `decodeSyscallArgs : SyscallRegisterLayout → RegisterFile → Except KernelError SyscallDecodeResult`
+5. Add round-trip lemmas (`decodeCapPtr_roundtrip`, etc.).
+6. Add determinism theorem for `decodeSyscallArgs`.
+7. Add new `KernelError` variants: `invalidRegister`,
+   `invalidSyscallNumber`, `invalidMessageInfo`.
 
-Exit criteria:
+**Exit criteria:**
 - `lake build` passes.
-- Existing smoke suite unchanged.
+- Round-trip and determinism lemmas proved (zero `sorry`).
+- `./scripts/test_smoke.sh` passes.
+
+**Files modified:**
+- `SeLe4n/Model/Object/Types.lean` — `SyscallId`, `MessageInfo`
+- `SeLe4n/Model/State.lean` — new `KernelError` variants
+- `SeLe4n/Kernel/Architecture/RegisterDecode.lean` — **new file**
+- `SeLe4n/Machine.lean` — `SyscallRegisterLayout`, `arm64DefaultLayout`
 
 ---
 
-## WS-J1-B — Authoritative namespace registry foundations
+### WS-J1-C — Syscall entry point and dispatch
 
-**Goal:** Introduce canonical namespace ownership and resolver.
+**Goal:** Wire the decode layer into a register-sourced syscall entry point.
 
-Tasks:
-1. Add `NamespaceRegistry` structure and initialization defaults.
-2. Implement total resolver with explicit `KernelError` mapping.
-3. Add preservation lemmas for unaffected subsystems.
+**Tasks:**
 
-Exit criteria:
-- Resolver round-trip/uniqueness lemmas proved.
-- Negative tests for unknown index and kind mismatch.
+1. Add `lookupThreadRegisterContext : ThreadId → Kernel RegisterFile` that
+   extracts the current thread's register context from `SystemState`.
+2. Add `dispatchSyscall : SyscallDecodeResult → ThreadId → Kernel Unit`
+   that routes decoded arguments to the appropriate `api*` wrapper.
+3. Add `syscallEntry : SyscallRegisterLayout → Kernel Unit` as the
+   top-level user-space entry point.
+4. Prove `syscallEntry_requires_valid_decode`: if `syscallEntry` succeeds,
+   the register values decoded successfully.
+5. Prove `syscallEntry_implies_capability_held`: if `syscallEntry` succeeds
+   for a capability-gated operation, the caller held the required right
+   (threading through existing `syscallInvoke_requires_right`).
+6. Add `MachineConfig.registerCount` field (default 32 for ARM64).
 
----
+**Exit criteria:**
+- `lake build` passes.
+- Soundness theorems proved (zero `sorry`).
+- `./scripts/test_smoke.sh` passes.
 
-## WS-J1-C — API and transition-path adoption
-
-**Goal:** Move authority-bearing transitions from raw register `Nat` decode to typed resolution.
-
-Tasks:
-1. Update syscall boundary wrappers that pull IDs from registers.
-2. Route capability and IPC entry points through typed resolver.
-3. Preserve determinism and capability checks in the same transition step.
-
-Exit criteria:
-- Existing API soundness theorems re-proved.
-- Trace harness includes successful + denied resolution scenarios.
-
----
-
-## WS-J1-D — Invariant and information-flow integration
-
-**Goal:** Make namespace indexing first-class in proof surfaces.
-
-Tasks:
-1. Add/extend invariants for namespace registry well-formedness.
-2. Extend NI bridge lemmas for resolver-observable behavior.
-3. Add composition coverage for new step variants.
-
-Exit criteria:
-- `test_full.sh` passes.
-- NI theorem surface remains sorry-free.
+**Files modified:**
+- `SeLe4n/Kernel/API.lean` — `syscallEntry`, `dispatchSyscall`, soundness
+  theorems
+- `SeLe4n/Machine.lean` — `MachineConfig.registerCount`
 
 ---
 
-## WS-J1-E — Evidence, migration cleanup, and docs sync
+### WS-J1-D — Invariant and information-flow integration
 
-**Goal:** Finalize migration and documentation coherence.
+**Goal:** Extend the proof surface to cover the decode path.
 
-Tasks:
-1. Remove temporary compatibility shims that are no longer needed.
-2. Update fixtures (if trace output changes) with rationale.
-3. Synchronize canonical docs + GitBook mirror + claim/evidence links.
+**Tasks:**
 
-Exit criteria:
-- `test_smoke.sh` (minimum) and `test_full.sh` pass.
-- Documentation index references WS-J1 and its evidence.
+1. Add `registerDecodeConsistent` predicate to
+   `proofLayerInvariantBundle`: decoded register values that produce typed
+   references must index into valid kernel state.
+2. Prove `syscallEntry_preserves_proofLayerInvariantBundle` for both
+   success and error paths.
+3. Extend `NonInterferenceStep` with decode-related constructors
+   (`syscallDecode`, `syscallDispatch`).
+4. Prove NI for the decode path: register contents in the current
+   thread's domain are not observable by threads in other domains
+   (threading through existing `projectStateFast` with domain-gated
+   `machineRegs`).
+5. Add composition coverage for the new `NonInterferenceStep` constructors
+   in `composedNonInterference_trace`.
+
+**Exit criteria:**
+- `./scripts/test_full.sh` passes.
+- NI theorem surface remains zero `sorry`/`axiom`.
+- Tier 3 anchor checks pass with new theorem names.
+
+**Files modified:**
+- `SeLe4n/Kernel/Architecture/Invariant.lean` — decode consistency predicate
+- `SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean` — NI theorems
+- `SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean` — composition
+- `SeLe4n/Kernel/InformationFlow/Projection.lean` — projection updates
+- `scripts/test_tier3_invariant_surface.sh` — new anchor entries
 
 ---
 
-## 6. File impact map (expected)
+### WS-J1-E — Testing and trace evidence
+
+**Goal:** Complete test coverage for decode paths.
+
+**Tasks:**
+
+1. Add negative decode tests to `tests/NegativeStateSuite.lean`:
+   - Invalid register index (out of bounds)
+   - Invalid syscall number
+   - Malformed message info word
+   - Decode of zero-valued registers
+2. Add register-sourced syscall trace scenarios to
+   `SeLe4n/Testing/MainTraceHarness.lean`:
+   - Successful register decode → capability check → kernel operation
+   - Failed register decode → explicit error return
+   - Register decode with namespace mismatch
+3. Add operation-chain tests to `tests/OperationChainSuite.lean`:
+   - Multi-syscall sequence via register decode
+   - Register decode followed by IPC with message transfer
+4. Update `tests/fixtures/main_trace_smoke.expected` with new scenarios.
+5. Update `tests/fixtures/scenario_registry.yaml` with new scenario IDs.
+6. Add Tier 3 anchors for new theorem and definition names.
+
+**Exit criteria:**
+- `./scripts/test_smoke.sh` passes.
+- `./scripts/test_full.sh` passes.
+- All new tests produce deterministic output.
+
+**Files modified:**
+- `tests/NegativeStateSuite.lean` — decode error tests
+- `SeLe4n/Testing/MainTraceHarness.lean` — trace scenarios
+- `tests/OperationChainSuite.lean` — chain tests
+- `tests/fixtures/main_trace_smoke.expected` — fixture update
+- `tests/fixtures/scenario_registry.yaml` — scenario ID mappings
+- `scripts/test_tier3_invariant_surface.sh` — anchors
+
+---
+
+### WS-J1-F — CdtNodeId cleanup and documentation sync
+
+**Goal:** Wrap `CdtNodeId`, remove all compatibility shims, synchronize
+documentation.
+
+**Tasks:**
+
+1. Replace `abbrev CdtNodeId := Nat` with typed wrapper structure in
+   `Model/Object/Structures.lean`.
+2. Add `DecidableEq`, `Hashable`, `LawfulHashable`, `EquivBEq`,
+   `LawfulBEq`, `Repr`, `ToString`, `ofNat`/`toNat` instances.
+3. Fix all downstream compilation from `CdtNodeId` type change (HashMap
+   key usage in `State.lean:141–143`, CDT operations in
+   `Capability/Operations.lean`).
+4. Remove any temporary compatibility shims from WS-J1-A that are no
+   longer needed.
+5. Synchronize documentation:
+   - `README.md` — metrics via `codebase_map.json`
+   - `docs/spec/SELE4N_SPEC.md` — architecture section
+   - `docs/DEVELOPMENT.md` — baseline contracts
+   - `docs/WORKSTREAM_HISTORY.md` — WS-J1 entry
+   - `docs/CLAIM_EVIDENCE_INDEX.md` — register decode claims
+   - `docs/gitbook/03-architecture-and-module-map.md` — module updates
+   - `docs/gitbook/04-project-design-deep-dive.md` — design section
+   - `docs/gitbook/05-specification-and-roadmap.md` — milestone history
+   - `docs/gitbook/12-proof-and-invariant-map.md` — new theorems
+6. Regenerate `docs/codebase_map.json`.
+
+**Exit criteria:**
+- `./scripts/test_full.sh` passes.
+- Zero `sorry`/`axiom` in production.
+- All documentation synchronized.
+- Tier 0 hygiene passes (website links, fixture validation).
+
+**Files modified:**
+- `SeLe4n/Model/Object/Structures.lean` — `CdtNodeId` wrapper
+- `SeLe4n/Prelude.lean` — lawful instances for `CdtNodeId`
+- `SeLe4n/Model/State.lean` — HashMap key type updates
+- `SeLe4n/Kernel/Capability/Operations.lean` — CDT operations
+- All documentation files listed above
+
+---
+
+## 6. File impact map
 
 ### Core model and machine
-- `SeLe4n/Machine.lean`
-- `SeLe4n/Model/State.lean`
-- `SeLe4n/Prelude.lean` (if additional typed wrappers are needed)
+| File | Change |
+|------|--------|
+| `SeLe4n/Machine.lean` | `RegName`/`RegValue` wrappers, `SyscallRegisterLayout`, `MachineConfig.registerCount` |
+| `SeLe4n/Prelude.lean` | Lawful instances for `RegName`, `RegValue`, `CdtNodeId` |
+| `SeLe4n/Model/Object/Types.lean` | `SyscallId`, `MessageInfo` |
+| `SeLe4n/Model/Object/Structures.lean` | `CdtNodeId` wrapper |
+| `SeLe4n/Model/State.lean` | New `KernelError` variants, `CdtNodeId` key updates |
 
-### Kernel transition surfaces (expected first adopters)
-- `SeLe4n/Kernel/API.lean`
-- `SeLe4n/Kernel/Capability/*`
-- `SeLe4n/Kernel/IPC/*`
-- `SeLe4n/Kernel/Architecture/*` (if ASID/VSpace references are register-fed)
+### New module
+| File | Contents |
+|------|----------|
+| `SeLe4n/Kernel/Architecture/RegisterDecode.lean` | Decode functions, round-trip lemmas, determinism |
 
-### Proof/test surfaces
-- `SeLe4n/Kernel/*/Invariant*.lean`
-- `SeLe4n/Kernel/InformationFlow/*`
-- `SeLe4n/Testing/MainTraceHarness.lean`
-- `tests/OperationChainSuite.lean`
-- `tests/NegativeStateSuite.lean`
+### Kernel transition surfaces
+| File | Change |
+|------|--------|
+| `SeLe4n/Kernel/API.lean` | `syscallEntry`, `dispatchSyscall`, soundness theorems |
+| `SeLe4n/Kernel/Architecture/Adapter.lean` | Type annotation updates |
+| `SeLe4n/Kernel/Architecture/Assumptions.lean` | Contract signature updates |
+| `SeLe4n/Kernel/Scheduler/Operations/Selection.lean` | Context switch type updates |
+| `SeLe4n/Kernel/Scheduler/Operations/Core.lean` | Save/restore type updates |
+| `SeLe4n/Kernel/Capability/Operations.lean` | CDT `CdtNodeId` updates |
+
+### Proof surfaces
+| File | Change |
+|------|--------|
+| `SeLe4n/Kernel/Architecture/Invariant.lean` | `registerDecodeConsistent` predicate |
+| `SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean` | Decode NI theorems |
+| `SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean` | New step constructors |
+| `SeLe4n/Kernel/InformationFlow/Projection.lean` | Projection updates |
+
+### Platform contracts
+| File | Change |
+|------|--------|
+| `SeLe4n/Platform/Sim/RuntimeContract.lean` | Type annotation updates |
+| `SeLe4n/Platform/Sim/ProofHooks.lean` | Type annotation updates |
+| `SeLe4n/Platform/RPi5/RuntimeContract.lean` | Type annotation updates |
+| `SeLe4n/Platform/RPi5/ProofHooks.lean` | Type annotation updates |
+
+### Test surfaces
+| File | Change |
+|------|--------|
+| `SeLe4n/Testing/MainTraceHarness.lean` | Register decode trace scenarios |
+| `tests/NegativeStateSuite.lean` | Decode error negative tests |
+| `tests/OperationChainSuite.lean` | Register-sourced chain tests |
+| `tests/fixtures/main_trace_smoke.expected` | Updated fixture |
+| `tests/fixtures/scenario_registry.yaml` | New scenario IDs |
 
 ### Documentation surfaces
-- `README.md`
-- `docs/DEVELOPMENT.md`
-- `docs/spec/SELE4N_SPEC.md`
-- `docs/WORKSTREAM_HISTORY.md`
-- `docs/CLAIM_EVIDENCE_INDEX.md`
-- `docs/gitbook/*` roadmap pages
+| File | Change |
+|------|--------|
+| `README.md` | Metrics sync |
+| `docs/DEVELOPMENT.md` | Baseline contracts |
+| `docs/spec/SELE4N_SPEC.md` | Architecture section |
+| `docs/WORKSTREAM_HISTORY.md` | WS-J1 entry |
+| `docs/CLAIM_EVIDENCE_INDEX.md` | Decode claims |
+| `docs/gitbook/03-architecture-and-module-map.md` | Module map |
+| `docs/gitbook/04-project-design-deep-dive.md` | Design section |
+| `docs/gitbook/05-specification-and-roadmap.md` | Milestone history |
+| `docs/gitbook/12-proof-and-invariant-map.md` | Theorem inventory |
 
 ---
 
 ## 7. Risk register and mitigations
 
-1. **Proof churn in large invariant files** (High)
-   - Mitigation: adopt WS-J1-A/B first with compatibility bridge; only then migrate call paths.
-2. **Namespace/model over-coupling** (Medium)
-   - Mitigation: keep resolver interface minimal and subsystem-neutral.
-3. **Trace fixture instability** (Medium)
-   - Mitigation: stage fixture updates in WS-J1-E with diff rationale.
-4. **Performance regressions in hot paths** (Low/Medium)
-   - Mitigation: use O(1) map lookup structures and avoid repeated decode passes.
+| # | Risk | Severity | Mitigation |
+|---|------|----------|------------|
+| 1 | **Proof churn from type change** — replacing `abbrev Nat` with wrapper structures will break every file that uses `RegName`/`RegValue` | High | WS-J1-A introduces types with zero behavior change; downstream fixes are mechanical. Compatibility `ofNat`/`toNat` conversions ease migration. |
+| 2 | **Scheduler preservation re-proof** — the `Preservation.lean` file (2170 lines) contains register-related proofs that must be re-proved | High | Read-after-write lemmas are re-proved first in WS-J1-A; scheduler proofs only need `simp` hint updates pointing to new wrapper lemmas. |
+| 3 | **Decode layer over-coupling** — making the decode layer subsystem-aware could create unwanted dependencies | Medium | `RegisterDecode.lean` depends only on `Machine.lean` and `Model/Object/Types.lean`. It does not import any kernel subsystem. Subsystems consume decoded results, not the decode module. |
+| 4 | **Trace fixture instability** — new trace scenarios change expected output | Medium | Fixture updates staged in WS-J1-E with explicit diff rationale. Determinism test (`test_tier2_determinism.sh`) catches non-deterministic output. |
+| 5 | **NI composition expansion** — adding `NonInterferenceStep` constructors requires re-proving `composedNonInterference_trace` | Medium | The decode path is pure and domain-local; NI proofs follow the existing per-constructor pattern with minimal new proof obligations. |
+| 6 | **`CdtNodeId` migration ripple** — wrapping `CdtNodeId` touches CDT operations in capability and lifecycle modules | Low | CDT operations use `CdtNodeId` as a HashMap key; the wrapper's `Hashable` instance makes this transparent. Migration is mechanical. |
 
 ---
 
 ## 8. Validation plan
 
-Minimum gate per slice:
+### Per-slice minimum gate
 
 ```bash
-./scripts/test_smoke.sh
+./scripts/test_smoke.sh   # Tier 0+1+2: hygiene + build + trace + negative
 ```
 
-Required for theorem/invariant slices:
+### Required for theorem/invariant slices (WS-J1-D)
 
 ```bash
-./scripts/test_full.sh
+./scripts/test_full.sh    # Tier 0-3: + invariant surface anchors
 ```
 
-Nightly confidence (optional when touching NI composition broadly):
+### Nightly confidence (optional for NI composition changes)
 
 ```bash
 NIGHTLY_ENABLE_EXPERIMENTAL=1 ./scripts/test_nightly.sh
 ```
 
-Additionally for this workstream:
-- Resolver property tests (success/failure determinism).
-- Cross-subsystem negative tests for namespace mismatch.
-- Trace scenario IDs for decode/resolve failures.
+### Workstream-specific validation
+
+| Category | Test |
+|----------|------|
+| Decode correctness | Round-trip lemmas for each decode function |
+| Decode determinism | `decodeSyscallArgs` produces identical results on identical inputs |
+| Error completeness | Every `KernelError` decode variant exercised by negative test |
+| Syscall soundness | `syscallEntry_requires_valid_decode` theorem |
+| Authority chain | `syscallEntry_implies_capability_held` theorem |
+| NI coverage | Decode-related `NonInterferenceStep` constructors in composition |
+| Fixture stability | `test_tier2_determinism.sh` double-run diff |
 
 ---
 
 ## 9. Completion evidence checklist
 
-- [ ] Typed register-namespace model merged with no `sorry`/`axiom`.
-- [ ] All authority-bearing register decode sites migrated.
-- [ ] Invariant and NI surfaces updated and passing.
-- [ ] Fixture updates (if any) justified and reviewed.
-- [ ] Canonical docs and GitBook mirrors synchronized.
+- [ ] `RegName` and `RegValue` are typed wrapper structures (not `abbrev Nat`)
+- [ ] Full instance suite: `DecidableEq`, `Hashable`, `LawfulHashable`,
+      `EquivBEq`, `LawfulBEq`, `Repr`, `ToString`
+- [ ] All 10 existing machine lemmas re-proved with typed registers
+- [ ] `RegisterDecode.lean` module merged with round-trip and determinism
+      lemmas (zero `sorry`/`axiom`)
+- [ ] `syscallEntry` wired through decode layer to `api*` wrappers
+- [ ] `syscallEntry` soundness theorems proved
+- [ ] `registerDecodeConsistent` invariant predicate added and preserved
+- [ ] NI theorems cover decode path via new `NonInterferenceStep` constructors
+- [ ] `CdtNodeId` converted to typed wrapper with full instance suite
+- [ ] Negative tests for every decode error path
+- [ ] Trace scenarios for register-sourced syscall execution
+- [ ] Fixtures updated with rationale
+- [ ] All canonical docs and GitBook mirrors synchronized
+- [ ] `./scripts/test_full.sh` passes
+- [ ] Zero `sorry`/`axiom` in production proof surface
 
 ---
 
-## 10. Relationship to WS-I5 Part A
+## 10. Relationship to prior work
 
-WS-I5 Part A intentionally documented the prior `abbrev Nat` choice as a
-low-risk simplification. WS-J1 supersedes that simplification for authority
-resolution paths by introducing typed, authoritative register namespace
-indexing while preserving deterministic semantics and proof ergonomics.
+### WS-I5 Part A (R-12)
 
-Both statements remain consistent:
-- WS-I5 Part A explains why the old model was reasonable at that stage.
-- WS-J1 defines the migration path now that deeper hardware-binding realism and
-  namespace authority modeling are priority.
+WS-I5 Part A documented the `abbrev Nat` choice as a deliberate
+simplification. WS-J1 supersedes that simplification by converting
+`RegName`/`RegValue` to typed wrappers and introducing the decode layer.
+The prior justification was valid at its stage — register types were internal
+to the abstract machine and did not cross authority boundaries. WS-J1
+changes this by making registers the authoritative source of syscall
+arguments, which requires type-level namespace discrimination.
+
+### WS-H12c (per-TCB register context)
+
+WS-H12c added `registerContext : RegisterFile` to TCB and proved
+`contextMatchesCurrent` (machine registers equal current thread's saved
+context). WS-J1 builds on this by reading syscall arguments from the
+same `registerContext`, making the WS-H12c invariant a prerequisite for
+decode correctness.
+
+### WS-H15c (syscall capability-checking wrappers)
+
+WS-H15c introduced `SyscallGate` and the `api*` wrappers. WS-J1 adds the
+missing layer *below* `SyscallGate` — the decode from raw registers into
+the typed parameters that construct a `SyscallGate`. The `api*` wrappers
+continue to serve as the internal kernel API; `syscallEntry` becomes the
+new user-space entry point.
+
+### WS-H14 (type safety and Prelude foundations)
+
+WS-H14 established the pattern for typed identifier instances (`EquivBEq`,
+`LawfulBEq`, `LawfulHashable`, roundtrip lemmas). WS-J1 follows this exact
+pattern for `RegName`, `RegValue`, and `CdtNodeId`.

--- a/docs/audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md
@@ -892,36 +892,40 @@ improvements that were deferred.
 **Dependencies**: None (fully independent)
 **Recommendations addressed**: R-12, R-13, R-14, R-17, R-18
 
-#### Part A: Document RegName/RegValue Design Decision (R-12)
+#### Part A: Replace RegName/RegValue with Typed Register Wrappers (R-12)
 
 **Problem**: `Machine.lean` defines `RegName` and `RegValue` as `abbrev Nat`
 (lines 14, 17), inconsistent with the typed-identifier convention used for all
-other identifiers (wrapper structures in `Prelude.lean`). The design decision
-is intentional but undocumented.
+other identifiers (wrapper structures in `Prelude.lean`). The original R-12
+recommendation was to *document* this as an intentional design decision.
 
-**Deliverables**:
+**Updated design decision**: After deeper audit (WS-J1 planning, v0.14.10+),
+the bare `Nat` approach was found to be insufficient. `RegName`/`RegValue` are
+the **only** `abbrev Nat` types that flow into authority-sensitive operations.
+The syscall API (`SyscallGate`) accepts pre-typed Lean parameters directly
+instead of extracting them from the machine register file, meaning the model
+omits the entire syscall argument decode path that real ARM64 hardware
+mandates. This is a modeling fidelity gap, not merely a documentation gap.
 
-1. Add a documentation comment block above lines 14–17 in `Machine.lean`:
-   ```lean
-   /-- Register names and values are intentionally defined as bare `Nat` aliases
-   (not wrapper structures like `ObjId`, `ThreadId`, etc.) for two reasons:
+**Superseded by**: WS-J1 (Register-Indexed Authoritative Namespaces), which:
+1. Replaces `RegName` and `RegValue` with typed wrapper structures matching
+   the `Prelude.lean` pattern (`DecidableEq`, `Hashable`, `LawfulHashable`,
+   `EquivBEq`, `LawfulBEq`, `Repr`, `ToString`, `ofNat`/`toNat`).
+2. Introduces a `RegisterDecode.lean` module providing total, deterministic
+   decode functions from raw register words to typed kernel references.
+3. Adds `syscallEntry` as a register-sourced syscall dispatch path, closing
+   the gap between the model and real hardware.
+4. Also wraps `CdtNodeId` (secondary bare-Nat alias) for consistency.
 
-   1. **Abstract machine simplicity**: The register file is a mathematical
-      function `RegName → RegValue` used only within `MachineState`. It never
-      interacts with kernel object identifiers, so the type-safety benefit of
-      wrapping is minimal while the syntactic overhead is significant.
+See [`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md)
+for the full workstream plan.
 
-   2. **Proof ergonomics**: Register read-after-write lemmas
-      (`readReg_writeReg_eq`, `readReg_writeReg_ne`) rely on `Nat` decidable
-      equality for `if r' = r then v else rf.gpr r'`. Wrapping would require
-      additional `DecidableEq` boilerplate with no safety improvement.
-
-   See `SeLe4n/Prelude.lean` for the project's typed-identifier convention and
-   the rationale for wrapping kernel-facing identifiers. -/
-   ```
-
-**Files modified**:
-- `SeLe4n/Machine.lean` — add documentation comment (~12 lines)
+**Files modified** (by WS-J1, not this workstream):
+- `SeLe4n/Machine.lean` — typed `RegName`/`RegValue` wrappers
+- `SeLe4n/Prelude.lean` — lawful instances
+- `SeLe4n/Kernel/Architecture/RegisterDecode.lean` — decode layer (new)
+- `SeLe4n/Kernel/API.lean` — `syscallEntry` dispatch
+- See WS-J1 plan for complete file impact map
 
 #### Part B: Information-Flow Architecture Readers' Guide (R-13)
 

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -46,9 +46,16 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
   - `OfNat` instances removed for type-safety enforcement (WS-H14e),
   - `Std.Data.HashMap` and `Std.Data.HashSet` imports.
 - `SeLe4n/Machine.lean`
-  - machine registers, memory abstraction, and pure update/read helpers,
-  - `MachineConfig` (register/address width, page size with `isPowerOfTwo` validation + correctness proof, ASID limit) and
-    `MemoryRegion`/`MemoryKind` for platform memory map declaration.
+  - machine registers (`RegName`, `RegValue` — currently `abbrev Nat`, planned
+    typed wrapper migration in WS-J1), memory abstraction, and pure update/read
+    helpers,
+  - `RegisterFile` with `pc`, `sp`, `gpr` fields; 10 read-after-write and frame
+    lemmas,
+  - `MachineConfig` (register/address width, page size with `isPowerOfTwo`
+    validation + correctness proof, ASID limit) and `MemoryRegion`/`MemoryKind`
+    for platform memory map declaration.
+  - **WS-J1 planned**: `SyscallRegisterLayout` for ARM64 register-to-argument
+    mapping, `MachineConfig.registerCount` for bounded register space.
 
 ### Model
 
@@ -156,6 +163,10 @@ determinism. See `Service/Operations.lean` for the full design rationale.
 - `SeLe4n/Kernel/Architecture/TlbModel.lean`
   - Abstract TLB model (`TlbEntry`, `TlbState`), flush operations (`adapterFlushTlb`, `adapterFlushTlbByAsid`, `adapterFlushTlbByVAddr`),
     `tlbConsistent` invariant with flush-restoration theorems, cross-ASID isolation proof.
+- `SeLe4n/Kernel/Architecture/RegisterDecode.lean` *(WS-J1 planned)*
+  - Total, deterministic decode functions from raw register words to typed kernel
+    references (`decodeCapPtr`, `decodeMsgInfo`, `decodeSyscallId`,
+    `decodeSyscallArgs`), round-trip lemmas, determinism theorem.
 - `SeLe4n/Kernel/Architecture/Invariant.lean`
   - `proofLayerInvariantBundle` connecting adapter assumptions to theorem-layer invariants,
     composed preservation hooks for success and failure paths.

--- a/docs/gitbook/04-project-design-deep-dive.md
+++ b/docs/gitbook/04-project-design-deep-dive.md
@@ -130,7 +130,35 @@ The `PlatformBinding` typeclass decouples kernel semantics from hardware:
 
 The simulation platform (`Platform/Sim/`) provides permissive contracts for testing. The RPi5 platform (`Platform/RPi5/`) provides substantive hardware-specific contracts (WS-H15b: SP-preservation register stability, GIC-400 IRQ range validation, MMIO disjointness proof, empty-initial-state boot checks). Both platforms provide concrete `AdapterProofHooks` instantiations (WS-H15d) grounding the adapter preservation chain end-to-end. Kernel logic is identical in both — only platform contracts differ.
 
-## 8. Testing: obligation-based coverage
+## 8. Syscall argument decode: register-sourced authority (WS-J1 planned)
+
+The current model passes syscall arguments as pre-typed Lean parameters directly
+to `api*` wrappers. Real ARM64 hardware delivers syscall arguments in
+general-purpose registers (x0–x7), and the kernel must decode these raw machine
+words into typed references before any authority check can proceed.
+
+WS-J1 addresses this modeling gap:
+
+1. **Typed register wrappers**: `RegName` and `RegValue` become wrapper
+   structures (matching the 13 existing typed identifiers in `Prelude.lean`)
+   instead of bare `Nat` abbreviations.
+2. **Register decode layer**: A new `RegisterDecode.lean` module provides total,
+   deterministic functions that convert raw register words into typed kernel
+   references (`CPtr`, `MessageInfo`, `SyscallId`).
+3. **Syscall entry point**: `syscallEntry` reads arguments from the current
+   thread's register context (via the `contextMatchesCurrent` invariant from
+   WS-H12c) and dispatches through the decode layer to `api*` wrappers.
+
+```
+User space → hardware trap → RegisterDecode.decodeSyscallArgs → syscallEntry
+    → SyscallGate → api* wrapper → internal kernel operation
+```
+
+The existing `api*` functions remain as the internal kernel API. `syscallEntry`
+models the user-space boundary where untrusted register values become trusted
+kernel references — exactly where real-world confusion attacks occur.
+
+## 9. Testing: obligation-based coverage
 
 seLe4n defines coverage as **obligation coverage**: every transition, error path, and invariant component must have both a theorem and a fixture witness.
 
@@ -143,7 +171,7 @@ seLe4n defines coverage as **obligation coverage**: every transition, error path
 
 Tier 3 is the key innovation: it checks that named theorems and definitions still exist after refactors. If you rename `chooseThread_preserves_schedulerInvariantBundle`, Tier 3 fails.
 
-## 9. Related chapters
+## 10. Related chapters
 
 - [Architecture & Module Map](03-architecture-and-module-map.md) — module responsibilities and dependency flow
 - [Kernel Performance Optimization](08-kernel-performance-optimization.md) — WS-G technical breakdown

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -20,7 +20,7 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 | Proved declarations | 1,086 theorem/lemma declarations (zero sorry/axiom) |
 | Total declarations | 2,006 across 70 modules |
 | Latest audit | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| Next workstreams | WS-J1 register-indexed authoritative namespaces (v0.14.10 plan); Raspberry Pi 5 hardware binding |
+| Next workstreams | WS-J1 register-indexed authoritative namespaces with typed wrappers, syscall decode layer, and `CdtNodeId` cleanup (v0.14.10 plan, 6 phases); Raspberry Pi 5 hardware binding |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | Metrics source of truth | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -1069,3 +1069,30 @@ structural properties rather than just symbol existence:
 - `runQueueThreadPriorityConsistent` definition and default theorem exist
 - `runWSH16LifecycleChecks` test function exists
 - `schedule` uses O(1) `runQueue` membership
+
+## 30. WS-J1 Register-indexed authoritative namespaces (planned)
+
+WS-J1 introduces a register decode layer and typed register wrappers,
+closing the gap between the abstract model and real ARM64 syscall argument
+delivery. See [`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md).
+
+**Planned proof surface:**
+
+- `decodeCapPtr_roundtrip` — decode ∘ encode = identity for CPtr values.
+- `decodeMsgInfo_roundtrip` — decode ∘ encode = identity for MessageInfo.
+- `decodeSyscallArgs_deterministic` — identical register inputs produce identical decode results.
+- `syscallEntry_requires_valid_decode` — successful syscall entry implies valid register decode.
+- `syscallEntry_implies_capability_held` — successful capability-gated syscall implies caller held required right (threads through `syscallInvoke_requires_right`).
+- `registerDecodeConsistent` — decoded register values index into valid kernel state.
+- `syscallEntry_preserves_proofLayerInvariantBundle` — success and error paths preserve top-level invariant.
+- Decode-related `NonInterferenceStep` constructors with NI preservation.
+
+**Planned types:**
+
+- `RegName` — typed wrapper structure (replacing `abbrev Nat`)
+- `RegValue` — typed wrapper structure (replacing `abbrev Nat`)
+- `SyscallId` — inductive covering modeled syscall set
+- `MessageInfo` — seL4 message-info word layout
+- `SyscallRegisterLayout` — ARM64 register-to-argument mapping
+- `SyscallDecodeResult` — decoded syscall arguments
+- `CdtNodeId` — typed wrapper structure (replacing `abbrev Nat`)

--- a/docs/gitbook/22-next-slice-development-path.md
+++ b/docs/gitbook/22-next-slice-development-path.md
@@ -70,9 +70,31 @@ addresses low-priority findings from the v0.12.2 audits:
 See [v0.12.2 Audit Remediation (WS-F)](24-comprehensive-audit-2026-workstream-planning.md)
 for the full execution plan.
 
-## After remaining workstreams: Raspberry Pi 5 binding (H3)
+## WS-J1: Register-indexed authoritative namespaces
 
-Once WS-F closes remaining proof and model gaps:
+The next high-priority workstream replaces `RegName`/`RegValue` bare `Nat`
+aliases with typed wrapper structures and introduces a syscall argument decode
+layer. This closes the modeling gap where the `api*` wrappers accept pre-typed
+Lean parameters instead of extracting arguments from the machine register file,
+as real ARM64 hardware does.
+
+Six phases:
+
+| Phase | Focus |
+|-------|-------|
+| **J1-A** | Typed `RegName`/`RegValue` wrappers + compatibility bridge |
+| **J1-B** | Register decode layer (`RegisterDecode.lean`) |
+| **J1-C** | `syscallEntry` dispatch + soundness theorems |
+| **J1-D** | Invariant and NI integration |
+| **J1-E** | Testing and trace evidence |
+| **J1-F** | `CdtNodeId` cleanup and documentation sync |
+
+See [`AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md)
+for the full workstream plan.
+
+## After WS-J1: Raspberry Pi 5 binding (H3)
+
+Once WS-J1 closes the register modeling gap:
 
 1. Populate RPi5 runtime contract with hardware-validated predicates.
 2. Implement ARMv8 multi-level page table walk as a `VSpaceBackend` instance.

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -56,7 +56,7 @@ enforcement, and scheduling.
 | **Total declarations** | 2,006 across 70 modules |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_CODEBASE_v0.13.6.md`](../audits/AUDIT_CODEBASE_v0.13.6.md) — zero critical issues |
-| **Next workstreams** | WS-J1 register-indexed authoritative namespaces (v0.14.10 plan) + Raspberry Pi 5 hardware binding |
+| **Next workstreams** | WS-J1 register-indexed authoritative namespaces with typed register wrappers, syscall decode layer, and `CdtNodeId` cleanup (v0.14.10 plan, 6 phases: J1-A through J1-F) + Raspberry Pi 5 hardware binding |
 | **Workstream history** | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |
 | **Metrics source of truth** | [`docs/codebase_map.json`](../../docs/codebase_map.json) (`readme_sync` key) |
 | **Codebase map** | `docs/codebase_map.json` (generated via `./scripts/generate_codebase_map.py --pretty`; validated with `--check`; auto-refreshed on `main` by `.github/workflows/codebase_map_sync.yml`) |
@@ -132,6 +132,7 @@ security model while introducing improvements that the Lean 4 proof framework en
 | **Information flow** | Binary high/low partition | Parameterized N-domain labels with per-endpoint flow policies |
 | **Scheduling** | Priority-based round-robin | Priority + EDF scheduling with dequeue-on-dispatch semantics, per-TCB register context with inline context switch, and domain-aware partitioning |
 | **Revocation** | Silent error swallowing | Strict variant (`cspaceRevokeCdtStrict`) reporting first failure with context |
+| **Syscall boundary** *(WS-J1 planned)* | C code extracts args from registers | Typed register wrappers + total decode layer with round-trip lemmas, determinism proof, and NI coverage |
 
 These are not abstract research extensions — they are design decisions that will be
 carried forward into the production kernel.


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced:** WS-J1 (Register-indexed authoritative namespaces) — comprehensive planning audit
- **Recommendation IDs closed:** R-12 (superseded with deeper analysis), R-13, R-14, R-17, R-18
- **Scope notes:** This is a planning and documentation PR. No source code changes to the kernel or proof surface. The diff updates the WS-J1 audit document with a complete design specification, work breakdown structure (6 phases), file impact map, risk register, and validation plan. Also synchronizes related documentation across canonical sources and GitBook mirrors.

## Changes overview

### Primary: WS-J1 audit document expansion

**`docs/audits/AUDIT_v0.14.10_REGISTER_NAMESPACE_WORKSTREAM_PLAN.md`** — expanded from ~270 to ~765 lines with:

1. **Problem analysis (§2):** Code-level audit findings identifying four gaps:
   - Bare `Nat` aliases for `RegName`/`RegValue` bypass type safety (inconsistent with 13 typed identifiers in `Prelude.lean`)
   - Syscall API bypasses machine register file entirely — no decode path modeled
   - Unbounded register space (infinite `Nat → Nat` function vs. bounded ARM64 GPRs)
   - `CdtNodeId` lacks typed wrapper and lawful instances

2. **Design specification (§3):** Detailed architecture including:
   - Design principles (register values as authoritative source, total/deterministic decode, typed identifiers at every boundary)
   - New core types: `RegName` (bounded register index), `RegValue` (machine word), `SyscallRegisterLayout`, `SyscallDecodeResult`, `MessageInfo`, `SyscallId`
   - Register decode layer (`RegisterDecode.lean` module) with total decode functions and round-trip lemmas
   - Syscall gate integration showing how `syscallEntry` reads from register file and routes to `api*` wrappers
   - Architecture diagram illustrating the decode path from user-space trap through typed kernel operations

3. **Work breakdown structure (§5):** Six independently reviewable phases (WS-J1-A through WS-J1-F):
   - **A:** Typed register wrappers + compatibility bridge (zero behavior change)
   - **B:** Register decode layer with round-trip lemmas
   - **C:** Syscall entry point and dispatch
   - **D:** Invariant and information-flow integration
   - **E:** Testing and trace evidence
   - **F:** `CdtNodeId` cleanup and documentation sync

4. **File impact map (§6):** Detailed table of 30+ files across core model, kernel subsystems, proof surfaces, platforms, and tests

5. **Risk register (§7):** Seven identified risks with mitigations (proof churn, scheduler preservation, decode coupling, fixture instability, NI composition, `CdtNodeId` ripple)

6. **Validation plan (§8):** Per-slice gates and workstream-specific validation criteria

7. **Completion evidence checklist (§9):** 14 concrete deliverables

8. **Relationship to prior work (§10):** Clarifies how WS-J1 supersedes WS-I5 Part A and builds on WS-H12c

### Secondary: Documentation synchronization

- **`docs/audits/AUDIT_v0.14.9_IMPROVEMENT_WORKSTREAM_PLAN.md`** — updated WS-I5 Part A recommendation to reflect WS-J1 supersession
- **`docs/gitbook/04-project-design-deep-dive.md`** — added §8 on syscall argument decode and WS-J1 planned work
- **`docs/gitbook/12-proof-and-invariant-map.md`** — added §30 with planned proof surface for WS-J1
- **`docs/gitbook/22-next-slice-development-path.md`** — added WS-J1 section with phase table and link to audit
- **`docs/WORKSTREAM_

https://claude.ai/code/session_01P9utfbYBhQJixHUVSmwuCe