### PR TITLE
WS-L1: Eliminate 4 redundant TCB lookups on IPC hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.16.9] — IPC Performance Optimization (WS-L1)
+
+- Eliminated 4 redundant TCB lookups on IPC hot paths (L-P01, L-P02, L-P03)
+- Changed `endpointQueuePopHead` return type to `(ThreadId × TCB × SystemState)`,
+  providing pre-dequeue TCB to callers (L1-A)
+- Added `storeTcbIpcStateAndMessage_fromTcb` and `storeTcbIpcState_fromTcb`
+  variants with equivalence theorems — zero new preservation lemmas needed (L1-B, L1-C)
+- Added `lookupTcb_preserved_by_storeObject_notification` helper for cross-store
+  TCB stability
+- Updated all transport lemmas and preservation theorems for new PopHead return type
+  (~18 mechanical pattern-match updates across 6 invariant files)
+- Refined WS-L1 workstream plan with smaller task units and optimal implementation
+  strategy (equivalence-theorem approach vs. duplicated lemmas)
+- Regenerated `docs/codebase_map.json`
+- Bumped `lakefile.toml` version to 0.16.9
+- Zero sorry/axiom; all proofs machine-checked; test_full.sh passes
+
 ## [0.16.8] — Documentation Sync and Workstream Closeout (WS-K-H)
 
 - Synchronized all project documentation with completed WS-K implementation

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.16.8-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.16.9-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -57,11 +57,11 @@ architectural improvements compared to other microkernels:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.16.8` |
+| **Version** | `0.16.9` |
 | **Lean toolchain** | `v4.28.0` |
-| **Production Lean LoC** | 37,245 across 69 files |
+| **Production Lean LoC** | 37,217 across 69 files |
 | **Test Lean LoC** | 4,098 across 4 test suites |
-| **Proved declarations** | 1,198 theorem/lemma declarations (zero sorry/axiom) |
+| **Proved declarations** | 1,202 theorem/lemma declarations (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md) — IPC subsystem end-to-end audit |
 | **Codebase map** | [`docs/codebase_map.json`](docs/codebase_map.json) — machine-readable declaration inventory |

--- a/SeLe4n/Kernel/Capability/Invariant/Authority.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Authority.lean
@@ -454,6 +454,8 @@ theorem notificationWait_recovers_pending_badge
                   | error e => simp
                   | ok pair =>
                       simp only []
+                      have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hObj hStore
+                      simp only [storeTcbIpcState_fromTcb_eq hLk']
                       intro hWait
                       revert hWait
                       cases storeTcbIpcState pair.2 waiter _ with

--- a/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
@@ -798,6 +798,7 @@ theorem endpointReply_preserves_capabilityInvariantBundle
   | none => simp [hLookup] at hStep
   | some tcb =>
       simp only [hLookup] at hStep
+      rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
       cases hIpc : tcb.ipcState with
       | ready => simp [hIpc] at hStep
       | blockedOnSend _ => simp [hIpc] at hStep

--- a/SeLe4n/Kernel/IPC/DualQueue/Core.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue/Core.lean
@@ -169,10 +169,13 @@ theorem storeTcbQueueLinks_tcb_forward
         exact ⟨_, storeObject_objects_eq st pair.2 tid.toObjId _ hStore⟩
   · exact ⟨tcb, by rw [storeTcbQueueLinks_preserves_objects_ne st st' tid prev pprev next oid hEq hStep]; exact hTcb⟩
 
+-- WS-L1/L1-A: Return type includes pre-dequeue TCB. Non-queue fields
+-- (ipcState, pendingMessage, priority, domain) are accurate; queue link
+-- fields (queuePrev, queuePPrev, queueNext) are stale (cleared in post-state).
 def endpointQueuePopHead
     (endpointId : SeLe4n.ObjId)
     (isReceiveQ : Bool)
-    (st : SystemState) : Except KernelError (SeLe4n.ThreadId × SystemState) :=
+    (st : SystemState) : Except KernelError (SeLe4n.ThreadId × TCB × SystemState) :=
   match st.objects[endpointId]? with
   | some (.endpoint ep) =>
       let q := if isReceiveQ then ep.receiveQ else ep.sendQ
@@ -203,7 +206,7 @@ def endpointQueuePopHead
                   | .ok st2 =>
                       match storeTcbQueueLinks st2 tid none none none with
                       | .error e => .error e
-                      | .ok st3 => .ok (tid, st3)
+                      | .ok st3 => .ok (tid, headTcb, st3)
   | some _ => .error .invalidCapability
   | none => .error .objectNotFound
 

--- a/SeLe4n/Kernel/IPC/DualQueue/Transport.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue/Transport.lean
@@ -20,7 +20,7 @@ open SeLe4n.Model
 theorem endpointQueuePopHead_scheduler_eq
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st st' : SystemState)
     (tid : SeLe4n.ThreadId)
-    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st')) :
+    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st')) :
     st'.scheduler = st.scheduler := by
   unfold endpointQueuePopHead at hStep
   cases hObj : st.objects[endpointId]? with
@@ -46,7 +46,7 @@ theorem endpointQueuePopHead_scheduler_eq
               | error e => simp
               | ok st3 =>
                 simp only [Except.ok.injEq, Prod.mk.injEq]
-                intro ⟨_, hEq⟩; subst hEq
+                intro ⟨_, _, hEq⟩; subst hEq
                 exact (storeTcbQueueLinks_scheduler_eq _ _ headTid none none none hFinal).trans
                   (storeObject_scheduler_eq _ _ endpointId _ hStore)
             | some nextTid =>
@@ -63,7 +63,7 @@ theorem endpointQueuePopHead_scheduler_eq
                   | error e => simp
                   | ok st3 =>
                     simp only [Except.ok.injEq, Prod.mk.injEq]
-                    intro ⟨_, hEq⟩; subst hEq
+                    intro ⟨_, _, hEq⟩; subst hEq
                     exact (storeTcbQueueLinks_scheduler_eq _ _ headTid none none none hFinal).trans
                       ((storeTcbQueueLinks_scheduler_eq _ _ nextTid none (some QueuePPrev.endpointHead) nextTcb.queueNext hLink).trans
                         (storeObject_scheduler_eq _ _ endpointId _ hStore))
@@ -73,7 +73,7 @@ theorem endpointQueuePopHead_endpoint_backward_ne
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st st' : SystemState)
     (tid : SeLe4n.ThreadId) (oid : SeLe4n.ObjId) (ep : Endpoint)
     (hNe : oid ≠ endpointId)
-    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st'))
+    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st'))
     (hEp : st'.objects[oid]? = some (.endpoint ep)) :
     st.objects[oid]? = some (.endpoint ep) := by
   unfold endpointQueuePopHead at hStep
@@ -100,7 +100,7 @@ theorem endpointQueuePopHead_endpoint_backward_ne
               | error e => simp
               | ok st3 =>
                 simp only [Except.ok.injEq, Prod.mk.injEq]
-                intro ⟨_, hEq⟩; subst hEq
+                intro ⟨_, _, hEq⟩; subst hEq
                 have h1 := storeTcbQueueLinks_endpoint_backward _ _ headTid none none none oid ep hFinal hEp
                 rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at h1
             | some nextTid =>
@@ -117,7 +117,7 @@ theorem endpointQueuePopHead_endpoint_backward_ne
                   | error e => simp
                   | ok st3 =>
                     simp only [Except.ok.injEq, Prod.mk.injEq]
-                    intro ⟨_, hEq⟩; subst hEq
+                    intro ⟨_, _, hEq⟩; subst hEq
                     have h3 := storeTcbQueueLinks_endpoint_backward _ _ headTid none none none oid ep hFinal hEp
                     have h2 := storeTcbQueueLinks_endpoint_backward _ _ nextTid none (some QueuePPrev.endpointHead) nextTcb.queueNext oid ep hLink h3
                     rwa [storeObject_objects_ne st pair.2 endpointId oid _ hNe hStore] at h2
@@ -126,7 +126,7 @@ theorem endpointQueuePopHead_endpoint_backward_ne
 theorem endpointQueuePopHead_notification_backward
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st st' : SystemState)
     (tid : SeLe4n.ThreadId) (oid : SeLe4n.ObjId) (ntfn : Notification)
-    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st'))
+    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st'))
     (hNtfn : st'.objects[oid]? = some (.notification ntfn)) :
     st.objects[oid]? = some (.notification ntfn) := by
   unfold endpointQueuePopHead at hStep
@@ -153,7 +153,7 @@ theorem endpointQueuePopHead_notification_backward
               | error e => simp
               | ok st3 =>
                 simp only [Except.ok.injEq, Prod.mk.injEq]
-                intro ⟨_, hEq⟩; subst hEq
+                intro ⟨_, _, hEq⟩; subst hEq
                 have h1 := storeTcbQueueLinks_notification_backward _ _ headTid none none none oid ntfn hFinal hNtfn
                 by_cases hEqId : oid = endpointId
                 · subst hEqId; rw [storeObject_objects_eq st pair.2 oid _ hStore] at h1; cases h1
@@ -172,7 +172,7 @@ theorem endpointQueuePopHead_notification_backward
                   | error e => simp
                   | ok st3 =>
                     simp only [Except.ok.injEq, Prod.mk.injEq]
-                    intro ⟨_, hEq⟩; subst hEq
+                    intro ⟨_, _, hEq⟩; subst hEq
                     have h3 := storeTcbQueueLinks_notification_backward _ _ headTid none none none oid ntfn hFinal hNtfn
                     have h2 := storeTcbQueueLinks_notification_backward _ _ nextTid none (some QueuePPrev.endpointHead) nextTcb.queueNext oid ntfn hLink h3
                     by_cases hEqId : oid = endpointId
@@ -184,7 +184,7 @@ at oid in the pre-state, some TCB exists at oid in the post-state. -/
 theorem endpointQueuePopHead_tcb_forward
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st st' : SystemState)
     (tid : SeLe4n.ThreadId) (oid : SeLe4n.ObjId) (tcb : TCB)
-    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st'))
+    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st'))
     (hTcb : st.objects[oid]? = some (.tcb tcb)) :
     ∃ tcb', st'.objects[oid]? = some (.tcb tcb') := by
   unfold endpointQueuePopHead at hStep
@@ -216,7 +216,7 @@ theorem endpointQueuePopHead_tcb_forward
               | error e => simp
               | ok st3 =>
                 simp only [Except.ok.injEq, Prod.mk.injEq]
-                intro ⟨_, hEq⟩; subst hEq
+                intro ⟨_, _, hEq⟩; subst hEq
                 exact storeTcbQueueLinks_tcb_forward pair.2 st3 headTid none none none oid tcb hFinal hTcb1
             | some nextTid =>
               simp only []
@@ -233,7 +233,7 @@ theorem endpointQueuePopHead_tcb_forward
                   | error e => simp
                   | ok st3 =>
                     simp only [Except.ok.injEq, Prod.mk.injEq]
-                    intro ⟨_, hEq⟩; subst hEq
+                    intro ⟨_, _, hEq⟩; subst hEq
                     exact storeTcbQueueLinks_tcb_forward st2 st3 headTid none none none oid tcb2 hFinal hTcb2
 
 /-- WS-F1: endpointQueuePopHead backward-preserves TCB ipcStates. For any TCB
@@ -241,7 +241,7 @@ in the post-state, a TCB with the same ipcState exists in the pre-state. -/
 theorem endpointQueuePopHead_tcb_ipcState_backward
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st st' : SystemState)
     (tid : SeLe4n.ThreadId) (anyTid : SeLe4n.ThreadId) (tcb' : TCB)
-    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st'))
+    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st'))
     (hTcb' : st'.objects[anyTid.toObjId]? = some (.tcb tcb')) :
     ∃ tcb, st.objects[anyTid.toObjId]? = some (.tcb tcb) ∧ tcb.ipcState = tcb'.ipcState := by
   unfold endpointQueuePopHead at hStep
@@ -270,7 +270,7 @@ theorem endpointQueuePopHead_tcb_ipcState_backward
               | error e => simp
               | ok st3 =>
                 simp only [Except.ok.injEq, Prod.mk.injEq]
-                intro ⟨_, hEq⟩; subst hEq
+                intro ⟨_, _, hEq⟩; subst hEq
                 obtain ⟨tcb1, hTcb1, hIpc1⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ headTid none none none hFinal anyTid tcb' hTcb'
                 by_cases hEqEp : anyTid.toObjId = endpointId
                 · rw [hEqEp] at hTcb1; rw [storeObject_objects_eq st pair.2 endpointId _ hStore] at hTcb1; cases hTcb1
@@ -290,7 +290,7 @@ theorem endpointQueuePopHead_tcb_ipcState_backward
                   | error e => simp
                   | ok st3 =>
                     simp only [Except.ok.injEq, Prod.mk.injEq]
-                    intro ⟨_, hEq⟩; subst hEq
+                    intro ⟨_, _, hEq⟩; subst hEq
                     obtain ⟨tcb2, hTcb2, hIpc2⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ headTid none none none hFinal anyTid tcb' hTcb'
                     obtain ⟨tcb1, hTcb1, hIpc1⟩ := storeTcbQueueLinks_tcb_ipcState_backward _ _ nextTid _ _ _ hLink anyTid tcb2 hTcb2
                     by_cases hEqEp : anyTid.toObjId = endpointId
@@ -1305,9 +1305,10 @@ def endpointSendDual (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
     | some (.endpoint ep) =>
         match ep.receiveQ.head with
         | some _ =>
+            -- WS-L1/L1-A: PopHead now returns (ThreadId × TCB × SystemState)
             match endpointQueuePopHead endpointId true st with
             | .error e => .error e
-            | .ok (receiver, st') =>
+            | .ok (receiver, _tcb, st') =>
                 -- WS-F1: Transfer message to receiver and unblock
                 match storeTcbIpcStateAndMessage st' receiver .ready (some msg) with
                 | .error e => .error e
@@ -1346,17 +1347,17 @@ def endpointReceiveDual (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
     | some (.endpoint ep) =>
         match ep.sendQ.head with
         | some _ =>
+            -- WS-L1/L1-A: PopHead returns pre-dequeue TCB; read fields directly
             match endpointQueuePopHead endpointId false st with
             | .error e => .error e
-            | .ok (sender, st') =>
-                -- WS-F1/WS-H1: Extract message and IPC state from sender's TCB in a single lookup.
-                -- blockedOnCall → blockedOnReply (caller stays blocked awaiting reply)
-                -- blockedOnSend → ready (plain send, unblock sender)
-                let (senderMsg, senderWasCall) := match lookupTcb st' sender with
-                  | some tcb => (tcb.pendingMessage, match tcb.ipcState with
+            | .ok (sender, senderTcb, st') =>
+                -- WS-L1/L1-A: Read pendingMessage and ipcState directly from
+                -- returned TCB instead of redundant lookupTcb. These fields are
+                -- unchanged by PopHead (only queue links are modified).
+                let (senderMsg, senderWasCall) :=
+                  (senderTcb.pendingMessage, match senderTcb.ipcState with
                     | .blockedOnCall _ => true
                     | _ => false)
-                  | none => (none, false)
                 if senderWasCall then
                   -- Call path: sender transitions to blockedOnReply, NOT ready
                   match storeTcbIpcStateAndMessage st' sender
@@ -1409,9 +1410,10 @@ def endpointCall (endpointId : SeLe4n.ObjId) (caller : SeLe4n.ThreadId)
     | some (.endpoint ep) =>
         match ep.receiveQ.head with
         | some _ =>
+            -- WS-L1/L1-A: PopHead now returns (ThreadId × TCB × SystemState)
             match endpointQueuePopHead endpointId true st with
             | .error e => .error e
-            | .ok (receiver, st') =>
+            | .ok (receiver, _tcb, st') =>
                 -- WS-F1: Transfer message to receiver and unblock
                 match storeTcbIpcStateAndMessage st' receiver .ready (some msg) with
                 | .error e => .error e
@@ -1458,7 +1460,8 @@ def endpointReply (replier : SeLe4n.ThreadId) (target : SeLe4n.ThreadId)
               | some expected => replier == expected
               | none => true
             if authorized then
-              match storeTcbIpcStateAndMessage st target .ready (some msg) with
+              -- WS-L1/L1-B: Use _fromTcb to avoid redundant lookupTcb on same state
+              match storeTcbIpcStateAndMessage_fromTcb st target tcb .ready (some msg) with
               | .error e => .error e
               | .ok st' => .ok ((), ensureRunnable st' target)
             else .error .replyCapInvalid
@@ -1488,8 +1491,8 @@ def endpointReplyRecv
               | some expected => receiver == expected
               | none => true
             if authorized then
-              -- WS-F1: Deliver reply message and unblock target
-              match storeTcbIpcStateAndMessage st replyTarget .ready (some msg) with
+              -- WS-L1/L1-B: Use _fromTcb to avoid redundant lookupTcb on same state
+              match storeTcbIpcStateAndMessage_fromTcb st replyTarget tcb .ready (some msg) with
               | .error e => .error e
               | .ok st' =>
                   let st'' := ensureRunnable st' replyTarget

--- a/SeLe4n/Kernel/IPC/Invariant/CallReplyRecv.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/CallReplyRecv.lean
@@ -51,12 +51,12 @@ theorem endpointCall_preserves_ipcInvariant
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hInv1 := endpointQueuePopHead_preserves_ipcInvariant endpointId true st pair.2 pair.1 hInv hPop
-          cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          have hInv1 := endpointQueuePopHead_preserves_ipcInvariant endpointId true st pair.2.2 pair.1 hInv hPop
+          cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hMsg] at hStep
           | ok st2 =>
             simp only [hMsg] at hStep
-            have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2 st2 pair.1 .ready (some msg) hInv1 hMsg
+            have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2.2 st2 pair.1 .ready (some msg) hInv1 hMsg
             have hInv3 : ipcInvariant (ensureRunnable st2 pair.1) :=
               fun oid ntfn h => hInv2 oid ntfn (by rwa [ensureRunnable_preserves_objects] at h)
             cases hIpc : storeTcbIpcState (ensureRunnable st2 pair.1) caller (.blockedOnReply endpointId (some pair.1)) with
@@ -109,12 +109,12 @@ theorem endpointCall_preserves_schedulerInvariantBundle
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2 pair.1 hPop
-          cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2.2 pair.1 hPop
+          cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hMsg] at hStep
           | ok st2 =>
             simp only [hMsg] at hStep
-            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready (some msg) hMsg
+            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg
             cases hIpc : storeTcbIpcState (ensureRunnable st2 pair.1) caller (.blockedOnReply endpointId (some pair.1)) with
             | error e => simp [hIpc] at hStep
             | ok st4 =>
@@ -137,7 +137,7 @@ theorem endpointCall_preserves_schedulerInvariantBundle
                     have hNotMem : x ∉ st.scheduler.runnable := by
                       have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
                     have hNePair : x ≠ pair.1 := by
-                      have hHeadEq := endpointQueuePopHead_returns_head endpointId true st ep pair.1 pair.2 hObj hPop
+                      have hHeadEq := endpointQueuePopHead_returns_head endpointId true st ep pair.1 pair.2.2 hObj hPop
                       simp at hHeadEq
                       intro hEq; rw [hEq] at hCurr
                       have := hCurrNotHead; simp [currentNotEndpointQueueHead, hCurr] at this
@@ -164,14 +164,14 @@ theorem endpointCall_preserves_schedulerInvariantBundle
                     have hCTV' : ∃ tcb', st.objects[x.toObjId]? = some (.tcb tcb') := by
                       simp [currentThreadValid, hCurr] at hCTV; exact hCTV
                     rcases hCTV' with ⟨tcbX, hTcbX⟩
-                    obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId true st pair.2 pair.1 x.toObjId tcbX hPop hTcbX
+                    obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId true st pair.2.2 pair.1 x.toObjId tcbX hPop hTcbX
                     have hNeCaller : x.toObjId ≠ caller.toObjId := fun h => hEq' (threadId_toObjId_injective h)
                     have hTcb2 : ∃ tcb2, st2.objects[x.toObjId]? = some (.tcb tcb2) := by
                       by_cases hNeTid : x.toObjId = pair.1.toObjId
-                      · have hTargetTcb : ∃ t, pair.2.objects[pair.1.toObjId]? = some (.tcb t) := hNeTid ▸ ⟨tcb1, hTcb1⟩
-                        have h := storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2 st2 pair.1 .ready (some msg) hMsg hTargetTcb
+                      · have hTargetTcb : ∃ t, pair.2.2.objects[pair.1.toObjId]? = some (.tcb t) := hNeTid ▸ ⟨tcb1, hTcb1⟩
+                        have h := storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2.2 st2 pair.1 .ready (some msg) hMsg hTargetTcb
                         rwa [← hNeTid] at h
-                      · exact ⟨tcb1, (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) x.toObjId hNeTid hMsg) ▸ hTcb1⟩
+                      · exact ⟨tcb1, (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) x.toObjId hNeTid hMsg) ▸ hTcb1⟩
                     rcases hTcb2 with ⟨tcb2, hTcb2⟩
                     exact ⟨tcb2, by rw [storeTcbIpcState_preserves_objects_ne _ st4 caller _ x.toObjId hNeCaller hIpc, ensureRunnable_preserves_objects]; exact hTcb2⟩
       | none =>
@@ -246,15 +246,15 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2 pair.1 hPop
-          have hContractPop := contracts_of_same_scheduler_ipcState st pair.2 hSchedPop
-            (fun tid tcb' h => endpointQueuePopHead_tcb_ipcState_backward endpointId true st pair.2 pair.1 tid tcb' hPop h)
+          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2.2 pair.1 hPop
+          have hContractPop := contracts_of_same_scheduler_ipcState st pair.2.2 hSchedPop
+            (fun tid tcb' h => endpointQueuePopHead_tcb_ipcState_backward endpointId true st pair.2.2 pair.1 tid tcb' hPop h)
             ⟨hReady, hBlockSend, hBlockRecv, hBlockCall, hBlockReply, hBlockNotif⟩
-          cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hMsg] at hStep
           | ok st2 =>
             simp only [hMsg] at hStep
-            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready (some msg) hMsg
+            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg
             cases hIpc : storeTcbIpcState (ensureRunnable st2 pair.1) caller (.blockedOnReply endpointId (some pair.1)) with
             | error e => simp [hIpc] at hStep
             | ok st4 =>
@@ -271,13 +271,13 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
                 · have hNeCallerObjId : tid.toObjId ≠ caller.toObjId := fun h => hNeCaller (threadId_toObjId_injective h)
                   rw [storeTcbIpcState_preserves_objects_ne _ st4 caller _ tid.toObjId hNeCallerObjId hIpc, ensureRunnable_preserves_objects] at hTcb'
                   by_cases hNeRecv : tid.toObjId = pair.1.toObjId
-                  · exact storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
-                  · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
+                  · exact storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
+                  · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
                     have hNeTid : tid ≠ pair.1 := fun h => hNeRecv (congrArg ThreadId.toObjId h)
                     have ⟨hRunSt4, _⟩ := (removeRunnable_runnable_mem st4 caller tid).mp hRun'
                     rw [congrArg SchedulerState.runnable hSchedIpc] at hRunSt4
                     rcases ensureRunnable_mem_reverse st2 pair.1 tid hRunSt4 with hOld | hEq
-                    · exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                    · exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                     · exact absurd hEq hNeTid
               · -- blockedOnSendNotRunnable
                 intro tid tcb' eid hTcb' hIpcState'
@@ -287,15 +287,15 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
                 · have hNeCallerObjId : tid.toObjId ≠ caller.toObjId := fun h => hNeCaller (threadId_toObjId_injective h)
                   rw [storeTcbIpcState_preserves_objects_ne _ st4 caller _ tid.toObjId hNeCallerObjId hIpc, ensureRunnable_preserves_objects] at hTcb'
                   by_cases hNeRecv : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
+                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
                     rw [this] at hIpcState'; cases hIpcState'
                   · have hNeTid : tid ≠ pair.1 := fun h => hNeRecv (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
+                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
                     intro hRun'
                     have ⟨hRunSt4, _⟩ := (removeRunnable_runnable_mem st4 caller tid).mp hRun'
                     rw [congrArg SchedulerState.runnable hSchedIpc] at hRunSt4
                     rcases ensureRunnable_mem_reverse st2 pair.1 tid hRunSt4 with hOld | hEq
-                    · exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                    · exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                     · exact absurd hEq hNeTid
               · -- blockedOnReceiveNotRunnable
                 intro tid tcb' eid hTcb' hIpcState'
@@ -305,15 +305,15 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
                 · have hNeCallerObjId : tid.toObjId ≠ caller.toObjId := fun h => hNeCaller (threadId_toObjId_injective h)
                   rw [storeTcbIpcState_preserves_objects_ne _ st4 caller _ tid.toObjId hNeCallerObjId hIpc, ensureRunnable_preserves_objects] at hTcb'
                   by_cases hNeRecv : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
+                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
                     rw [this] at hIpcState'; cases hIpcState'
                   · have hNeTid : tid ≠ pair.1 := fun h => hNeRecv (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
+                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
                     intro hRun'
                     have ⟨hRunSt4, _⟩ := (removeRunnable_runnable_mem st4 caller tid).mp hRun'
                     rw [congrArg SchedulerState.runnable hSchedIpc] at hRunSt4
                     rcases ensureRunnable_mem_reverse st2 pair.1 tid hRunSt4 with hOld | hEq
-                    · exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                    · exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                     · exact absurd hEq hNeTid
               · -- blockedOnCallNotRunnable
                 intro tid tcb' eid hTcb' hIpcState'
@@ -323,15 +323,15 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
                 · have hNeCallerObjId : tid.toObjId ≠ caller.toObjId := fun h => hNeCaller (threadId_toObjId_injective h)
                   rw [storeTcbIpcState_preserves_objects_ne _ st4 caller _ tid.toObjId hNeCallerObjId hIpc, ensureRunnable_preserves_objects] at hTcb'
                   by_cases hNeRecv : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
+                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
                     rw [this] at hIpcState'; cases hIpcState'
                   · have hNeTid : tid ≠ pair.1 := fun h => hNeRecv (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
+                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
                     intro hRun'
                     have ⟨hRunSt4, _⟩ := (removeRunnable_runnable_mem st4 caller tid).mp hRun'
                     rw [congrArg SchedulerState.runnable hSchedIpc] at hRunSt4
                     rcases ensureRunnable_mem_reverse st2 pair.1 tid hRunSt4 with hOld | hEq
-                    · exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                    · exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                     · exact absurd hEq hNeTid
               · -- blockedOnReplyNotRunnable
                 intro tid tcb' eid rt hTcb' hIpcState'
@@ -341,15 +341,15 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
                 · have hNeCallerObjId : tid.toObjId ≠ caller.toObjId := fun h => hNeCaller (threadId_toObjId_injective h)
                   rw [storeTcbIpcState_preserves_objects_ne _ st4 caller _ tid.toObjId hNeCallerObjId hIpc, ensureRunnable_preserves_objects] at hTcb'
                   by_cases hNeRecv : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
+                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
                     rw [this] at hIpcState'; cases hIpcState'
                   · have hNeTid : tid ≠ pair.1 := fun h => hNeRecv (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
+                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
                     intro hRun'
                     have ⟨hRunSt4, _⟩ := (removeRunnable_runnable_mem st4 caller tid).mp hRun'
                     rw [congrArg SchedulerState.runnable hSchedIpc] at hRunSt4
                     rcases ensureRunnable_mem_reverse st2 pair.1 tid hRunSt4 with hOld | hEq
-                    · exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                    · exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                     · exact absurd hEq hNeTid
               · -- blockedOnNotificationNotRunnable (WS-F6/D2)
                 intro tid tcb' nid hTcb' hIpcState'
@@ -359,15 +359,15 @@ theorem endpointCall_preserves_ipcSchedulerContractPredicates
                 · have hNeCallerObjId : tid.toObjId ≠ caller.toObjId := fun h => hNeCaller (threadId_toObjId_injective h)
                   rw [storeTcbIpcState_preserves_objects_ne _ st4 caller _ tid.toObjId hNeCallerObjId hIpc, ensureRunnable_preserves_objects] at hTcb'
                   by_cases hNeRecv : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
+                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNeRecv ▸ hTcb')
                     rw [this] at hIpcState'; cases hIpcState'
                   · have hNeTid : tid ≠ pair.1 := fun h => hNeRecv (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
+                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNeRecv hMsg).symm.trans hTcb'
                     intro hRun'
                     have ⟨hRunSt4, _⟩ := (removeRunnable_runnable_mem st4 caller tid).mp hRun'
                     rw [congrArg SchedulerState.runnable hSchedIpc] at hRunSt4
                     rcases ensureRunnable_mem_reverse st2 pair.1 tid hRunSt4 with hOld | hEq
-                    · exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                    · exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                     · exact absurd hEq hNeTid
       | none =>
         -- Blocking: Enqueue → storeTcbIpcStateAndMessage → removeRunnable (same as SendDual blocking)
@@ -470,7 +470,7 @@ theorem endpointCall_blocked_stays_blocked
         | error e => simp [hPop] at hStep
         | ok pair =>
           simp only [hPop] at hStep
-          cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hMsg] at hStep
           | ok st'' =>
             simp only [hMsg] at hStep
@@ -512,6 +512,7 @@ theorem endpointReplyRecv_preserves_ipcInvariant
   | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
+    rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
     cases hIpc : tcb.ipcState with
     | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnCall _ =>
       simp [hIpc] at hStep
@@ -573,6 +574,7 @@ theorem endpointReplyRecv_preserves_schedulerInvariantBundle
   | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
+    rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
     cases hIpc : tcb.ipcState with
     | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnCall _ =>
       simp [hIpc] at hStep
@@ -681,6 +683,7 @@ theorem endpointReplyRecv_preserves_ipcSchedulerContractPredicates
   | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
+    rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
     cases hIpc : tcb.ipcState with
     | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnCall _ =>
       simp [hIpc] at hStep
@@ -808,6 +811,7 @@ theorem endpointReply_preserves_ipcSchedulerContractPredicates
   | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
+    rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
     cases hIpc : tcb.ipcState with
     | ready => simp [hIpc] at hStep
     | blockedOnSend _ => simp [hIpc] at hStep

--- a/SeLe4n/Kernel/IPC/Invariant/Defs.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Defs.lean
@@ -296,7 +296,7 @@ theorem endpointQueuePopHead_returns_head
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st : SystemState)
     (ep : Endpoint) (tid : SeLe4n.ThreadId) (st' : SystemState)
     (hObj : st.objects[endpointId]? = some (.endpoint ep))
-    (hPop : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st')) :
+    (hPop : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st')) :
     (if isReceiveQ then ep.receiveQ else ep.sendQ).head = some tid := by
   unfold endpointQueuePopHead at hPop
   rw [hObj] at hPop; simp only at hPop
@@ -320,7 +320,7 @@ theorem endpointQueuePopHead_returns_head
           | error e => simp
           | ok st3 =>
             simp only [Except.ok.injEq, Prod.mk.injEq]
-            rintro ⟨rfl, _⟩; rfl
+            rintro ⟨rfl, _, _⟩; rfl
         | some nextTid =>
           simp only []
           cases hLkNext : lookupTcb pair.2 nextTid with
@@ -335,8 +335,56 @@ theorem endpointQueuePopHead_returns_head
               | error e => simp
               | ok st3 =>
                 simp only [Except.ok.injEq, Prod.mk.injEq]
-                rintro ⟨rfl, _⟩; rfl
+                rintro ⟨rfl, _, _⟩; rfl
 
+/-- Helper: endpointQueuePopHead returns the pre-state TCB for the dequeued thread.
+The returned TCB matches the one at tid.toObjId in the pre-state st. -/
+theorem endpointQueuePopHead_returns_pre_tcb
+    (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st : SystemState)
+    (ep : Endpoint) (tid : SeLe4n.ThreadId) (headTcb : TCB) (st' : SystemState)
+    (hObj : st.objects[endpointId]? = some (.endpoint ep))
+    (hPop : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, headTcb, st')) :
+    st.objects[tid.toObjId]? = some (.tcb headTcb) := by
+  unfold endpointQueuePopHead at hPop
+  rw [hObj] at hPop; simp only at hPop
+  cases hHead : (if isReceiveQ then ep.receiveQ else ep.sendQ).head with
+  | none => simp [hHead] at hPop
+  | some headTid =>
+    simp only [hHead] at hPop
+    cases hLk : lookupTcb st headTid with
+    | none => simp [hLk] at hPop
+    | some tcb =>
+      simp only [hLk] at hPop
+      revert hPop
+      cases hStore : storeObject endpointId _ st with
+      | error e => simp
+      | ok pair =>
+        simp only []
+        cases tcb.queueNext with
+        | none =>
+          simp only []
+          cases hFinal : storeTcbQueueLinks pair.2 headTid none none none with
+          | error e => simp
+          | ok st3 =>
+            simp only [Except.ok.injEq, Prod.mk.injEq]
+            rintro ⟨rfl, rfl, _⟩
+            exact lookupTcb_some_objects st headTid tcb hLk
+        | some nextTid =>
+          simp only []
+          cases hLkNext : lookupTcb pair.2 nextTid with
+          | none => simp
+          | some nextTcb =>
+            simp only []
+            cases hLink : storeTcbQueueLinks pair.2 nextTid _ _ _ with
+            | error e => simp
+            | ok st2 =>
+              simp only []
+              cases hFinal : storeTcbQueueLinks st2 headTid none none none with
+              | error e => simp
+              | ok st3 =>
+                simp only [Except.ok.injEq, Prod.mk.injEq]
+                rintro ⟨rfl, rfl, _⟩
+                exact lookupTcb_some_objects st headTid tcb hLk
 
 -- ============================================================================
 -- Scheduler invariant bundle preservation
@@ -483,7 +531,9 @@ theorem notificationWait_preserves_uniqueWaiters
               cases hStore : storeObject notificationId _ st with
               | error e => simp
               | ok pair =>
-                simp only []
+                -- WS-L1: rewrite _fromTcb back to original for proof compatibility
+                have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hLookup hStore
+                simp only [storeTcbIpcState_fromTcb_eq hLk']
                 cases hTcb : storeTcbIpcState pair.2 waiter _ with
                 | error e => simp
                 | ok st2 =>

--- a/SeLe4n/Kernel/IPC/Invariant/EndpointPreservation.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/EndpointPreservation.lean
@@ -37,6 +37,7 @@ theorem endpointReply_preserves_schedulerInvariantBundle
   | none => simp [hLookup] at hStep
   | some tcb =>
       simp only [hLookup] at hStep
+      rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
       cases hIpc : tcb.ipcState with
       | ready => simp [hIpc] at hStep
       | blockedOnSend _ => simp [hIpc] at hStep
@@ -157,6 +158,7 @@ theorem endpointReply_preserves_ipcInvariant
   | none => simp [hLookup] at hStep
   | some tcb =>
       simp only [hLookup] at hStep
+      rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
       cases hIpc : tcb.ipcState with
       | ready => simp [hIpc] at hStep
       | blockedOnSend _ => simp [hIpc] at hStep
@@ -293,7 +295,7 @@ private theorem storeTcbPendingMessage_preserves_ipcInvariant
 theorem endpointQueuePopHead_preserves_ipcInvariant
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool) (st st' : SystemState) (tid : SeLe4n.ThreadId)
     (hInv : ipcInvariant st)
-    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st')) :
+    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st')) :
     ipcInvariant st' := by
   exact fun oid ntfn hObjPost => hInv oid ntfn (endpointQueuePopHead_notification_backward endpointId isReceiveQ st st' tid oid ntfn hStep hObjPost)
 
@@ -384,13 +386,13 @@ theorem endpointSendDual_preserves_ipcInvariant
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hInv1 := endpointQueuePopHead_preserves_ipcInvariant endpointId true st pair.2 pair.1 hInv hPop
-          cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          have hInv1 := endpointQueuePopHead_preserves_ipcInvariant endpointId true st pair.2.2 pair.1 hInv hPop
+          cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hMsg] at hStep
           | ok st2 =>
             simp only [hMsg, Except.ok.injEq, Prod.mk.injEq] at hStep
             obtain ⟨_, hEq⟩ := hStep; subst hEq
-            have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2 st2 pair.1 .ready (some msg) hInv1 hMsg
+            have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2.2 st2 pair.1 .ready (some msg) hInv1 hMsg
             exact fun oid ntfn h => hInv2 oid ntfn (by rwa [ensureRunnable_preserves_objects] at h)
       | none =>
         -- Blocking path: Enqueue → storeTcbIpcStateAndMessage → removeRunnable
@@ -491,13 +493,13 @@ theorem endpointSendDual_preserves_schedulerInvariantBundle
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2 pair.1 hPop
-          cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2.2 pair.1 hPop
+          cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hMsg] at hStep
           | ok st2 =>
             simp only [hMsg, Except.ok.injEq, Prod.mk.injEq] at hStep
             obtain ⟨_, hEq⟩ := hStep; subst hEq
-            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready (some msg) hMsg
+            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg
             have hSchedEq : st2.scheduler = st.scheduler := hSchedMsg.trans hSchedPop
             refine ⟨?_, ?_, ?_⟩
             · unfold queueCurrentConsistent
@@ -508,7 +510,7 @@ theorem endpointSendDual_preserves_schedulerInvariantBundle
                 have hNotMem : x ∉ st.scheduler.runnable := by
                   have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
                 have hNe : x ≠ pair.1 := by
-                  have hHeadEq := endpointQueuePopHead_returns_head endpointId true st ep pair.1 pair.2 hObj hPop
+                  have hHeadEq := endpointQueuePopHead_returns_head endpointId true st ep pair.1 pair.2.2 hObj hPop
                   simp at hHeadEq
                   intro hEq; rw [hEq] at hCurr
                   have := hCurrNotHead; simp [currentNotEndpointQueueHead, hCurr] at this
@@ -525,12 +527,12 @@ theorem endpointSendDual_preserves_schedulerInvariantBundle
                 have hCTV' : ∃ tcb', st.objects[x.toObjId]? = some (.tcb tcb') := by
                   simp [currentThreadValid, hCurr] at hCTV; exact hCTV
                 rcases hCTV' with ⟨tcbX, hTcbX⟩
-                obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId true st pair.2 pair.1 x.toObjId tcbX hPop hTcbX
+                obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId true st pair.2.2 pair.1 x.toObjId tcbX hPop hTcbX
                 by_cases hNeTid : x.toObjId = pair.1.toObjId
-                · have hTargetTcb : ∃ t, pair.2.objects[pair.1.toObjId]? = some (.tcb t) := hNeTid ▸ ⟨tcb1, hTcb1⟩
-                  have h := storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2 st2 pair.1 .ready (some msg) hMsg hTargetTcb
+                · have hTargetTcb : ∃ t, pair.2.2.objects[pair.1.toObjId]? = some (.tcb t) := hNeTid ▸ ⟨tcb1, hTcb1⟩
+                  have h := storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2.2 st2 pair.1 .ready (some msg) hMsg hTargetTcb
                   rwa [← hNeTid] at h
-                · exact ⟨tcb1, (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) x.toObjId hNeTid hMsg) ▸ hTcb1⟩
+                · exact ⟨tcb1, (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) x.toObjId hNeTid hMsg) ▸ hTcb1⟩
       | none =>
         -- Blocking: Enqueue → storeTcbIpcStateAndMessage(.blockedOnSend) → removeRunnable
         cases hEnq : endpointQueueEnqueue endpointId false sender st with
@@ -604,88 +606,88 @@ theorem endpointSendDual_preserves_ipcSchedulerContractPredicates
         | ok pair =>
           simp only [hHead, hPop] at hStep
           -- PopHead preserves scheduler and TCB ipcStates → contracts preserved through PopHead
-          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2 pair.1 hPop
-          have hContractPop := contracts_of_same_scheduler_ipcState st pair.2 hSchedPop
-            (fun tid tcb' h => endpointQueuePopHead_tcb_ipcState_backward endpointId true st pair.2 pair.1 tid tcb' hPop h)
+          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId true st pair.2.2 pair.1 hPop
+          have hContractPop := contracts_of_same_scheduler_ipcState st pair.2.2 hSchedPop
+            (fun tid tcb' h => endpointQueuePopHead_tcb_ipcState_backward endpointId true st pair.2.2 pair.1 tid tcb' hPop h)
             ⟨hReady, hBlockSend, hBlockRecv, hBlockCall, hBlockReply, hBlockNotif⟩
           -- Now storeTcbIpcStateAndMessage(.ready, receiver) + ensureRunnable
-          cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hMsg] at hStep
           | ok st2 =>
             simp only [hMsg, Except.ok.injEq, Prod.mk.injEq] at hStep
             obtain ⟨_, hEq⟩ := hStep; subst hEq
             rcases hContractPop with ⟨hReady', hBlockSend', hBlockRecv', hBlockCall', hBlockReply', hBlockNotif'⟩
-            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready (some msg) hMsg
+            have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg
             refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
             · -- runnableThreadIpcReady
               intro tid tcb' hTcb' hRun'
               rw [ensureRunnable_preserves_objects] at hTcb'
               by_cases hNe : tid.toObjId = pair.1.toObjId
-              · exact storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
-              · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+              · exact storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
                 have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
                 rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                · exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                · exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                 · exact absurd hEq hNeTid
             · -- blockedOnSendNotRunnable
               intro tid tcb' eid hTcb' hIpcState'
               rw [ensureRunnable_preserves_objects] at hTcb'
               by_cases hNe : tid.toObjId = pair.1.toObjId
-              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
                 rw [this] at hIpcState'; cases hIpcState'
               · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
                 intro hRun'
                 rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                · exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                · exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                 · exact absurd hEq hNeTid
             · -- blockedOnReceiveNotRunnable
               intro tid tcb' eid hTcb' hIpcState'
               rw [ensureRunnable_preserves_objects] at hTcb'
               by_cases hNe : tid.toObjId = pair.1.toObjId
-              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
                 rw [this] at hIpcState'; cases hIpcState'
               · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
                 intro hRun'
                 rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                · exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                · exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                 · exact absurd hEq hNeTid
             · -- blockedOnCallNotRunnable
               intro tid tcb' eid hTcb' hIpcState'
               rw [ensureRunnable_preserves_objects] at hTcb'
               by_cases hNe : tid.toObjId = pair.1.toObjId
-              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
                 rw [this] at hIpcState'; cases hIpcState'
               · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
                 intro hRun'
                 rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                · exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                · exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                 · exact absurd hEq hNeTid
             · -- blockedOnReplyNotRunnable
               intro tid tcb' eid rt hTcb' hIpcState'
               rw [ensureRunnable_preserves_objects] at hTcb'
               by_cases hNe : tid.toObjId = pair.1.toObjId
-              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
                 rw [this] at hIpcState'; cases hIpcState'
               · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
                 intro hRun'
                 rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                · exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                · exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                 · exact absurd hEq hNeTid
             · -- blockedOnNotificationNotRunnable (WS-F6/D2)
               intro tid tcb' nid hTcb' hIpcState'
               rw [ensureRunnable_preserves_objects] at hTcb'
               by_cases hNe : tid.toObjId = pair.1.toObjId
-              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
+              · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready (some msg) hMsg tcb' (hNe ▸ hTcb')
                 rw [this] at hIpcState'; cases hIpcState'
               · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
+                have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready (some msg) tid.toObjId hNe hMsg).symm.trans hTcb'
                 intro hRun'
                 rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                · exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                · exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                 · exact absurd hEq hNeTid
       | none =>
         -- Blocking: Enqueue → storeTcbIpcStateAndMessage(.blockedOnSend) → removeRunnable
@@ -786,17 +788,30 @@ theorem endpointReceiveDual_preserves_ipcInvariant
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hInv1 := endpointQueuePopHead_preserves_ipcInvariant endpointId false st pair.2 pair.1 hInv hPop
-          -- Branch on senderWasCall (requires case-split on lookupTcb + ipcState)
-          cases hLk : lookupTcb pair.2 pair.1 with
-          | none =>
-            -- senderWasCall = false (no TCB found), send path
-            simp only [hLk] at hStep
-            cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
+          have hInv1 := endpointQueuePopHead_preserves_ipcInvariant endpointId false st pair.2.2 pair.1 hInv hPop
+          -- Branch on senderWasCall (case-split on returned TCB's ipcState)
+          cases hSenderIpc : pair.2.1.ipcState with
+          | blockedOnCall _ =>
+            -- senderWasCall = true, call path
+            simp only [hSenderIpc, ite_true] at hStep
+            cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 (.blockedOnReply endpointId (some receiver)) none with
             | error e => simp [hMsg] at hStep
             | ok st2 =>
               simp only [hMsg] at hStep
-              have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2 st2 pair.1 .ready none hInv1 hMsg
+              have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hInv1 hMsg
+              revert hStep
+              cases hPend : storeTcbPendingMessage st2 receiver _ with
+              | ok st4 =>
+                exact fun h => (Prod.mk.inj (Except.ok.inj h)).2 ▸ storeTcbPendingMessage_preserves_ipcInvariant _ _ receiver _ hInv2 hPend
+              | error _ => simp
+          | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnReply _ _ =>
+            -- senderWasCall = false, send path
+            simp only [hSenderIpc] at hStep
+            cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready none with
+            | error e => simp [hMsg] at hStep
+            | ok st2 =>
+              simp only [hMsg] at hStep
+              have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2.2 st2 pair.1 .ready none hInv1 hMsg
               have hInv3 : ipcInvariant (ensureRunnable st2 pair.1) :=
                 fun oid ntfn h => hInv2 oid ntfn (by rwa [ensureRunnable_preserves_objects] at h)
               revert hStep
@@ -804,37 +819,6 @@ theorem endpointReceiveDual_preserves_ipcInvariant
               | ok st4 =>
                 exact fun h => (Prod.mk.inj (Except.ok.inj h)).2 ▸ storeTcbPendingMessage_preserves_ipcInvariant _ _ receiver _ hInv3 hPend
               | error _ => simp
-          | some senderTcb =>
-            simp only [hLk] at hStep
-            cases hSenderIpc : senderTcb.ipcState with
-            | blockedOnCall _ =>
-              -- senderWasCall = true, call path
-              simp only [hSenderIpc, ite_true] at hStep
-              cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 (.blockedOnReply endpointId (some receiver)) none with
-              | error e => simp [hMsg] at hStep
-              | ok st2 =>
-                simp only [hMsg] at hStep
-                have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hInv1 hMsg
-                revert hStep
-                cases hPend : storeTcbPendingMessage st2 receiver _ with
-                | ok st4 =>
-                  exact fun h => (Prod.mk.inj (Except.ok.inj h)).2 ▸ storeTcbPendingMessage_preserves_ipcInvariant _ _ receiver _ hInv2 hPend
-                | error _ => simp
-            | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnReply _ _ =>
-              -- senderWasCall = false, send path
-              simp only [hSenderIpc] at hStep
-              cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
-              | error e => simp [hMsg] at hStep
-              | ok st2 =>
-                simp only [hMsg] at hStep
-                have hInv2 := storeTcbIpcStateAndMessage_preserves_ipcInvariant pair.2 st2 pair.1 .ready none hInv1 hMsg
-                have hInv3 : ipcInvariant (ensureRunnable st2 pair.1) :=
-                  fun oid ntfn h => hInv2 oid ntfn (by rwa [ensureRunnable_preserves_objects] at h)
-                revert hStep
-                cases hPend : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver _ with
-                | ok st4 =>
-                  exact fun h => (Prod.mk.inj (Except.ok.inj h)).2 ▸ storeTcbPendingMessage_preserves_ipcInvariant _ _ receiver _ hInv3 hPend
-                | error _ => simp
       | none =>
         -- Blocking: Enqueue → storeTcbIpcState → removeRunnable
         cases hEnq : endpointQueueEnqueue endpointId true receiver st with
@@ -873,17 +857,51 @@ theorem endpointReceiveDual_preserves_schedulerInvariantBundle
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId false st pair.2 pair.1 hPop
-          -- Branch on senderWasCall (requires case-split on lookupTcb + ipcState)
-          cases hLk : lookupTcb pair.2 pair.1 with
-          | none =>
-            -- senderWasCall = false
-            simp only [hLk] at hStep
-            cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
+          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId false st pair.2.2 pair.1 hPop
+          -- Branch on senderWasCall (case-split on returned TCB's ipcState)
+          cases hSenderIpc : pair.2.1.ipcState with
+          | blockedOnCall _ =>
+            -- senderWasCall = true, call path
+            simp only [hSenderIpc, ite_true] at hStep
+            cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 (.blockedOnReply endpointId (some receiver)) none with
             | error e => simp [hMsg] at hStep
             | ok st2 =>
               simp only [hMsg] at hStep
-              have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready none hMsg
+              have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg
+              have hSchedEq : st2.scheduler = st.scheduler := hSchedMsg.trans hSchedPop
+              revert hStep
+              cases hPend : storeTcbPendingMessage st2 receiver _ with
+              | ok st4 =>
+                intro h; have h_eq := (Prod.mk.inj (Except.ok.inj h)).2; subst h_eq
+                have hSchedPend := storeTcbPendingMessage_scheduler_eq _ _ receiver _ hPend
+                refine ⟨?_, ?_, ?_⟩
+                · rw [queueCurrentConsistent]; rw [queueCurrentConsistent] at hQCC; rwa [hSchedPend, hSchedEq]
+                · show st4.scheduler.runnable.Nodup
+                  rw [show st4.scheduler.runnable = st2.scheduler.runnable from congrArg SchedulerState.runnable hSchedPend, hSchedEq]; exact hRQU
+                · unfold currentThreadValid; rw [hSchedPend, hSchedEq]
+                  cases hCurr : st.scheduler.current with
+                  | none => simp
+                  | some x =>
+                    simp only []
+                    have hCTV' : ∃ tcb', st.objects[x.toObjId]? = some (.tcb tcb') := by simp [currentThreadValid, hCurr] at hCTV; exact hCTV
+                    rcases hCTV' with ⟨tcbX, hTcbX⟩
+                    obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId false st pair.2.2 pair.1 x.toObjId tcbX hPop hTcbX
+                    by_cases hNeTid : x.toObjId = pair.1.toObjId
+                    · have hTargetTcb : ∃ t, pair.2.2.objects[pair.1.toObjId]? = some (.tcb t) := hNeTid ▸ ⟨tcb1, hTcb1⟩
+                      have htgt := storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg hTargetTcb
+                      obtain ⟨tcb_tgt, htcb_tgt⟩ := htgt
+                      exact storeTcbPendingMessage_tcb_forward _ _ receiver _ x.toObjId tcb_tgt hPend (by rwa [← hNeTid] at htcb_tgt)
+                    · have h1 := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none x.toObjId hNeTid hMsg) ▸ hTcb1
+                      exact storeTcbPendingMessage_tcb_forward _ _ receiver _ x.toObjId tcb1 hPend h1
+              | error _ => simp
+          | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnReply _ _ =>
+            -- senderWasCall = false, send path
+            simp only [hSenderIpc] at hStep
+            cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready none with
+            | error e => simp [hMsg] at hStep
+            | ok st2 =>
+              simp only [hMsg] at hStep
+              have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 .ready none hMsg
               have hSchedEq : st2.scheduler = st.scheduler := hSchedMsg.trans hSchedPop
               have hInvER : schedulerInvariantBundle (ensureRunnable st2 pair.1) := by
                 refine ⟨?_, ?_, ?_⟩
@@ -894,7 +912,7 @@ theorem endpointReceiveDual_preserves_schedulerInvariantBundle
                     have hNotMem : x ∉ st.scheduler.runnable := by
                       have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
                     have hNe : x ≠ pair.1 := by
-                      have hHeadEq := endpointQueuePopHead_returns_head endpointId false st ep pair.1 pair.2 hObj hPop
+                      have hHeadEq := endpointQueuePopHead_returns_head endpointId false st ep pair.1 pair.2.2 hObj hPop
                       simp at hHeadEq
                       intro hEq; rw [hEq] at hCurr
                       have := hCurrNotHead; simp [currentNotEndpointQueueHead, hCurr] at this
@@ -910,10 +928,10 @@ theorem endpointReceiveDual_preserves_schedulerInvariantBundle
                     simp only []
                     have hCTV' : ∃ tcb', st.objects[x.toObjId]? = some (.tcb tcb') := by simp [currentThreadValid, hCurr] at hCTV; exact hCTV
                     rcases hCTV' with ⟨tcbX, hTcbX⟩
-                    obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId false st pair.2 pair.1 x.toObjId tcbX hPop hTcbX
+                    obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId false st pair.2.2 pair.1 x.toObjId tcbX hPop hTcbX
                     by_cases hNeTid : x.toObjId = pair.1.toObjId
-                    · exact storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2 st2 pair.1 .ready none hMsg (hNeTid ▸ ⟨tcb1, hTcb1⟩) |>.imp fun _ h => by rwa [← hNeTid] at h
-                    · exact ⟨tcb1, (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none x.toObjId hNeTid hMsg) ▸ hTcb1⟩
+                    · exact storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2.2 st2 pair.1 .ready none hMsg (hNeTid ▸ ⟨tcb1, hTcb1⟩) |>.imp fun _ h => by rwa [← hNeTid] at h
+                    · exact ⟨tcb1, (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready none x.toObjId hNeTid hMsg) ▸ hTcb1⟩
               revert hStep
               cases hPend : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver _ with
               | ok st4 =>
@@ -932,99 +950,6 @@ theorem endpointReceiveDual_preserves_schedulerInvariantBundle
                     have ⟨tcbX, hTcbX⟩ : ∃ tcb', (ensureRunnable st2 pair.1).objects[x.toObjId]? = some (.tcb tcb') := by simp [currentThreadValid, hCurr] at hCTV'; exact hCTV'
                     exact storeTcbPendingMessage_tcb_forward _ _ receiver _ x.toObjId tcbX hPend hTcbX
               | error _ => simp
-          | some senderTcb =>
-            simp only [hLk] at hStep
-            cases hSenderIpc : senderTcb.ipcState with
-            | blockedOnCall _ =>
-              -- senderWasCall = true, call path
-              simp only [hSenderIpc, ite_true] at hStep
-              cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 (.blockedOnReply endpointId (some receiver)) none with
-              | error e => simp [hMsg] at hStep
-              | ok st2 =>
-                simp only [hMsg] at hStep
-                have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg
-                have hSchedEq : st2.scheduler = st.scheduler := hSchedMsg.trans hSchedPop
-                revert hStep
-                cases hPend : storeTcbPendingMessage st2 receiver _ with
-                | ok st4 =>
-                  intro h; have h_eq := (Prod.mk.inj (Except.ok.inj h)).2; subst h_eq
-                  have hSchedPend := storeTcbPendingMessage_scheduler_eq _ _ receiver _ hPend
-                  refine ⟨?_, ?_, ?_⟩
-                  · rw [queueCurrentConsistent]; rw [queueCurrentConsistent] at hQCC; rwa [hSchedPend, hSchedEq]
-                  · show st4.scheduler.runnable.Nodup
-                    rw [show st4.scheduler.runnable = st2.scheduler.runnable from congrArg SchedulerState.runnable hSchedPend, hSchedEq]; exact hRQU
-                  · unfold currentThreadValid; rw [hSchedPend, hSchedEq]
-                    cases hCurr : st.scheduler.current with
-                    | none => simp
-                    | some x =>
-                      simp only []
-                      have hCTV' : ∃ tcb', st.objects[x.toObjId]? = some (.tcb tcb') := by simp [currentThreadValid, hCurr] at hCTV; exact hCTV
-                      rcases hCTV' with ⟨tcbX, hTcbX⟩
-                      obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId false st pair.2 pair.1 x.toObjId tcbX hPop hTcbX
-                      by_cases hNeTid : x.toObjId = pair.1.toObjId
-                      · have hTargetTcb : ∃ t, pair.2.objects[pair.1.toObjId]? = some (.tcb t) := hNeTid ▸ ⟨tcb1, hTcb1⟩
-                        have htgt := storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg hTargetTcb
-                        obtain ⟨tcb_tgt, htcb_tgt⟩ := htgt
-                        exact storeTcbPendingMessage_tcb_forward _ _ receiver _ x.toObjId tcb_tgt hPend (by rwa [← hNeTid] at htcb_tgt)
-                      · have h1 := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none x.toObjId hNeTid hMsg) ▸ hTcb1
-                        exact storeTcbPendingMessage_tcb_forward _ _ receiver _ x.toObjId tcb1 hPend h1
-                | error _ => simp
-            | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnReply _ _ =>
-              -- senderWasCall = false, send path
-              simp only [hSenderIpc] at hStep
-              cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
-              | error e => simp [hMsg] at hStep
-              | ok st2 =>
-                simp only [hMsg] at hStep
-                have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready none hMsg
-                have hSchedEq : st2.scheduler = st.scheduler := hSchedMsg.trans hSchedPop
-                have hInvER : schedulerInvariantBundle (ensureRunnable st2 pair.1) := by
-                  refine ⟨?_, ?_, ?_⟩
-                  · unfold queueCurrentConsistent; rw [ensureRunnable_scheduler_current, hSchedEq]
-                    cases hCurr : st.scheduler.current with
-                    | none => trivial
-                    | some x =>
-                      have hNotMem : x ∉ st.scheduler.runnable := by
-                        have := hQCC; simp [queueCurrentConsistent, hCurr] at this; exact this
-                      have hNe : x ≠ pair.1 := by
-                        have hHeadEq := endpointQueuePopHead_returns_head endpointId false st ep pair.1 pair.2 hObj hPop
-                        simp at hHeadEq
-                        intro hEq; rw [hEq] at hCurr
-                        have := hCurrNotHead; simp [currentNotEndpointQueueHead, hCurr] at this
-                        exact (this endpointId ep hObj).2 hHeadEq
-                      exact ensureRunnable_not_mem_of_not_mem st2 pair.1 x (hSchedEq ▸ hNotMem) hNe
-                  · exact ensureRunnable_nodup st2 pair.1 (hSchedEq ▸ hRQU)
-                  · show currentThreadValid (ensureRunnable st2 pair.1)
-                    unfold currentThreadValid
-                    simp only [ensureRunnable_scheduler_current, ensureRunnable_preserves_objects, hSchedEq]
-                    cases hCurr : st.scheduler.current with
-                    | none => simp
-                    | some x =>
-                      simp only []
-                      have hCTV' : ∃ tcb', st.objects[x.toObjId]? = some (.tcb tcb') := by simp [currentThreadValid, hCurr] at hCTV; exact hCTV
-                      rcases hCTV' with ⟨tcbX, hTcbX⟩
-                      obtain ⟨tcb1, hTcb1⟩ := endpointQueuePopHead_tcb_forward endpointId false st pair.2 pair.1 x.toObjId tcbX hPop hTcbX
-                      by_cases hNeTid : x.toObjId = pair.1.toObjId
-                      · exact storeTcbIpcStateAndMessage_tcb_exists_at_target pair.2 st2 pair.1 .ready none hMsg (hNeTid ▸ ⟨tcb1, hTcb1⟩) |>.imp fun _ h => by rwa [← hNeTid] at h
-                      · exact ⟨tcb1, (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none x.toObjId hNeTid hMsg) ▸ hTcb1⟩
-                revert hStep
-                cases hPend : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver _ with
-                | ok st4 =>
-                  intro h; have h_eq := (Prod.mk.inj (Except.ok.inj h)).2; subst h_eq
-                  rcases hInvER with ⟨hQCC', hRQU', hCTV'⟩
-                  have hSchedPend := storeTcbPendingMessage_scheduler_eq _ _ receiver _ hPend
-                  refine ⟨?_, ?_, ?_⟩
-                  · rw [queueCurrentConsistent]; rw [queueCurrentConsistent] at hQCC'; rwa [hSchedPend]
-                  · show st4.scheduler.runnable.Nodup
-                    rw [show st4.scheduler.runnable = (ensureRunnable st2 pair.1).scheduler.runnable from congrArg SchedulerState.runnable hSchedPend]; exact hRQU'
-                  · unfold currentThreadValid; rw [hSchedPend]
-                    cases hCurr : (ensureRunnable st2 pair.1).scheduler.current with
-                    | none => simp
-                    | some x =>
-                      simp only []
-                      have ⟨tcbX, hTcbX⟩ : ∃ tcb', (ensureRunnable st2 pair.1).objects[x.toObjId]? = some (.tcb tcb') := by simp [currentThreadValid, hCurr] at hCTV'; exact hCTV'
-                      exact storeTcbPendingMessage_tcb_forward _ _ receiver _ x.toObjId tcbX hPend hTcbX
-                | error _ => simp
       | none =>
         -- Blocking: Enqueue → storeTcbIpcState → removeRunnable
         cases hEnq : endpointQueueEnqueue endpointId true receiver st with
@@ -1092,111 +1017,28 @@ theorem endpointReceiveDual_preserves_ipcSchedulerContractPredicates
         | error e => simp [hHead, hPop] at hStep
         | ok pair =>
           simp only [hHead, hPop] at hStep
-          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId false st pair.2 pair.1 hPop
-          have hContractPop := contracts_of_same_scheduler_ipcState st pair.2 hSchedPop
-            (fun tid tcb' h => endpointQueuePopHead_tcb_ipcState_backward endpointId false st pair.2 pair.1 tid tcb' hPop h)
+          have hSchedPop := endpointQueuePopHead_scheduler_eq endpointId false st pair.2.2 pair.1 hPop
+          have hContractPop := contracts_of_same_scheduler_ipcState st pair.2.2 hSchedPop
+            (fun tid tcb' h => endpointQueuePopHead_tcb_ipcState_backward endpointId false st pair.2.2 pair.1 tid tcb' hPop h)
             ⟨hReady, hBlockSend, hBlockRecv, hBlockCall, hBlockReply, hBlockNotif⟩
-          -- Branch on senderWasCall (case-split on lookupTcb + ipcState)
-          cases hLk : lookupTcb pair.2 pair.1 with
-          | none =>
-            -- senderWasCall = false
-            simp only [hLk] at hStep
+          -- Establish pre-state TCB for the helper lemma
+          have hPreTcb := endpointQueuePopHead_returns_pre_tcb endpointId false st ep pair.1 pair.2.1 pair.2.2 hObj hPop
+          -- Branch on senderWasCall (case-split on returned TCB's ipcState)
+          cases hSenderIpc : pair.2.1.ipcState with
+          | blockedOnCall _ =>
+            -- senderWasCall = true, call path
+            simp only [hSenderIpc, ite_true] at hStep
             rcases hContractPop with ⟨hReady', hBlockSend', hBlockRecv', hBlockCall', hBlockReply', hBlockNotif'⟩
-            cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
-            | error e => simp [hMsg] at hStep
-            | ok st2 =>
-              simp only [hMsg] at hStep
-              have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready none hMsg
-              -- Build contracts for ensureRunnable st2 pair.1 (same handshake pattern as sendDual)
-              have hContractER : ipcSchedulerContractPredicates (ensureRunnable st2 pair.1) := by
-                refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
-                · intro tid tcb' hTcb' hRun'
-                  rw [ensureRunnable_preserves_objects] at hTcb'
-                  by_cases hNe : tid.toObjId = pair.1.toObjId
-                  · exact storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
-                  · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
-                    have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                    rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                    · exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
-                    · exact absurd hEq hNeTid
-                · intro tid tcb' eid hTcb' hIpcState'
-                  rw [ensureRunnable_preserves_objects] at hTcb'
-                  by_cases hNe : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
-                    rw [this] at hIpcState'; cases hIpcState'
-                  · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
-                    intro hRun'
-                    rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                    · exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
-                    · exact absurd hEq hNeTid
-                · intro tid tcb' eid hTcb' hIpcState'
-                  rw [ensureRunnable_preserves_objects] at hTcb'
-                  by_cases hNe : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
-                    rw [this] at hIpcState'; cases hIpcState'
-                  · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
-                    intro hRun'
-                    rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                    · exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
-                    · exact absurd hEq hNeTid
-                · intro tid tcb' eid hTcb' hIpcState'
-                  rw [ensureRunnable_preserves_objects] at hTcb'
-                  by_cases hNe : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
-                    rw [this] at hIpcState'; cases hIpcState'
-                  · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
-                    intro hRun'
-                    rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                    · exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
-                    · exact absurd hEq hNeTid
-                · intro tid tcb' eid rt hTcb' hIpcState'
-                  rw [ensureRunnable_preserves_objects] at hTcb'
-                  by_cases hNe : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
-                    rw [this] at hIpcState'; cases hIpcState'
-                  · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
-                    intro hRun'
-                    rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                    · exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
-                    · exact absurd hEq hNeTid
-                · -- blockedOnNotificationNotRunnable (WS-F6/D2)
-                  intro tid tcb' nid hTcb' hIpcState'
-                  rw [ensureRunnable_preserves_objects] at hTcb'
-                  by_cases hNe : tid.toObjId = pair.1.toObjId
-                  · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
-                    rw [this] at hIpcState'; cases hIpcState'
-                  · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                    have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
-                    intro hRun'
-                    rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                    · exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
-                    · exact absurd hEq hNeTid
-              -- storeTcbPendingMessage: error propagated, success preserves contracts
-              revert hStep
-              cases hPend : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver _ with
-              | ok st4 =>
-                intro h; have h_eq := (Prod.mk.inj (Except.ok.inj h)).2; subst h_eq
-                have hSchedPend := storeTcbPendingMessage_scheduler_eq _ st4 receiver _ hPend
-                exact contracts_of_same_scheduler_ipcState _ st4 hSchedPend
-                  (fun tid tcb'' hTcb'' => storeTcbPendingMessage_tcb_ipcState_backward _ st4 receiver _ tid tcb'' hPend hTcb'')
-                  hContractER
-              | error _ => simp
-          | some senderTcb =>
-            simp only [hLk] at hStep
-            cases hSenderIpc : senderTcb.ipcState with
-            | blockedOnCall _ =>
-              -- senderWasCall = true, call path
-              simp only [hSenderIpc, ite_true] at hStep
-              rcases hContractPop with ⟨hReady', hBlockSend', hBlockRecv', hBlockCall', hBlockReply', hBlockNotif'⟩
-              cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 (.blockedOnReply endpointId (some receiver)) none with
+            -- Establish post-state TCB for pair.1 and its ipcState relation
+            obtain ⟨postTcb, hPostTcb⟩ := endpointQueuePopHead_tcb_forward endpointId false st pair.2.2 pair.1 pair.1.toObjId pair.2.1 hPop hPreTcb
+            obtain ⟨preTcb, hPreTcb2, hIpcRel⟩ := endpointQueuePopHead_tcb_ipcState_backward endpointId false st pair.2.2 pair.1 pair.1 postTcb hPop hPostTcb
+            have : preTcb = pair.2.1 := by rw [hPreTcb] at hPreTcb2; exact (KernelObject.tcb.inj (Option.some.inj hPreTcb2.symm))
+            subst this
+            cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 (.blockedOnReply endpointId (some receiver)) none with
               | error e => simp [hMsg] at hStep
               | ok st2 =>
                 simp only [hMsg] at hStep
-                have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg
+                have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg
                 -- Build contracts for st2 (sender set to blockedOnReply, no ensureRunnable)
                 have hContractSt2 : ipcSchedulerContractPredicates st2 := by
                   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
@@ -1205,51 +1047,51 @@ theorem endpointReceiveDual_preserves_ipcSchedulerContractPredicates
                     · -- tid is the sender (same ObjId); sender had blockedOnCall, so not runnable
                       have hTidEq := ThreadId.toObjId_injective tid pair.1 hNe
                       subst hTidEq
-                      exact absurd (show pair.1 ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
-                        (hBlockCall' pair.1 senderTcb _ (lookupTcb_some_objects _ _ _ hLk) hSenderIpc)
-                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
-                      exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      exact absurd (show pair.1 ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
+                        (hBlockCall' pair.1 postTcb _ hPostTcb (by rw [← hIpcRel]; exact hSenderIpc))
+                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
+                      exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                   · intro tid tcb' eid hTcb' hIpcState'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
-                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
+                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'
-                      exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                   · intro tid tcb' eid hTcb' hIpcState'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
-                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
+                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'
-                      exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                   · intro tid tcb' eid hTcb' hIpcState'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
-                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
+                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'
-                      exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                   · intro tid tcb' eid rt hTcb' hIpcState'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
                     · -- tid is the sender; its ipc state in st2 is .blockedOnReply
-                      -- The sender had .blockedOnCall in pair.2, so was not runnable
+                      -- The sender had .blockedOnCall in pair.2.2, so was not runnable
                       have hTidEq := ThreadId.toObjId_injective tid pair.1 hNe
                       subst hTidEq
                       intro hRun'
-                      have hRunPre : pair.1 ∈ pair.2.scheduler.runnable := by rwa [← hSchedMsg]
-                      exact hBlockCall' pair.1 senderTcb _ (lookupTcb_some_objects _ _ _ hLk) hSenderIpc hRunPre
-                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
+                      have hRunPre : pair.1 ∈ pair.2.2.scheduler.runnable := by rwa [← hSchedMsg]
+                      exact hBlockCall' pair.1 postTcb _ hPostTcb (by rw [← hIpcRel]; exact hSenderIpc) hRunPre
+                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'
-                      exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                   · -- blockedOnNotificationNotRunnable (WS-F6/D2)
                     intro tid tcb' nid hTcb' hIpcState'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 (.blockedOnReply endpointId (some receiver)) none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
-                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
+                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 _ none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'
-                      exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                 -- storeTcbPendingMessage preserves contracts
                 revert hStep
                 cases hPend : storeTcbPendingMessage st2 receiver _ with
@@ -1264,72 +1106,72 @@ theorem endpointReceiveDual_preserves_ipcSchedulerContractPredicates
               -- senderWasCall = false, send path
               simp only [hSenderIpc] at hStep
               rcases hContractPop with ⟨hReady', hBlockSend', hBlockRecv', hBlockCall', hBlockReply', hBlockNotif'⟩
-              cases hMsg : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
+              cases hMsg : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready none with
               | error e => simp [hMsg] at hStep
               | ok st2 =>
                 simp only [hMsg] at hStep
-                have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2 st2 pair.1 .ready none hMsg
+                have hSchedMsg := storeTcbIpcStateAndMessage_scheduler_eq pair.2.2 st2 pair.1 .ready none hMsg
                 have hContractER : ipcSchedulerContractPredicates (ensureRunnable st2 pair.1) := by
                   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
                   · intro tid tcb' hTcb' hRun'
                     rw [ensureRunnable_preserves_objects] at hTcb'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · exact storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
-                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
+                    · exact storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
+                    · have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
                       have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
                       rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                      · exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      · exact hReady' tid tcb' hTcbPre (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                       · exact absurd hEq hNeTid
                   · intro tid tcb' eid hTcb' hIpcState'
                     rw [ensureRunnable_preserves_objects] at hTcb'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
                     · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
+                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'; rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                      · exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      · exact hBlockSend' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                       · exact absurd hEq hNeTid
                   · intro tid tcb' eid hTcb' hIpcState'
                     rw [ensureRunnable_preserves_objects] at hTcb'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
                     · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
+                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'; rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                      · exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      · exact hBlockRecv' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                       · exact absurd hEq hNeTid
                   · intro tid tcb' eid hTcb' hIpcState'
                     rw [ensureRunnable_preserves_objects] at hTcb'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
                     · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
+                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'; rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                      · exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      · exact hBlockCall' tid tcb' eid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                       · exact absurd hEq hNeTid
                   · intro tid tcb' eid rt hTcb' hIpcState'
                     rw [ensureRunnable_preserves_objects] at hTcb'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
                     · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
+                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'; rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                      · exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      · exact hBlockReply' tid tcb' eid rt hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                       · exact absurd hEq hNeTid
                   · -- blockedOnNotificationNotRunnable (WS-F6/D2)
                     intro tid tcb' nid hTcb' hIpcState'
                     rw [ensureRunnable_preserves_objects] at hTcb'
                     by_cases hNe : tid.toObjId = pair.1.toObjId
-                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
+                    · have := storeTcbIpcStateAndMessage_ipcState_eq pair.2.2 st2 pair.1 .ready none hMsg tcb' (hNe ▸ hTcb')
                       rw [this] at hIpcState'; cases hIpcState'
                     · have hNeTid : tid ≠ pair.1 := fun h => hNe (congrArg ThreadId.toObjId h)
-                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
+                      have hTcbPre := (storeTcbIpcStateAndMessage_preserves_objects_ne pair.2.2 st2 pair.1 .ready none tid.toObjId hNe hMsg).symm.trans hTcb'
                       intro hRun'; rcases ensureRunnable_mem_reverse st2 pair.1 tid hRun' with hOld | hEq
-                      · exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.scheduler.runnable by rwa [← hSchedMsg])
+                      · exact hBlockNotif' tid tcb' nid hTcbPre hIpcState' (show tid ∈ pair.2.2.scheduler.runnable by rwa [← hSchedMsg])
                       · exact absurd hEq hNeTid
                 revert hStep
                 cases hPend : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver _ with

--- a/SeLe4n/Kernel/IPC/Invariant/NotificationPreservation.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/NotificationPreservation.lean
@@ -222,6 +222,8 @@ theorem notificationWait_preserves_ipcInvariant
             | error e => simp
             | ok pair =>
               simp only []
+              have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hObj hStore
+              simp only [storeTcbIpcState_fromTcb_eq hLk']
               have hInv1 := storeObject_notification_preserves_ipcInvariant st pair.2 notificationId
                 _ hInv hStore (notificationWait_result_wellFormed_wait waiter ntfn.waitingThreads)
               cases hTcb : storeTcbIpcState pair.2 waiter (.blockedOnNotification notificationId) with
@@ -312,6 +314,8 @@ theorem notificationWait_preserves_schedulerInvariantBundle
             | error e => simp
             | ok pair =>
               simp only []
+              have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hObj hStore
+              simp only [storeTcbIpcState_fromTcb_eq hLk']
               cases hTcb : storeTcbIpcState pair.2 waiter (.blockedOnNotification notificationId) with
               | error e => simp
               | ok st'' =>
@@ -666,6 +670,8 @@ theorem notificationWait_preserves_ipcSchedulerContractPredicates
             | error e => simp
             | ok pair =>
               simp only []
+              have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hObj hStore
+              simp only [storeTcbIpcState_fromTcb_eq hLk']
               cases hTcb : storeTcbIpcState pair.2 waiter
                   (.blockedOnNotification notificationId) with
               | error e => simp
@@ -966,7 +972,10 @@ theorem notificationWait_preserves_badgeWellFormed
             cases hStore1 : storeObject notificationId _ st with
             | error e => simp
             | ok pair1 =>
-              simp only []; intro hStep; revert hStep
+              simp only []
+              have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hObjSrc hStore1
+              simp only [storeTcbIpcState_fromTcb_eq hLk']
+              intro hStep; revert hStep
               cases hStoreTcb : storeTcbIpcState pair1.2 waiter _ with
               | error e => simp
               | ok st2 =>

--- a/SeLe4n/Kernel/IPC/Invariant/Structural.lean
+++ b/SeLe4n/Kernel/IPC/Invariant/Structural.lean
@@ -486,6 +486,7 @@ theorem endpointReply_preserves_dualQueueSystemInvariant
   | none => simp [hLookup] at hStep
   | some tcb =>
       simp only [hLookup] at hStep
+      rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
       cases hIpc : tcb.ipcState with
       | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _
         | blockedOnCall _ => simp [hIpc] at hStep
@@ -747,7 +748,7 @@ private theorem storeTcbQueueLinks_append_tail_preserves_linkInteg
 theorem endpointQueuePopHead_preserves_dualQueueSystemInvariant
     (endpointId : SeLe4n.ObjId) (isReceiveQ : Bool)
     (st st' : SystemState) (tid : SeLe4n.ThreadId)
-    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st'))
+    (hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st'))
     (hInv : dualQueueSystemInvariant st) :
     dualQueueSystemInvariant st' := by
   obtain ⟨hEpInv, hLink⟩ := hInv
@@ -794,7 +795,7 @@ theorem endpointQueuePopHead_preserves_dualQueueSystemInvariant
               | error e => simp at hStep
               | ok st3 =>
                 simp only [Except.ok.injEq, Prod.mk.injEq] at hStep
-                obtain ⟨rfl, rfl⟩ := hStep
+                obtain ⟨rfl, _, rfl⟩ := hStep
                 have hLink1 := storeObject_endpoint_preserves_tcbQueueLinkIntegrity
                   st pair.2 endpointId _ hStoreEp hPreEp hLink
                 have hTransport : ∀ (x : SeLe4n.ThreadId) (t : TCB),
@@ -870,7 +871,7 @@ theorem endpointQueuePopHead_preserves_dualQueueSystemInvariant
                   | error e => simp [hStoreEpB, hLkN, hStN, hClH] at hStep
                   | ok st3 =>
                     simp [hStoreEpB, hLkN, hStN, hClH] at hStep
-                    obtain ⟨rfl, rfl⟩ := hStep
+                    obtain ⟨rfl, _, rfl⟩ := hStep
                     -- Key facts
                     have hNeEpNextB : endpointId ≠ nextTid.toObjId := by
                       intro h; have := lookupTcb_some_objects pairB.2 nextTid nextTcb hLkN
@@ -1439,7 +1440,7 @@ theorem endpointSendDual_preserves_dualQueueSystemInvariant
         | error e => simp [hPop] at hStep
         | ok pair =>
           simp only [hPop] at hStep
-          cases hStore : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          cases hStore : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hStore] at hStep
           | ok st2 =>
             simp only [hStore, Except.ok.injEq, Prod.mk.injEq] at hStep
@@ -1503,16 +1504,33 @@ theorem endpointReceiveDual_preserves_dualQueueSystemInvariant
           simp only [hPop] at hStep
           have hInv1 := endpointQueuePopHead_preserves_dualQueueSystemInvariant
             _ _ _ _ _ hPop hInv
-          -- Case on lookupTcb to determine senderMsg and senderWasCall
-          cases hLk : lookupTcb pair.2 pair.1 with
-          | none =>
-            simp only [hLk] at hStep
-            -- senderWasCall = false, senderMsg = none → send path
-            cases hStore : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
+          -- Case-split on returned TCB's ipcState to determine senderWasCall
+          cases hSenderIpc : pair.2.1.ipcState with
+          | blockedOnCall epCall =>
+            -- Call path: senderWasCall = true
+            simp only [hSenderIpc, ite_true] at hStep
+            cases hStore : storeTcbIpcStateAndMessage pair.2.2 pair.1
+                (.blockedOnReply endpointId (some receiver)) none with
             | error e => simp [hStore] at hStep
             | ok st2 =>
               simp only [hStore] at hStep
-              cases hMsg : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver none with
+              cases hMsg : storeTcbPendingMessage st2 receiver pair.2.1.pendingMessage with
+              | error e => simp [hMsg] at hStep
+              | ok st3 =>
+                simp only [hMsg] at hStep; rcases hStep with ⟨-, rfl⟩
+                exact storeTcbPendingMessage_preserves_dualQueueSystemInvariant _ _ _ _ hMsg
+                  (storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant
+                    _ _ _ _ _ hStore hInv1)
+          | ready | blockedOnSend _ | blockedOnReceive _
+            | blockedOnReply _ _ | blockedOnNotification _ =>
+            -- Send path: senderWasCall = false
+            simp only [hSenderIpc] at hStep
+            cases hStore : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready none with
+            | error e => simp [hStore] at hStep
+            | ok st2 =>
+              simp only [hStore] at hStep
+              cases hMsg : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver
+                  pair.2.1.pendingMessage with
               | error e => simp [hMsg] at hStep
               | ok st3 =>
                 simp only [hMsg] at hStep; rcases hStep with ⟨-, rfl⟩
@@ -1520,41 +1538,6 @@ theorem endpointReceiveDual_preserves_dualQueueSystemInvariant
                   (ensureRunnable_preserves_dualQueueSystemInvariant _ _
                     (storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant
                       _ _ _ _ _ hStore hInv1))
-          | some tcb =>
-            simp only [hLk] at hStep
-            cases hIpc : tcb.ipcState with
-            | blockedOnCall epCall =>
-              -- Call path: senderWasCall = true
-              simp only [hIpc] at hStep
-              cases hStore : storeTcbIpcStateAndMessage pair.2 pair.1
-                  (.blockedOnReply endpointId (some receiver)) none with
-              | error e => simp [hStore] at hStep
-              | ok st2 =>
-                simp only [hStore] at hStep
-                cases hMsg : storeTcbPendingMessage st2 receiver tcb.pendingMessage with
-                | error e => simp [hMsg] at hStep
-                | ok st3 =>
-                  simp only [hMsg] at hStep; rcases hStep with ⟨-, rfl⟩
-                  exact storeTcbPendingMessage_preserves_dualQueueSystemInvariant _ _ _ _ hMsg
-                    (storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant
-                      _ _ _ _ _ hStore hInv1)
-            | ready | blockedOnSend _ | blockedOnReceive _
-              | blockedOnReply _ _ | blockedOnNotification _ =>
-              -- Send path: senderWasCall = false
-              simp only [hIpc] at hStep
-              cases hStore : storeTcbIpcStateAndMessage pair.2 pair.1 .ready none with
-              | error e => simp [hStore] at hStep
-              | ok st2 =>
-                simp only [hStore] at hStep
-                cases hMsg : storeTcbPendingMessage (ensureRunnable st2 pair.1) receiver
-                    tcb.pendingMessage with
-                | error e => simp [hMsg] at hStep
-                | ok st3 =>
-                  simp only [hMsg] at hStep; rcases hStep with ⟨-, rfl⟩
-                  exact storeTcbPendingMessage_preserves_dualQueueSystemInvariant _ _ _ _ hMsg
-                    (ensureRunnable_preserves_dualQueueSystemInvariant _ _
-                      (storeTcbIpcStateAndMessage_preserves_dualQueueSystemInvariant
-                        _ _ _ _ _ hStore hInv1))
       | none =>
         -- Path B: enqueue receiver, block
         simp only [hHead] at hStep
@@ -1604,6 +1587,7 @@ theorem endpointReplyRecv_preserves_dualQueueSystemInvariant
   | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
+    rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
     cases hIpc : tcb.ipcState with
     | ready | blockedOnSend _ | blockedOnReceive _ | blockedOnNotification _ | blockedOnCall _ =>
       simp [hIpc] at hStep
@@ -1716,7 +1700,7 @@ theorem endpointCall_preserves_dualQueueSystemInvariant
           simp only [hPop] at hStep
           have hInv1 := endpointQueuePopHead_preserves_dualQueueSystemInvariant
             _ _ _ _ _ hPop hInv
-          cases hStore1 : storeTcbIpcStateAndMessage pair.2 pair.1 .ready (some msg) with
+          cases hStore1 : storeTcbIpcStateAndMessage pair.2.2 pair.1 .ready (some msg) with
           | error e => simp [hStore1] at hStep
           | ok st2 =>
             simp only [hStore1] at hStep
@@ -2172,6 +2156,8 @@ theorem notificationWait_preserves_allPendingMessagesBounded
                 | error e => simp
                 | ok pair =>
                     simp only []
+                    have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hObj hStore
+                    simp only [storeTcbIpcState_fromTcb_eq hLk']
                     have hInv1 := storeObject_notification_preserves_allPendingMessagesBounded
                       st pair.2 notificationId _ hStore hInv
                     cases hIpc : storeTcbIpcState pair.2 waiter (.blockedOnNotification notificationId) with
@@ -2205,6 +2191,7 @@ theorem endpointReply_preserves_allPendingMessagesBounded
   | none => simp [hLookup] at hStep
   | some tcb =>
       simp only [hLookup] at hStep
+      rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
       cases hIpc : tcb.ipcState with
       | ready => simp [hIpc] at hStep
       | blockedOnSend _ => simp [hIpc] at hStep

--- a/SeLe4n/Kernel/IPC/Operations/Endpoint.lean
+++ b/SeLe4n/Kernel/IPC/Operations/Endpoint.lean
@@ -69,6 +69,24 @@ def storeTcbIpcState (st : SystemState) (tid : SeLe4n.ThreadId) (ipcState : Thre
       | .error e => .error e
       | .ok ((), st') => .ok st'
 
+/-- WS-L1/L1-C: Variant of `storeTcbIpcState` that accepts a pre-looked-up
+TCB, bypassing the internal `lookupTcb`. Use when the caller has already
+validated the TCB and no intervening operation has modified it. -/
+def storeTcbIpcState_fromTcb (st : SystemState) (tid : SeLe4n.ThreadId)
+    (tcb : TCB) (ipcState : ThreadIpcState) : Except KernelError SystemState :=
+  match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState }) st with
+  | .error e => .error e
+  | .ok ((), st') => .ok st'
+
+/-- WS-L1/L1-C: Equivalence theorem — `_fromTcb` produces identical results
+to the original when the provided TCB matches the state. -/
+theorem storeTcbIpcState_fromTcb_eq
+    (hLookup : lookupTcb st tid = some tcb) :
+    storeTcbIpcState_fromTcb st tid tcb ipcState =
+    storeTcbIpcState st tid ipcState := by
+  unfold storeTcbIpcState_fromTcb storeTcbIpcState
+  simp [hLookup]
+
 /-- WS-F1: Store a pending IPC message in a thread's TCB.
 Used during IPC send to stage the message for transfer. -/
 def storeTcbPendingMessage (st : SystemState) (tid : SeLe4n.ThreadId) (msg : Option IpcMessage) : Except KernelError SystemState :=
@@ -89,6 +107,48 @@ def storeTcbIpcStateAndMessage (st : SystemState) (tid : SeLe4n.ThreadId)
       match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState, pendingMessage := msg }) st with
       | .error e => .error e
       | .ok ((), st') => .ok st'
+
+/-- WS-L1/L1-B: Variant of `storeTcbIpcStateAndMessage` that accepts a
+pre-looked-up TCB, bypassing the internal `lookupTcb`. Use when the caller
+has already validated the TCB on the same state. -/
+def storeTcbIpcStateAndMessage_fromTcb (st : SystemState) (tid : SeLe4n.ThreadId)
+    (tcb : TCB) (ipcState : ThreadIpcState) (msg : Option IpcMessage)
+    : Except KernelError SystemState :=
+  match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState, pendingMessage := msg }) st with
+  | .error e => .error e
+  | .ok ((), st') => .ok st'
+
+/-- WS-L1/L1-B: Equivalence theorem — `_fromTcb` produces identical results
+to the original when the provided TCB matches the state. All existing
+preservation theorems for `storeTcbIpcStateAndMessage` apply to `_fromTcb`
+via rewriting with this theorem. -/
+theorem storeTcbIpcStateAndMessage_fromTcb_eq
+    (hLookup : lookupTcb st tid = some tcb) :
+    storeTcbIpcStateAndMessage_fromTcb st tid tcb ipcState msg =
+    storeTcbIpcStateAndMessage st tid ipcState msg := by
+  unfold storeTcbIpcStateAndMessage_fromTcb storeTcbIpcStateAndMessage
+  simp [hLookup]
+
+/-- WS-L1: `lookupTcb` is preserved when `storeObject` targets a notification
+(different ObjId from any TCB). Used to justify `_fromTcb` usage after an
+intervening notification store. Accepts both `((), st')` and `pair` forms. -/
+theorem lookupTcb_preserved_by_storeObject_notification
+    {st : SystemState} {pair : Unit × SystemState} {tid : SeLe4n.ThreadId}
+    {tcb : TCB} {notifId : SeLe4n.ObjId} {ntfn : Notification}
+    {obj : KernelObject}
+    (hLookup : lookupTcb st tid = some tcb)
+    (hNtfn : st.objects[notifId]? = some (.notification ntfn))
+    (hStore : storeObject notifId obj st = .ok pair) :
+    lookupTcb pair.2 tid = some tcb := by
+  have hStore' : storeObject notifId obj st = .ok ((), pair.2) := by
+    rw [show pair = ((), pair.2) from by cases pair; rfl] at hStore; exact hStore
+  have hTcbObj := lookupTcb_some_objects st tid tcb hLookup
+  have hNe : tid.toObjId ≠ notifId := by
+    intro heq; rw [← heq] at hNtfn; rw [hNtfn] at hTcbObj; cases hTcbObj
+  have hPreserved := storeObject_objects_ne st pair.2 notifId tid.toObjId obj hNe hStore'
+  unfold lookupTcb at hLookup ⊢
+  rw [hPreserved]
+  exact hLookup
 
 /-- Signal a notification: wake one waiter or mark one pending badge. -/
 def notificationSignal (notificationId : SeLe4n.ObjId) (badge : SeLe4n.Badge) : Kernel Unit :=
@@ -166,7 +226,9 @@ def notificationWait
                   match storeObject notificationId (.notification ntfn') st with
                   | .error e => .error e
                   | .ok ((), st') =>
-                      match storeTcbIpcState st' waiter (.blockedOnNotification notificationId) with
+                      -- WS-L1/L1-C: Use _fromTcb — storeObject at notificationId
+                      -- does not modify waiter's TCB, so tcb is still valid in st'
+                      match storeTcbIpcState_fromTcb st' waiter tcb (.blockedOnNotification notificationId) with
                       | .error e => .error e
                       | .ok st'' => .ok (none, removeRunnable st'' waiter)
     | some _ => .error .invalidCapability
@@ -443,6 +505,9 @@ theorem notificationWait_badge_path_notification
             | ok pair =>
               simp only []
               intro hStep
+              -- WS-L1: rewrite _fromTcb back to original for proof compatibility
+              have hLookup' := lookupTcb_preserved_by_storeObject_notification hLookup hObj hStore
+              rw [storeTcbIpcState_fromTcb_eq hLookup'] at hStep
               revert hStep
               cases hTcb : storeTcbIpcState pair.2 waiter _ with
               | error e => simp
@@ -527,6 +592,9 @@ theorem notificationWait_wait_path_notification
             | ok pair =>
               simp only []
               intro hStep
+              -- WS-L1: rewrite _fromTcb back to original for proof compatibility
+              have hLookup' := lookupTcb_preserved_by_storeObject_notification hLookup hObj hStore
+              rw [storeTcbIpcState_fromTcb_eq hLookup'] at hStep
               revert hStep
               cases hTcb : storeTcbIpcState pair.2 waiter (.blockedOnNotification notifId) with
               | error e => simp

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Helpers.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Helpers.lean
@@ -811,6 +811,8 @@ theorem notificationWait_projection_preserved
             | error e => simp
             | ok pair =>
               simp only []
+              have hLk' := lookupTcb_preserved_by_storeObject_notification hLk hObj hStore
+              simp only [storeTcbIpcState_fromTcb_eq hLk']
               cases hTcb : storeTcbIpcState pair.2 waiter _ with
               | error e => simp
               | ok st2 =>

--- a/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
+++ b/SeLe4n/Kernel/InformationFlow/Invariant/Operations.lean
@@ -1252,6 +1252,7 @@ theorem endpointReply_preserves_projection
   | none => simp [hLookup] at hStep
   | some tcb =>
     simp only [hLookup] at hStep
+    rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup] at hStep
     cases hIpc : tcb.ipcState with
     | blockedOnReply ep replyTarget =>
       -- Resolve ipcState match and storeTcbIpcStateAndMessage in hStep

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -25,11 +25,22 @@ all deferred WS-I5 items.
 
 | ID | Focus | Priority |
 |----|-------|----------|
-| **WS-L1** | IPC performance optimization: eliminate redundant TCB lookups in endpointReceiveDual, endpointReply, notificationWait | HIGH — planned |
+| **WS-L1** | IPC performance optimization: eliminate redundant TCB lookups in endpointReceiveDual, endpointReply, notificationWait | HIGH — **COMPLETED** (v0.16.9) |
 | **WS-L2** | Code quality: HashMap.fold migration for detachCNodeSlots (closes WS-I5/R-17) | MEDIUM — planned |
 | **WS-L3** | Proof strengthening: enqueue-dequeue round-trip, queue link integrity, ipcState-queue consistency, tail preservation, reply contract preservation | MEDIUM — planned |
 | **WS-L4** | Test coverage: ReplyRecv positive-path, blocked thread rejection, multi-endpoint interleaving | MEDIUM — **PARTIALLY COMPLETE** |
 | **WS-L5** | Documentation: IF readers' guide, fixture update process, metrics automation, full doc sync (closes WS-I5/R-13/R-14/R-18) | LOW — **IN PROGRESS** |
+
+**WS-L1** (v0.16.9): Eliminated 4 redundant TCB lookups on IPC hot paths.
+L1-A: changed `endpointQueuePopHead` return type to `(ThreadId × TCB × SystemState)`,
+providing pre-dequeue TCB to callers and eliminating redundant `lookupTcb` in
+`endpointReceiveDual`. L1-B: added `storeTcbIpcStateAndMessage_fromTcb` with
+equivalence theorem, eliminating redundant lookups in `endpointReply` and
+`endpointReplyRecv`. L1-C: added `storeTcbIpcState_fromTcb` with equivalence
+theorem, eliminating redundant lookup in `notificationWait`. Added
+`lookupTcb_preserved_by_storeObject_notification` helper for cross-store TCB
+stability. ~18 mechanical pattern-match updates across 6 invariant files. Zero
+sorry/axiom; all proofs machine-checked.
 
 See [`AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md`](audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md)
 for the full workstream plan (5 phases: L1 through L5).

--- a/docs/audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md
@@ -138,8 +138,8 @@ Phase 5: WS-L5 (Documentation)    [after all implementation phases]
 
 ### WS-L1: IPC Performance Optimization
 
-**Objective**: Eliminate 5 redundant TCB lookups on IPC hot paths (4 on the
-endpoint send/receive/reply critical path, 1 on the notification wait path),
+**Objective**: Eliminate 4 redundant TCB lookups on IPC hot paths (3 on the
+endpoint receive/reply critical path, 1 on the notification wait path),
 reducing per-operation overhead by ~15–20% on critical paths.
 
 **Priority**: HIGH — Phase 1

--- a/docs/audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md
@@ -138,89 +138,325 @@ Phase 5: WS-L5 (Documentation)    [after all implementation phases]
 
 ### WS-L1: IPC Performance Optimization
 
-**Objective**: Eliminate 3 redundant TCB lookups on IPC hot paths, reducing
-per-operation overhead by ~15–20% on critical paths.
+**Objective**: Eliminate 5 redundant TCB lookups on IPC hot paths (4 on the
+endpoint send/receive/reply critical path, 1 on the notification wait path),
+reducing per-operation overhead by ~15–20% on critical paths.
 
 **Priority**: HIGH — Phase 1
 **Dependencies**: None
 **Findings addressed**: L-P01, L-P02, L-P03
 
+**Key design decisions**:
+
+1. **Equivalence-theorem strategy**: Instead of duplicating preservation lemmas
+   for `_fromTcb` variants, each variant ships with an equivalence theorem
+   proving `_fromTcb st tid tcb ... = original st tid ...` when
+   `lookupTcb st tid = some tcb`. All existing preservation proofs apply via
+   `simp`/`rw` rewriting. Zero new preservation lemmas needed.
+
+2. **Pre-dequeue TCB semantics**: `endpointQueuePopHead` returns the TCB as
+   captured at the internal `lookupTcb` (Core.lean:182), before queue links are
+   cleared. Non-queue fields (`ipcState`, `pendingMessage`, `priority`,
+   `domain`) are unchanged by PopHead and safe to read. Queue link fields
+   (`queuePrev`, `queuePPrev`, `queueNext`) are stale and must not be written
+   back. Callers that need to write to the TCB (via `storeTcbIpcStateAndMessage`)
+   must still use the state-based lookup since the post-state TCB has cleared
+   queue links.
+
+3. **Cascade minimization**: Transport lemma and preservation theorem updates
+   for PopHead are purely mechanical pattern-match changes (`(tid, st')` →
+   `(tid, _tcb, st')`). Proof bodies are unchanged because `unfold
+   endpointQueuePopHead` produces the same case structure with an additional
+   binding.
+
+---
+
 #### L1-A: Return dequeued TCB from `endpointQueuePopHead` (L-P01)
 
 **Problem**: `endpointQueuePopHead` (Core.lean:172–208) internally looks up the
 head TCB at line 182 to read `queueNext`, but returns only `(ThreadId, SystemState)`.
-Callers like `endpointReceiveDual` (Transport.lean:1355) must re-lookup the same
-TCB to read `pendingMessage` and `ipcState`.
+The most impacted caller, `endpointReceiveDual` (Transport.lean:1355), must
+re-lookup the same TCB to read `pendingMessage` and `ipcState` — fields that
+PopHead did not modify. This is a redundant O(log n) HashMap lookup on every
+endpoint receive rendezvous.
 
-**Deliverables**:
+**Sub-tasks**:
 
-1. Change `endpointQueuePopHead` return type from
-   `Except KernelError (ThreadId × SystemState)` to
-   `Except KernelError (ThreadId × TCB × SystemState)`.
-2. Return the dequeued TCB (captured at line 182) as the second tuple element.
-3. Update all callers:
-   - `endpointSendDual` (Transport.lean:1308)
-   - `endpointReceiveDual` (Transport.lean:1349)
-   - `endpointCall` (Transport.lean:1412)
-4. Remove the redundant `lookupTcb` call at Transport.lean:1355.
-5. Update all transport lemmas in `Transport.lean` that reference
-   `endpointQueuePopHead` return type.
-6. Update preservation theorems in `EndpointPreservation.lean`,
-   `CallReplyRecv.lean`, `Structural.lean` that pattern-match on PopHead result.
+##### L1-A.1: Change PopHead signature and implementation (Core.lean)
 
-**Files modified**:
-- `SeLe4n/Kernel/IPC/DualQueue/Core.lean` — signature + implementation
-- `SeLe4n/Kernel/IPC/DualQueue/Transport.lean` — callers + transport lemmas
-- `SeLe4n/Kernel/IPC/Invariant/EndpointPreservation.lean` — preservation proofs
-- `SeLe4n/Kernel/IPC/Invariant/CallReplyRecv.lean` — preservation proofs
-- `SeLe4n/Kernel/IPC/Invariant/Structural.lean` — structural preservation proofs
+**Scope**: `SeLe4n/Kernel/IPC/DualQueue/Core.lean`, lines 172–208
 
-**Exit evidence**:
+1. Change return type from `Except KernelError (SeLe4n.ThreadId × SystemState)`
+   to `Except KernelError (SeLe4n.ThreadId × TCB × SystemState)`.
+2. At line 206, change `.ok (tid, st3)` to `.ok (tid, headTcb, st3)` where
+   `headTcb` is the TCB captured at line 182–184. This is the pre-dequeue TCB;
+   non-queue fields are accurate, queue link fields are stale (cleared in `st3`).
+3. No other changes to Core.lean.
+
+**Exit**: `Core.lean` compiles (callers will temporarily break).
+
+##### L1-A.2: Update PopHead transport lemmas (Transport.lean:19–299)
+
+**Scope**: 5 transport lemmas that pattern-match on PopHead result
+
+Each lemma's hypothesis changes mechanically:
+```
+hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, st')
+  →
+hStep : endpointQueuePopHead endpointId isReceiveQ st = .ok (tid, _headTcb, st')
+```
+
+Affected lemmas (all in `Transport.lean`):
+- `endpointQueuePopHead_scheduler_eq` (lines 20–69)
+- `endpointQueuePopHead_endpoint_backward_ne` (lines 72–123)
+- `endpointQueuePopHead_notification_backward` (lines 126–180)
+- `endpointQueuePopHead_tcb_forward` (lines 184–237)
+- `endpointQueuePopHead_tcb_ipcState_backward` (lines 241–299)
+
+Proof bodies unchanged — `unfold endpointQueuePopHead at hStep` still produces
+the same case tree; the additional `headTcb` binding is consumed by existing
+`simp`/`cases` tactics.
+
+**Exit**: All transport lemmas compile.
+
+##### L1-A.3: Update `endpointReceiveDual` — eliminate redundant lookup
+
+**Scope**: `Transport.lean`, lines 1342–1388
+
+Change destructuring at line 1351 from `(sender, st')` to
+`(sender, senderTcb, st')`. Replace the redundant `lookupTcb st' sender`
+block (lines 1355–1359) with direct field access:
+```lean
+let (senderMsg, senderWasCall) :=
+  (senderTcb.pendingMessage, match senderTcb.ipcState with
+    | .blockedOnCall _ => true
+    | _ => false)
+```
+
+This eliminates 1 redundant lookup. The `senderTcb` fields `pendingMessage`
+and `ipcState` are unchanged by PopHead (only queue links are modified).
+
+**Exit**: `endpointReceiveDual` compiles with zero `lookupTcb` after PopHead.
+
+##### L1-A.4: Update `endpointSendDual` and `endpointCall` — mechanical
+
+**Scope**: `Transport.lean`, lines 1297–1324 and 1401–1433
+
+- `endpointSendDual` line 1311: `(receiver, st')` → `(receiver, _tcb, st')`
+- `endpointCall` line 1415: `(receiver, st')` → `(receiver, _tcb, st')`
+
+These callers don't use the returned TCB (they operate on the receiver, not the
+dequeued thread's TCB data). Change is purely mechanical.
+
+**Exit**: Both functions compile.
+
+##### L1-A.5: Update preservation theorems — mechanical cascade
+
+**Scope**: Preservation theorems across 3 invariant files
+
+All theorems that destructure PopHead results need the same mechanical update:
+`(tid, st')` → `(tid, _tcb, st')` in hypothesis patterns. The proof bodies
+are unchanged because `unfold endpointQueuePopHead` still works identically.
+
+Files and estimated theorem counts:
+- `EndpointPreservation.lean`: ~6 theorems referencing PopHead
+- `CallReplyRecv.lean`: ~4 theorems referencing PopHead
+- `Structural.lean`: ~8 theorems referencing PopHead
+
+**Exit**: `lake build` succeeds with zero warnings.
+
+**Files modified (L1-A total)**:
+- `SeLe4n/Kernel/IPC/DualQueue/Core.lean` — signature + return value
+- `SeLe4n/Kernel/IPC/DualQueue/Transport.lean` — lemmas + callers
+- `SeLe4n/Kernel/IPC/Invariant/EndpointPreservation.lean` — mechanical
+- `SeLe4n/Kernel/IPC/Invariant/CallReplyRecv.lean` — mechanical
+- `SeLe4n/Kernel/IPC/Invariant/Structural.lean` — mechanical
+
+**L1-A exit evidence**:
 - `lake build` succeeds with zero warnings
 - `test_smoke.sh` passes
-- `rg "lookupTcb.*sender" Transport.lean` returns zero hits after PopHead call
+- `rg "lookupTcb.*sender" Transport.lean` returns zero hits in receive path
+
+---
 
 #### L1-B: Cache validated TCB in `endpointReply`/`endpointReplyRecv` (L-P02)
 
-**Problem**: `endpointReply` (Transport.lean:1451) calls `lookupTcb` to validate
-the target's `ipcState = .blockedOnReply`, then `storeTcbIpcStateAndMessage`
-(line 1461) internally calls `lookupTcb` again on the same thread.
+**Problem**: `endpointReply` (Transport.lean:1451) calls `lookupTcb st target`
+to validate `ipcState = .blockedOnReply`, then `storeTcbIpcStateAndMessage`
+(line 1461) internally calls `lookupTcb st target` again on the **same state**
+`st`. Similarly, `endpointReplyRecv` (line 1481/1492) has the same pattern.
+Each redundant lookup is an O(log n) HashMap operation on every reply.
 
-**Deliverables**:
+**Sub-tasks**:
 
-1. Add `storeTcbIpcStateAndMessage_fromTcb` variant that accepts a pre-looked-up
-   TCB instead of performing internal lookup.
-2. Update `endpointReply` to pass the validated TCB directly.
-3. Update `endpointReplyRecv` similarly.
-4. Add preservation lemmas for the `_fromTcb` variant mirroring existing ones.
+##### L1-B.1: Add `storeTcbIpcStateAndMessage_fromTcb` with equivalence theorem
 
-**Files modified**:
-- `SeLe4n/Kernel/IPC/Operations/Endpoint.lean` — add `_fromTcb` variant
-- `SeLe4n/Kernel/IPC/DualQueue/Transport.lean` — update callers
-- `SeLe4n/Kernel/IPC/Operations/SchedulerLemmas.lean` — add preservation lemmas
+**Scope**: `SeLe4n/Kernel/IPC/Operations/Endpoint.lean`, after line 91
 
-**Exit evidence**:
-- `lake build` succeeds
+1. Add the `_fromTcb` variant:
+   ```lean
+   def storeTcbIpcStateAndMessage_fromTcb (st : SystemState) (tid : SeLe4n.ThreadId)
+       (tcb : TCB) (ipcState : ThreadIpcState) (msg : Option IpcMessage)
+       : Except KernelError SystemState :=
+     match storeObject tid.toObjId
+       (.tcb { tcb with ipcState := ipcState, pendingMessage := msg }) st with
+     | .error e => .error e
+     | .ok ((), st') => .ok st'
+   ```
+
+2. Add equivalence theorem (immediately after):
+   ```lean
+   theorem storeTcbIpcStateAndMessage_fromTcb_eq
+       (hLookup : lookupTcb st tid = some tcb) :
+       storeTcbIpcStateAndMessage_fromTcb st tid tcb ipcState msg =
+       storeTcbIpcStateAndMessage st tid ipcState msg
+   ```
+   Proof: unfold both, rewrite with `hLookup`, `rfl`.
+
+This equivalence theorem means **zero new preservation lemmas** are needed.
+Any existing theorem about `storeTcbIpcStateAndMessage` applies to the
+`_fromTcb` variant via `rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup]`.
+
+**Exit**: New function and theorem compile with zero sorry.
+
+##### L1-B.2: Update `endpointReply` to use `_fromTcb`
+
+**Scope**: `Transport.lean`, lines 1444–1465
+
+At line 1461, replace:
+```lean
+match storeTcbIpcStateAndMessage st target .ready (some msg) with
+```
+with:
+```lean
+match storeTcbIpcStateAndMessage_fromTcb st target tcb .ready (some msg) with
+```
+where `tcb` is the TCB already bound at line 1453. Both lookups operate on the
+same state `st`, so the TCB is guaranteed to match.
+
+**Exit**: `endpointReply` compiles. 1 redundant lookup eliminated.
+
+##### L1-B.3: Update `endpointReplyRecv` to use `_fromTcb`
+
+**Scope**: `Transport.lean`, lines 1471–1501
+
+At line 1492, replace:
+```lean
+match storeTcbIpcStateAndMessage st replyTarget .ready (some msg) with
+```
+with:
+```lean
+match storeTcbIpcStateAndMessage_fromTcb st replyTarget tcb .ready (some msg) with
+```
+where `tcb` is bound at line 1483. Same-state guarantee applies.
+
+**Exit**: `endpointReplyRecv` compiles. 1 redundant lookup eliminated.
+
+**Files modified (L1-B total)**:
+- `SeLe4n/Kernel/IPC/Operations/Endpoint.lean` — new function + theorem
+- `SeLe4n/Kernel/IPC/DualQueue/Transport.lean` — 2 caller updates
+
+**L1-B exit evidence**:
+- `lake build` succeeds with zero warnings
 - `test_smoke.sh` passes
+- Zero new preservation lemmas needed (equivalence theorem covers all cases)
+
+---
 
 #### L1-C: Cache validated TCB in `notificationWait` (L-P03)
 
-**Problem**: `notificationWait` (Endpoint.lean:155) calls `lookupTcb` for the
-duplicate-wait check, then `storeTcbIpcState` (line 169) re-lookups the same TCB.
+**Problem**: `notificationWait` (Endpoint.lean:155) calls `lookupTcb st waiter`
+for the O(1) duplicate-wait check, then `storeTcbIpcState` (line 169) re-lookups
+the same TCB. The intermediate `storeObject` (line 165) modifies only the
+notification object at `notificationId`, not the waiter's TCB, so the looked-up
+TCB is still valid in the post-store state.
 
-**Deliverables**:
+**Sub-tasks**:
 
-1. Add `storeTcbIpcState_fromTcb` variant that accepts a pre-looked-up TCB.
-2. Update `notificationWait` to pass the cached TCB from line 155.
-3. Add preservation lemmas for the `_fromTcb` variant.
+##### L1-C.1: Add `storeTcbIpcState_fromTcb` with equivalence theorem
 
-**Files modified**:
-- `SeLe4n/Kernel/IPC/Operations/Endpoint.lean` — add variant + update caller
-- `SeLe4n/Kernel/IPC/Operations/SchedulerLemmas.lean` — preservation lemmas
+**Scope**: `SeLe4n/Kernel/IPC/Operations/Endpoint.lean`, after `storeTcbIpcState`
 
-**Exit evidence**:
-- `lake build` succeeds
+1. Add the `_fromTcb` variant:
+   ```lean
+   def storeTcbIpcState_fromTcb (st : SystemState) (tid : SeLe4n.ThreadId)
+       (tcb : TCB) (ipcState : ThreadIpcState) : Except KernelError SystemState :=
+     match storeObject tid.toObjId (.tcb { tcb with ipcState := ipcState }) st with
+     | .error e => .error e
+     | .ok ((), st') => .ok st'
+   ```
+
+2. Add equivalence theorem:
+   ```lean
+   theorem storeTcbIpcState_fromTcb_eq
+       (hLookup : lookupTcb st tid = some tcb) :
+       storeTcbIpcState_fromTcb st tid tcb ipcState =
+       storeTcbIpcState st tid ipcState
+   ```
+
+3. Add TCB cross-store stability lemma (used to justify `_fromTcb` usage
+   after an intervening `storeObject` at a different ObjId):
+   ```lean
+   theorem lookupTcb_preserved_by_storeObject_ne
+       (hLookup : lookupTcb st tid = some tcb)
+       (hNe : oid ≠ tid.toObjId)
+       (hStore : storeObject oid obj st = .ok ((), st')) :
+       lookupTcb st' tid = some tcb
+   ```
+   This lemma proves the TCB is unchanged when `storeObject` targets a
+   different ObjId — which is exactly the case in `notificationWait` where
+   the notification is stored at `notificationId` but the TCB is at
+   `waiter.toObjId`.
+
+**Exit**: New function, equivalence theorem, and stability lemma compile.
+
+##### L1-C.2: Update `notificationWait` to use `_fromTcb`
+
+**Scope**: `Endpoint.lean`, lines 138–173
+
+In the no-pending-badge branch, after `lookupTcb st waiter` succeeds with
+`tcb` at line 155, and after `storeObject notificationId (.notification ntfn')
+st` produces `st'` at line 165, replace:
+```lean
+match storeTcbIpcState st' waiter (.blockedOnNotification notificationId) with
+```
+with:
+```lean
+match storeTcbIpcState_fromTcb st' waiter tcb (.blockedOnNotification notificationId) with
+```
+**Correctness justification**: `storeObject` at `notificationId` does not modify
+the TCB at `waiter.toObjId` (different ObjId), so `lookupTcb st' waiter =
+some tcb` holds. The equivalence theorem then guarantees identical behavior.
+
+**Exit**: `notificationWait` compiles. 1 redundant lookup eliminated.
+
+**Files modified (L1-C total)**:
+- `SeLe4n/Kernel/IPC/Operations/Endpoint.lean` — new function + theorems + caller
+
+**L1-C exit evidence**:
+- `lake build` succeeds with zero warnings
 - `test_smoke.sh` passes
+
+---
+
+#### WS-L1 Aggregate Summary
+
+| Sub-task | Lookups eliminated | Cascade scope | Risk |
+|----------|-------------------|---------------|------|
+| L1-A (PopHead TCB) | 1 (endpointReceiveDual) | ~18 theorem pattern-match updates | Medium: wide cascade but mechanical |
+| L1-B (reply _fromTcb) | 2 (endpointReply + ReplyRecv) | 2 caller updates, 0 new lemmas | Low: additive, equivalence theorem |
+| L1-C (notification _fromTcb) | 1 (notificationWait) | 1 caller update, 0 new lemmas | Low: additive, single file |
+| **Total** | **4 redundant lookups** | | |
+
+**Recommended execution order**: L1-B → L1-C → L1-A. Start with additive
+changes (new `_fromTcb` functions) that don't cascade, then tackle the
+signature change (L1-A) which has the widest impact but is mechanically safe.
+
+**WS-L1 aggregate exit evidence**:
+- `lake build` succeeds with zero warnings
+- `test_smoke.sh` passes
+- Zero `sorry` in any new theorem or function
+- 4 redundant `lookupTcb` calls eliminated across IPC hot paths
 
 ---
 
@@ -561,9 +797,9 @@ undocumented.
 
 | Finding | Phase | Task | Status |
 |---------|-------|------|--------|
-| L-P01 | WS-L1 | L1-A | Planned |
-| L-P02 | WS-L1 | L1-B | Planned |
-| L-P03 | WS-L1 | L1-C | Planned |
+| L-P01 | WS-L1 | L1-A | **COMPLETED** (v0.16.9) |
+| L-P02 | WS-L1 | L1-B | **COMPLETED** (v0.16.9) |
+| L-P03 | WS-L1 | L1-C | **COMPLETED** (v0.16.9) |
 | L-D04 | WS-L2 | L2-A | Planned |
 | L-G01 | WS-L3 | L3-A | Planned |
 | L-G02 | WS-L3 | L3-B | Planned |

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "main",
-      "commit_sha": "3ce5845be86d78822d113fad0f77c93cce9929b2",
-      "tree_sha": "3970c8a19e32273905aedbb7078e3adb8027e20d",
-      "committed_at_utc": "2026-03-15T02:38:32-04:00"
+      "branch": "claude/refine-ipc-workstream-4D5YG",
+      "commit_sha": "182bf432fd8214eacfd4a6d105b541d4fe580f18",
+      "tree_sha": "df0a3983a8220ee398e6fe27a1a946750efec159",
+      "committed_at_utc": "2026-03-15T06:38:40+00:00"
     }
   },
   "source_sync": {
@@ -17,20 +17,20 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "77f768f7045fb73b7c34ac198be360958165b33535bac31ea4b06f3f4a58d265"
+    "source_digest": "2374a89b7ede8c1e50f2699362694c23a2ba68329cffce469723257948a90f23"
   },
   "summary": {
     "module_count": 73,
-    "declaration_count": 2238
+    "declaration_count": 2244
   },
   "readme_sync": {
-    "version": "0.16.8",
+    "version": "0.16.9",
     "lean_toolchain": "v4.28.0",
     "production_files": 69,
-    "production_loc": 37245,
+    "production_loc": 37217,
     "test_files": 4,
     "test_loc": 4098,
-    "proved_theorem_lemma_decls": 1198,
+    "proved_theorem_lemma_decls": 1202,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
   "modules": [
@@ -2442,7 +2442,7 @@
         {
           "kind": "theorem",
           "name": "badge_notification_routing_consistent",
-          "line": 491,
+          "line": 493,
           "called": [
             "notificationSignal_badge_stored_fresh",
             "notificationWait_recovers_pending_badge"
@@ -2451,31 +2451,31 @@
         {
           "kind": "theorem",
           "name": "badge_merge_idempotent",
-          "line": 519,
+          "line": 521,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceLookupSound_of_cspaceSlotUnique",
-          "line": 533,
+          "line": 535,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeObject_nonCNode",
-          "line": 544,
+          "line": 546,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeObject_cnode",
-          "line": 563,
+          "line": 565,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_endpoint_store",
-          "line": 581,
+          "line": 583,
           "called": [
             "cspaceSlotUnique_of_storeObject_nonCNode"
           ]
@@ -2483,13 +2483,13 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_objects_eq",
-          "line": 590,
+          "line": 592,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceAttenuationRule_holds",
-          "line": 604,
+          "line": 606,
           "called": [
             "mintDerivedCap_attenuates"
           ]
@@ -2497,7 +2497,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleAuthorityMonotonicity_holds",
-          "line": 610,
+          "line": 612,
           "called": [
             "cspaceDeleteSlot_authority_reduction",
             "cspaceRevoke_local_target_reduction"
@@ -2506,7 +2506,7 @@
         {
           "kind": "theorem",
           "name": "capabilityInvariantBundle_of_slotUnique",
-          "line": 622,
+          "line": 624,
           "called": [
             "cspaceLookupSound_of_cspaceSlotUnique"
           ]
@@ -3125,13 +3125,13 @@
         {
           "kind": "def",
           "name": "coreIpcInvariantBundle",
-          "line": 872,
+          "line": 873,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_ipcInvariant",
-          "line": 877,
+          "line": 878,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3139,7 +3139,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_dualQueueSystemInvariant",
-          "line": 882,
+          "line": 883,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3147,7 +3147,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_allPendingMessagesBounded",
-          "line": 887,
+          "line": 888,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3155,7 +3155,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_badgeWellFormed",
-          "line": 892,
+          "line": 893,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3163,43 +3163,43 @@
         {
           "kind": "def",
           "name": "ipcSchedulerRunnableReadyComponent",
-          "line": 897,
+          "line": 898,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedSendComponent",
-          "line": 901,
+          "line": 902,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedReceiveComponent",
-          "line": 905,
+          "line": 906,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedCallComponent",
-          "line": 909,
+          "line": 910,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedReplyComponent",
-          "line": 913,
+          "line": 914,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedNotificationComponent",
-          "line": 917,
+          "line": 918,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerCoherenceComponent",
-          "line": 921,
+          "line": 922,
           "called": [
             "ipcSchedulerBlockedCallComponent",
             "ipcSchedulerBlockedNotificationComponent",
@@ -3212,7 +3212,7 @@
         {
           "kind": "theorem",
           "name": "ipcSchedulerCoherenceComponent_iff_contractPredicates",
-          "line": 929,
+          "line": 930,
           "called": [
             "ipcSchedulerCoherenceComponent"
           ]
@@ -3220,7 +3220,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerCouplingInvariantBundle",
-          "line": 939,
+          "line": 940,
           "called": [
             "coreIpcInvariantBundle",
             "ipcSchedulerCoherenceComponent"
@@ -3229,7 +3229,7 @@
         {
           "kind": "def",
           "name": "lifecycleCompositionInvariantBundle",
-          "line": 945,
+          "line": 946,
           "called": [
             "ipcSchedulerCouplingInvariantBundle"
           ]
@@ -3237,25 +3237,25 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_schedulerInvariantBundle",
-          "line": 948,
+          "line": 949,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
-          "line": 967,
+          "line": 968,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_ipcInvariant",
-          "line": 1023,
+          "line": 1024,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_coreIpcInvariantBundle",
-          "line": 1049,
+          "line": 1050,
           "called": [
             "coreIpcInvariantBundle",
             "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
@@ -3266,7 +3266,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1075,
+          "line": 1076,
           "called": [
             "coreIpcInvariantBundle",
             "ipcSchedulerCoherenceComponent",
@@ -3277,7 +3277,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle",
-          "line": 1106,
+          "line": 1107,
           "called": [
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
             "cspaceRevoke_preserves_capabilityInvariantBundle",
@@ -3287,7 +3287,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityInvariant",
-          "line": 1127,
+          "line": 1128,
           "called": [
             "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle"
           ]
@@ -3295,7 +3295,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_error_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1158,
+          "line": 1159,
           "called": [
             "lifecycleCompositionInvariantBundle"
           ]
@@ -3303,13 +3303,13 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeTcbIpcState",
-          "line": 1171,
+          "line": 1172,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_blocking_path",
-          "line": 1190,
+          "line": 1191,
           "called": [
             "cspaceSlotUnique_of_storeTcbIpcState"
           ]
@@ -3317,7 +3317,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_handshake_path",
-          "line": 1203,
+          "line": 1204,
           "called": [
             "cspaceSlotUnique_of_storeTcbIpcState"
           ]
@@ -3325,25 +3325,25 @@
         {
           "kind": "theorem",
           "name": "storeObject_cnode_preserves_notificationBadgesWellFormed",
-          "line": 1221,
+          "line": 1222,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_cnode_preserves_capabilityBadgesWellFormed",
-          "line": 1231,
+          "line": 1232,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "badgeWellFormed_of_objects_eq",
-          "line": 1246,
+          "line": 1247,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMint_preserves_badgeWellFormed",
-          "line": 1257,
+          "line": 1258,
           "called": [
             "badgeWellFormed_of_objects_eq",
             "storeObject_cnode_preserves_capabilityBadgesWellFormed",
@@ -3353,7 +3353,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMutate_preserves_badgeWellFormed",
-          "line": 1317,
+          "line": 1318,
           "called": [
             "badgeWellFormed_of_objects_eq",
             "storeObject_cnode_preserves_capabilityBadgesWellFormed",
@@ -3814,7 +3814,7 @@
         {
           "kind": "def",
           "name": "endpointQueuePopHead",
-          "line": 172,
+          "line": 175,
           "called": [
             "storeTcbQueueLinks"
           ]
@@ -3822,7 +3822,7 @@
         {
           "kind": "def",
           "name": "endpointQueueEnqueue",
-          "line": 210,
+          "line": 213,
           "called": [
             "storeTcbQueueLinks"
           ]
@@ -3955,25 +3955,25 @@
         {
           "kind": "def",
           "name": "endpointReceiveDual",
-          "line": 1342,
+          "line": 1343,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointCall",
-          "line": 1401,
+          "line": 1402,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointReply",
-          "line": 1444,
+          "line": 1446,
           "called": []
         },
         {
           "kind": "def",
           "name": "endpointReplyRecv",
-          "line": 1471,
+          "line": 1474,
           "called": [
             "endpointReceiveDual"
           ]
@@ -4030,19 +4030,19 @@
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_schedulerInvariantBundle",
-          "line": 558,
+          "line": 559,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_ipcSchedulerContractPredicates",
-          "line": 667,
+          "line": 669,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_ipcSchedulerContractPredicates",
-          "line": 794,
+          "line": 797,
           "called": []
         }
       ]
@@ -4050,7 +4050,7 @@
     {
       "module": "SeLe4n.Kernel.IPC.Invariant.Defs",
       "path": "SeLe4n/Kernel/IPC/Invariant/Defs.lean",
-      "declaration_count": 43,
+      "declaration_count": 44,
       "declarations": [
         {
           "kind": "namespace",
@@ -4281,8 +4281,14 @@
         },
         {
           "kind": "theorem",
+          "name": "endpointQueuePopHead_returns_pre_tcb",
+          "line": 342,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "scheduler_unchanged_through_store_tcb",
-          "line": 347,
+          "line": 395,
           "called": [
             "storeObject_scheduler_eq"
           ]
@@ -4290,7 +4296,7 @@
         {
           "kind": "theorem",
           "name": "tcb_preserved_through_endpoint_store",
-          "line": 357,
+          "line": 405,
           "called": [
             "storeObject_objects_ne"
           ]
@@ -4298,13 +4304,13 @@
         {
           "kind": "def",
           "name": "notificationWaiterConsistent",
-          "line": 374,
+          "line": 422,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "not_mem_waitingThreads_of_ipcState_ne",
-          "line": 383,
+          "line": 431,
           "called": [
             "notificationWaiterConsistent"
           ]
@@ -4312,13 +4318,13 @@
         {
           "kind": "def",
           "name": "uniqueWaiters",
-          "line": 400,
+          "line": 448,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_uniqueWaiters",
-          "line": 406,
+          "line": 454,
           "called": [
             "not_mem_waitingThreads_of_ipcState_ne",
             "notificationWaiterConsistent",
@@ -4329,7 +4335,7 @@
         {
           "kind": "theorem",
           "name": "default_notificationWaiterConsistent",
-          "line": 506,
+          "line": 556,
           "called": [
             "notificationWaiterConsistent"
           ]
@@ -4337,7 +4343,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_wake",
-          "line": 555,
+          "line": 605,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -4345,7 +4351,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_result_wellFormed_merge",
-          "line": 567,
+          "line": 617,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -4353,7 +4359,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_badge",
-          "line": 577,
+          "line": 627,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -4361,7 +4367,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_result_wellFormed_wait",
-          "line": 584,
+          "line": 634,
           "called": [
             "notificationQueueWellFormed"
           ]
@@ -4388,67 +4394,67 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_ipcInvariant",
-          "line": 143,
+          "line": 144,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "scheduler_unchanged_through_store_tcb_msg",
-          "line": 204,
+          "line": 206,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_ipcInvariant",
-          "line": 248,
+          "line": 250,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_endpoint_preserves_ipcInvariant",
-          "line": 258,
+          "line": 260,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_ipcInvariant",
-          "line": 270,
+          "line": 272,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_ipcInvariant",
-          "line": 277,
+          "line": 279,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_ipcInvariant",
-          "line": 284,
+          "line": 286,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_preserves_ipcInvariant",
-          "line": 293,
+          "line": 295,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_preserves_ipcInvariant",
-          "line": 302,
+          "line": 304,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "contracts_of_same_scheduler_ipcState",
-          "line": 318,
+          "line": 320,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_ipcInvariant",
-          "line": 362,
+          "line": 364,
           "called": [
             "endpointQueueEnqueue_preserves_ipcInvariant",
             "endpointQueuePopHead_preserves_ipcInvariant",
@@ -4458,37 +4464,37 @@
         {
           "kind": "theorem",
           "name": "endpointSendDual_message_bounded",
-          "line": 413,
+          "line": 415,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_message_bounded",
-          "line": 427,
+          "line": 429,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_message_bounded",
-          "line": 440,
+          "line": 442,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_message_bounded",
-          "line": 453,
+          "line": 455,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_schedulerInvariantBundle",
-          "line": 467,
+          "line": 469,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_ipcSchedulerContractPredicates",
-          "line": 580,
+          "line": 582,
           "called": [
             "contracts_of_same_scheduler_ipcState"
           ]
@@ -4496,7 +4502,7 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_ipcInvariant",
-          "line": 769,
+          "line": 771,
           "called": [
             "endpointQueueEnqueue_preserves_ipcInvariant",
             "endpointQueuePopHead_preserves_ipcInvariant",
@@ -4508,13 +4514,13 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_schedulerInvariantBundle",
-          "line": 854,
+          "line": 838,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_ipcSchedulerContractPredicates",
-          "line": 1074,
+          "line": 999,
           "called": [
             "contracts_of_same_scheduler_ipcState"
           ]
@@ -4522,19 +4528,19 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_preserves_ipcInvariant",
-          "line": 1424,
+          "line": 1266,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_preserves_schedulerInvariantBundle",
-          "line": 1433,
+          "line": 1275,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_preserves_ipcSchedulerContractPredicates",
-          "line": 1457,
+          "line": 1299,
           "called": [
             "contracts_of_same_scheduler_ipcState"
           ]
@@ -4583,55 +4589,55 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_schedulerInvariantBundle",
-          "line": 239,
+          "line": 241,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_ipcSchedulerContractPredicates",
-          "line": 360,
+          "line": 364,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_ipcSchedulerContractPredicates",
-          "line": 526,
+          "line": 530,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_notification_preserves_notificationBadgesWellFormed",
-          "line": 801,
+          "line": 807,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_nonNotification_preserves_notificationBadgesWellFormed",
-          "line": 814,
+          "line": 820,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_nonCNode_preserves_capabilityBadgesWellFormed",
-          "line": 830,
+          "line": 836,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_badgeWellFormed",
-          "line": 847,
+          "line": 853,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_badgeWellFormed",
-          "line": 856,
+          "line": 862,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_badgeWellFormed",
-          "line": 862,
+          "line": 868,
           "called": [
             "storeObject_nonCNode_preserves_capabilityBadgesWellFormed",
             "storeObject_nonNotification_preserves_notificationBadgesWellFormed"
@@ -4640,7 +4646,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_badgeWellFormed",
-          "line": 884,
+          "line": 890,
           "called": [
             "ensureRunnable_preserves_badgeWellFormed",
             "storeObject_nonCNode_preserves_capabilityBadgesWellFormed",
@@ -4651,7 +4657,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_badgeWellFormed",
-          "line": 929,
+          "line": 935,
           "called": [
             "removeRunnable_preserves_badgeWellFormed",
             "storeObject_nonCNode_preserves_capabilityBadgesWellFormed",
@@ -4851,13 +4857,13 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_result_tcb",
-          "line": 519,
+          "line": 520,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_iqwf",
-          "line": 539,
+          "line": 540,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -4865,7 +4871,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_clearing_preserves_linkInteg",
-          "line": 565,
+          "line": 566,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -4873,7 +4879,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_noprevnext_preserves_linkInteg",
-          "line": 601,
+          "line": 602,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -4881,7 +4887,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_append_tail_preserves_linkInteg",
-          "line": 637,
+          "line": 638,
           "called": [
             "storeTcbQueueLinks_result_tcb"
           ]
@@ -4889,7 +4895,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
-          "line": 747,
+          "line": 748,
           "called": [
             "intrusiveQueueWellFormed_empty",
             "storeObject_endpoint_preserves_intrusiveQueueWellFormed",
@@ -4902,7 +4908,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
-          "line": 1087,
+          "line": 1088,
           "called": [
             "storeObject_endpoint_preserves_intrusiveQueueWellFormed",
             "storeObject_endpoint_preserves_tcbQueueLinkIntegrity",
@@ -4915,7 +4921,7 @@
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_dualQueueSystemInvariant",
-          "line": 1402,
+          "line": 1403,
           "called": [
             "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
             "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
@@ -4927,7 +4933,7 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_dualQueueSystemInvariant",
-          "line": 1469,
+          "line": 1470,
           "called": [
             "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
             "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
@@ -4941,7 +4947,7 @@
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_dualQueueSystemInvariant",
-          "line": 1578,
+          "line": 1561,
           "called": [
             "endpointReceiveDual_preserves_dualQueueSystemInvariant",
             "ensureRunnable_preserves_dualQueueSystemInvariant",
@@ -4951,7 +4957,7 @@
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_dualQueueSystemInvariant",
-          "line": 1677,
+          "line": 1661,
           "called": [
             "endpointQueueEnqueue_preserves_dualQueueSystemInvariant",
             "endpointQueuePopHead_preserves_dualQueueSystemInvariant",
@@ -4964,13 +4970,13 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_contextMatchesCurrent",
-          "line": 1761,
+          "line": 1745,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_contextMatchesCurrent",
-          "line": 1792,
+          "line": 1776,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -4978,7 +4984,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_contextMatchesCurrent",
-          "line": 1813,
+          "line": 1797,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -4986,7 +4992,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_contextMatchesCurrent",
-          "line": 1834,
+          "line": 1818,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -4994,7 +5000,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_contextMatchesCurrent",
-          "line": 1855,
+          "line": 1839,
           "called": [
             "storeObject_preserves_contextMatchesCurrent"
           ]
@@ -5002,67 +5008,67 @@
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_contextMatchesCurrent",
-          "line": 1880,
+          "line": 1864,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_contextMatchesCurrent",
-          "line": 1901,
+          "line": 1885,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_allPendingMessagesBounded",
-          "line": 1921,
+          "line": 1905,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_allPendingMessagesBounded",
-          "line": 1931,
+          "line": 1915,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_allPendingMessagesBounded",
-          "line": 1941,
+          "line": 1925,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcStateAndMessage_preserves_allPendingMessagesBounded",
-          "line": 1968,
+          "line": 1952,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbPendingMessage_preserves_allPendingMessagesBounded",
-          "line": 1996,
+          "line": 1980,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_endpoint_preserves_allPendingMessagesBounded",
-          "line": 2022,
+          "line": 2006,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeTcbQueueLinks_preserves_allPendingMessagesBounded",
-          "line": 2037,
+          "line": 2021,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_notification_preserves_allPendingMessagesBounded",
-          "line": 2067,
+          "line": 2051,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_allPendingMessagesBounded",
-          "line": 2086,
+          "line": 2070,
           "called": [
             "ensureRunnable_preserves_allPendingMessagesBounded",
             "storeObject_notification_preserves_allPendingMessagesBounded",
@@ -5072,7 +5078,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_allPendingMessagesBounded",
-          "line": 2127,
+          "line": 2111,
           "called": [
             "removeRunnable_preserves_allPendingMessagesBounded",
             "storeObject_notification_preserves_allPendingMessagesBounded",
@@ -5082,7 +5088,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_allPendingMessagesBounded",
-          "line": 2190,
+          "line": 2176,
           "called": [
             "ensureRunnable_preserves_allPendingMessagesBounded",
             "storeTcbIpcStateAndMessage_preserves_allPendingMessagesBounded"
@@ -5091,7 +5097,7 @@
         {
           "kind": "theorem",
           "name": "notificationSignal_preserves_ipcInvariantFull",
-          "line": 2252,
+          "line": 2239,
           "called": [
             "notificationSignal_preserves_allPendingMessagesBounded"
           ]
@@ -5099,7 +5105,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_ipcInvariantFull",
-          "line": 2267,
+          "line": 2254,
           "called": [
             "notificationWait_preserves_allPendingMessagesBounded"
           ]
@@ -5107,7 +5113,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_ipcInvariantFull",
-          "line": 2286,
+          "line": 2273,
           "called": [
             "endpointReply_preserves_allPendingMessagesBounded"
           ]
@@ -5115,25 +5121,25 @@
         {
           "kind": "theorem",
           "name": "endpointSendDual_preserves_ipcInvariantFull",
-          "line": 2304,
+          "line": 2291,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_ipcInvariantFull",
-          "line": 2317,
+          "line": 2304,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_ipcInvariantFull",
-          "line": 2330,
+          "line": 2317,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_ipcInvariantFull",
-          "line": 2343,
+          "line": 2330,
           "called": []
         }
       ]
@@ -5147,7 +5153,7 @@
     {
       "module": "SeLe4n.Kernel.IPC.Operations.Endpoint",
       "path": "SeLe4n/Kernel/IPC/Operations/Endpoint.lean",
-      "declaration_count": 24,
+      "declaration_count": 29,
       "declarations": [
         {
           "kind": "namespace",
@@ -5191,8 +5197,24 @@
         },
         {
           "kind": "def",
+          "name": "storeTcbIpcState_fromTcb",
+          "line": 75,
+          "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "storeTcbIpcState_fromTcb_eq",
+          "line": 83,
+          "called": [
+            "lookupTcb",
+            "storeTcbIpcState",
+            "storeTcbIpcState_fromTcb"
+          ]
+        },
+        {
+          "kind": "def",
           "name": "storeTcbPendingMessage",
-          "line": 74,
+          "line": 92,
           "called": [
             "lookupTcb"
           ]
@@ -5200,15 +5222,40 @@
         {
           "kind": "def",
           "name": "storeTcbIpcStateAndMessage",
-          "line": 84,
+          "line": 102,
           "called": [
             "lookupTcb"
           ]
         },
         {
           "kind": "def",
+          "name": "storeTcbIpcStateAndMessage_fromTcb",
+          "line": 114,
+          "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "storeTcbIpcStateAndMessage_fromTcb_eq",
+          "line": 125,
+          "called": [
+            "lookupTcb",
+            "storeTcbIpcStateAndMessage",
+            "storeTcbIpcStateAndMessage_fromTcb"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "lookupTcb_preserved_by_storeObject_notification",
+          "line": 135,
+          "called": [
+            "lookupTcb",
+            "lookupTcb_some_objects"
+          ]
+        },
+        {
+          "kind": "def",
           "name": "notificationSignal",
-          "line": 94,
+          "line": 154,
           "called": [
             "ensureRunnable",
             "storeTcbIpcState"
@@ -5217,17 +5264,18 @@
         {
           "kind": "def",
           "name": "notificationWait",
-          "line": 138,
+          "line": 198,
           "called": [
             "lookupTcb",
             "removeRunnable",
-            "storeTcbIpcState"
+            "storeTcbIpcState",
+            "storeTcbIpcState_fromTcb"
           ]
         },
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_objects_ne",
-          "line": 180,
+          "line": 242,
           "called": [
             "lookupTcb",
             "storeTcbIpcState"
@@ -5236,7 +5284,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_notification",
-          "line": 204,
+          "line": 266,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -5246,7 +5294,7 @@
         {
           "kind": "theorem",
           "name": "removeRunnable_preserves_objects",
-          "line": 223,
+          "line": 285,
           "called": [
             "removeRunnable"
           ]
@@ -5254,7 +5302,7 @@
         {
           "kind": "theorem",
           "name": "ensureRunnable_preserves_objects",
-          "line": 230,
+          "line": 292,
           "called": [
             "ensureRunnable"
           ]
@@ -5262,7 +5310,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_scheduler_eq",
-          "line": 240,
+          "line": 302,
           "called": [
             "lookupTcb",
             "storeTcbIpcState"
@@ -5271,7 +5319,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_endpoint",
-          "line": 261,
+          "line": 323,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -5281,7 +5329,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_cnode",
-          "line": 280,
+          "line": 342,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -5291,7 +5339,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_preserves_vspaceRoot",
-          "line": 299,
+          "line": 361,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -5301,7 +5349,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_cnode_backward",
-          "line": 319,
+          "line": 381,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -5311,7 +5359,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_endpoint_backward",
-          "line": 345,
+          "line": 407,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -5321,7 +5369,7 @@
         {
           "kind": "theorem",
           "name": "storeTcbIpcState_notification_backward",
-          "line": 371,
+          "line": 433,
           "called": [
             "lookupTcb",
             "storeTcbIpcState",
@@ -5331,7 +5379,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_error_alreadyWaiting",
-          "line": 399,
+          "line": 461,
           "called": [
             "lookupTcb",
             "notificationWait"
@@ -5340,23 +5388,27 @@
         {
           "kind": "theorem",
           "name": "notificationWait_badge_path_notification",
-          "line": 415,
+          "line": 477,
           "called": [
             "lookupTcb",
+            "lookupTcb_preserved_by_storeObject_notification",
             "notificationWait",
             "storeTcbIpcState",
+            "storeTcbIpcState_fromTcb_eq",
             "storeTcbIpcState_preserves_notification"
           ]
         },
         {
           "kind": "theorem",
           "name": "notificationWait_wait_path_notification",
-          "line": 478,
+          "line": 543,
           "called": [
             "lookupTcb",
+            "lookupTcb_preserved_by_storeObject_notification",
             "notificationWait",
             "removeRunnable",
             "storeTcbIpcState",
+            "storeTcbIpcState_fromTcb_eq",
             "storeTcbIpcState_preserves_notification"
           ]
         }
@@ -6240,7 +6292,7 @@
         {
           "kind": "theorem",
           "name": "notificationWait_preserves_lowEquivalent",
-          "line": 823,
+          "line": 825,
           "called": [
             "notificationWait_projection_preserved"
           ]
@@ -6248,7 +6300,7 @@
         {
           "kind": "theorem",
           "name": "cspaceInsertSlot_preserves_lowEquivalent",
-          "line": 848,
+          "line": 850,
           "called": [
             "cspaceInsertSlot_preserves_projectObjectIndex"
           ]
@@ -6578,7 +6630,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_lowEquivalent",
-          "line": 1272,
+          "line": 1273,
           "called": [
             "endpointReply_preserves_projection"
           ]
@@ -6586,37 +6638,37 @@
         {
           "kind": "theorem",
           "name": "endpointReceiveDualChecked_NI",
-          "line": 1297,
+          "line": 1298,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReceiveDual_preserves_lowEquivalent",
-          "line": 1325,
+          "line": 1326,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointCall_preserves_lowEquivalent",
-          "line": 1343,
+          "line": 1344,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReplyRecv_preserves_lowEquivalent",
-          "line": 1361,
+          "line": 1362,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "rotateToBack_preserves_projection",
-          "line": 1385,
+          "line": 1386,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "handleYield_preserves_projection",
-          "line": 1398,
+          "line": 1399,
           "called": [
             "schedule_preserves_projection"
           ]
@@ -6624,7 +6676,7 @@
         {
           "kind": "theorem",
           "name": "handleYield_preserves_lowEquivalent",
-          "line": 1447,
+          "line": 1448,
           "called": [
             "handleYield_preserves_projection"
           ]
@@ -6632,13 +6684,13 @@
         {
           "kind": "theorem",
           "name": "insert_tick_preserves_projection",
-          "line": 1469,
+          "line": 1470,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "timerTick_preserves_projection",
-          "line": 1488,
+          "line": 1489,
           "called": [
             "insert_tick_preserves_projection",
             "schedule_preserves_projection"
@@ -6647,7 +6699,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_lowEquivalent",
-          "line": 1551,
+          "line": 1552,
           "called": [
             "timerTick_preserves_projection"
           ]
@@ -6655,13 +6707,13 @@
         {
           "kind": "theorem",
           "name": "retypeFromUntyped_preserves_lowEquivalent",
-          "line": 1584,
+          "line": 1585,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_projection",
-          "line": 1625,
+          "line": 1626,
           "called": [
             "cspaceDeleteSlot_preserves_projection",
             "cspaceRevoke_preserves_projection"
@@ -6670,7 +6722,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_lowEquivalent",
-          "line": 1645,
+          "line": 1646,
           "called": [
             "lifecycleRevokeDeleteRetype_preserves_projection"
           ]

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/refine-ipc-workstream-4D5YG",
-      "commit_sha": "182bf432fd8214eacfd4a6d105b541d4fe580f18",
-      "tree_sha": "df0a3983a8220ee398e6fe27a1a946750efec159",
-      "committed_at_utc": "2026-03-15T06:38:40+00:00"
+      "commit_sha": "76f288f580bf6de7e5bcc62864e90d5de9aa00f7",
+      "tree_sha": "31dbe34282871fd5b8a118c8e455a5ef5106859c",
+      "committed_at_utc": "2026-03-15T08:21:42+00:00"
     }
   },
   "source_sync": {

--- a/docs/gitbook/04-project-design-deep-dive.md
+++ b/docs/gitbook/04-project-design-deep-dive.md
@@ -120,6 +120,8 @@ The `queuePPrev` field enables O(1) mid-queue removal without scanning — criti
 
 WS-H5 formalized this with `intrusiveQueueWellFormed` and `tcbQueueLinkIntegrity`, with 13 preservation theorems covering all queue operations.
 
+WS-L1 (v0.16.9) eliminated 4 redundant TCB lookups on IPC hot paths by returning the pre-dequeue TCB from `endpointQueuePopHead` and adding `_fromTcb` variants of store operations with equivalence theorems. This avoids O(log n) HashMap lookups on every endpoint receive, reply, and notification wait — zero new preservation lemmas needed.
+
 ## 4. Capability derivation tree: node-stable CDT
 
 seL4's CDT uses mutable doubly-linked lists. seLe4n replaces this with a node-stable design:

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -13,11 +13,11 @@ machine-checked proofs, improving on seL4 architecture. First hardware target:
 
 | Attribute | Value |
 |-----------|-------|
-| Version | `0.16.8` |
+| Version | `0.16.9` |
 | Lean toolchain | `v4.28.0` |
-| Production LoC | 37,245 across 69 files |
+| Production LoC | 37,217 across 69 files |
 | Test LoC | 4,098 across 4 suites |
-| Proved declarations | 1,198 theorem/lemma declarations (zero sorry/axiom) |
+| Proved declarations | 1,202 theorem/lemma declarations (zero sorry/axiom) |
 | Latest audit | [`AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md) — IPC subsystem end-to-end audit |
 | Next workstreams | **WS-L** IPC subsystem audit & remediation — 5 phases: L1 (performance), L2 (code quality), L3 (proof strengthening), L4 (test coverage — partially complete), L5 (documentation — in progress). Supersedes WS-I5. See [workstream plan](../audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md). WS-K **PORTFOLIO COMPLETE** (v0.16.0–v0.16.8). WS-J1 **PORTFOLIO COMPLETE** (v0.15.4–v0.15.10). **Next after WS-L: Raspberry Pi 5 hardware binding** |
 | Workstream history | [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) |

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -156,6 +156,7 @@ Preservation shape:
 - WS-F4 notification: `notificationSignal_preserves_ipcInvariant`, `notificationSignal_preserves_schedulerInvariantBundle`, `notificationWait_preserves_ipcInvariant`, `notificationWait_preserves_schedulerInvariantBundle` (F-12).
 - WS-F4 notification contract predicates: `notificationSignal_preserves_ipcSchedulerContractPredicates`, `notificationWait_preserves_ipcSchedulerContractPredicates` (M3.5 gap closure).
 - WS-H5 dual-queue structural invariant: 13 `*_preserves_dualQueueSystemInvariant` theorems covering `endpointQueuePopHead`, `endpointQueueEnqueue`, `endpointSendDual`, `endpointReceiveDual`, `endpointCall`, `endpointReply`, `endpointReplyRecv`, plus 5 state-only ops (`ensureRunnable`, `removeRunnable`, `storeTcbIpcState`, `storeTcbIpcStateAndMessage`, `storeTcbPendingMessage`).
+- WS-L1 IPC performance optimization (v0.16.9): `endpointQueuePopHead` returns pre-dequeue TCB in 3-tuple `(ThreadId × TCB × SystemState)`, eliminating redundant lookups. `storeTcbIpcStateAndMessage_fromTcb` and `storeTcbIpcState_fromTcb` bypass internal lookup with equivalence theorems (`storeTcbIpcStateAndMessage_fromTcb_eq`, `storeTcbIpcState_fromTcb_eq`). `lookupTcb_preserved_by_storeObject_notification` proves cross-store TCB stability. 4 redundant O(log n) lookups eliminated; zero new preservation lemmas needed.
 
 ### 4.2 IPC message payload bounds (WS-H12d)
 

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -5,8 +5,8 @@
 This GitBook is the long-form guide for seLe4n — a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.
 
 ## Current project state
-- **Version:** 0.16.8 (Lean v4.28.0).
-- **Codebase metrics:** 37,245 production LoC across 69 files; 4,098 test LoC across 4 suites; 1,198 theorem/lemma declarations (zero sorry/axiom).
+- **Version:** 0.16.9 (Lean v4.28.0).
+- **Codebase metrics:** 37,217 production LoC across 69 files; 4,098 test LoC across 4 suites; 1,202 theorem/lemma declarations (zero sorry/axiom).
 - **Latest audit:** [`AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md) — IPC subsystem end-to-end audit, zero critical issues.
 - **Active workstream:** WS-L IPC subsystem audit & remediation (5 phases: L1–L5). All prior portfolios (WS-B through WS-K) completed.
 - **Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.

--- a/docs/gitbook/navigation_manifest.json
+++ b/docs/gitbook/navigation_manifest.json
@@ -1,8 +1,8 @@
 {
   "description": "This GitBook is the long-form guide for seLe4n \u2014 a production-oriented microkernel written in Lean 4 with machine-checked proofs, targeting Raspberry Pi 5.",
   "current_state_bullets": [
-    "**Version:** 0.16.8 (Lean v4.28.0).",
-    "**Codebase metrics:** 37,245 production LoC across 69 files; 4,098 test LoC across 4 suites; 1,198 theorem/lemma declarations (zero sorry/axiom).",
+    "**Version:** 0.16.9 (Lean v4.28.0).",
+    "**Codebase metrics:** 37,217 production LoC across 69 files; 4,098 test LoC across 4 suites; 1,202 theorem/lemma declarations (zero sorry/axiom).",
     "**Latest audit:** [`AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md) — IPC subsystem end-to-end audit, zero critical issues.",
     "**Active workstream:** WS-L IPC subsystem audit & remediation (5 phases: L1–L5). All prior portfolios (WS-B through WS-K) completed.",
     "**Workstream history:** [`docs/WORKSTREAM_HISTORY.md`](../WORKSTREAM_HISTORY.md) — complete portfolio record and roadmap.",

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -48,11 +48,11 @@ enforcement, and scheduling.
 
 | Attribute | Value |
 |-----------|-------|
-| **Package version** | `0.16.8` (`lakefile.toml`) |
+| **Package version** | `0.16.9` (`lakefile.toml`) |
 | **Lean toolchain** | `v4.28.0` (`lean-toolchain`) |
-| **Production LoC** | 37,245 across 69 Lean files |
+| **Production LoC** | 37,217 across 69 Lean files |
 | **Test LoC** | 4,098 across 4 Lean test suites |
-| **Proved declarations** | 1,198 theorem/lemma declarations (zero sorry/axiom) |
+| **Proved declarations** | 1,202 theorem/lemma declarations (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md) — IPC subsystem end-to-end audit, zero critical issues |
 | **Next workstreams** | **WS-L** IPC subsystem audit & remediation — see [workstream plan](../audits/AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md). 5 phases: L1 (performance), L2 (code quality), L3 (proof strengthening), L4 (test coverage — partially complete), L5 (documentation). Supersedes WS-I5 (pending). WS-K **PORTFOLIO COMPLETE** (v0.16.0–v0.16.8). WS-J1 **PORTFOLIO COMPLETE** (v0.15.4–v0.15.10). **Next after WS-L: Raspberry Pi 5 hardware binding** |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,7 +5,7 @@
 # under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 
 name = "seLe4n"
-version = "0.16.8"
+version = "0.16.9"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced**: WS-L1 (IPC Performance Optimization)
- **Recommendation IDs closed**: L-P01, L-P02, L-P03
- **Scope notes**: Eliminates 4 redundant TCB lookups on critical IPC paths (endpoint send/receive/reply) by returning pre-dequeued TCB from `endpointQueuePopHead` and adding `_fromTcb` variants of TCB storage operations with equivalence theorems.

## Changes

### Core optimization (L1-A): Return dequeued TCB from `endpointQueuePopHead`

- **`DualQueue/Core.lean`**: Changed `endpointQueuePopHead` return type from `(ThreadId × SystemState)` to `(ThreadId × TCB × SystemState)`, returning the pre-dequeue TCB captured at the internal `lookupTcb` call.
- **`DualQueue/Transport.lean`**: Updated 5 transport lemmas (`endpointQueuePopHead_scheduler_eq`, `endpointQueuePopHead_endpoint_backward_ne`, `endpointQueuePopHead_notification_backward`, `endpointQueuePopHead_tcb_forward`, `endpointQueuePopHead_tcb_ipcState_backward`) to destructure the new 3-tuple return value. Proof bodies unchanged.
- **`Transport.lean` callers**: 
  - `endpointReceiveDual`: Eliminated redundant `lookupTcb st' sender` by using returned `senderTcb` directly to access `pendingMessage` and `ipcState`.
  - `endpointSendDual`, `endpointCall`: Mechanical destructuring updates (TCB not used by these callers).

### Equivalence-theorem strategy (L1-B, L1-C): Cache validated TCBs without duplicating preservation lemmas

- **`Operations/Endpoint.lean`**: Added two `_fromTcb` variants:
  - `storeTcbIpcStateAndMessage_fromTcb`: Accepts pre-looked-up TCB, bypassing internal `lookupTcb`.
  - `storeTcbIpcState_fromTcb`: Variant for IPC state-only updates.
  - Each includes an equivalence theorem proving `_fromTcb st tid tcb ... = original st tid ...` when `lookupTcb st tid = some tcb`.
- **Preservation lemmas**: Zero new preservation lemmas added. Existing theorems apply via `rw [storeTcbIpcStateAndMessage_fromTcb_eq hLookup]` rewriting, eliminating the need for duplicate lemma sets.
- **`endpointReply` / `endpointReplyRecv`**: Updated to use `_fromTcb` variants, eliminating redundant `lookupTcb` calls on the same state after validation.

### Preservation theorem cascade (mechanical)

- **`EndpointPreservation.lean`**: Updated 6 theorems to destructure PopHead's new 3-tuple and apply equivalence rewrites.
- **`CallReplyRecv.lean`**: Updated 4 theorems similarly.
- **`Structural.lean`**: Updated 8 theorems; added equivalence rewrites in `endpointReply_preserves_dualQueueSystemInvariant`.
- **`Invariant/Defs.lean`**: Updated `endpointQueuePopHead_returns_head` and added helper `endpointQueuePopHead_returns_pre_tcb`.
- **Capability/Notification/InformationFlow invariants**: Added `lookupTcb_preserved_by_storeObject_notification` helper to support notification wait path optimization.

### Documentation & metadata

- **`CHANGELOG.md`**: Documented L1-A, L1-B, L1-C completions.
- **`AUDIT_v0.16.8_IPC_SUBSYSTEM_WORKSTREAM_PLAN.md`**: Expanded L1 section with detailed design

https://claude.ai/code/session_01MQZJfHGaUJFxsqUmBXxwga