### PR TITLE
Add lake build step to ensure oleans are up-to-date for #check

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Setup Lean toolchain
         run: ./scripts/setup_lean_env.sh
 
+      - name: Build (ensure oleans are up-to-date for #check anchors)
+        run: source ~/.elan/env && lake build
+
       - name: Run Tier 3 invariant surface checks
         run: ./scripts/ci_capture_timing.sh full ./scripts/test_tier3_invariant_surface.sh
 


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: CI/Build infrastructure
- Recommendation IDs closed: N/A
- Scope notes: Adds a build step in the CI pipeline to ensure compiled Lean object files (oleans) are up-to-date before running Tier 3 invariant surface checks that depend on `#check` anchors.

## Description

This change inserts a `lake build` step in the GitHub Actions CI workflow after the Lean toolchain setup and before the Tier 3 invariant surface checks. This ensures that all Lean source files are compiled and their object files are current, which is necessary for `#check` anchors used in the surface checks to work correctly.

The build step sources the elan environment to ensure the correct Lean toolchain is active during compilation.

## Validation evidence

- [x] CI workflow change only—no source code modifications
- [x] Existing CI tests will validate this step integrates correctly

## Documentation synchronization checklist

- [x] N/A—CI workflow change only, no documentation updates required

## Risks / follow-ups

- Residual risks: None—this is a straightforward addition to ensure build artifacts are current
- Deferred items: None

https://claude.ai/code/session_01LKgMXqkAbAUcVV42PcXTeu