### PR TITLE
WS-R2: Fix revocation error propagation & add CDT ancestor check

### DIFF
--- a/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
@@ -672,29 +672,26 @@ private theorem capabilityInvariantBundle_of_cdt_update
     cspaceDepthConsistent_of_objects_eq st _ hDepthPre hObjEq,
     hObjEq ▸ hObjInvPre⟩
 
-/-- `processRevokeNode` preserves `cdtNodeSlot.invExt` and the size bound. -/
+/-- `processRevokeNode` preserves `cdtNodeSlot.invExt` and the size bound
+when it succeeds. -/
 private theorem processRevokeNode_preserves_cdtNodeSlot
-    (st : SystemState) (node : CdtNodeId)
+    (st st' : SystemState) (node : CdtNodeId)
     (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity) :
-    (processRevokeNode st node).cdtNodeSlot.invExt ∧
-    (processRevokeNode st node).cdtNodeSlot.size < (processRevokeNode st node).cdtNodeSlot.capacity := by
-  unfold processRevokeNode
+    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hStep : processRevokeNode st node = .ok st') :
+    st'.cdtNodeSlot.invExt ∧ st'.cdtNodeSlot.size < st'.cdtNodeSlot.capacity := by
+  unfold processRevokeNode at hStep
   cases hSlot : SystemState.lookupCdtSlotOfNode st node with
-  | none => simp only []; exact ⟨hNodeSlotInv, hNodeSlotSize⟩
+  | none => simp [hSlot] at hStep; cases hStep; exact ⟨hNodeSlotInv, hNodeSlotSize⟩
   | some descAddr =>
-    simp only []
+    simp [hSlot] at hStep
     cases hDel : cspaceDeleteSlot descAddr st with
-    | error _ => simp only []; exact ⟨hNodeSlotInv, hNodeSlotSize⟩
+    | error _ => simp [hDel] at hStep
     | ok pair =>
       obtain ⟨_, stDel⟩ := pair
-      simp only []
+      simp [hDel] at hStep; cases hStep
       have ⟨hInvDel, hSzDel⟩ := cspaceDeleteSlot_preserves_cdtNodeSlot st stDel descAddr
         hNodeSlotInv hNodeSlotSize hDel
-      -- The result is { stDetached with cdt := ... } where stDetached = detachSlotFromCdt stDel descAddr
-      -- The struct update only changes cdt, so cdtNodeSlot is unchanged from stDetached.
-      -- We need to show stDetached's cdtNodeSlot properties.
-      -- detachSlotFromCdt either leaves cdtNodeSlot unchanged or erases one key
       have hDetachNS : (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.invExt ∧
           (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.size <
           (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.capacity := by
@@ -707,39 +704,40 @@ private theorem processRevokeNode_preserves_cdtNodeSlot
                  SeLe4n.Kernel.RobinHood.RHTable.erase_size_lt_capacity stDel.cdtNodeSlot origNode hSzDel⟩
       exact hDetachNS
 
-/-- M-P04/M5: `processRevokeNode` preserves the full capability invariant bundle.
+/-- R2-A/R2-F: `processRevokeNode` preserves the full capability invariant bundle
+when it succeeds.
 
-Three cases handled:
+Two cases handled:
 - **No slot mapping** (`lookupCdtSlotOfNode = none`): just `removeNode` — CDT-only
   update preserves all object-level invariants.
-- **Delete error**: same as above (error swallowed, node removed).
 - **Successful delete**: chains `cspaceDeleteSlot_preserves` → `detachSlotFromCdt`
   invariant reconstruction → `removeNode` CDT update.
+
+The error case (`cspaceDeleteSlot` fails) now returns `.error` and does not
+produce a post-state, so no invariant proof is needed for that path.
 
 This is the single proof obligation for per-node revocation, shared by both the
 materialized fold (`cspaceRevokeCdt`) and streaming BFS (`streamingRevokeBFS`). -/
 theorem processRevokeNode_preserves_capabilityInvariantBundle
-    (st : SystemState) (node : CdtNodeId)
+    (st st' : SystemState) (node : CdtNodeId)
     (hInv : capabilityInvariantBundle st)
     (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity) :
-    capabilityInvariantBundle (processRevokeNode st node) := by
-  unfold processRevokeNode
+    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hStep : processRevokeNode st node = .ok st') :
+    capabilityInvariantBundle st' := by
+  unfold processRevokeNode at hStep
   cases hSlot : SystemState.lookupCdtSlotOfNode st node with
   | none =>
-    simp
+    simp [hSlot] at hStep; cases hStep
     exact capabilityInvariantBundle_of_cdt_update st _ hInv
       (CapDerivationTree.edgeWellFounded_sub _ _ hInv.2.2.2.2.1 (CapDerivationTree.removeNode_edges_sub st.cdt node))
   | some descAddr =>
-    simp
+    simp [hSlot] at hStep
     cases hDel : cspaceDeleteSlot descAddr st with
-    | error _ =>
-      simp
-      exact capabilityInvariantBundle_of_cdt_update st _ hInv
-        (CapDerivationTree.edgeWellFounded_sub _ _ hInv.2.2.2.2.1 (CapDerivationTree.removeNode_edges_sub st.cdt node))
+    | error _ => simp [hDel] at hStep
     | ok pair =>
       obtain ⟨_, stDel⟩ := pair
-      simp
+      simp [hDel] at hStep; cases hStep
       have hDelInv := cspaceDeleteSlot_preserves_capabilityInvariantBundle st stDel descAddr hInv
         hNodeSlotInv hNodeSlotSize hDel
       have ⟨hNodeSlotInvDel, hNodeSlotSizeDel⟩ :=
@@ -759,13 +757,17 @@ theorem processRevokeNode_preserves_capabilityInvariantBundle
           (CapDerivationTree.removeNode_edges_sub (SystemState.detachSlotFromCdt stDel descAddr).cdt node))
 
 /-- Fold body function for cspaceRevokeCdt: processes one CDT descendant node.
-Delegates to `processRevokeNode` for the actual state transformation. -/
+Delegates to `processRevokeNode` for the actual state transformation.
+Updated in WS-R2 to handle `processRevokeNode`'s `Except` return type. -/
 private def revokeCdtFoldBody
     (acc : Except KernelError (Unit × SystemState)) (node : CdtNodeId) :
     Except KernelError (Unit × SystemState) :=
   match acc with
   | .error e => .error e
-  | .ok ((), stAcc) => .ok ((), processRevokeNode stAcc node)
+  | .ok ((), stAcc) =>
+      match processRevokeNode stAcc node with
+      | .error e => .error e
+      | .ok stNext => .ok ((), stNext)
 
 /-- Single fold step preserves capabilityInvariantBundle.
 Delegates to `processRevokeNode_preserves_capabilityInvariantBundle`. -/
@@ -778,9 +780,13 @@ private theorem revokeCdtFoldBody_preserves
     capabilityInvariantBundle stNext ∧
     stNext.cdtNodeSlot.invExt ∧ stNext.cdtNodeSlot.size < stNext.cdtNodeSlot.capacity := by
   unfold revokeCdtFoldBody at hStep
-  simp at hStep; cases hStep
-  exact ⟨processRevokeNode_preserves_capabilityInvariantBundle stAcc node hInv hNodeSlotInv hNodeSlotSize,
-         processRevokeNode_preserves_cdtNodeSlot stAcc node hNodeSlotInv hNodeSlotSize⟩
+  simp only [] at hStep
+  cases hProc : processRevokeNode stAcc node with
+  | error e => simp [hProc] at hStep
+  | ok stMid =>
+    simp [hProc] at hStep; subst hStep
+    exact ⟨processRevokeNode_preserves_capabilityInvariantBundle stAcc stMid node hInv hNodeSlotInv hNodeSlotSize hProc,
+           processRevokeNode_preserves_cdtNodeSlot stAcc stMid node hNodeSlotInv hNodeSlotSize hProc⟩
 
 /-- Error propagation: revokeCdtFoldBody propagates errors unchanged. -/
 private theorem revokeCdtFoldBody_error (e : KernelError) (node : CdtNodeId) :
@@ -869,30 +875,31 @@ theorem cspaceRevokeCdt_preserves_capabilityInvariantBundle
           (.ok ((), stLocal)) = .ok ((), st') at hStep
       exact revokeCdtFold_preserves _ stLocal st' hLocalInv hLocalNSInv hLocalNSSz hStep
 
-/-- WS-M1/M-G04: Error-swallowing consistency theorem. When `revokeCdtFoldBody`
-encounters a `cspaceDeleteSlot` error, it drops the error and performs only a
-CDT `removeNode`. This theorem proves that invariant preservation holds through
-the swallowed-error path specifically — the resulting state satisfies
-`capabilityInvariantBundle` because `removeNode` only shrinks the edge set
-(via `edgeWellFounded_sub`), leaving all other CSpace state untouched. -/
-theorem cspaceRevokeCdt_swallowed_error_consistent
-    (stAcc stNext : SystemState) (node : CdtNodeId)
+/-- R2-F: Error propagation consistency theorem. When `cspaceDeleteSlot` fails
+for a CDT descendant, `processRevokeNode` (and therefore `revokeCdtFoldBody`)
+now propagates the error. This theorem proves that the error propagation is
+correct: the fold body returns the same error that `cspaceDeleteSlot` produced.
+This replaces the former `cspaceRevokeCdt_swallowed_error_consistent` theorem. -/
+theorem cspaceRevokeCdt_error_propagation_consistent
+    (stAcc : SystemState) (node : CdtNodeId)
     (descAddr : CSpaceAddr) (err : KernelError)
-    (hInv : capabilityInvariantBundle stAcc)
     (hSlot : SystemState.lookupCdtSlotOfNode stAcc node = some descAddr)
-    (hDelErr : cspaceDeleteSlot descAddr stAcc = .error err)
-    (hStep : revokeCdtFoldBody (.ok ((), stAcc)) node = .ok ((), stNext)) :
-    capabilityInvariantBundle stNext ∧
-    stNext.objects = stAcc.objects ∧
-    stNext.cdt.edges ⊆ stAcc.cdt.edges := by
-  unfold revokeCdtFoldBody at hStep
-  unfold processRevokeNode at hStep
-  simp [hSlot, hDelErr] at hStep; cases hStep
-  exact ⟨capabilityInvariantBundle_of_cdt_update stAcc _ hInv
-    (CapDerivationTree.edgeWellFounded_sub _ _ hInv.2.2.2.2.1
-      (CapDerivationTree.removeNode_edges_sub stAcc.cdt node)),
-   rfl,
-   CapDerivationTree.removeNode_edges_sub stAcc.cdt node⟩
+    (hDelErr : cspaceDeleteSlot descAddr stAcc = .error err) :
+    revokeCdtFoldBody (.ok ((), stAcc)) node = .error err := by
+  unfold revokeCdtFoldBody
+  simp only []
+  unfold processRevokeNode
+  simp [hSlot, hDelErr]
+
+/-- R2-F/M-05: Fuel exhaustion preservation theorem. When `streamingRevokeBFS`
+returns `.error .resourceExhausted`, the input state is unchanged — the error
+is returned before any state modification occurs in the exhaustion case. -/
+theorem streamingRevokeBFS_fuel_exhaustion_returns_error
+    (queue : List CdtNodeId) (st : SystemState) (node : CdtNodeId)
+    (rest : List CdtNodeId)
+    (hQueue : queue = node :: rest) :
+    streamingRevokeBFS 0 queue st = .error .resourceExhausted := by
+  subst hQueue; unfold streamingRevokeBFS; rfl
 
 /-- WS-F4/F-06: cspaceRevokeCdtStrict preserves capabilityInvariantBundle.
 The strict variant composes cspaceRevoke + a fold that only does cspaceDeleteSlot
@@ -1032,21 +1039,25 @@ theorem cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle
 -- M-P04: Streaming CDT revocation preservation (WS-M5)
 -- ============================================================================
 
-/-- M-P04: Each node-processing step in the streaming BFS preserves the
+/-- M-P04/R2-F: Each node-processing step in the streaming BFS preserves the
 capability invariant bundle. Direct delegation to
 `processRevokeNode_preserves_capabilityInvariantBundle`. -/
 private theorem streamingRevokeBFS_step_preserves
-    (st : SystemState) (node : CdtNodeId)
+    (st st' : SystemState) (node : CdtNodeId)
     (hInv : capabilityInvariantBundle st)
     (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity) :
-    capabilityInvariantBundle (processRevokeNode st node) :=
-  processRevokeNode_preserves_capabilityInvariantBundle st node hInv hNodeSlotInv hNodeSlotSize
+    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hStep : processRevokeNode st node = .ok st') :
+    capabilityInvariantBundle st' :=
+  processRevokeNode_preserves_capabilityInvariantBundle st st' node hInv hNodeSlotInv hNodeSlotSize hStep
 
-/-- M-P04: The full streaming BFS loop preserves the capability invariant bundle.
+/-- M-P04/R2-F: The full streaming BFS loop preserves the capability invariant bundle.
 Proof by induction on `fuel`. Each step processes one node (preserving
 the invariant by `streamingRevokeBFS_step_preserves`) then recurses with
-fuel-1 and the updated queue + state. -/
+fuel-1 and the updated queue + state.
+
+Updated in WS-R2: fuel exhaustion case (`0, _ :: _`) now returns `.error`,
+so the proof obligation for that case is vacuously discharged by contradiction. -/
 private theorem streamingRevokeBFS_preserves
     (fuel : Nat) (queue : List CdtNodeId)
     (stInit stFinal : SystemState)
@@ -1060,14 +1071,20 @@ private theorem streamingRevokeBFS_preserves
     unfold streamingRevokeBFS at hBFS
     cases queue with
     | nil => simp at hBFS; cases hBFS; exact hInv
-    | cons _ _ => simp at hBFS; cases hBFS; exact hInv
+    | cons _ _ => simp at hBFS  -- .error ≠ .ok → contradiction
   | succ n ih =>
     unfold streamingRevokeBFS at hBFS
     cases queue with
     | nil => simp at hBFS; cases hBFS; exact hInv
     | cons node rest =>
-      have ⟨hNSInvPost, hNSSzPost⟩ := processRevokeNode_preserves_cdtNodeSlot stInit node hNodeSlotInv hNodeSlotSize
-      exact ih _ _ _ (streamingRevokeBFS_step_preserves stInit node hInv hNodeSlotInv hNodeSlotSize) hNSInvPost hNSSzPost hBFS
+      simp only [] at hBFS
+      cases hProc : processRevokeNode stInit node with
+      | error e => simp [hProc] at hBFS
+      | ok stNext =>
+        simp [hProc] at hBFS
+        have hStepInv := streamingRevokeBFS_step_preserves stInit stNext node hInv hNodeSlotInv hNodeSlotSize hProc
+        have ⟨hNSInvPost, hNSSzPost⟩ := processRevokeNode_preserves_cdtNodeSlot stInit stNext node hNodeSlotInv hNodeSlotSize hProc
+        exact ih _ _ _ hStepInv hNSInvPost hNSSzPost hBFS
 
 /-- M-P04: `cspaceRevokeCdtStreaming` preserves the capability invariant bundle.
 Composes `cspaceRevoke_preserves_capabilityInvariantBundle` with

--- a/SeLe4n/Kernel/Capability/Operations.lean
+++ b/SeLe4n/Kernel/Capability/Operations.lean
@@ -713,14 +713,34 @@ def cspaceMintWithCdt (src dst : CSpaceAddr) (rights : AccessRightSet)
 -- M-P04/M5: Shared per-node revocation step
 -- ============================================================================
 
-/-- M-P04/M5: Process a single CDT descendant node during revocation.
+/-- R2-A: Process a single CDT descendant node during revocation.
 
 Shared transition used by both `cspaceRevokeCdt` (materialized fold) and
 `streamingRevokeBFS` (streaming BFS). Given a CDT node:
-1. If no slot mapping exists, just remove the CDT node.
-2. If delete fails, remove the CDT node (swallow error).
-3. If delete succeeds, detach the slot→node mapping and remove the CDT node. -/
-def processRevokeNode (st : SystemState) (node : CdtNodeId) : SystemState :=
+1. If no slot mapping exists, just remove the CDT node → `.ok`.
+2. If delete fails, propagate the error → `.error e`.
+3. If delete succeeds, detach the slot→node mapping and remove the CDT node → `.ok`.
+
+Changed in WS-R2/M-06: errors from `cspaceDeleteSlot` are now propagated
+instead of swallowed. For the legacy lenient behavior, use
+`processRevokeNode_lenient`. -/
+def processRevokeNode (st : SystemState) (node : CdtNodeId)
+    : Except KernelError SystemState :=
+  match SystemState.lookupCdtSlotOfNode st node with
+  | none => .ok { st with cdt := st.cdt.removeNode node }
+  | some descAddr =>
+      match cspaceDeleteSlot descAddr st with
+      | .error e => .error e
+      | .ok ((), stDel) =>
+          let stDetached := SystemState.detachSlotFromCdt stDel descAddr
+          .ok { stDetached with cdt := stDetached.cdt.removeNode node }
+
+/-- Legacy lenient variant of `processRevokeNode` that swallows delete errors.
+
+Deprecated since WS-R2/M-06. Retained for backward compatibility with callers
+that explicitly require lenient revocation semantics. -/
+@[deprecated "Use processRevokeNode (error-propagating) instead" (since := "v0.18.1")]
+def processRevokeNode_lenient (st : SystemState) (node : CdtNodeId) : SystemState :=
   match SystemState.lookupCdtSlotOfNode st node with
   | none => { st with cdt := st.cdt.removeNode node }
   | some descAddr =>
@@ -743,11 +763,11 @@ Extends local revoke with CDT-based global traversal:
 3. Delete each descendant's capability from its CNode
 4. Clean up CDT edges for deleted slots
 
-**Error handling**: Descendant deletion errors are swallowed — the CDT node is
-removed regardless, preventing stale references. This is safe because
-`removeNode` only shrinks the edge set (proven by
-`cspaceRevokeCdt_swallowed_error_consistent`). For callers requiring error
-visibility, use `cspaceRevokeCdtStrict`. -/
+**Error handling** (WS-R2/M-06): Descendant deletion errors are now propagated
+to callers. If any descendant's `cspaceDeleteSlot` fails, the fold stops and
+returns the error. For the legacy lenient behavior (swallow errors), use
+`cspaceRevokeCdt_lenient`. For callers requiring structured failure reports,
+use `cspaceRevokeCdtStrict`. -/
 def cspaceRevokeCdt (addr : CSpaceAddr) : Kernel Unit :=
   fun st =>
     -- First do local revocation
@@ -762,7 +782,10 @@ def cspaceRevokeCdt (addr : CSpaceAddr) : Kernel Unit :=
             let result := descendants.foldl (fun acc node =>
               match acc with
               | .error e => .error e
-              | .ok ((), stAcc) => .ok ((), processRevokeNode stAcc node)
+              | .ok ((), stAcc) =>
+                  match processRevokeNode stAcc node with
+                  | .error e => .error e
+                  | .ok stNext => .ok ((), stNext)
             ) (.ok ((), stLocal))
             result
 
@@ -780,16 +803,22 @@ Each iteration:
 4. Appends newly-discovered children to the queue tail.
 
 Fuel = initial edge count, guaranteeing termination since each step
-removes at least one CDT node (shrinking the edge set). -/
+removes at least one CDT node (shrinking the edge set).
+
+Changed in WS-R2/M-05: fuel exhaustion now returns `.error .resourceExhausted`
+instead of `.ok`, making incomplete revocation visible to callers. -/
 def streamingRevokeBFS
     (fuel : Nat) (queue : List CdtNodeId)
     (st : SystemState) : Except KernelError (Unit × SystemState) :=
   match fuel, queue with
   | _, [] => .ok ((), st)
-  | 0, _ :: _ => .ok ((), st)  -- fuel exhausted (safety bound)
+  | 0, _ :: _ => .error .resourceExhausted  -- WS-R2/M-05: fuel exhausted
   | fuel + 1, node :: rest =>
-      let children := st.cdt.childrenOf node
-      streamingRevokeBFS fuel (rest ++ children) (processRevokeNode st node)
+      match processRevokeNode st node with
+      | .error e => .error e
+      | .ok stNext =>
+          let children := st.cdt.childrenOf node
+          streamingRevokeBFS fuel (rest ++ children) stNext
 
 /-- M-P04: Streaming CDT revocation — interleaves BFS discovery with deletion.
 
@@ -802,8 +831,8 @@ factor) instead of O(N).
 3. Initialize the BFS queue with the root node's direct children.
 4. Run `streamingRevokeBFS` with fuel = `cdt.edges.length`.
 
-Error handling: identical to `cspaceRevokeCdt` — descendant deletion errors
-are swallowed, CDT nodes are always removed. -/
+Error handling (WS-R2/M-05, M-06): descendant deletion errors are propagated.
+Fuel exhaustion returns `.error .resourceExhausted`. -/
 def cspaceRevokeCdtStreaming (addr : CSpaceAddr) : Kernel Unit :=
   fun st =>
     match cspaceRevoke addr st with

--- a/SeLe4n/Model/Object/Structures.lean
+++ b/SeLe4n/Model/Object/Structures.lean
@@ -1361,6 +1361,20 @@ def projectObservedEdges
     | some p, some c => some { parent := p, child := c, op := e.op }
     | _, _ => none)
 
+/-- R2-D/M-08: Decidable ancestor check — returns `true` if `ancestor` is
+reachable from `start` by following parent edges upward through the CDT.
+Uses `parentMap` for O(depth) lookup. Fuel = edges.length for termination. -/
+def isAncestor (cdt : CapDerivationTree) (ancestor start : CdtNodeId) : Bool :=
+  go cdt.edges.length start
+where
+  go : Nat → CdtNodeId → Bool
+    | 0, _ => false
+    | n + 1, current =>
+      if current == ancestor then true
+      else match cdt.parentMap[current]? with
+        | none => false
+        | some par => go n par
+
 end CapDerivationTree
 
 /-- WS-G5: `DecidableEq` removed from `KernelObject` because `CNode.slots` is

--- a/SeLe4n/Model/Object/Structures.lean
+++ b/SeLe4n/Model/Object/Structures.lean
@@ -1375,6 +1375,141 @@ where
         | none => false
         | some par => go n par
 
+set_option maxHeartbeats 2000000 in
+/-- R2-D/M-08: `addEdge` preserves `edgeWellFounded` when:
+1. `parent ≠ child`
+2. Existing CDT is acyclic
+3. No existing edge targets `child` (no incoming edges)
+4. No old-edge path from `child` to `parent` exists
+
+Generalizes `addEdge_preserves_edgeWellFounded_fresh` to non-fresh child nodes
+(child may have outgoing edges/subtree). The proof projects each cycle edge onto
+old CDT edges; when the new edge is encountered, constructs a rotated sub-path
+from child to parent using only old edges, contradicting hypothesis 4. -/
+theorem addEdge_preserves_edgeWellFounded_noParent
+    (cdt : CapDerivationTree) (parent child : CdtNodeId) (op : DerivationOp)
+    (hNeq : parent ≠ child)
+    (hAcyclic : cdt.edgeWellFounded)
+    (hNoIncoming : ∀ e ∈ cdt.edges, e.child ≠ child)
+    (hNoPath : ∀ (p : List CdtNodeId),
+      p.length > 1 → p.head? = some child → p.getLast? = some parent →
+      (∀ i, (h : i + 1 < p.length) → ∃ e ∈ cdt.edges, e.parent = p[i] ∧ e.child = p[i + 1]) →
+      False) :
+    (cdt.addEdge parent child op).edgeWellFounded := by
+  intro node ⟨path, hLen, hHead, hLast, hEdges⟩
+  -- Project each edge to old CDT. If old, keep. If new (parent→child), derive ⊥ via hNoPath.
+  apply hAcyclic node
+  refine ⟨path, hLen, hHead, hLast, fun idx hIdx => ?_⟩
+  have ⟨e, heMem, hep, hec⟩ := hEdges idx hIdx
+  simp only [addEdge] at heMem
+  rcases List.mem_cons.mp heMem with heq | hOld
+  · -- The edge at idx is the new edge: path[idx] = parent, path[idx+1] = child
+    exfalso
+    have hCidx : path[idx + 1] = child := by rw [← hec]; exact congrArg CapDerivationEdge.child heq
+    have hPidx : path[idx] = parent := by rw [← hep]; exact congrArg CapDerivationEdge.parent heq
+    -- At positions where path[j] ≠ parent, the edge is provably old
+    have hOldAt : ∀ j (hj : j + 1 < path.length), path[j] ≠ parent →
+        ∃ e ∈ cdt.edges, e.parent = path[j] ∧ e.child = path[j + 1] := by
+      intro j hj hjNe
+      obtain ⟨ej, hejMem, hejp, hejc⟩ := hEdges j hj
+      simp only [addEdge] at hejMem
+      rcases List.mem_cons.mp hejMem with heq' | hold
+      · exact absurd (by rw [← hejp]; exact congrArg CapDerivationEdge.parent heq') hjNe
+      · exact ⟨ej, hold, hejp, hejc⟩
+    -- Cycle boundary properties
+    have hFirst : path[0]'(by omega) = node := by
+      cases path with | nil => simp at hLen | cons a rest => simp [List.head?] at hHead; exact hHead
+    have hLastIdx : path[path.length - 1] = node := by
+      rw [List.getLast?_eq_getElem?] at hLast; exact (List.getElem?_eq_some_iff.mp hLast).2
+    -- Base case: cycle of length 2 forces parent = child, contradiction
+    have hL3 : path.length ≥ 3 := by
+      rcases Nat.lt_or_ge path.length 3 with h | h
+      · exfalso
+        have hp : path[idx]'(by omega) = path[0]'(by omega) := by congr 1; omega
+        have hc : path[idx + 1]'(by omega) = path[1]'(by omega) := by congr 1; omega
+        have hn : path[1]'(by omega) = path[path.length - 1]'(by omega) := by congr 1; omega
+        exact hNeq (hPidx.symm.trans (hp ▸ hFirst) |>.trans (hn ▸ hLastIdx).symm |>.trans (hc ▸ hCidx))
+      · exact h
+    -- Build rotated path from child (at idx+1) back to parent (at idx)
+    let L := path.length
+    let nodeAt : Fin (L - 1) → CdtNodeId := fun k =>
+      if h : idx + 1 + k.val < L then path[idx + 1 + k.val]
+      else path[idx + 1 + k.val - L + 1]'(by omega)
+    let rotPath := List.ofFn nodeAt
+    have hRotLen : rotPath.length = L - 1 := List.length_ofFn ..
+    have hRotGet : ∀ (k : Nat) (hk : k < L - 1),
+        rotPath[k]'(by rw [hRotLen]; exact hk) = nodeAt ⟨k, hk⟩ :=
+      fun k hk => List.getElem_ofFn ..
+    -- rotPath[0] = child
+    have hRotFirst : rotPath[0]'(by rw [hRotLen]; omega) = child := by
+      rw [hRotGet 0 (by omega)]
+      simp only [nodeAt, dif_pos (show idx + 1 + (⟨0, by omega⟩ : Fin (L - 1)).val < L from by simp; omega)]
+      exact hCidx
+    -- rotPath[L-2] = parent
+    have hRotLastP : rotPath[L - 2]'(by rw [hRotLen]; omega) = parent := by
+      rw [hRotGet (L - 2) (by omega)]; simp only [nodeAt]
+      split
+      · next h =>
+        have : path[idx + 1 + (L - 2)]'(by omega) = path[L - 1]'(by omega) := by congr 1; omega
+        rw [this, hLastIdx, ← hFirst]
+        have : path[idx]'(by omega) = path[0]'(by omega) := by congr 1; omega
+        rwa [← this]
+      · next h =>
+        have : path[idx + 1 + (L - 2) - L + 1]'(by omega) = path[idx]'(by omega) := by congr 1; omega
+        rw [this]; exact hPidx
+    -- Find first parent in rotation, truncate, apply hNoPath
+    have hParInRot : ∃ x ∈ rotPath, (x == parent) = true :=
+      ⟨rotPath[L - 2], List.getElem_mem .., by rw [hRotLastP]; exact beq_self_eq_true _⟩
+    let m := rotPath.findIdx (· == parent)
+    have hm : m < rotPath.length := List.findIdx_lt_length_of_exists hParInRot
+    have hmP : rotPath[m]'hm = parent := eq_of_beq (List.findIdx_getElem (w := hm))
+    have hBNe : ∀ (i : Nat) (hi : i < m), rotPath[i]'(by omega) ≠ parent := by
+      intro i hi habs; have := List.not_of_lt_findIdx hi; simp [habs] at this
+    have hm0 : m > 0 := by
+      rcases Nat.eq_zero_or_pos m with h | h
+      · exact absurd (hRotFirst.symm.trans (by congr 1; omega) |>.trans hmP).symm hNeq
+      · exact h
+    -- opath = rotPath.take (m+1): sub-path from child to parent, all edges old
+    let opath := rotPath.take (m + 1)
+    have hOL : opath.length = m + 1 := by simp [opath, List.length_take, hRotLen]; omega
+    apply hNoPath opath
+    · rw [hOL]; omega
+    · rw [List.head?_take]; simp
+      cases hrot : rotPath with
+      | nil => rw [hrot] at hm; simp at hm
+      | cons a rest =>
+        simp only [List.head?]; congr 1
+        have : rotPath[0]'(by simp [hrot]) = a := by simp [hrot]
+        rw [← hRotFirst, this]
+    · rw [List.getLast?_take]; simp [show m + 1 - 1 = m from by omega]
+      rw [show rotPath[m]? = some parent from List.getElem?_eq_some_iff.mpr ⟨hm, hmP⟩]; simp
+    · intro i hi; rw [hOL] at hi
+      have him : i < m := by omega
+      rw [show opath[i] = rotPath[i] from List.getElem_take ..,
+          show opath[i + 1] = rotPath[i + 1] from List.getElem_take ..,
+          hRotGet i (by omega), hRotGet (i + 1) (by omega)]
+      simp only [nodeAt]
+      have hSrcNePar : nodeAt ⟨i, by omega⟩ ≠ parent := by
+        rw [← hRotGet i (by omega)]; exact hBNe i him
+      split <;> rename_i h1 <;> split <;> rename_i h2
+      · exact hOldAt (idx + 1 + i) (by omega) (by simp only [nodeAt, dif_pos h1] at hSrcNePar; exact hSrcNePar)
+      · have hSrc : path[idx + 1 + i]'(by omega) = path[0]'(by omega) := by
+          have : path[idx + 1 + i]'(by omega) = path[L - 1]'(by omega) := by congr 1; omega
+          rw [this, hLastIdx, ← hFirst]
+        have hTgt : path[idx + 1 + (i + 1) - L + 1]'(by omega) = path[1]'(by omega) := by congr 1; omega
+        rw [hSrc, hTgt]
+        exact hOldAt 0 (by omega) (by
+          intro h; simp only [nodeAt, dif_pos h1] at hSrcNePar; exact hSrcNePar (hSrc.symm ▸ h))
+      · omega
+      · have hNP : path[idx + 1 + i - L + 1]'(by omega) ≠ parent := by
+          simp only [nodeAt, dif_neg h1] at hSrcNePar; exact hSrcNePar
+        obtain ⟨e', he', hep', hec'⟩ := hOldAt (idx + 1 + i - L + 1) (by omega) hNP
+        refine ⟨e', he', hep', ?_⟩
+        have : path[(idx + 1 + i - L + 1) + 1]'(by omega) = path[idx + 1 + (i + 1) - L + 1]'(by omega) := by
+          congr 1; omega
+        rwa [← this]
+  · exact ⟨e, hOld, hep, hec⟩
+
 end CapDerivationTree
 
 /-- WS-G5: `DecidableEq` removed from `KernelObject` because `CNode.slots` is

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -51,6 +51,7 @@ inductive KernelError where
   | invalidSyscallNumber    -- WS-J1-B: syscall number register value not in modeled set
   | invalidMessageInfo      -- WS-J1-B: malformed message-info word (length/caps out of bounds)
   | invalidTypeTag          -- WS-K-D: retype type tag not in modeled object set (0–5)
+  | resourceExhausted       -- WS-R2/M-05: fuel exhaustion in streaming BFS revocation
   deriving Repr, DecidableEq
 
 /-- M-05/WS-E6: One entry in the round-robin domain schedule table.

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -27,7 +27,16 @@ comprehensive pre-release audit (`AUDIT_COMPREHENSIVE_v0.17.13_PRE_RELEASE.md`).
   SyscallResponse semantic overlap (R-M03), api* wrapper capability-target bypass
   (M-04), frozen context save/restore silent failures (M-10, M-11). All 14 api*
   wrappers deprecated with validation guards.
-- **R2–R8**: Pending. See workstream plan for details.
+- **R2 (v0.18.1) — COMPLETE**: Capability & CDT hardening. Fixed `processRevokeNode`
+  error swallowing (M-06) — revocation now propagates `cspaceDeleteSlot` errors
+  instead of silently dropping them. Fixed `streamingRevokeBFS` fuel exhaustion
+  (M-05) — returns `.error .resourceExhausted` instead of `.ok`. Added
+  `resourceExhausted` to `KernelError`. Updated all preservation proofs for new
+  `Except` return types. Added `isAncestor` decidable predicate for CDT cycle
+  detection (M-08). Existing `removeNode_parentMapConsistent` proof covers CDT
+  remove consistency (M-07). Added `processRevokeNode_lenient` deprecated variant
+  for backward compatibility. Added revocation error propagation test cases.
+- **R3–R8**: Pending. See workstream plan for details.
 
 ### WS-Q1 workstream (Service Interface Simplification)
 

--- a/docs/audits/AUDIT_v0.17.14_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.17.14_WORKSTREAM_PLAN.md
@@ -166,7 +166,7 @@ inclusion based on security relevance and proof chain completeness.
 | Phase | ID | Focus | Tasks / Sub-tasks | Deps | Target | Findings |
 |-------|----|-------|-------------------|------|--------|----------|
 | 1 | **R1** ✅ | Pre-Release Blockers | 6 / 17 | — | v0.18.0 | H-01, M-04, M-10, M-11, R-M01, R-M02, R-M03 |
-| 2 | **R2** | Capability & CDT Hardening | 7 / 17 | — | v0.18.1 | M-05, M-06, M-07, M-08, L-07 |
+| 2 | **R2** ✅ | Capability & CDT Hardening | 7 / 17 | — | v0.18.1 | M-05, M-06, M-07, M-08, L-07 |
 | 3 | **R3** | IPC Invariant Completion | 6 / 15 | R2 | v0.18.2 | M-16, M-18, M-19, L-05, L-08 |
 | 4 | **R4** | Lifecycle & Service Coherence | 6 / 19 | R2 | v0.18.3 | M-12, M-13, M-14, M-15, L-09 |
 | 5 | **R5** | Information Flow Completion | 5 / 13 | R3, R4 | v0.18.4 | M-01, M-02, M-03 |
@@ -534,9 +534,10 @@ codebase map with any new files or changed line counts.
 
 ---
 
-### Phase R2: Capability & CDT Hardening
+### Phase R2: Capability & CDT Hardening — **COMPLETE** (v0.18.1)
 
 **Target version**: v0.18.1
+**Status**: **COMPLETE** — all 7 task groups (R2-A through R2-G) delivered.
 **Goal**: Eliminate silent failure paths in capability revocation and close
 CDT consistency/acyclicity proof gaps.
 **Priority**: HIGH — revocation soundness is a security-critical property.

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "main",
-      "commit_sha": "f0f3ddd836e67df3d8f43e9b804e9aeeae36e95e",
-      "tree_sha": "c42298337f3a5b94a04a57ba2a4c413be460e226",
-      "committed_at_utc": "2026-03-21T02:15:46-04:00"
+      "branch": "claude/audit-phase-r2-workstream-JSz4E",
+      "commit_sha": "82da0d4438628339617be6c887d03f65f2573c84",
+      "tree_sha": "80517559c94ffc23b13bdb3a3456e85d61237efe",
+      "committed_at_utc": "2026-03-21T06:15:56+00:00"
     }
   },
   "source_sync": {
@@ -17,20 +17,20 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "5db54bc8e68b67af76e29682a627b7f77967eb23155f8cdb8619873fd667bd1c"
+    "source_digest": "a6c2db186d3ad126c36fcbaffa8345c8ea2cf50d8c02d0fe6a8e83107afa395c"
   },
   "summary": {
     "module_count": 107,
-    "declaration_count": 3034
+    "declaration_count": 3038
   },
   "readme_sync": {
     "version": "0.17.14",
     "lean_toolchain": "v4.28.0",
     "production_files": 97,
-    "production_loc": 53223,
+    "production_loc": 53284,
     "test_files": 10,
-    "test_loc": 7051,
-    "proved_theorem_lemma_decls": 1628,
+    "test_loc": 7117,
+    "proved_theorem_lemma_decls": 1629,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
   "modules": [
@@ -3193,7 +3193,7 @@
     {
       "module": "SeLe4n.Kernel.Capability.Invariant.Preservation",
       "path": "SeLe4n/Kernel/Capability/Invariant/Preservation.lean",
-      "declaration_count": 60,
+      "declaration_count": 61,
       "declarations": [
         {
           "kind": "namespace",
@@ -3279,7 +3279,7 @@
         {
           "kind": "theorem",
           "name": "processRevokeNode_preserves_cdtNodeSlot",
-          "line": 676,
+          "line": 677,
           "called": [
             "cspaceDeleteSlot_preserves_cdtNodeSlot"
           ]
@@ -3297,13 +3297,13 @@
         {
           "kind": "def",
           "name": "revokeCdtFoldBody",
-          "line": 763,
+          "line": 762,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_preserves",
-          "line": 772,
+          "line": 774,
           "called": [
             "processRevokeNode_preserves_capabilityInvariantBundle",
             "processRevokeNode_preserves_cdtNodeSlot",
@@ -3313,7 +3313,7 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_error",
-          "line": 786,
+          "line": 792,
           "called": [
             "revokeCdtFoldBody"
           ]
@@ -3321,7 +3321,7 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_foldl_error",
-          "line": 791,
+          "line": 797,
           "called": [
             "revokeCdtFoldBody",
             "revokeCdtFoldBody_error"
@@ -3330,7 +3330,7 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFold_preserves",
-          "line": 799,
+          "line": 805,
           "called": [
             "revokeCdtFoldBody",
             "revokeCdtFoldBody_foldl_error",
@@ -3340,7 +3340,7 @@
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdt_preserves_capabilityInvariantBundle",
-          "line": 824,
+          "line": 830,
           "called": [
             "cspaceRevoke_preserves_capabilityInvariantBundle",
             "revokeCdtFoldBody",
@@ -3349,17 +3349,22 @@
         },
         {
           "kind": "theorem",
-          "name": "cspaceRevokeCdt_swallowed_error_consistent",
-          "line": 878,
+          "name": "cspaceRevokeCdt_error_propagation_consistent",
+          "line": 883,
           "called": [
-            "capabilityInvariantBundle_of_cdt_update",
             "revokeCdtFoldBody"
           ]
         },
         {
           "kind": "theorem",
+          "name": "streamingRevokeBFS_fuel_exhaustion_returns_error",
+          "line": 897,
+          "called": []
+        },
+        {
+          "kind": "theorem",
           "name": "cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle",
-          "line": 900,
+          "line": 907,
           "called": [
             "capabilityInvariantBundle_of_cdt_update",
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
@@ -3370,7 +3375,7 @@
         {
           "kind": "theorem",
           "name": "streamingRevokeBFS_step_preserves",
-          "line": 1038,
+          "line": 1045,
           "called": [
             "processRevokeNode_preserves_capabilityInvariantBundle"
           ]
@@ -3378,7 +3383,7 @@
         {
           "kind": "theorem",
           "name": "streamingRevokeBFS_preserves",
-          "line": 1050,
+          "line": 1061,
           "called": [
             "processRevokeNode_preserves_cdtNodeSlot",
             "streamingRevokeBFS_step_preserves"
@@ -3387,7 +3392,7 @@
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdtStreaming_preserves_capabilityInvariantBundle",
-          "line": 1075,
+          "line": 1092,
           "called": [
             "cspaceRevoke_preserves_capabilityInvariantBundle",
             "streamingRevokeBFS_preserves"
@@ -3396,13 +3401,13 @@
         {
           "kind": "theorem",
           "name": "capabilityInvariantBundle_of_storeTcbAndEnsureRunnable",
-          "line": 1129,
+          "line": 1146,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_capabilityInvariantBundle",
-          "line": 1176,
+          "line": 1193,
           "called": [
             "capabilityInvariantBundle_of_storeTcbAndEnsureRunnable"
           ]
@@ -3410,13 +3415,13 @@
         {
           "kind": "def",
           "name": "coreIpcInvariantBundle",
-          "line": 1242,
+          "line": 1259,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_ipcInvariant",
-          "line": 1247,
+          "line": 1264,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3424,7 +3429,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_dualQueueSystemInvariant",
-          "line": 1252,
+          "line": 1269,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3432,7 +3437,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_allPendingMessagesBounded",
-          "line": 1257,
+          "line": 1274,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3440,7 +3445,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_badgeWellFormed",
-          "line": 1262,
+          "line": 1279,
           "called": [
             "coreIpcInvariantBundle"
           ]
@@ -3448,43 +3453,43 @@
         {
           "kind": "def",
           "name": "ipcSchedulerRunnableReadyComponent",
-          "line": 1267,
+          "line": 1284,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedSendComponent",
-          "line": 1271,
+          "line": 1288,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedReceiveComponent",
-          "line": 1275,
+          "line": 1292,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedCallComponent",
-          "line": 1279,
+          "line": 1296,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedReplyComponent",
-          "line": 1283,
+          "line": 1300,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedNotificationComponent",
-          "line": 1287,
+          "line": 1304,
           "called": []
         },
         {
           "kind": "def",
           "name": "ipcSchedulerCoherenceComponent",
-          "line": 1291,
+          "line": 1308,
           "called": [
             "ipcSchedulerBlockedCallComponent",
             "ipcSchedulerBlockedNotificationComponent",
@@ -3497,7 +3502,7 @@
         {
           "kind": "theorem",
           "name": "ipcSchedulerCoherenceComponent_iff_contractPredicates",
-          "line": 1299,
+          "line": 1316,
           "called": [
             "ipcSchedulerCoherenceComponent"
           ]
@@ -3505,7 +3510,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerCouplingInvariantBundle",
-          "line": 1309,
+          "line": 1326,
           "called": [
             "coreIpcInvariantBundle",
             "ipcSchedulerCoherenceComponent"
@@ -3514,7 +3519,7 @@
         {
           "kind": "def",
           "name": "lifecycleCompositionInvariantBundle",
-          "line": 1315,
+          "line": 1332,
           "called": [
             "ipcSchedulerCouplingInvariantBundle"
           ]
@@ -3522,25 +3527,25 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_schedulerInvariantBundle",
-          "line": 1318,
+          "line": 1335,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
-          "line": 1337,
+          "line": 1354,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_ipcInvariant",
-          "line": 1394,
+          "line": 1411,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_coreIpcInvariantBundle",
-          "line": 1421,
+          "line": 1438,
           "called": [
             "coreIpcInvariantBundle",
             "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
@@ -3551,7 +3556,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1447,
+          "line": 1464,
           "called": [
             "coreIpcInvariantBundle",
             "ipcSchedulerCoherenceComponent",
@@ -3562,7 +3567,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle",
-          "line": 1479,
+          "line": 1496,
           "called": [
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
             "cspaceRevoke_preserves_capabilityInvariantBundle",
@@ -3572,7 +3577,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityInvariant",
-          "line": 1527,
+          "line": 1544,
           "called": [
             "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle"
           ]
@@ -3580,7 +3585,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_error_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1574,
+          "line": 1591,
           "called": [
             "lifecycleCompositionInvariantBundle"
           ]
@@ -3588,13 +3593,13 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeTcbIpcState",
-          "line": 1587,
+          "line": 1604,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_blocking_path",
-          "line": 1607,
+          "line": 1624,
           "called": [
             "cspaceSlotUnique_of_storeTcbIpcState"
           ]
@@ -3602,7 +3607,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_handshake_path",
-          "line": 1622,
+          "line": 1639,
           "called": [
             "cspaceSlotUnique_of_storeTcbIpcState"
           ]
@@ -3610,25 +3615,25 @@
         {
           "kind": "theorem",
           "name": "storeObject_cnode_preserves_notificationBadgesWellFormed",
-          "line": 1642,
+          "line": 1659,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "storeObject_cnode_preserves_capabilityBadgesWellFormed",
-          "line": 1653,
+          "line": 1670,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "badgeWellFormed_of_objects_eq",
-          "line": 1669,
+          "line": 1686,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "cspaceMint_preserves_badgeWellFormed",
-          "line": 1680,
+          "line": 1697,
           "called": [
             "badgeWellFormed_of_objects_eq",
             "storeObject_cnode_preserves_capabilityBadgesWellFormed",
@@ -3638,7 +3643,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMutate_preserves_badgeWellFormed",
-          "line": 1743,
+          "line": 1760,
           "called": [
             "badgeWellFormed_of_objects_eq",
             "storeObject_cnode_preserves_capabilityBadgesWellFormed",
@@ -3648,7 +3653,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_capabilityInvariantBundle",
-          "line": 1822,
+          "line": 1839,
           "called": [
             "cspaceInsertSlot_preserves_capabilityInvariantBundle"
           ]
@@ -3656,7 +3661,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_capabilityInvariantBundle_noGrant",
-          "line": 1897,
+          "line": 1914,
           "called": []
         }
       ]
@@ -3670,7 +3675,7 @@
     {
       "module": "SeLe4n.Kernel.Capability.Operations",
       "path": "SeLe4n/Kernel/Capability/Operations.lean",
-      "declaration_count": 58,
+      "declaration_count": 59,
       "declarations": [
         {
           "kind": "namespace",
@@ -4006,7 +4011,15 @@
         {
           "kind": "def",
           "name": "processRevokeNode",
-          "line": 723,
+          "line": 727,
+          "called": [
+            "cspaceDeleteSlot"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "processRevokeNode_lenient",
+          "line": 743,
           "called": [
             "cspaceDeleteSlot"
           ]
@@ -4014,7 +4027,7 @@
         {
           "kind": "def",
           "name": "cspaceRevokeCdt",
-          "line": 751,
+          "line": 771,
           "called": [
             "CSpaceAddr",
             "cspaceRevoke",
@@ -4024,7 +4037,7 @@
         {
           "kind": "def",
           "name": "streamingRevokeBFS",
-          "line": 784,
+          "line": 810,
           "called": [
             "processRevokeNode"
           ]
@@ -4032,7 +4045,7 @@
         {
           "kind": "def",
           "name": "cspaceRevokeCdtStreaming",
-          "line": 807,
+          "line": 836,
           "called": [
             "CSpaceAddr",
             "cspaceRevoke",
@@ -4042,7 +4055,7 @@
         {
           "kind": "structure",
           "name": "RevokeCdtStrictFailure",
-          "line": 823,
+          "line": 852,
           "called": [
             "CSpaceAddr"
           ]
@@ -4050,7 +4063,7 @@
         {
           "kind": "structure",
           "name": "RevokeCdtStrictReport",
-          "line": 833,
+          "line": 862,
           "called": [
             "CSpaceAddr",
             "RevokeCdtStrictFailure"
@@ -4059,7 +4072,7 @@
         {
           "kind": "def",
           "name": "cspaceRevokeCdtStrict",
-          "line": 848,
+          "line": 877,
           "called": [
             "CSpaceAddr",
             "RevokeCdtStrictFailure",
@@ -4071,7 +4084,7 @@
         {
           "kind": "def",
           "name": "ipcTransferSingleCap",
-          "line": 903,
+          "line": 932,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot"
@@ -4080,19 +4093,19 @@
         {
           "kind": "theorem",
           "name": "ensureCdtNodeForSlot_scheduler_eq",
-          "line": 926,
+          "line": 955,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ensureCdtNodeForSlot_services_eq",
-          "line": 931,
+          "line": 960,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_scheduler",
-          "line": 936,
+          "line": 965,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -4104,7 +4117,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_objects_ne",
-          "line": 969,
+          "line": 998,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -4115,7 +4128,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_services",
-          "line": 1004,
+          "line": 1033,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -4127,7 +4140,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_objects_invExt",
-          "line": 1037,
+          "line": 1066,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -4138,7 +4151,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_ntfn_objects",
-          "line": 1075,
+          "line": 1104,
           "called": [
             "CSpaceAddr",
             "ipcTransferSingleCap",
@@ -4148,7 +4161,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_receiverRoot_not_ntfn",
-          "line": 1097,
+          "line": 1126,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -4158,7 +4171,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_ep_objects",
-          "line": 1171,
+          "line": 1200,
           "called": [
             "CSpaceAddr",
             "ipcTransferSingleCap",
@@ -4168,7 +4181,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_tcb_objects",
-          "line": 1192,
+          "line": 1221,
           "called": [
             "CSpaceAddr",
             "ipcTransferSingleCap",
@@ -4178,7 +4191,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_receiverRoot_stays_cnode",
-          "line": 1214,
+          "line": 1243,
           "called": [
             "CSpaceAddr",
             "cspaceInsertSlot",
@@ -16783,7 +16796,7 @@
     {
       "module": "SeLe4n.Model.Object.Structures",
       "path": "SeLe4n/Model/Object/Structures.lean",
-      "declaration_count": 119,
+      "declaration_count": 120,
       "declarations": [
         {
           "kind": "namespace",
@@ -17706,17 +17719,26 @@
           ]
         },
         {
+          "kind": "def",
+          "name": "isAncestor",
+          "line": 1367,
+          "called": [
+            "CapDerivationTree",
+            "CdtNodeId"
+          ]
+        },
+        {
           "kind": "inductive",
           "name": "KernelObject",
-          "line": 1370,
+          "line": 1384,
           "called": [
             "VSpaceRoot"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:1381>",
-          "line": 1381,
+          "name": "<anonymous:instance:1395>",
+          "line": 1395,
           "called": [
             "KernelObject"
           ]
@@ -17724,19 +17746,19 @@
         {
           "kind": "inductive",
           "name": "KernelObjectType",
-          "line": 1391,
+          "line": 1405,
           "called": []
         },
         {
           "kind": "namespace",
           "name": "KernelObject",
-          "line": 1400,
+          "line": 1414,
           "called": []
         },
         {
           "kind": "def",
           "name": "objectType",
-          "line": 1402,
+          "line": 1416,
           "called": [
             "KernelObject",
             "KernelObjectType"
@@ -17745,7 +17767,7 @@
         {
           "kind": "def",
           "name": "makeObjectCap",
-          "line": 1414,
+          "line": 1428,
           "called": []
         }
       ]
@@ -18552,13 +18574,13 @@
         {
           "kind": "structure",
           "name": "DomainScheduleEntry",
-          "line": 59,
+          "line": 60,
           "called": []
         },
         {
           "kind": "structure",
           "name": "SchedulerState",
-          "line": 64,
+          "line": 65,
           "called": [
             "DomainScheduleEntry"
           ]
@@ -18566,7 +18588,7 @@
         {
           "kind": "abbrev",
           "name": "SchedulerState.runnable",
-          "line": 85,
+          "line": 86,
           "called": [
             "SchedulerState"
           ]
@@ -18574,13 +18596,13 @@
         {
           "kind": "structure",
           "name": "SlotRef",
-          "line": 89,
+          "line": 90,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:97>",
-          "line": 97,
+          "name": "<anonymous:instance:98>",
+          "line": 98,
           "called": [
             "SlotRef"
           ]
@@ -18588,7 +18610,7 @@
         {
           "kind": "structure",
           "name": "LifecycleMetadata",
-          "line": 107,
+          "line": 108,
           "called": [
             "SlotRef"
           ]
@@ -18596,7 +18618,7 @@
         {
           "kind": "structure",
           "name": "SystemState",
-          "line": 111,
+          "line": 112,
           "called": [
             "LifecycleMetadata",
             "SchedulerState",
@@ -18606,21 +18628,21 @@
         {
           "kind": "abbrev",
           "name": "CSpaceOwner",
-          "line": 157,
+          "line": 158,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:159>",
-          "line": 159,
+          "name": "<anonymous:instance:160>",
+          "line": 160,
           "called": [
             "SchedulerState"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:162>",
-          "line": 162,
+          "name": "<anonymous:instance:163>",
+          "line": 163,
           "called": [
             "SystemState"
           ]
@@ -18628,7 +18650,7 @@
         {
           "kind": "def",
           "name": "SystemState.allTablesInvExt",
-          "line": 188,
+          "line": 189,
           "called": [
             "SystemState"
           ]
@@ -18636,7 +18658,7 @@
         {
           "kind": "theorem",
           "name": "default_allTablesInvExt",
-          "line": 214,
+          "line": 215,
           "called": [
             "SystemState"
           ]
@@ -18644,7 +18666,7 @@
         {
           "kind": "abbrev",
           "name": "Kernel",
-          "line": 232,
+          "line": 233,
           "called": [
             "KernelError",
             "SystemState"
@@ -18653,7 +18675,7 @@
         {
           "kind": "def",
           "name": "lookupObject",
-          "line": 234,
+          "line": 235,
           "called": [
             "Kernel"
           ]
@@ -18661,7 +18683,7 @@
         {
           "kind": "def",
           "name": "lookupVSpaceRoot",
-          "line": 241,
+          "line": 242,
           "called": [
             "Kernel"
           ]
@@ -18669,7 +18691,7 @@
         {
           "kind": "def",
           "name": "storeObject",
-          "line": 256,
+          "line": 257,
           "called": [
             "Kernel"
           ]
@@ -18677,7 +18699,7 @@
         {
           "kind": "def",
           "name": "storeCapabilityRef",
-          "line": 284,
+          "line": 285,
           "called": [
             "Kernel",
             "LifecycleMetadata",
@@ -18687,7 +18709,7 @@
         {
           "kind": "def",
           "name": "revokeAndClearRefsState",
-          "line": 299,
+          "line": 300,
           "called": [
             "SystemState"
           ]
@@ -18695,7 +18717,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsFoldBody_preserves_objects",
-          "line": 310,
+          "line": 311,
           "called": [
             "SystemState"
           ]
@@ -18703,7 +18725,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_objects",
-          "line": 325,
+          "line": 326,
           "called": [
             "SystemState",
             "revokeAndClearRefsState"
@@ -18712,7 +18734,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsFoldBody_preserves_cdt",
-          "line": 333,
+          "line": 334,
           "called": [
             "SystemState"
           ]
@@ -18720,7 +18742,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_cdt_eq",
-          "line": 364,
+          "line": 365,
           "called": [
             "SystemState",
             "revokeAndClearRefsState"
@@ -18729,7 +18751,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsFoldBody_preserves_fields",
-          "line": 379,
+          "line": 380,
           "called": [
             "SystemState"
           ]
@@ -18737,7 +18759,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_allFields",
-          "line": 403,
+          "line": 404,
           "called": [
             "SystemState",
             "revokeAndClearRefsState"
@@ -18746,7 +18768,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_scheduler",
-          "line": 420,
+          "line": 421,
           "called": [
             "SystemState",
             "revokeAndClearRefsState",
@@ -18756,7 +18778,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_machine",
-          "line": 427,
+          "line": 428,
           "called": [
             "SystemState",
             "revokeAndClearRefsState",
@@ -18766,7 +18788,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_services",
-          "line": 434,
+          "line": 435,
           "called": [
             "SystemState",
             "revokeAndClearRefsState",
@@ -18776,7 +18798,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_irqHandlers",
-          "line": 441,
+          "line": 442,
           "called": [
             "SystemState",
             "revokeAndClearRefsState",
@@ -18786,7 +18808,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_objectIndex",
-          "line": 448,
+          "line": 449,
           "called": [
             "SystemState",
             "revokeAndClearRefsState",
@@ -18796,7 +18818,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_preserves_objectIndexSet",
-          "line": 455,
+          "line": 456,
           "called": [
             "SystemState",
             "revokeAndClearRefsState",
@@ -18806,7 +18828,7 @@
         {
           "kind": "def",
           "name": "setCurrentThread",
-          "line": 461,
+          "line": 462,
           "called": [
             "Kernel"
           ]
@@ -18814,7 +18836,7 @@
         {
           "kind": "def",
           "name": "lookupService",
-          "line": 467,
+          "line": 468,
           "called": [
             "SystemState"
           ]
@@ -18822,7 +18844,7 @@
         {
           "kind": "theorem",
           "name": "revokeAndClearRefsState_lookupService",
-          "line": 471,
+          "line": 472,
           "called": [
             "SystemState",
             "lookupService",
@@ -18833,7 +18855,7 @@
         {
           "kind": "def",
           "name": "hasServiceDependency",
-          "line": 480,
+          "line": 481,
           "called": [
             "SystemState",
             "lookupService"
@@ -18842,7 +18864,7 @@
         {
           "kind": "def",
           "name": "hasIsolationEdge",
-          "line": 486,
+          "line": 487,
           "called": [
             "SystemState",
             "lookupService"
@@ -18851,7 +18873,7 @@
         {
           "kind": "def",
           "name": "storeServiceState",
-          "line": 492,
+          "line": 493,
           "called": [
             "SystemState"
           ]
@@ -18859,7 +18881,7 @@
         {
           "kind": "theorem",
           "name": "storeServiceState_lookup_eq",
-          "line": 498,
+          "line": 499,
           "called": [
             "SystemState",
             "lookupService",
@@ -18869,7 +18891,7 @@
         {
           "kind": "theorem",
           "name": "storeServiceState_lookup_ne",
-          "line": 507,
+          "line": 508,
           "called": [
             "SystemState",
             "lookupService",
@@ -18879,7 +18901,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_services",
-          "line": 519,
+          "line": 520,
           "called": [
             "SystemState",
             "storeObject"
@@ -18888,7 +18910,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_scheduler",
-          "line": 529,
+          "line": 530,
           "called": [
             "SlotRef",
             "SystemState",
@@ -18898,7 +18920,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_services",
-          "line": 538,
+          "line": 539,
           "called": [
             "SlotRef",
             "SystemState",
@@ -18908,7 +18930,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_objects",
-          "line": 547,
+          "line": 548,
           "called": [
             "SlotRef",
             "SystemState",
@@ -18918,7 +18940,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_irqHandlers",
-          "line": 557,
+          "line": 558,
           "called": [
             "SlotRef",
             "SystemState",
@@ -18928,7 +18950,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_objectIndex",
-          "line": 567,
+          "line": 568,
           "called": [
             "SlotRef",
             "SystemState",
@@ -18938,7 +18960,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_preserves_machine",
-          "line": 577,
+          "line": 578,
           "called": [
             "SlotRef",
             "SystemState",
@@ -18948,7 +18970,7 @@
         {
           "kind": "theorem",
           "name": "storeCapabilityRef_lookup_eq",
-          "line": 586,
+          "line": 587,
           "called": [
             "SlotRef",
             "SystemState",
@@ -18958,7 +18980,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objects_eq'",
-          "line": 605,
+          "line": 606,
           "called": [
             "SystemState",
             "storeObject"
@@ -18967,7 +18989,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objects_eq",
-          "line": 617,
+          "line": 618,
           "called": [
             "SystemState",
             "storeObject",
@@ -18977,7 +18999,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objects_ne'",
-          "line": 626,
+          "line": 627,
           "called": [
             "SystemState",
             "storeObject"
@@ -18986,7 +19008,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objects_ne",
-          "line": 640,
+          "line": 641,
           "called": [
             "SystemState",
             "storeObject",
@@ -18996,7 +19018,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_objects_invExt'",
-          "line": 650,
+          "line": 651,
           "called": [
             "SystemState",
             "storeObject"
@@ -19005,7 +19027,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_scheduler_eq",
-          "line": 662,
+          "line": 663,
           "called": [
             "SystemState",
             "storeObject"
@@ -19014,7 +19036,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_irqHandlers_eq",
-          "line": 672,
+          "line": 673,
           "called": [
             "SystemState",
             "storeObject"
@@ -19023,7 +19045,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_machine_eq",
-          "line": 682,
+          "line": 683,
           "called": [
             "SystemState",
             "storeObject"
@@ -19032,7 +19054,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_objects_invExt",
-          "line": 692,
+          "line": 693,
           "called": [
             "SystemState",
             "storeObject",
@@ -19042,7 +19064,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_cdt_eq",
-          "line": 702,
+          "line": 703,
           "called": [
             "SystemState",
             "storeObject"
@@ -19051,7 +19073,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_asidTable_vspaceRoot",
-          "line": 717,
+          "line": 718,
           "called": [
             "SystemState",
             "storeObject"
@@ -19060,7 +19082,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_asidTable_vspaceRoot_ne",
-          "line": 731,
+          "line": 732,
           "called": [
             "SystemState",
             "storeObject"
@@ -19069,7 +19091,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_asidTable_non_vspaceRoot",
-          "line": 762,
+          "line": 763,
           "called": [
             "SystemState",
             "storeObject"
@@ -19078,7 +19100,7 @@
         {
           "kind": "def",
           "name": "objectIndexSetSync",
-          "line": 781,
+          "line": 782,
           "called": [
             "SystemState"
           ]
@@ -19086,7 +19108,7 @@
         {
           "kind": "theorem",
           "name": "objectIndexSetSync_contains_of_mem",
-          "line": 785,
+          "line": 786,
           "called": [
             "SystemState",
             "objectIndexSetSync"
@@ -19095,7 +19117,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_updates_objectTypeMeta",
-          "line": 791,
+          "line": 792,
           "called": [
             "SystemState",
             "storeObject"
@@ -19104,13 +19126,13 @@
         {
           "kind": "namespace",
           "name": "SystemState",
-          "line": 802,
+          "line": 803,
           "called": []
         },
         {
           "kind": "def",
           "name": "lookupCNode",
-          "line": 805,
+          "line": 806,
           "called": [
             "SystemState"
           ]
@@ -19118,7 +19140,7 @@
         {
           "kind": "def",
           "name": "lookupSlotCap",
-          "line": 811,
+          "line": 812,
           "called": [
             "SlotRef",
             "SystemState",
@@ -19128,7 +19150,7 @@
         {
           "kind": "def",
           "name": "ownerOfSlot",
-          "line": 817,
+          "line": 818,
           "called": [
             "CSpaceOwner",
             "SlotRef"
@@ -19137,7 +19159,7 @@
         {
           "kind": "def",
           "name": "ownsSlot",
-          "line": 821,
+          "line": 822,
           "called": [
             "CSpaceOwner",
             "SlotRef",
@@ -19149,7 +19171,7 @@
         {
           "kind": "def",
           "name": "ownedSlots",
-          "line": 826,
+          "line": 827,
           "called": [
             "CSpaceOwner",
             "SystemState",
@@ -19159,7 +19181,7 @@
         {
           "kind": "def",
           "name": "lookupObjectTypeMeta",
-          "line": 832,
+          "line": 833,
           "called": [
             "SystemState"
           ]
@@ -19167,7 +19189,7 @@
         {
           "kind": "def",
           "name": "lookupCapabilityRefMeta",
-          "line": 836,
+          "line": 837,
           "called": [
             "SlotRef",
             "SystemState",
@@ -19177,7 +19199,7 @@
         {
           "kind": "def",
           "name": "lookupCdtNodeOfSlot",
-          "line": 841,
+          "line": 842,
           "called": [
             "SlotRef",
             "SystemState"
@@ -19186,7 +19208,7 @@
         {
           "kind": "def",
           "name": "lookupCdtSlotOfNode",
-          "line": 845,
+          "line": 846,
           "called": [
             "SlotRef",
             "SystemState"
@@ -19195,7 +19217,7 @@
         {
           "kind": "def",
           "name": "observedCdtEdges",
-          "line": 849,
+          "line": 850,
           "called": [
             "SystemState",
             "lookupCdtSlotOfNode"
@@ -19204,7 +19226,7 @@
         {
           "kind": "theorem",
           "name": "observedCdtEdges_eq_projection",
-          "line": 855,
+          "line": 856,
           "called": [
             "SystemState",
             "lookupCdtSlotOfNode",
@@ -19214,7 +19236,7 @@
         {
           "kind": "def",
           "name": "attachSlotToCdtNode",
-          "line": 863,
+          "line": 864,
           "called": [
             "SlotRef",
             "SystemState"
@@ -19223,7 +19245,7 @@
         {
           "kind": "def",
           "name": "detachSlotFromCdt",
-          "line": 881,
+          "line": 882,
           "called": [
             "SlotRef",
             "SystemState"
@@ -19232,7 +19254,7 @@
         {
           "kind": "def",
           "name": "ensureCdtNodeForSlot",
-          "line": 892,
+          "line": 893,
           "called": [
             "SlotRef",
             "SystemState"
@@ -19241,7 +19263,7 @@
         {
           "kind": "theorem",
           "name": "attachSlotToCdtNode_objects_eq",
-          "line": 907,
+          "line": 908,
           "called": [
             "SlotRef",
             "SystemState",
@@ -19251,7 +19273,7 @@
         {
           "kind": "theorem",
           "name": "detachSlotFromCdt_objects_eq",
-          "line": 911,
+          "line": 912,
           "called": [
             "SlotRef",
             "SystemState",
@@ -19261,7 +19283,7 @@
         {
           "kind": "theorem",
           "name": "ensureCdtNodeForSlot_objects_eq",
-          "line": 916,
+          "line": 917,
           "called": [
             "SlotRef",
             "SystemState",
@@ -19271,7 +19293,7 @@
         {
           "kind": "theorem",
           "name": "lookupSlotCap_eq_of_objects_eq",
-          "line": 922,
+          "line": 923,
           "called": [
             "SlotRef",
             "SystemState",
@@ -19282,7 +19304,7 @@
         {
           "kind": "def",
           "name": "objectTypeMetadataConsistent",
-          "line": 930,
+          "line": 931,
           "called": [
             "SystemState",
             "lookupObjectTypeMeta"
@@ -19291,7 +19313,7 @@
         {
           "kind": "def",
           "name": "capabilityRefMetadataConsistent",
-          "line": 934,
+          "line": 935,
           "called": [
             "SystemState",
             "lookupCapabilityRefMeta",
@@ -19301,7 +19323,7 @@
         {
           "kind": "def",
           "name": "lifecycleMetadataConsistent",
-          "line": 938,
+          "line": 939,
           "called": [
             "SystemState",
             "capabilityRefMetadataConsistent",
@@ -19311,7 +19333,7 @@
         {
           "kind": "theorem",
           "name": "lookupSlotCap_eq_none_of_lookupCNode_eq_none",
-          "line": 941,
+          "line": 942,
           "called": [
             "SlotRef",
             "SystemState",
@@ -19322,7 +19344,7 @@
         {
           "kind": "theorem",
           "name": "ownsSlot_iff",
-          "line": 948,
+          "line": 949,
           "called": [
             "CSpaceOwner",
             "SlotRef",
@@ -19335,7 +19357,7 @@
         {
           "kind": "theorem",
           "name": "ownedSlots_eq_nil_of_lookupCNode_eq_none",
-          "line": 956,
+          "line": 957,
           "called": [
             "CSpaceOwner",
             "SystemState",
@@ -19346,7 +19368,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_objectTypeMetadataConsistent",
-          "line": 965,
+          "line": 966,
           "called": [
             "SystemState",
             "storeObject"
@@ -19355,7 +19377,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_capabilityRefMetadataConsistent",
-          "line": 989,
+          "line": 990,
           "called": [
             "SystemState",
             "storeObject"
@@ -19364,7 +19386,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_lifecycleMetadataConsistent",
-          "line": 999,
+          "line": 1000,
           "called": [
             "SystemState",
             "storeObject",
@@ -19375,7 +19397,7 @@
         {
           "kind": "theorem",
           "name": "default_systemState_lifecycleConsistent",
-          "line": 1020,
+          "line": 1021,
           "called": [
             "SystemState"
           ]
@@ -19383,7 +19405,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_metadata_sync_type_change",
-          "line": 1042,
+          "line": 1043,
           "called": [
             "SystemState",
             "storeObject",
@@ -19393,7 +19415,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_metadata_sync_capref_at_stored",
-          "line": 1060,
+          "line": 1061,
           "called": [
             "SystemState",
             "storeObject"
@@ -19402,7 +19424,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objectIndex_monotone",
-          "line": 1084,
+          "line": 1085,
           "called": [
             "SystemState",
             "storeObject"
@@ -19411,7 +19433,7 @@
         {
           "kind": "def",
           "name": "objectIndexLive",
-          "line": 1110,
+          "line": 1111,
           "called": [
             "SystemState"
           ]
@@ -19419,7 +19441,7 @@
         {
           "kind": "theorem",
           "name": "objectIndexLive_default",
-          "line": 1114,
+          "line": 1115,
           "called": [
             "objectIndexLive"
           ]
@@ -19427,7 +19449,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_objectIndexLive",
-          "line": 1123,
+          "line": 1124,
           "called": [
             "SystemState",
             "objectIndexLive",
@@ -23581,7 +23603,7 @@
     {
       "module": "tests.NegativeStateSuite",
       "path": "tests/NegativeStateSuite.lean",
-      "declaration_count": 43,
+      "declaration_count": 44,
       "declarations": [
         {
           "kind": "namespace",
@@ -23935,8 +23957,14 @@
         },
         {
           "kind": "def",
+          "name": "runWSR2RevocationChecks",
+          "line": 2674,
+          "called": []
+        },
+        {
+          "kind": "def",
           "name": "main",
-          "line": 2667,
+          "line": 2732,
           "called": []
         }
       ]

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/audit-phase-r2-workstream-JSz4E",
-      "commit_sha": "82da0d4438628339617be6c887d03f65f2573c84",
-      "tree_sha": "80517559c94ffc23b13bdb3a3456e85d61237efe",
-      "committed_at_utc": "2026-03-21T06:15:56+00:00"
+      "commit_sha": "0a64b0f871ce36583ebb0c600eb1621c31fbc24f",
+      "tree_sha": "760eda379c5c674e398eca5e4efdf7261a964a01",
+      "committed_at_utc": "2026-03-21T07:02:53+00:00"
     }
   },
   "source_sync": {
@@ -17,7 +17,7 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "a6c2db186d3ad126c36fcbaffa8345c8ea2cf50d8c02d0fe6a8e83107afa395c"
+    "source_digest": "37266a0f3a72bb98483364472ce87bd118431fc0150b48363553fec0839f1a56"
   },
   "summary": {
     "module_count": 107,
@@ -29,7 +29,7 @@
     "production_files": 97,
     "production_loc": 53284,
     "test_files": 10,
-    "test_loc": 7117,
+    "test_loc": 7155,
     "proved_theorem_lemma_decls": 1629,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
@@ -23964,7 +23964,7 @@
         {
           "kind": "def",
           "name": "main",
-          "line": 2732,
+          "line": 2770,
           "called": []
         }
       ]

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/audit-phase-r2-workstream-JSz4E",
-      "commit_sha": "0a64b0f871ce36583ebb0c600eb1621c31fbc24f",
-      "tree_sha": "760eda379c5c674e398eca5e4efdf7261a964a01",
-      "committed_at_utc": "2026-03-21T07:02:53+00:00"
+      "commit_sha": "12ae573c8292e9dcf664cc1f4b92b79ed3d9de26",
+      "tree_sha": "af7d6700d2e0fe584093d8acc285f4235689ec16",
+      "committed_at_utc": "2026-03-21T07:45:25+00:00"
     }
   },
   "source_sync": {
@@ -17,20 +17,20 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "37266a0f3a72bb98483364472ce87bd118431fc0150b48363553fec0839f1a56"
+    "source_digest": "3f443d400b2c20586e6c0082e76653a70419b60159f94cc88fb7e0fdfb61733b"
   },
   "summary": {
     "module_count": 107,
-    "declaration_count": 3038
+    "declaration_count": 3039
   },
   "readme_sync": {
     "version": "0.17.14",
     "lean_toolchain": "v4.28.0",
     "production_files": 97,
-    "production_loc": 53284,
+    "production_loc": 53419,
     "test_files": 10,
     "test_loc": 7155,
-    "proved_theorem_lemma_decls": 1629,
+    "proved_theorem_lemma_decls": 1630,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
   "modules": [
@@ -16796,7 +16796,7 @@
     {
       "module": "SeLe4n.Model.Object.Structures",
       "path": "SeLe4n/Model/Object/Structures.lean",
-      "declaration_count": 120,
+      "declaration_count": 121,
       "declarations": [
         {
           "kind": "namespace",
@@ -17728,17 +17728,29 @@
           ]
         },
         {
+          "kind": "theorem",
+          "name": "addEdge_preserves_edgeWellFounded_noParent",
+          "line": 1389,
+          "called": [
+            "CapDerivationTree",
+            "CdtNodeId",
+            "DerivationOp",
+            "addEdge",
+            "edgeWellFounded"
+          ]
+        },
+        {
           "kind": "inductive",
           "name": "KernelObject",
-          "line": 1384,
+          "line": 1519,
           "called": [
             "VSpaceRoot"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:1395>",
-          "line": 1395,
+          "name": "<anonymous:instance:1530>",
+          "line": 1530,
           "called": [
             "KernelObject"
           ]
@@ -17746,19 +17758,19 @@
         {
           "kind": "inductive",
           "name": "KernelObjectType",
-          "line": 1405,
+          "line": 1540,
           "called": []
         },
         {
           "kind": "namespace",
           "name": "KernelObject",
-          "line": 1414,
+          "line": 1549,
           "called": []
         },
         {
           "kind": "def",
           "name": "objectType",
-          "line": 1416,
+          "line": 1551,
           "called": [
             "KernelObject",
             "KernelObjectType"
@@ -17767,7 +17779,7 @@
         {
           "kind": "def",
           "name": "makeObjectCap",
-          "line": 1428,
+          "line": 1563,
           "called": []
         }
       ]

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -102,8 +102,8 @@ Badge routing chain (H-03, WS-F5/D1):
 
 - M-G01: ~~proof incomplete~~ → **RESOLVED** (v0.16.14): existing proof was complete; added forward-direction `resolveCapAddress_guard_match` companion theorem,
 - M-G02: ~~`cdtMintCompleteness` gap~~ → **RESOLVED** (v0.16.14): `cdtMintCompleteness` predicate + transfer theorem + extended bundle `capabilityInvariantBundleWithMintCompleteness`,
-- M-G03: ~~CDT acyclicity hypotheses deferred~~ → **PARTIALLY RESOLVED** (v0.16.14): `addEdge_preserves_edgeWellFounded_fresh` proves acyclicity for fresh nodes; general `descendantsOf`-based theorem deferred to Phase 2,
-- M-G04: ~~unnamed error-swallowing pattern~~ → **RESOLVED** (v0.16.14): `cspaceRevokeCdt_swallowed_error_consistent` explicitly named theorem + docstring update,
+- M-G03: ~~CDT acyclicity hypotheses deferred~~ → **RESOLVED** (v0.18.1): `addEdge_preserves_edgeWellFounded_fresh` for fresh nodes + `isAncestor` decidable predicate + `addEdgeWouldBeSafe` runtime cycle check. General no-parent theorem (`addEdge_preserves_edgeWellFounded_noParent`) requires descendant hypothesis,
+- M-G04: ~~unnamed error-swallowing pattern~~ → **RESOLVED** (v0.18.1): Error-swallowing eliminated in R2-A/R2-B. `processRevokeNode` now propagates errors. `cspaceRevokeCdt_error_propagation_consistent` replaces `cspaceRevokeCdt_swallowed_error_consistent`. `streamingRevokeBFS` returns `.error .resourceExhausted` on fuel exhaustion,
 - M-P01: ~~`cspaceRevokeCdt` double-pass revoke fold~~ → **RESOLVED** (v0.16.15): `revokeAndClearRefsState` fuses revoke and clear-refs into a single-pass fold (M2-A),
 - M-P02: ~~CDT parent lookup O(E) scan~~ → **RESOLVED** (v0.16.15): `parentMap : Std.HashMap CdtNodeId CdtNodeId` index added to `CapDerivationTree`; `parentOf` now O(1) HashMap lookup; `parentMapConsistent` invariant with runtime check (M2-B),
 - M-P03: ~~reply lemma duplication~~ → **RESOLVED** (v0.16.15): reply lemmas extracted as shared infrastructure; new field preservation lemmas for NI proofs (M2-C),

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -2662,6 +2662,71 @@ def runWSM4ResolveEdgeCaseChecks : IO Unit := do
 
   IO.println "all WS-M4-A resolveCapAddress edge case tests passed"
 
+-- ============================================================================
+-- WS-R2: Revocation error propagation & fuel exhaustion tests
+-- ============================================================================
+
+/-- WS-R2/M-05,M-06: Negative tests for revocation error propagation.
+Verifies that:
+- `processRevokeNode` propagates `cspaceDeleteSlot` errors (M-06)
+- `streamingRevokeBFS` returns `.resourceExhausted` on fuel exhaustion (M-05)
+- `cspaceRevokeCdt` propagates descendant delete failures -/
+def runWSR2RevocationChecks : IO Unit := do
+  -- R2-NEG-01: processRevokeNode propagates error when cspaceDeleteSlot fails
+  -- Set up: CDT node mapped to a slot in a non-existent CNode → delete fails
+  let r2CnodeId : SeLe4n.ObjId := ⟨10⟩
+  let r2BadCnodeId : SeLe4n.ObjId := ⟨777⟩
+  let r2NodeId : CdtNodeId := ⟨50⟩
+  let r2BadSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := r2BadCnodeId, slot := ⟨0⟩ }
+  let r2State : SystemState :=
+    (BootstrapBuilder.empty
+      |>.withObject r2CnodeId (.cnode {
+            depth := 0, guardWidth := 0, guardValue := 0, radixWidth := 0,
+            slots := SeLe4n.Kernel.RobinHood.RHTable.ofList []
+          })
+      |>.build)
+  let r2Seed := { r2State with
+    cdtNodeSlot := r2State.cdtNodeSlot.insert r2NodeId r2BadSlot
+    cdtSlotNode := r2State.cdtSlotNode.insert r2BadSlot r2NodeId
+    cdtNextNode := ⟨51⟩
+  }
+  -- processRevokeNode should return error (slot points to non-existent CNode 777)
+  match SeLe4n.Kernel.processRevokeNode r2Seed r2NodeId with
+  | .error e =>
+    if e = .objectNotFound then
+      IO.println "negative check passed [R2-NEG-01: processRevokeNode propagates cspaceDeleteSlot error]"
+    else
+      throw <| IO.userError s!"R2-NEG-01: expected objectNotFound, got {reprStr e}"
+  | .ok _ =>
+    throw <| IO.userError "R2-NEG-01: processRevokeNode should propagate error, not succeed"
+
+  -- R2-NEG-02: streamingRevokeBFS returns resourceExhausted on fuel exhaustion
+  let r2Node1 : CdtNodeId := ⟨60⟩
+  let r2Node2 : CdtNodeId := ⟨61⟩
+  let r2Slot1 : SeLe4n.Kernel.CSpaceAddr := { cnode := r2CnodeId, slot := ⟨0⟩ }
+  let r2BfsSeed := { r2State with
+    cdt := CapDerivationTree.empty
+      |>.addEdge r2Node1 r2Node2 .mint
+    cdtNodeSlot := (r2State.cdtNodeSlot
+      |>.insert r2Node1 r2Slot1)
+      |>.insert r2Node2 { cnode := r2CnodeId, slot := ⟨1⟩ }
+    cdtSlotNode := (r2State.cdtSlotNode
+      |>.insert r2Slot1 r2Node1)
+      |>.insert { cnode := r2CnodeId, slot := ⟨1⟩ } r2Node2
+    cdtNextNode := ⟨62⟩
+  }
+  -- Fuel = 0 with non-empty queue → resourceExhausted
+  match SeLe4n.Kernel.streamingRevokeBFS 0 [r2Node1, r2Node2] r2BfsSeed with
+  | .error e =>
+    if e = .resourceExhausted then
+      IO.println "negative check passed [R2-NEG-02: streamingRevokeBFS fuel exhaustion returns resourceExhausted]"
+    else
+      throw <| IO.userError s!"R2-NEG-02: expected resourceExhausted, got {reprStr e}"
+  | .ok _ =>
+    throw <| IO.userError "R2-NEG-02: streamingRevokeBFS with fuel=0 should return error, not succeed"
+
+  IO.println "all WS-R2 revocation error propagation checks passed"
+
 end SeLe4n.Testing
 
 def main : IO Unit := do
@@ -2679,3 +2744,4 @@ def main : IO Unit := do
   SeLe4n.Testing.runWSL4BlockedThreadChecks
   SeLe4n.Testing.runWSM3CapTransferNegativeChecks
   SeLe4n.Testing.runWSM4ResolveEdgeCaseChecks
+  SeLe4n.Testing.runWSR2RevocationChecks

--- a/tests/NegativeStateSuite.lean
+++ b/tests/NegativeStateSuite.lean
@@ -2725,6 +2725,44 @@ def runWSR2RevocationChecks : IO Unit := do
   | .ok _ =>
     throw <| IO.userError "R2-NEG-02: streamingRevokeBFS with fuel=0 should return error, not succeed"
 
+  -- R2-NEG-03: cspaceRevokeCdt propagates descendant delete failures
+  -- Set up: CNode with root cap at slot 5. CDT: rootNode → childNode (bad slot).
+  -- cspaceRevokeCdt should fail because descendant deletion fails.
+  let r2RootSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := r2CnodeId, slot := ⟨5⟩ }
+  let r2RootNode : CdtNodeId := ⟨70⟩
+  let r2ChildNode : CdtNodeId := ⟨71⟩
+  let r2ChildBadSlot : SeLe4n.Kernel.CSpaceAddr := { cnode := r2BadCnodeId, slot := ⟨0⟩ }
+  let r2RevokeSeed : SystemState :=
+    { r2State with
+      objects := r2State.objects.insert r2CnodeId (.cnode {
+            depth := 0, guardWidth := 0, guardValue := 0, radixWidth := 0,
+            slots := SeLe4n.Kernel.RobinHood.RHTable.ofList [
+              (r2RootSlot.slot, {
+                target := .object ⟨40⟩
+                rights := AccessRightSet.ofList [.read, .write]
+                badge := none
+              })
+            ]
+          })
+      cdt := CapDerivationTree.empty
+        |>.addEdge r2RootNode r2ChildNode .mint
+      cdtSlotNode := ((r2State.cdtSlotNode
+        |>.insert r2RootSlot r2RootNode)
+        |>.insert r2ChildBadSlot r2ChildNode)
+      cdtNodeSlot := ((r2State.cdtNodeSlot
+        |>.insert r2RootNode r2RootSlot)
+        |>.insert r2ChildNode r2ChildBadSlot)
+      cdtNextNode := ⟨72⟩
+    }
+  match SeLe4n.Kernel.cspaceRevokeCdt r2RootSlot r2RevokeSeed with
+  | .error e =>
+    if e = .objectNotFound then
+      IO.println "negative check passed [R2-NEG-03: cspaceRevokeCdt propagates descendant delete error]"
+    else
+      throw <| IO.userError s!"R2-NEG-03: expected objectNotFound from cspaceRevokeCdt, got {reprStr e}"
+  | .ok _ =>
+    throw <| IO.userError "R2-NEG-03: cspaceRevokeCdt should propagate descendant delete error, not succeed"
+
   IO.println "all WS-R2 revocation error propagation checks passed"
 
 end SeLe4n.Testing


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced**: R2 (Capability & CDT hardening)
- **Recommendation IDs closed**: M-06 (error swallowing in `processRevokeNode`), M-05 (fuel exhaustion handling)
- **Scope notes**: Error propagation semantics change; legacy lenient variant retained for compatibility

## Changes

### Core Revocation Error Propagation (M-06)

**`processRevokeNode` now propagates errors instead of swallowing them:**
- Changed return type from `SystemState` → `Except KernelError SystemState`
- When `cspaceDeleteSlot` fails, error is returned immediately (`.error e`)
- When successful, returns `.ok st'` with updated state
- Added `processRevokeNode_lenient` (deprecated) for backward compatibility with legacy swallow-error semantics

**Cascading updates to callers:**
- `revokeCdtFoldBody`: Updated to handle `Except` return; propagates errors through fold
- `cspaceRevokeCdt`: Now propagates descendant deletion errors instead of silently continuing
- `streamingRevokeBFS`: Error propagation through BFS traversal
- `cspaceRevokeCdtStrict`: Structured error reporting with per-node failure tracking

### Invariant Proofs (M-06 & M-05)

**Updated theorem signatures to reflect error propagation:**
- `processRevokeNode_preserves_cdtNodeSlot`: Now takes success hypothesis `hStep : processRevokeNode st node = .ok st'`
- `processRevokeNode_preserves_capabilityInvariantBundle`: Same; only proves invariant when step succeeds
- `revokeCdtFoldBody_preserves`: Updated to handle error cases in fold body
- Removed `cspaceRevokeCdt_swallowed_error_consistent` (no longer applicable; errors propagate)
- Added `streamingRevokeBFS_fuel_exhaustion_returns_error` theorem for M-05

**Proof strategy:** Errors are now part of the control flow; invariants only need to hold on success paths. This simplifies reasoning by eliminating the "swallowed error" case.

### CDT Ancestor Check (R2-D/M-08)

**New decidable ancestor predicate in `SeLe4n/Model/Object/Structures.lean`:**
- `isAncestor (cdt : CapDerivationTree) (ancestor start : CdtNodeId) : Bool`
  - O(depth) lookup using `parentMap`
  - Fuel = `edges.length` for termination
  - Returns `true` if `ancestor` is reachable from `start` by following parent edges upward

**New acyclicity preservation theorem:**
- `addEdge_preserves_edgeWellFounded_noParent`: Generalizes fresh-child case to non-fresh children
  - Allows adding edges to nodes with existing outgoing edges/subtrees
  - Proof projects cycle edges onto old CDT; when new edge encountered, constructs rotated sub-path from child to parent using only old edges, contradicting no-path hypothesis
  - Enables more flexible CDT construction patterns

### Test Coverage (WS-R2)

**Added `runWSR2RevocationChecks` in `tests/NegativeStateSuite.lean`:**
- **R2-NEG-01**: `processRevokeNode` propagates `cspaceDeleteSlot` errors (M-06)
- **R2-NEG-02**: `streamingRevokeBFS` returns `.resourceExhausted` on fuel exhaustion (M-05)
- **R2-NEG-03**: `cspaceRevokeCdt` propagates descendant delete failures

### Documentation

- Updated `WORKSTREAM_HISTORY.md`: R2 marked COMPLETE with summary of fixes
- Updated `AUDIT_v0.17.14_WORKSTREAM_PLAN.md`: R2 status and findings
- Updated `docs/gitbook/12-proof-and-invariant-map.md`: M-

https://claude.ai/code/session_01WrXpXFXFuzefmGqz75jjjU