### PR TITLE
refine(WS-K-G): deduplicate cspaceRevoke NI case via standalone theorem

### DIFF
--- a/SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Composition.lean
@@ -288,32 +288,7 @@ theorem step_preserves_projection
       · simp [projectMachineRegs, cspaceInsertSlot_preserves_scheduler st st' dst c hInsert,
               cspaceInsertSlot_preserves_machine st st' dst c hInsert]
   | cspaceRevoke addr hAddrH hOp =>
-    unfold cspaceRevoke at hOp
-    cases hL : cspaceLookupSlot addr st with
-    | error e => simp [hL] at hOp
-    | ok p =>
-      rcases p with ⟨par, stL⟩
-      have hEqL : stL = st := cspaceLookupSlot_preserves_state st stL addr par hL
-      subst stL
-      cases hC : st.objects[addr.cnode]? with
-      | none => simp [hL, hC] at hOp
-      | some obj =>
-        cases obj with
-        | tcb _ | endpoint _ | notification _ | vspaceRoot _ | untyped _ => simp [hL, hC] at hOp
-        | cnode cn =>
-          simp [hL, hC, storeObject] at hOp; cases hOp
-          rw [clearCapabilityRefsState_preserves_projectState]
-          simp only [projectState]; congr 1
-          · funext oid; by_cases hObs : objectObservable ctx observer oid
-            · simp [projectObjects, hObs]
-              have hNe : oid ≠ addr.cnode := by
-                intro hEq; subst hEq; simp [hAddrH] at hObs
-              simp [HashMap_getElem?_insert, Ne.symm hNe]
-            · simp [projectObjects, hObs]
-          · simp only [projectObjectIndex]
-            split
-            · rfl
-            · rw [List.filter_cons]; simp [hAddrH]
+    exact cspaceRevoke_preserves_projection ctx observer addr st st' hAddrH hOp
   | lifecycleRetype authority target newObj hTH hOp =>
     rcases lifecycleRetypeObject_ok_as_storeObject st st' authority target newObj hOp with
       ⟨_, _, _, _, _, _, hStore⟩

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/implement-type-proofs-GShUO",
-      "commit_sha": "7521f3de4e4cf673541a295ee65b53e25c057297",
-      "tree_sha": "e25b21b95daf6bff0da81c75cb591a2ec753b33f",
-      "committed_at_utc": "2026-03-15T02:47:26+00:00"
+      "commit_sha": "8126395df2aff8e1199a6e85e49d74115744b96c",
+      "tree_sha": "d2d319f7fecd73c4d75f0da7274bf657b1b2630b",
+      "committed_at_utc": "2026-03-15T03:13:08+00:00"
     }
   },
   "source_sync": {
@@ -17,7 +17,7 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "e26e7eb23be67f4f41aa7186219c698217c3d3a311ec2aa3a223b2fc41a0bda9"
+    "source_digest": "63b509695f460c6957be213f976e7a514a90a0bc9e1687acac977e57f21762dd"
   },
   "summary": {
     "module_count": 73,
@@ -27,7 +27,7 @@
     "version": "0.16.6",
     "lean_toolchain": "v4.28.0",
     "production_files": 69,
-    "production_loc": 36979,
+    "production_loc": 36954,
     "test_files": 4,
     "test_loc": 3755,
     "proved_theorem_lemma_decls": 1198,
@@ -6012,7 +6012,7 @@
         {
           "kind": "theorem",
           "name": "composedNonInterference_step",
-          "line": 518,
+          "line": 493,
           "called": [
             "NonInterferenceStep",
             "step_preserves_projection"
@@ -6021,7 +6021,7 @@
         {
           "kind": "inductive",
           "name": "NonInterferenceTrace",
-          "line": 530,
+          "line": 505,
           "called": [
             "NonInterferenceStep"
           ]
@@ -6029,7 +6029,7 @@
         {
           "kind": "theorem",
           "name": "trace_preserves_projection",
-          "line": 540,
+          "line": 515,
           "called": [
             "NonInterferenceTrace",
             "step_preserves_projection"
@@ -6038,7 +6038,7 @@
         {
           "kind": "theorem",
           "name": "composedNonInterference_trace",
-          "line": 551,
+          "line": 526,
           "called": [
             "NonInterferenceTrace",
             "trace_preserves_projection"
@@ -6047,19 +6047,19 @@
         {
           "kind": "theorem",
           "name": "declassifyStore_NI",
-          "line": 579,
+          "line": 554,
           "called": []
         },
         {
           "kind": "def",
           "name": "preservesLowEquivalence",
-          "line": 603,
+          "line": 578,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "compose_preservesLowEquivalence",
-          "line": 613,
+          "line": 588,
           "called": [
             "preservesLowEquivalence"
           ]
@@ -6067,7 +6067,7 @@
         {
           "kind": "theorem",
           "name": "errorAction_preserves_lowEquiv",
-          "line": 632,
+          "line": 607,
           "called": [
             "preservesLowEquivalence"
           ]
@@ -6075,7 +6075,7 @@
         {
           "kind": "theorem",
           "name": "syscallNI_coverage_witness",
-          "line": 670,
+          "line": 645,
           "called": [
             "NonInterferenceStep",
             "NonInterferenceTrace",


### PR DESCRIPTION
Replace 15-line inline cspaceRevoke proof in step_preserves_projection with single `exact cspaceRevoke_preserves_projection` call, reusing the standalone theorem added in Operations.lean. Regenerate codebase map.

https://claude.ai/code/session_01WrP1mw4TfaDrqbpvH5zABG

## Summary

- Workstream(s) advanced:
- Recommendation IDs closed:
- Scope notes:

## Validation evidence

- [ ] `./scripts/test_smoke.sh`
- [ ] `./scripts/test_full.sh`
- [ ] `./scripts/test_nightly.sh` (or justify omission)
- [ ] Targeted `rg -n` checks for new docs/anchors

## Documentation synchronization checklist (required)

- [ ] Canonical source docs updated first (`docs/*`, `docs/audits/*`)
- [ ] GitBook mirrors synchronized in the same PR (`docs/gitbook/*`)
- [ ] Generated navigation files refreshed (`scripts/generate_doc_navigation.py`)
- [ ] Markdown-link automation passed (`scripts/test_docs_sync.sh`)
- [ ] Active slice/workstream status synchronized across `README.md`, `docs/spec/SELE4N_SPEC.md`, `docs/DEVELOPMENT.md`, and `docs/gitbook/24-comprehensive-audit-2026-workstream-planning.md`
- [ ] Any deferrals explicitly linked to owning workstream

## Risks / follow-ups

- Residual risks:
- Deferred items + owning workstream:
