### PR TITLE
V3-B Phase 1-2: Introduce invExtK kernel-level invariant bundle

### DIFF
--- a/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
+++ b/SeLe4n/Kernel/Architecture/VSpaceInvariant.lean
@@ -451,9 +451,7 @@ theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
     (hAsidInv : ∀ (oid : SeLe4n.ObjId) (root : VSpaceRoot), st.objects[oid]? = some (.vspaceRoot root) →
         (st.asidTable.erase root.asid).invExt)
     (hAsidSize : st.asidTable.size < st.asidTable.capacity)
-    (hMappingsWF : ∀ (oid : SeLe4n.ObjId) (root : VSpaceRoot), st.objects[oid]? = some (.vspaceRoot root) → root.mappings.invExt)
-    (hMappingsSize : ∀ (oid : SeLe4n.ObjId) (root : VSpaceRoot), st.objects[oid]? = some (.vspaceRoot root) →
-        root.mappings.size < root.mappings.capacity)
+    (hMappingsK : ∀ (oid : SeLe4n.ObjId) (root : VSpaceRoot), st.objects[oid]? = some (.vspaceRoot root) → root.mappings.invExtK)
     (hTableInv : st.asidTable.invExt)
     (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
     vspaceInvariantBundle st' := by
@@ -474,9 +472,10 @@ theorem vspaceUnmapPage_success_preserves_vspaceInvariantBundle
             fun oid hNe => storeObject_objects_ne st st' rootId oid (.vspaceRoot root') hNe hObjInv hStore
           have hAsidPreserved : root'.asid = root.asid :=
             VSpaceRoot.unmapPage_asid_eq root root' vaddr hUnmapRoot
-          have hMappingsInv : root.mappings.invExt := hMappingsWF rootId root hObjRoot
+          have hMappingsInvK : root.mappings.invExtK := hMappingsK rootId root hObjRoot
+          have hMappingsInv : root.mappings.invExt := hMappingsInvK.1
           have hMappingsSize' : root.mappings.size < root.mappings.capacity :=
-            hMappingsSize rootId root hObjRoot
+            hMappingsInvK.2.1
           have hAsidInv' : (match st.objects[rootId]? with
               | some (.vspaceRoot oldRoot) => st.asidTable.erase oldRoot.asid
               | _ => st.asidTable).invExt := by
@@ -730,9 +729,7 @@ theorem vspaceLookup_unmap_other
     (hObjInv : st.objects.invExt)
     (hAsidInv : ∀ (oid : ObjId) (root : VSpaceRoot), st.objects[oid]? = some (KernelObject.vspaceRoot root) →
         (st.asidTable.erase root.asid).invExt)
-    (hMappingsWF : ∀ (oid : ObjId) (root : VSpaceRoot), st.objects[oid]? = some (KernelObject.vspaceRoot root) → root.mappings.invExt)
-    (hMappingsSize : ∀ (oid : SeLe4n.ObjId) (root : VSpaceRoot), st.objects[oid]? = some (.vspaceRoot root) →
-        root.mappings.size < root.mappings.capacity)
+    (hMappingsK : ∀ (oid : ObjId) (root : VSpaceRoot), st.objects[oid]? = some (KernelObject.vspaceRoot root) → root.mappings.invExtK)
     (hStep : vspaceUnmapPage asid vaddr st = .ok ((), st')) :
     (vspaceLookup asid vaddr' st').map Prod.fst = (vspaceLookup asid vaddr' st).map Prod.fst := by
   unfold vspaceUnmapPage at hStep
@@ -760,12 +757,10 @@ theorem vspaceLookup_unmap_other
           have hResolve' : resolveAsidRoot st' asid = some (rootId, root') :=
             resolveAsidRoot_of_asidTable_entry st' asid rootId root'
               (hAsidEq ▸ hTablePost) hObjEq hAsidEq
-          have hMappingsInv : root.mappings.invExt := hMappingsWF rootId root hObjRoot
-          have hMappingsSize' : root.mappings.size < root.mappings.capacity :=
-            hMappingsSize rootId root hObjRoot
+          have hMappingsInvK : root.mappings.invExtK := hMappingsK rootId root hObjRoot
           have hLookupNe : root'.lookupAddr vaddr' = root.lookupAddr vaddr' := by
             simp [VSpaceRoot.lookupAddr,
-              VSpaceRoot.lookup_unmapPage_ne root root' vaddr vaddr' hNe hMappingsInv hMappingsSize' hUnmapRoot]
+              VSpaceRoot.lookup_unmapPage_ne root root' vaddr vaddr' hNe hMappingsInvK hUnmapRoot]
           simp [vspaceLookup, hResolve', hResolve, hLookupNe, Except.map]
           cases root.lookupAddr vaddr' <;> rfl
 

--- a/SeLe4n/Kernel/Capability/Invariant/Defs.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Defs.lean
@@ -676,8 +676,8 @@ private theorem CNode.remove_slots_sub (cn : CNode) (slot : SeLe4n.Slot)
     rw [this] at hLookup; exact absurd hLookup (by simp)
   · -- s ≠ slot: erase preserves lookup
     have hNe : slot ≠ s := fun heq => h (beq_iff_eq.mpr heq)
-    have := SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne cn.slots slot s
-      (fun hb => hNe (eq_of_beq hb)) hUniq.1 hUniq.2.1
+    have := SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K cn.slots slot s
+      (fun hb => hNe (eq_of_beq hb)) hUniq
     rw [this] at hLookup; change cn.slots.get? s = some cap at hLookup; exact hLookup
 
 /-- WS-H13: CNode.revokeTargetLocal preserves depth/guardWidth/radixWidth and has slot subset. -/

--- a/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
+++ b/SeLe4n/Kernel/Capability/Invariant/Preservation.lean
@@ -212,8 +212,7 @@ theorem cspaceDeleteSlotCore_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (addr : CSpaceAddr)
     (hInv : capabilityInvariantBundle st)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceDeleteSlotCore addr st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   rcases hInv with ⟨hUnique, _hSound, hBounded, hComp, hAcyclic, hDepthPre, hObjInv⟩
@@ -292,11 +291,10 @@ theorem cspaceDeleteSlotCore_preserves_capabilityInvariantBundle
             have hDepthRef := cspaceDepthConsistent_of_objects_eq stMid stRef hDepthMid hRefObj
             have hObjInvRef : stRef.objects.invExt := hRefObj ▸ hObjInvMid
             have hNSMid := (storeObject_cdtNodeSlot_eq st stMid addr.cnode _ hStore).1
-            have hNodeSlotInvRef : stRef.cdtNodeSlot.invExt := hRefNS ▸ hNSMid ▸ hNodeSlotInv
-            have hNodeSlotSizeRef : stRef.cdtNodeSlot.size < stRef.cdtNodeSlot.capacity := by
-              rw [hRefNS, hNSMid]; exact hNodeSlotSize
+            have hNodeSlotKRef : stRef.cdtNodeSlot.invExtK := by
+              rw [hRefNS, hNSMid]; exact hNodeSlotK
             exact ⟨cspaceSlotCountBounded_of_detachSlotFromCdt stRef addr hBndRef,
-              cdtCompleteness_of_detachSlotFromCdt stRef addr hCompRef hNodeSlotInvRef hNodeSlotSizeRef,
+              cdtCompleteness_of_detachSlotFromCdt stRef addr hCompRef hNodeSlotKRef.1 hNodeSlotKRef.2.1,
               cdtAcyclicity_of_detachSlotFromCdt stRef addr hAcyclicRef,
               cspaceDepthConsistent_of_detachSlotFromCdt stRef addr hDepthRef,
               (SystemState.detachSlotFromCdt_objects_eq stRef addr) ▸ hObjInvRef⟩
@@ -310,23 +308,21 @@ theorem cspaceDeleteSlot_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (addr : CSpaceAddr)
     (hInv : capabilityInvariantBundle st)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceDeleteSlot addr st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   unfold cspaceDeleteSlot at hStep
   split at hStep
   · simp at hStep
   · exact cspaceDeleteSlotCore_preserves_capabilityInvariantBundle
-      st st' addr hInv hNodeSlotInv hNodeSlotSize hStep
+      st st' addr hInv hNodeSlotK hStep
 
-/-- Core: `cspaceDeleteSlotCore` preserves `cdtNodeSlot.invExt` and the size bound. -/
+/-- Core: `cspaceDeleteSlotCore` preserves `cdtNodeSlot.invExtK`. -/
 private theorem cspaceDeleteSlotCore_preserves_cdtNodeSlot
     (st st' : SystemState) (addr : CSpaceAddr)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceDeleteSlotCore addr st = .ok ((), st')) :
-    st'.cdtNodeSlot.invExt ∧ st'.cdtNodeSlot.size < st'.cdtNodeSlot.capacity := by
+    st'.cdtNodeSlot.invExtK := by
   unfold cspaceDeleteSlotCore at hStep
   cases hPre : st.objects[addr.cnode]? with
   | none => simp [hPre] at hStep
@@ -352,26 +348,22 @@ private theorem cspaceDeleteSlotCore_preserves_cdtNodeSlot
           cases hLookup : stRef.cdtSlotNode[addr]? with
           | none =>
             simp only []
-            exact ⟨hRefEqSt ▸ hNodeSlotInv, by rw [hRefEqSt]; exact hNodeSlotSize⟩
+            exact hRefEqSt ▸ hNodeSlotK
           | some origNode =>
             simp only []
-            have hInvRef : stRef.cdtNodeSlot.invExt := hRefEqSt ▸ hNodeSlotInv
-            have hSzRef : stRef.cdtNodeSlot.size < stRef.cdtNodeSlot.capacity := by
-              rw [hRefEqSt]; exact hNodeSlotSize
-            exact ⟨stRef.cdtNodeSlot.erase_preserves_invExt origNode hInvRef hSzRef,
-                   SeLe4n.Kernel.RobinHood.RHTable.erase_size_lt_capacity stRef.cdtNodeSlot origNode hSzRef⟩
+            have hKRef : stRef.cdtNodeSlot.invExtK := by rw [hRefEqSt]; exact hNodeSlotK
+            exact stRef.cdtNodeSlot.erase_preserves_invExtK origNode hKRef
 
-/-- `cspaceDeleteSlot` preserves `cdtNodeSlot.invExt` and the size bound (guarded wrapper). -/
+/-- `cspaceDeleteSlot` preserves `cdtNodeSlot.invExtK` (guarded wrapper). -/
 private theorem cspaceDeleteSlot_preserves_cdtNodeSlot
     (st st' : SystemState) (addr : CSpaceAddr)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceDeleteSlot addr st = .ok ((), st')) :
-    st'.cdtNodeSlot.invExt ∧ st'.cdtNodeSlot.size < st'.cdtNodeSlot.capacity := by
+    st'.cdtNodeSlot.invExtK := by
   unfold cspaceDeleteSlot at hStep
   split at hStep
   · simp at hStep
-  · exact cspaceDeleteSlotCore_preserves_cdtNodeSlot st st' addr hNodeSlotInv hNodeSlotSize hStep
+  · exact cspaceDeleteSlotCore_preserves_cdtNodeSlot st st' addr hNodeSlotK hStep
 
 /-- WS-E2 / H-01: Compositional preservation of `cspaceRevoke`.
 Uses pre-state `cspaceSlotUnique` + `CNode.revokeTargetLocal_slotsUnique` to derive
@@ -529,8 +521,7 @@ theorem cspaceMove_preserves_capabilityInvariantBundle
     (hDstCapacity : ∀ cn cap, st.objects[dst.cnode]? = some (.cnode cn) →
       (cn.insert dst.slot cap).slotCountBounded)
     (hCdtPost : cdtCompleteness st' ∧ cdtAcyclicity st')
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceMove src dst st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   unfold cspaceMove at hStep
@@ -573,7 +564,7 @@ theorem cspaceMove_preserves_capabilityInvariantBundle
                         rw [hNS2, hNS1]
                   | tcb _ | endpoint _ | notification _ | vspaceRoot _ | untyped _ => simp [hPre] at hInsert
               have hBundleSt3 := cspaceDeleteSlotCore_preserves_capabilityInvariantBundle st2 st3 src hBundleSt2
-                (hNSSt2 ▸ hNodeSlotInv) (by rw [hNSSt2]; exact hNodeSlotSize) hDelete
+                (by rw [hNSSt2]; exact hNodeSlotK) hDelete
               rcases hBundleSt3 with ⟨hU3, _, hBnd3, _, _, hDepth3, hObjInv3⟩
               cases hNode : SystemState.lookupCdtNodeOfSlot st2 src with
               | none =>
@@ -768,17 +759,16 @@ private theorem capabilityInvariantBundle_of_cdt_update
     cspaceDepthConsistent_of_objects_eq st _ hDepthPre hObjEq,
     hObjEq ▸ hObjInvPre⟩
 
-/-- `processRevokeNode` preserves `cdtNodeSlot.invExt` and the size bound
+/-- `processRevokeNode` preserves `cdtNodeSlot.invExtK`
 when it succeeds. -/
 private theorem processRevokeNode_preserves_cdtNodeSlot
     (st st' : SystemState) (node : CdtNodeId)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : processRevokeNode st node = .ok st') :
-    st'.cdtNodeSlot.invExt ∧ st'.cdtNodeSlot.size < st'.cdtNodeSlot.capacity := by
+    st'.cdtNodeSlot.invExtK := by
   unfold processRevokeNode at hStep
   cases hSlot : SystemState.lookupCdtSlotOfNode st node with
-  | none => simp [hSlot] at hStep; cases hStep; exact ⟨hNodeSlotInv, hNodeSlotSize⟩
+  | none => simp [hSlot] at hStep; cases hStep; exact hNodeSlotK
   | some descAddr =>
     simp [hSlot] at hStep
     cases hDel : cspaceDeleteSlotCore descAddr st with
@@ -786,18 +776,15 @@ private theorem processRevokeNode_preserves_cdtNodeSlot
     | ok pair =>
       obtain ⟨_, stDel⟩ := pair
       simp [hDel] at hStep; cases hStep
-      have ⟨hInvDel, hSzDel⟩ := cspaceDeleteSlotCore_preserves_cdtNodeSlot st stDel descAddr
-        hNodeSlotInv hNodeSlotSize hDel
-      have hDetachNS : (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.invExt ∧
-          (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.size <
-          (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.capacity := by
+      have hKDel := cspaceDeleteSlotCore_preserves_cdtNodeSlot st stDel descAddr
+        hNodeSlotK hDel
+      have hDetachNS : (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.invExtK := by
         unfold SystemState.detachSlotFromCdt
         cases hLookup : stDel.cdtSlotNode[descAddr]? with
-        | none => simp only []; exact ⟨hInvDel, hSzDel⟩
+        | none => simp only []; exact hKDel
         | some origNode =>
           simp only []
-          exact ⟨stDel.cdtNodeSlot.erase_preserves_invExt origNode hInvDel hSzDel,
-                 SeLe4n.Kernel.RobinHood.RHTable.erase_size_lt_capacity stDel.cdtNodeSlot origNode hSzDel⟩
+          exact stDel.cdtNodeSlot.erase_preserves_invExtK origNode hKDel
       exact hDetachNS
 
 /-- R2-A/R2-F: `processRevokeNode` preserves the full capability invariant bundle
@@ -817,8 +804,7 @@ materialized fold (`cspaceRevokeCdt`) and streaming BFS (`streamingRevokeBFS`). 
 theorem processRevokeNode_preserves_capabilityInvariantBundle
     (st st' : SystemState) (node : CdtNodeId)
     (hInv : capabilityInvariantBundle st)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : processRevokeNode st node = .ok st') :
     capabilityInvariantBundle st' := by
   unfold processRevokeNode at hStep
@@ -835,16 +821,16 @@ theorem processRevokeNode_preserves_capabilityInvariantBundle
       obtain ⟨_, stDel⟩ := pair
       simp [hDel] at hStep; cases hStep
       have hDelInv := cspaceDeleteSlotCore_preserves_capabilityInvariantBundle st stDel descAddr hInv
-        hNodeSlotInv hNodeSlotSize hDel
-      have ⟨hNodeSlotInvDel, hNodeSlotSizeDel⟩ :=
-        cspaceDeleteSlotCore_preserves_cdtNodeSlot st stDel descAddr hNodeSlotInv hNodeSlotSize hDel
+        hNodeSlotK hDel
+      have hKDel :=
+        cspaceDeleteSlotCore_preserves_cdtNodeSlot st stDel descAddr hNodeSlotK hDel
       have hDetachObj := SystemState.detachSlotFromCdt_objects_eq stDel descAddr
       rcases hDelInv with ⟨hU2, _, hBnd2, hComp2, hAcyclic2, hDepth2del, hObjInv2⟩
       have hDetachInv : capabilityInvariantBundle (SystemState.detachSlotFromCdt stDel descAddr) :=
         ⟨cspaceSlotUnique_of_objects_eq stDel _ hU2 hDetachObj,
          cspaceLookupSound_of_cspaceSlotUnique _ (cspaceSlotUnique_of_objects_eq stDel _ hU2 hDetachObj),
          cspaceSlotCountBounded_of_detachSlotFromCdt stDel descAddr hBnd2,
-         cdtCompleteness_of_detachSlotFromCdt stDel descAddr hComp2 hNodeSlotInvDel hNodeSlotSizeDel,
+         cdtCompleteness_of_detachSlotFromCdt stDel descAddr hComp2 hKDel.1 hKDel.2.1,
          cdtAcyclicity_of_detachSlotFromCdt stDel descAddr hAcyclic2,
          cspaceDepthConsistent_of_objects_eq stDel _ hDepth2del hDetachObj,
          hDetachObj ▸ hObjInv2⟩
@@ -870,19 +856,17 @@ Delegates to `processRevokeNode_preserves_capabilityInvariantBundle`. -/
 private theorem revokeCdtFoldBody_preserves
     (stAcc stNext : SystemState) (node : CdtNodeId)
     (hInv : capabilityInvariantBundle stAcc)
-    (hNodeSlotInv : stAcc.cdtNodeSlot.invExt)
-    (hNodeSlotSize : stAcc.cdtNodeSlot.size < stAcc.cdtNodeSlot.capacity)
+    (hNodeSlotK : stAcc.cdtNodeSlot.invExtK)
     (hStep : revokeCdtFoldBody (.ok ((), stAcc)) node = .ok ((), stNext)) :
-    capabilityInvariantBundle stNext ∧
-    stNext.cdtNodeSlot.invExt ∧ stNext.cdtNodeSlot.size < stNext.cdtNodeSlot.capacity := by
+    capabilityInvariantBundle stNext ∧ stNext.cdtNodeSlot.invExtK := by
   unfold revokeCdtFoldBody at hStep
   simp only [] at hStep
   cases hProc : processRevokeNode stAcc node with
   | error e => simp [hProc] at hStep
   | ok stMid =>
     simp [hProc] at hStep; subst hStep
-    exact ⟨processRevokeNode_preserves_capabilityInvariantBundle stAcc stMid node hInv hNodeSlotInv hNodeSlotSize hProc,
-           processRevokeNode_preserves_cdtNodeSlot stAcc stMid node hNodeSlotInv hNodeSlotSize hProc⟩
+    exact ⟨processRevokeNode_preserves_capabilityInvariantBundle stAcc stMid node hInv hNodeSlotK hProc,
+           processRevokeNode_preserves_cdtNodeSlot stAcc stMid node hNodeSlotK hProc⟩
 
 /-- Error propagation: revokeCdtFoldBody propagates errors unchanged. -/
 private theorem revokeCdtFoldBody_error (e : KernelError) (node : CdtNodeId) :
@@ -902,8 +886,7 @@ private theorem revokeCdtFold_preserves
     (nodes : List CdtNodeId)
     (stInit stFinal : SystemState)
     (hInv : capabilityInvariantBundle stInit)
-    (hNodeSlotInv : stInit.cdtNodeSlot.invExt)
-    (hNodeSlotSize : stInit.cdtNodeSlot.size < stInit.cdtNodeSlot.capacity)
+    (hNodeSlotK : stInit.cdtNodeSlot.invExtK)
     (hFold : nodes.foldl revokeCdtFoldBody (.ok ((), stInit)) = .ok ((), stFinal)) :
     capabilityInvariantBundle stFinal := by
   induction nodes generalizing stInit stFinal with
@@ -918,8 +901,8 @@ private theorem revokeCdtFold_preserves
     | ok val =>
       obtain ⟨_, stMid⟩ := val
       rw [hStep] at hFold
-      have ⟨hInvMid, hNSInvMid, hNSSzMid⟩ := revokeCdtFoldBody_preserves stInit stMid node hInv hNodeSlotInv hNodeSlotSize hStep
-      exact ih stMid stFinal hInvMid hNSInvMid hNSSzMid hFold
+      have ⟨hInvMid, hKMid⟩ := revokeCdtFoldBody_preserves stInit stMid node hInv hNodeSlotK hStep
+      exact ih stMid stFinal hInvMid hKMid hFold
 
 /-- WS-F4/F-06: cspaceRevokeCdt preserves capabilityInvariantBundle.
 Composes cspaceRevoke (proven) + fold over CDT descendants. -/
@@ -927,8 +910,7 @@ theorem cspaceRevokeCdt_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (addr : CSpaceAddr)
     (hInv : capabilityInvariantBundle st)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceRevokeCdt addr st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   unfold cspaceRevokeCdt at hStep
@@ -960,16 +942,14 @@ theorem cspaceRevokeCdt_preserves_capabilityInvariantBundle
               have hNSMid := (storeObject_cdtNodeSlot_eq st stMid addr.cnode _ hStore).1
               have ⟨_, hNSClear, _, _⟩ := revokeAndClearRefsState_cdt_eq preCn addr.slot parent.target addr.cnode stMid
               rw [hNSClear, hNSMid]
-    have hLocalNSInv : stLocal.cdtNodeSlot.invExt := hLocalNS ▸ hNodeSlotInv
-    have hLocalNSSz : stLocal.cdtNodeSlot.size < stLocal.cdtNodeSlot.capacity := by
-      rw [hLocalNS]; exact hNodeSlotSize
+    have hLocalK : stLocal.cdtNodeSlot.invExtK := hLocalNS ▸ hNodeSlotK
     split at hStep
     · simp at hStep; cases hStep; exact hLocalInv
     · rename_i rootNode hLookup
       -- hStep has the fold result; the inline lambda is definitionally equal to revokeCdtFoldBody
       change (stLocal.cdt.descendantsOf rootNode).foldl revokeCdtFoldBody
           (.ok ((), stLocal)) = .ok ((), st') at hStep
-      exact revokeCdtFold_preserves _ stLocal st' hLocalInv hLocalNSInv hLocalNSSz hStep
+      exact revokeCdtFold_preserves _ stLocal st' hLocalInv hLocalK hStep
 
 /-- R2-F: Error propagation consistency theorem. When `cspaceDeleteSlotCore` fails
 for a CDT descendant, `processRevokeNode` (and therefore `revokeCdtFoldBody`)
@@ -1005,8 +985,7 @@ theorem cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle
     (addr : CSpaceAddr)
     (report : RevokeCdtStrictReport)
     (hInv : capabilityInvariantBundle st)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceRevokeCdtStrict addr st = .ok (report, st')) :
     capabilityInvariantBundle st' := by
   unfold cspaceRevokeCdtStrict at hStep
@@ -1038,9 +1017,7 @@ theorem cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle
               have hNSMid := (storeObject_cdtNodeSlot_eq st stMid addr.cnode _ hStore).1
               have ⟨_, hNSClear, _, _⟩ := revokeAndClearRefsState_cdt_eq preCn addr.slot parent.target addr.cnode stMid
               rw [hNSClear, hNSMid]
-    have hLocalNSInv : stLocal.cdtNodeSlot.invExt := hLocalNS ▸ hNodeSlotInv
-    have hLocalNSSz : stLocal.cdtNodeSlot.size < stLocal.cdtNodeSlot.capacity := by
-      rw [hLocalNS]; exact hNodeSlotSize
+    have hLocalK : stLocal.cdtNodeSlot.invExtK := hLocalNS ▸ hNodeSlotK
     split at hStep
     · -- No CDT root: stLocal is the final state
       simp at hStep; obtain ⟨_, rfl⟩ := hStep; exact hLocalInv
@@ -1048,8 +1025,7 @@ theorem cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle
       rename_i rootNode _hLookup
       suffices h : ∀ (nodes : List CdtNodeId) (rep : RevokeCdtStrictReport) (stAcc : SystemState),
           capabilityInvariantBundle stAcc →
-          stAcc.cdtNodeSlot.invExt →
-          stAcc.cdtNodeSlot.size < stAcc.cdtNodeSlot.capacity →
+          stAcc.cdtNodeSlot.invExtK →
           capabilityInvariantBundle (nodes.foldl (fun acc node =>
             let (report, stCur) := acc
             match report.firstFailure with
@@ -1070,17 +1046,17 @@ theorem cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle
           ) (rep, stAcc)).2 by
         simp at hStep
         have hInvFold := h (stLocal.cdt.descendantsOf rootNode)
-          { deletedSlots := [], firstFailure := none } stLocal hLocalInv hLocalNSInv hLocalNSSz
+          { deletedSlots := [], firstFailure := none } stLocal hLocalInv hLocalK
         obtain ⟨_, hStEq⟩ := hStep
         rw [← hStEq]; exact hInvFold
       intro nodes
       induction nodes with
-      | nil => intro rep stAcc hI _ _; simpa [List.foldl] using hI
+      | nil => intro rep stAcc hI _; simpa [List.foldl] using hI
       | cons node rest ih =>
-        intro rep stAcc hI hNSI hNSSz
+        intro rep stAcc hI hKAcc
         simp only [List.foldl]
         cases rep.firstFailure with
-        | some _ => exact ih rep stAcc hI hNSI hNSSz
+        | some _ => exact ih rep stAcc hI hKAcc
         | none =>
           cases hSlot : SystemState.lookupCdtSlotOfNode stAcc node with
           | none =>
@@ -1088,7 +1064,7 @@ theorem cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle
             exact ih rep { stAcc with cdt := stAcc.cdt.removeNode node }
               (capabilityInvariantBundle_of_cdt_update stAcc _ hI
                 (CapDerivationTree.edgeWellFounded_sub _ _ hI.2.2.2.2.1 (CapDerivationTree.removeNode_edges_sub stAcc.cdt node)))
-              hNSI hNSSz
+              hKAcc
           | some descAddr =>
             simp
             cases hDel : cspaceDeleteSlotCore descAddr stAcc with
@@ -1097,39 +1073,36 @@ theorem cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle
               exact ih _ { stAcc with cdt := stAcc.cdt.removeNode node }
                 (capabilityInvariantBundle_of_cdt_update stAcc _ hI
                   (CapDerivationTree.edgeWellFounded_sub _ _ hI.2.2.2.2.1 (CapDerivationTree.removeNode_edges_sub stAcc.cdt node)))
-                hNSI hNSSz
+                hKAcc
             | ok pair =>
               obtain ⟨_, stDel⟩ := pair
               simp
               have hDelInv := cspaceDeleteSlotCore_preserves_capabilityInvariantBundle stAcc stDel
-                descAddr hI hNSI hNSSz hDel
-              have ⟨hNSInvDel, hNSSzDel⟩ := cspaceDeleteSlotCore_preserves_cdtNodeSlot stAcc stDel
-                descAddr hNSI hNSSz hDel
+                descAddr hI hKAcc hDel
+              have hKDel := cspaceDeleteSlotCore_preserves_cdtNodeSlot stAcc stDel
+                descAddr hKAcc hDel
               have hDetachObj := SystemState.detachSlotFromCdt_objects_eq stDel descAddr
               rcases hDelInv with ⟨hU2, _, hBnd2, hComp2, hAcyclic2, hDepth2del, hObjInv2⟩
               have hDetachInv : capabilityInvariantBundle (SystemState.detachSlotFromCdt stDel descAddr) :=
                 ⟨cspaceSlotUnique_of_objects_eq stDel _ hU2 hDetachObj,
                  cspaceLookupSound_of_cspaceSlotUnique _ (cspaceSlotUnique_of_objects_eq stDel _ hU2 hDetachObj),
                  cspaceSlotCountBounded_of_detachSlotFromCdt stDel descAddr hBnd2,
-                 cdtCompleteness_of_detachSlotFromCdt stDel descAddr hComp2 hNSInvDel hNSSzDel,
+                 cdtCompleteness_of_detachSlotFromCdt stDel descAddr hComp2 hKDel.1 hKDel.2.1,
                  cdtAcyclicity_of_detachSlotFromCdt stDel descAddr hAcyclic2,
                  cspaceDepthConsistent_of_objects_eq stDel _ hDepth2del hDetachObj,
                  hDetachObj ▸ hObjInv2⟩
-              -- Derive cdtNodeSlot properties for the detached state
-              have hDetachNS : (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.invExt ∧
-                  (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.size <
-                  (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.capacity := by
+              -- Derive cdtNodeSlot invExtK for the detached state
+              have hDetachK : (SystemState.detachSlotFromCdt stDel descAddr).cdtNodeSlot.invExtK := by
                 unfold SystemState.detachSlotFromCdt
                 cases hL : stDel.cdtSlotNode[descAddr]? with
-                | none => simp only []; exact ⟨hNSInvDel, hNSSzDel⟩
+                | none => simp only []; exact hKDel
                 | some origNode =>
                   simp only []
-                  exact ⟨stDel.cdtNodeSlot.erase_preserves_invExt origNode hNSInvDel hNSSzDel,
-                         SeLe4n.Kernel.RobinHood.RHTable.erase_size_lt_capacity stDel.cdtNodeSlot origNode hNSSzDel⟩
+                  exact stDel.cdtNodeSlot.erase_preserves_invExtK origNode hKDel
               exact ih _ _ (capabilityInvariantBundle_of_cdt_update _ _ hDetachInv
                 (CapDerivationTree.edgeWellFounded_sub _ _ hDetachInv.2.2.2.2.1
                   (CapDerivationTree.removeNode_edges_sub (SystemState.detachSlotFromCdt stDel descAddr).cdt node)))
-                hDetachNS.1 hDetachNS.2
+                hDetachK
 
 -- ============================================================================
 -- M-P04: Streaming CDT revocation preservation (WS-M5)
@@ -1141,11 +1114,10 @@ capability invariant bundle. Direct delegation to
 private theorem streamingRevokeBFS_step_preserves
     (st st' : SystemState) (node : CdtNodeId)
     (hInv : capabilityInvariantBundle st)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : processRevokeNode st node = .ok st') :
     capabilityInvariantBundle st' :=
-  processRevokeNode_preserves_capabilityInvariantBundle st st' node hInv hNodeSlotInv hNodeSlotSize hStep
+  processRevokeNode_preserves_capabilityInvariantBundle st st' node hInv hNodeSlotK hStep
 
 /-- M-P04/R2-F: The full streaming BFS loop preserves the capability invariant bundle.
 Proof by induction on `fuel`. Each step processes one node (preserving
@@ -1158,8 +1130,7 @@ private theorem streamingRevokeBFS_preserves
     (fuel : Nat) (queue : List CdtNodeId)
     (stInit stFinal : SystemState)
     (hInv : capabilityInvariantBundle stInit)
-    (hNodeSlotInv : stInit.cdtNodeSlot.invExt)
-    (hNodeSlotSize : stInit.cdtNodeSlot.size < stInit.cdtNodeSlot.capacity)
+    (hNodeSlotK : stInit.cdtNodeSlot.invExtK)
     (hBFS : streamingRevokeBFS fuel queue stInit = .ok ((), stFinal)) :
     capabilityInvariantBundle stFinal := by
   induction fuel generalizing queue stInit stFinal with
@@ -1178,9 +1149,9 @@ private theorem streamingRevokeBFS_preserves
       | error e => simp [hProc] at hBFS
       | ok stNext =>
         simp [hProc] at hBFS
-        have hStepInv := streamingRevokeBFS_step_preserves stInit stNext node hInv hNodeSlotInv hNodeSlotSize hProc
-        have ⟨hNSInvPost, hNSSzPost⟩ := processRevokeNode_preserves_cdtNodeSlot stInit stNext node hNodeSlotInv hNodeSlotSize hProc
-        exact ih _ _ _ hStepInv hNSInvPost hNSSzPost hBFS
+        have hStepInv := streamingRevokeBFS_step_preserves stInit stNext node hInv hNodeSlotK hProc
+        have hKPost := processRevokeNode_preserves_cdtNodeSlot stInit stNext node hNodeSlotK hProc
+        exact ih _ _ _ hStepInv hKPost hBFS
 
 /-- M-P04: `cspaceRevokeCdtStreaming` preserves the capability invariant bundle.
 Composes `cspaceRevoke_preserves_capabilityInvariantBundle` with
@@ -1189,8 +1160,7 @@ theorem cspaceRevokeCdtStreaming_preserves_capabilityInvariantBundle
     (st st' : SystemState)
     (addr : CSpaceAddr)
     (hInv : capabilityInvariantBundle st)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : cspaceRevokeCdtStreaming addr st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   unfold cspaceRevokeCdtStreaming at hStep
@@ -1226,7 +1196,7 @@ theorem cspaceRevokeCdtStreaming_preserves_capabilityInvariantBundle
     · simp at hStep; cases hStep; exact hLocalInv
     · rename_i rootNode hLookup
       exact streamingRevokeBFS_preserves _ _ stLocal st' hLocalInv
-        (hLocalNS ▸ hNodeSlotInv) (by rw [hLocalNS]; exact hNodeSlotSize) hStep
+        (hLocalNS ▸ hNodeSlotK) hStep
 
 -- ============================================================================
 -- WS-E4: Preservation theorems for endpointReply
@@ -1606,8 +1576,7 @@ theorem lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle
     (hNewObjCNodeBounded : ∀ cn, newObj = .cnode cn → cn.slotCountBounded)
     (hNewObjCNodeDepth : ∀ cn, newObj = .cnode cn →
       cn.depth ≤ maxCSpaceDepth ∧ (cn.bitsConsumed > 0 → cn.wellFormed))
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hStep : lifecycleRevokeDeleteRetype authority cleanup target newObj st = .ok ((), st')) :
     capabilityInvariantBundle st' := by
   rcases lifecycleRevokeDeleteRetype_ok_implies_staged_steps st st' authority cleanup target newObj hStep with
@@ -1640,7 +1609,7 @@ theorem lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle
             rw [hNSClear, hNSMid]
   have hDeleted : capabilityInvariantBundle stDeleted :=
     cspaceDeleteSlot_preserves_capabilityInvariantBundle stRevoked stDeleted cleanup hRevoked
-      (hRevokedNS ▸ hNodeSlotInv) (by rw [hRevokedNS]; exact hNodeSlotSize) hDelete
+      (hRevokedNS ▸ hNodeSlotK) hDelete
   exact lifecycleRetypeObject_preserves_capabilityInvariantBundle stDeleted st' authority target newObj
     hDeleted hNewObjCNodeUniq hNewObjCNodeBounded hNewObjCNodeDepth hRetype
 
@@ -1670,8 +1639,7 @@ theorem lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityI
         cspaceRevoke cleanup st = .ok ((), stRevoked) →
         cspaceDeleteSlot cleanup stRevoked = .ok ((), stDeleted) →
         stDeleted.lifecycle.objectTypes.invExt)
-    (hNodeSlotInv : st.cdtNodeSlot.invExt)
-    (hNodeSlotSize : st.cdtNodeSlot.size < st.cdtNodeSlot.capacity)
+    (hNodeSlotK : st.cdtNodeSlot.invExtK)
     (hObjInvFinal : st'.objects.invExt)
     (hStep : lifecycleRevokeDeleteRetype authority cleanup target newObj st = .ok ((), st')) :
     lifecycleCapabilityStaleAuthorityInvariant st' := by
@@ -1679,7 +1647,7 @@ theorem lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityI
     ⟨stRevoked, stDeleted, _hNe, hRevoke, hDelete, hLookupDeleted, hRetype⟩
   have hCap' : capabilityInvariantBundle st' :=
     lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle st st' authority cleanup target
-      newObj hCap hNewObjCNodeUniq hNewObjCNodeBounded hNewObjCNodeDepth hNodeSlotInv hNodeSlotSize hStep
+      newObj hCap hNewObjCNodeUniq hNewObjCNodeBounded hNewObjCNodeDepth hNodeSlotK hStep
   have hLifecycleDeleted : lifecycleInvariantBundle stDeleted :=
     hLifecycleAfterCleanup stRevoked stDeleted hRevoke hDelete hLookupDeleted
   have hLifecycle' : lifecycleInvariantBundle st' :=

--- a/SeLe4n/Kernel/RobinHood/Bridge.lean
+++ b/SeLe4n/Kernel/RobinHood/Bridge.lean
@@ -890,4 +890,155 @@ theorem RHTable.filter_filter_getElem? [BEq α] [Hashable α] [LawfulBEq α]
 instance [BEq α] [Hashable α] : EmptyCollection (RHTable α β) where
   emptyCollection := RHTable.empty 16
 
+-- ============================================================================
+-- V3-B Phase 1: invExtK — Kernel-Level Extended Invariant Bundle
+-- ============================================================================
+
+/-- Kernel-level extended invariant: includes size bounds needed by erase and
+    insert. All kernel tables satisfy this. RobinHood internal proofs use
+    `invExt` (unchanged).
+
+    - `invExt`: data-structure invariant (WF ∧ distCorrect ∧ noDupKeys ∧ probeChainDominant)
+    - `size < capacity`: erase lookup correctness prerequisite
+    - `4 ≤ capacity`: insert size bound prerequisite -/
+def RHTable.invExtK [BEq α] [Hashable α] (t : RHTable α β) : Prop :=
+  t.invExt ∧ t.size < t.capacity ∧ 4 ≤ t.capacity
+
+-- Projection lemmas
+theorem RHTable.invExtK_invExt [BEq α] [Hashable α] {t : RHTable α β}
+    (h : t.invExtK) : t.invExt := h.1
+
+theorem RHTable.invExtK_size_lt_capacity [BEq α] [Hashable α] {t : RHTable α β}
+    (h : t.invExtK) : t.size < t.capacity := h.2.1
+
+theorem RHTable.invExtK_capacity_ge4 [BEq α] [Hashable α] {t : RHTable α β}
+    (h : t.invExtK) : 4 ≤ t.capacity := h.2.2
+
+-- Constructor lemma
+theorem RHTable.mk_invExtK [BEq α] [Hashable α] {t : RHTable α β}
+    (hExt : t.invExt) (hSize : t.size < t.capacity)
+    (hCap : 4 ≤ t.capacity) : t.invExtK := ⟨hExt, hSize, hCap⟩
+
+-- ============================================================================
+-- V3-B Phase 1: empty_invExtK
+-- ============================================================================
+
+/-- The empty table satisfies `invExtK` when `4 ≤ cap`. -/
+theorem RHTable.empty_invExtK [BEq α] [Hashable α]
+    (cap : Nat) (hPos : 0 < cap) (hCapGe4 : 4 ≤ cap) :
+    (RHTable.empty cap hPos : RHTable α β).invExtK :=
+  ⟨RHTable.empty_invExt cap hPos,
+   by simp [RHTable.empty]; exact hPos,
+   by simp [RHTable.empty]; exact hCapGe4⟩
+
+-- ============================================================================
+-- V3-B Phase 1: erase_preserves_invExtK
+-- ============================================================================
+
+/-- Erase preserves capacity (erase does not change capacity). -/
+private theorem RHTable.erase_capacity_eq [BEq α] [Hashable α]
+    (t : RHTable α β) (k : α) :
+    (t.erase k).capacity = t.capacity := by
+  unfold RHTable.erase; simp only []; split <;> rfl
+
+/-- Erase preserves `invExtK`. Composes `erase_preserves_invExt`,
+    `erase_size_lt_capacity`, and capacity preservation. -/
+theorem RHTable.erase_preserves_invExtK [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (k : α) (hK : t.invExtK) :
+    (t.erase k).invExtK :=
+  ⟨t.erase_preserves_invExt k hK.1 hK.2.1,
+   t.erase_size_lt_capacity k hK.2.1,
+   by rw [t.erase_capacity_eq k]; exact hK.2.2⟩
+
+-- ============================================================================
+-- V3-B Phase 1: insert_preserves_invExtK
+-- ============================================================================
+
+/-- Insert preserves capacity ≥ 4 (insert either keeps capacity or doubles it). -/
+private theorem RHTable.insert_capacity_ge4 [BEq α] [Hashable α]
+    (t : RHTable α β) (k : α) (v : β) (hCap : 4 ≤ t.capacity) :
+    4 ≤ (t.insert k v).capacity := by
+  unfold RHTable.insert; split
+  · rw [RHTable.insertNoResize_capacity, t.resize_fold_capacity]; omega
+  · rw [RHTable.insertNoResize_capacity]; exact hCap
+
+/-- Insert preserves `invExtK`. Composes `insert_preserves_invExt`,
+    `insert_size_lt_capacity`, and capacity preservation. -/
+theorem RHTable.insert_preserves_invExtK [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (k : α) (v : β) (hK : t.invExtK) :
+    (t.insert k v).invExtK :=
+  ⟨t.insert_preserves_invExt k v hK.1,
+   t.insert_size_lt_capacity k v hK.1 hK.2.1 hK.2.2,
+   t.insert_capacity_ge4 k v hK.2.2⟩
+
+-- ============================================================================
+-- V3-B Phase 1: getElem?_erase_ne_K
+-- ============================================================================
+
+/-- Erasing key `k` does not affect lookups of other keys (kernel-level API
+    taking `invExtK` instead of separate `hExt` + `hSize`). -/
+theorem RHTable.getElem?_erase_ne_K [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (k k' : α) (hNe : ¬(k == k') = true)
+    (hK : t.invExtK) :
+    (t.erase k).get? k' = t.get? k' :=
+  t.getElem?_erase_ne k k' hNe hK.1 hK.2.1
+
+-- ============================================================================
+-- V3-B Phase 1: filter_preserves_invExtK
+-- ============================================================================
+
+/-- Filter preserves capacity (filter rebuilds from `empty t.capacity`). -/
+private theorem RHTable.filter_capacity_eq [BEq α] [Hashable α]
+    (t : RHTable α β) (f : α → β → Bool) :
+    (t.filter f).capacity = t.capacity := by
+  unfold RHTable.filter RHTable.fold
+  exact Array.foldl_induction
+    (motive := fun _ (acc : RHTable α β) => acc.capacity = t.capacity)
+    (by simp [RHTable.empty])
+    (fun i acc hAcc => by
+      simp only []
+      split
+      · exact hAcc
+      · rename_i entry _
+        by_cases hf : f entry.key entry.value
+        · simp only [hf, ite_true]
+          rw [RHTable.insertNoResize_capacity]; exact hAcc
+        · simp only [show (f entry.key entry.value) = false from by simp [hf]]
+          exact hAcc)
+
+/-- Filter preserves `invExtK`. Composes `filter_preserves_invExt`,
+    `filter_size_lt_capacity`, and capacity preservation. -/
+theorem RHTable.filter_preserves_invExtK [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (f : α → β → Bool) (hK : t.invExtK) :
+    (t.filter f).invExtK :=
+  ⟨t.filter_preserves_invExt f hK.1,
+   t.filter_size_lt_capacity f hK.2.1 hK.1.1,
+   by rw [t.filter_capacity_eq f]; exact hK.2.2⟩
+
+-- ============================================================================
+-- V3-B Phase 1: ofList_invExtK
+-- ============================================================================
+
+/-- `ofList` produces a table with capacity ≥ 4 when `4 ≤ cap`. -/
+private theorem RHTable.ofList_capacity_ge4 [BEq α] [Hashable α] [LawfulBEq α]
+    (entries : List (α × β)) (cap : Nat) (hPos : 0 < cap) (hCapGe4 : 4 ≤ cap) :
+    4 ≤ (RHTable.ofList entries cap hPos).capacity := by
+  suffices ∀ (init : RHTable α β), 4 ≤ init.capacity →
+      4 ≤ (entries.foldl (fun acc (x : α × β) => acc.insert x.1 x.2) init).capacity from
+    this _ (by simp [RHTable.empty]; exact hCapGe4)
+  intro init hInit
+  induction entries generalizing init with
+  | nil => exact hInit
+  | cons hd tl ih =>
+    simp only [List.foldl_cons]
+    exact ih _ (init.insert_capacity_ge4 hd.1 hd.2 hInit)
+
+/-- `ofList` produces a table satisfying `invExtK` when `4 ≤ cap`. -/
+theorem RHTable.ofList_invExtK [BEq α] [Hashable α] [LawfulBEq α]
+    (entries : List (α × β)) (cap : Nat) (hPos : 0 < cap) (hCapGe4 : 4 ≤ cap) :
+    (RHTable.ofList entries cap hPos).invExtK :=
+  ⟨RHTable.ofList_invExt entries cap hPos,
+   RHTable.ofList_size_lt_capacity entries cap hPos hCapGe4,
+   RHTable.ofList_capacity_ge4 entries cap hPos hCapGe4⟩
+
 end SeLe4n.Kernel.RobinHood

--- a/SeLe4n/Kernel/RobinHood/Set.lean
+++ b/SeLe4n/Kernel/RobinHood/Set.lean
@@ -160,4 +160,35 @@ theorem RHSet.mem_iff_contains [BEq κ] [Hashable κ]
     k ∈ s ↔ s.contains k = true := by
   rfl
 
+-- ============================================================================
+-- V3-B Phase 2: invExtK wrappers for RHSet
+-- ============================================================================
+
+/-- Kernel-level extended invariant for RHSet (delegates to RHTable.invExtK). -/
+def RHSet.invExtK [BEq κ] [Hashable κ] (s : RHSet κ) : Prop := s.table.invExtK
+
+/-- Empty set satisfies invExtK. -/
+theorem RHSet.empty_invExtK [BEq κ] [Hashable κ] :
+    (RHSet.empty : RHSet κ).table.invExtK :=
+  RHTable.empty_invExtK 16 (by omega) (by omega)
+
+/-- Insert preserves invExtK. -/
+theorem RHSet.insert_preserves_invExtK [BEq κ] [Hashable κ] [LawfulBEq κ]
+    (s : RHSet κ) (k : κ) (hK : s.table.invExtK) :
+    (s.insert k).table.invExtK :=
+  s.table.insert_preserves_invExtK k () hK
+
+/-- Erase preserves invExtK. -/
+theorem RHSet.erase_preserves_invExtK [BEq κ] [Hashable κ] [LawfulBEq κ]
+    (s : RHSet κ) (k : κ) (hK : s.table.invExtK) :
+    (s.erase k).table.invExtK :=
+  s.table.erase_preserves_invExtK k hK
+
+/-- Erasing `k` does not affect containment of other keys (kernel-level API). -/
+theorem RHSet.contains_erase_ne_K [BEq κ] [Hashable κ] [LawfulBEq κ]
+    (s : RHSet κ) (k k' : κ) (hNe : ¬(k == k') = true) (hK : s.table.invExtK) :
+    (s.erase k).contains k' = s.contains k' := by
+  simp [RHSet.contains, RHSet.erase, RHTable.contains,
+        RHTable.getElem?_erase_ne_K s.table k k' hNe hK]
+
 end SeLe4n.Kernel.RobinHood

--- a/SeLe4n/Kernel/Scheduler/RunQueue.lean
+++ b/SeLe4n/Kernel/Scheduler/RunQueue.lean
@@ -25,24 +25,12 @@ structure RunQueue where
       the flat list. Together with `flat_wf`, this yields bidirectional
       consistency between O(1) membership checks and list-based scans. -/
   flat_wf_rev : ∀ tid, membership.contains tid = true → tid ∈ flat
-  /-- RHSet invariant extension — maintained by all RunQueue operations. -/
-  mem_invExt : membership.table.invExt
-  /-- RHTable invariant extension for byPriority — maintained by all operations. -/
-  byPrio_invExt : byPriority.invExt
-  /-- RHTable invariant extension for threadPriority — maintained by all operations. -/
-  threadPrio_invExt : threadPriority.invExt
-  /-- RHSet size bound — required for erase operations. -/
-  mem_sizeOk : membership.table.size < membership.table.capacity
-  /-- RHTable size bound for byPriority — required for erase operations. -/
-  byPrio_sizeOk : byPriority.size < byPriority.capacity
-  /-- RHTable size bound for threadPriority — required for erase operations. -/
-  threadPrio_sizeOk : threadPriority.size < threadPriority.capacity
-  /-- RHSet capacity ≥ 4 — required for insert_size_lt_capacity. -/
-  mem_capGe4 : 4 ≤ membership.table.capacity
-  /-- RHTable byPriority capacity ≥ 4. -/
-  byPrio_capGe4 : 4 ≤ byPriority.capacity
-  /-- RHTable threadPriority capacity ≥ 4. -/
-  threadPrio_capGe4 : 4 ≤ threadPriority.capacity
+  /-- RHSet kernel-level invariant bundle (invExt ∧ size < capacity ∧ 4 ≤ capacity). -/
+  mem_invExtK : membership.table.invExtK
+  /-- RHTable kernel-level invariant bundle for byPriority. -/
+  byPrio_invExtK : byPriority.invExtK
+  /-- RHTable kernel-level invariant bundle for threadPriority. -/
+  threadPrio_invExtK : threadPriority.invExtK
   /- WS-G4: Implicit invariant (maintained structurally by `insert`/`remove` API):
      Every thread in `membership` has a corresponding entry in `threadPriority`,
      and vice versa. This is NOT enforced as a proof obligation in the structure
@@ -51,6 +39,18 @@ structure RunQueue where
      Violation would require direct structure construction bypassing the API.
      Runtime verification: `InvariantChecks.runQueueThreadPriorityConsistentB`. -/
 namespace RunQueue
+
+-- Backward-compat projections: downstream files reference these field names
+theorem mem_invExt (rq : RunQueue) : rq.membership.table.invExt := rq.mem_invExtK.1
+theorem mem_sizeOk (rq : RunQueue) : rq.membership.table.size < rq.membership.table.capacity := rq.mem_invExtK.2.1
+theorem mem_capGe4 (rq : RunQueue) : 4 ≤ rq.membership.table.capacity := rq.mem_invExtK.2.2
+theorem byPrio_invExt (rq : RunQueue) : rq.byPriority.invExt := rq.byPrio_invExtK.1
+theorem byPrio_sizeOk (rq : RunQueue) : rq.byPriority.size < rq.byPriority.capacity := rq.byPrio_invExtK.2.1
+theorem byPrio_capGe4 (rq : RunQueue) : 4 ≤ rq.byPriority.capacity := rq.byPrio_invExtK.2.2
+theorem threadPrio_invExt (rq : RunQueue) : rq.threadPriority.invExt := rq.threadPrio_invExtK.1
+theorem threadPrio_sizeOk (rq : RunQueue) : rq.threadPriority.size < rq.threadPriority.capacity := rq.threadPrio_invExtK.2.1
+theorem threadPrio_capGe4 (rq : RunQueue) : 4 ≤ rq.threadPriority.capacity := rq.threadPrio_invExtK.2.2
+
 @[inline] def empty : RunQueue where
   byPriority := {}; membership := {}; threadPriority := {}
   flat := []; size := 0; maxPriority := none
@@ -59,29 +59,9 @@ namespace RunQueue
     intro tid h
     exact absurd h (by rw [show ({} : RHSet ThreadId) = RHSet.empty from rfl,
       RHSet.contains_empty]; decide)
-  mem_invExt := RHSet.empty_invExt
-  byPrio_invExt := RHTable.empty_invExt' 16 (by omega)
-  threadPrio_invExt := RHTable.empty_invExt' 16 (by omega)
-  mem_sizeOk := by
-    show (RHSet.empty : RHSet ThreadId).table.size < (RHSet.empty : RHSet ThreadId).table.capacity
-    decide
-  byPrio_sizeOk := by
-    show (EmptyCollection.emptyCollection : RHTable Priority (List ThreadId)).size <
-         (EmptyCollection.emptyCollection : RHTable Priority (List ThreadId)).capacity
-    decide
-  threadPrio_sizeOk := by
-    show (EmptyCollection.emptyCollection : RHTable ThreadId Priority).size <
-         (EmptyCollection.emptyCollection : RHTable ThreadId Priority).capacity
-    decide
-  mem_capGe4 := by
-    show 4 ≤ (RHSet.empty : RHSet ThreadId).table.capacity
-    decide
-  byPrio_capGe4 := by
-    show 4 ≤ (EmptyCollection.emptyCollection : RHTable Priority (List ThreadId)).capacity
-    decide
-  threadPrio_capGe4 := by
-    show 4 ≤ (EmptyCollection.emptyCollection : RHTable ThreadId Priority).capacity
-    decide
+  mem_invExtK := RHSet.empty_invExtK
+  byPrio_invExtK := RHTable.empty_invExtK 16 (by omega) (by omega)
+  threadPrio_invExtK := RHTable.empty_invExtK 16 (by omega) (by omega)
 instance : Inhabited RunQueue where default := empty
 instance : EmptyCollection RunQueue where emptyCollection := empty
 instance : Repr RunQueue where reprPrec rq _ := repr rq.flat
@@ -151,37 +131,11 @@ def insert (rq : RunQueue) (tid : ThreadId) (prio : Priority) : RunQueue :=
         rcases hx' with rfl | hOld
         · exact List.mem_append.mpr (Or.inr (by simp))
         · exact List.mem_append.mpr (Or.inl (rq.flat_wf_rev x hOld))
-      mem_invExt := RHSet.insert_preserves_invExt rq.membership tid rq.mem_invExt
-      byPrio_invExt := rq.byPriority.insert_preserves_invExt prio
-          ((rq.byPriority[prio]?).getD [] ++ [tid]) rq.byPrio_invExt
-      threadPrio_invExt := rq.threadPriority.insert_preserves_invExt tid prio
-          rq.threadPrio_invExt
-      mem_sizeOk := rq.membership.table.insert_size_lt_capacity tid ()
-          rq.mem_invExt rq.mem_sizeOk rq.mem_capGe4
-      byPrio_sizeOk := rq.byPriority.insert_size_lt_capacity prio
-          ((rq.byPriority[prio]?).getD [] ++ [tid]) rq.byPrio_invExt rq.byPrio_sizeOk
-          rq.byPrio_capGe4
-      threadPrio_sizeOk := rq.threadPriority.insert_size_lt_capacity tid prio
-          rq.threadPrio_invExt rq.threadPrio_sizeOk rq.threadPrio_capGe4
-      mem_capGe4 := by
-        show 4 ≤ (rq.membership.insert tid).table.capacity
-        simp only [RHSet.insert]
-        unfold RHTable.insert; split
-        · rw [RHTable.insertNoResize_capacity, rq.membership.table.resize_fold_capacity]
-          have := rq.mem_capGe4; omega
-        · rw [RHTable.insertNoResize_capacity]; exact rq.mem_capGe4
-      byPrio_capGe4 := by
-        show 4 ≤ (rq.byPriority.insert prio ((rq.byPriority[prio]?).getD [] ++ [tid])).capacity
-        unfold RHTable.insert; split
-        · rw [RHTable.insertNoResize_capacity, rq.byPriority.resize_fold_capacity]
-          have := rq.byPrio_capGe4; omega
-        · rw [RHTable.insertNoResize_capacity]; exact rq.byPrio_capGe4
-      threadPrio_capGe4 := by
-        show 4 ≤ (rq.threadPriority.insert tid prio).capacity
-        unfold RHTable.insert; split
-        · rw [RHTable.insertNoResize_capacity, rq.threadPriority.resize_fold_capacity]
-          have := rq.threadPrio_capGe4; omega
-        · rw [RHTable.insertNoResize_capacity]; exact rq.threadPrio_capGe4 }
+      mem_invExtK := RHSet.insert_preserves_invExtK rq.membership tid rq.mem_invExtK
+      byPrio_invExtK := rq.byPriority.insert_preserves_invExtK prio
+          ((rq.byPriority[prio]?).getD [] ++ [tid]) rq.byPrio_invExtK
+      threadPrio_invExtK := rq.threadPriority.insert_preserves_invExtK tid prio
+          rq.threadPrio_invExtK }
 
 /-- S5-J: Complexity is O(k + n) where k = priority bucket size for the
     removed thread, and n = flat list length. The bucket filter is O(k) and
@@ -230,8 +184,8 @@ def remove (rq : RunQueue) (tid : ThreadId) : RunQueue :=
                  fun h => hEq (by simp [beq_iff_eq]; exact h.symm)⟩
       have hFlat : x ∈ rq.flat := rq.flat_wf_rev x hx'.1
       exact List.mem_filter.mpr ⟨hFlat, by simpa [beq_iff_eq] using hx'.2⟩
-    mem_invExt := RHSet.erase_preserves_invExt rq.membership tid rq.mem_invExt rq.mem_sizeOk
-    byPrio_invExt := by
+    mem_invExtK := RHSet.erase_preserves_invExtK rq.membership tid rq.mem_invExtK
+    byPrio_invExtK := by
       -- byPrio' is let-bound to `match rq.threadPriority.get? tid with ...`
       -- Use `show` to replace byPrio' with its definition, then split on the match
       show (match rq.threadPriority.get? tid with
@@ -239,69 +193,15 @@ def remove (rq : RunQueue) (tid : ThreadId) : RunQueue :=
         | some p =>
           let bucket := ((rq.byPriority[p]?).getD []).filter (· ≠ tid)
           if bucket.isEmpty then rq.byPriority.erase p
-          else rq.byPriority.insert p bucket).invExt
+          else rq.byPriority.insert p bucket).invExtK
       split
-      · exact rq.byPrio_invExt
+      · exact rq.byPrio_invExtK
       next p _ =>
         dsimp only []
         split
-        · exact rq.byPriority.erase_preserves_invExt p rq.byPrio_invExt rq.byPrio_sizeOk
-        · exact rq.byPriority.insert_preserves_invExt p _ rq.byPrio_invExt
-    threadPrio_invExt := rq.threadPriority.erase_preserves_invExt tid rq.threadPrio_invExt
-        rq.threadPrio_sizeOk
-    mem_sizeOk := rq.membership.table.erase_size_lt_capacity tid rq.mem_sizeOk
-    byPrio_sizeOk := by
-      show (match rq.threadPriority.get? tid with
-        | none => rq.byPriority
-        | some p =>
-          let bucket := ((rq.byPriority[p]?).getD []).filter (· ≠ tid)
-          if bucket.isEmpty then rq.byPriority.erase p
-          else rq.byPriority.insert p bucket).size <
-        (match rq.threadPriority.get? tid with
-        | none => rq.byPriority
-        | some p =>
-          let bucket := ((rq.byPriority[p]?).getD []).filter (· ≠ tid)
-          if bucket.isEmpty then rq.byPriority.erase p
-          else rq.byPriority.insert p bucket).capacity
-      split
-      · exact rq.byPrio_sizeOk
-      · next p _ =>
-        dsimp only []
-        split
-        · exact rq.byPriority.erase_size_lt_capacity p rq.byPrio_sizeOk
-        · exact rq.byPriority.insert_size_lt_capacity p _ rq.byPrio_invExt rq.byPrio_sizeOk
-            rq.byPrio_capGe4
-    threadPrio_sizeOk := rq.threadPriority.erase_size_lt_capacity tid rq.threadPrio_sizeOk
-    mem_capGe4 := by
-      show 4 ≤ (rq.membership.erase tid).table.capacity
-      have : (rq.membership.erase tid).table.capacity = rq.membership.table.capacity := by
-        simp only [RHSet.erase, RHTable.erase]
-        split <;> simp_all
-      rw [this]; exact rq.mem_capGe4
-    byPrio_capGe4 := by
-      show 4 ≤ (match rq.threadPriority.get? tid with
-        | none => rq.byPriority
-        | some p =>
-          let bucket := ((rq.byPriority[p]?).getD []).filter (· ≠ tid)
-          if bucket.isEmpty then rq.byPriority.erase p
-          else rq.byPriority.insert p bucket).capacity
-      split
-      · exact rq.byPrio_capGe4
-      · next p _ =>
-        dsimp only []
-        split
-        · have : (rq.byPriority.erase p).capacity = rq.byPriority.capacity := by
-            simp only [RHTable.erase]; split <;> simp_all
-          rw [this]; exact rq.byPrio_capGe4
-        · unfold RHTable.insert; split
-          · rw [RHTable.insertNoResize_capacity, rq.byPriority.resize_fold_capacity]
-            have := rq.byPrio_capGe4; omega
-          · rw [RHTable.insertNoResize_capacity]; exact rq.byPrio_capGe4
-    threadPrio_capGe4 := by
-      show 4 ≤ (rq.threadPriority.erase tid).capacity
-      have : (rq.threadPriority.erase tid).capacity = rq.threadPriority.capacity := by
-        simp only [RHTable.erase]; split <;> simp_all
-      rw [this]; exact rq.threadPrio_capGe4 }
+        · exact rq.byPriority.erase_preserves_invExtK p rq.byPrio_invExtK
+        · exact rq.byPriority.insert_preserves_invExtK p _ rq.byPrio_invExtK
+    threadPrio_invExtK := rq.threadPriority.erase_preserves_invExtK tid rq.threadPrio_invExtK }
 
 /-- S5-J: Complexity is O(k + n) where k = priority bucket size and n = flat
     list length. Filters the thread from the bucket O(k), appends to end O(1),
@@ -328,14 +228,7 @@ def rotateToBack (rq : RunQueue) (tid : ThreadId) : RunQueue :=
           · subst hEq
             exact List.mem_append.mpr (Or.inr (by simp))
           · exact List.mem_append.mpr (Or.inl ((List.mem_erase_of_ne hEq).2 hFlat))
-        byPrio_invExt := rq.byPriority.insert_preserves_invExt prio bucket' rq.byPrio_invExt
-        byPrio_sizeOk := rq.byPriority.insert_size_lt_capacity prio bucket'
-            rq.byPrio_invExt rq.byPrio_sizeOk rq.byPrio_capGe4
-        byPrio_capGe4 := by
-          unfold RHTable.insert; split
-          · rw [RHTable.insertNoResize_capacity, rq.byPriority.resize_fold_capacity]
-            have := rq.byPrio_capGe4; omega
-          · rw [RHTable.insertNoResize_capacity]; exact rq.byPrio_capGe4 }
+        byPrio_invExtK := rq.byPriority.insert_preserves_invExtK prio bucket' rq.byPrio_invExtK }
   else rq
 
 @[inline] def toList (rq : RunQueue) : List ThreadId := rq.flat

--- a/SeLe4n/Model/Builder.lean
+++ b/SeLe4n/Model/Builder.lean
@@ -24,44 +24,44 @@ open SeLe4n.Kernel.RobinHood
 open SeLe4n.Model
 
 -- ============================================================================
--- Helper: allTablesInvExt decomposition/recomposition
+-- Helper: allTablesInvExtK decomposition/recomposition
 -- ============================================================================
 
-/-- Extract the objects invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_objects {st : SystemState}
-    (h : st.allTablesInvExt) : st.objects.invExt := h.1
+/-- Extract the objects invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_objects {st : SystemState}
+    (h : st.allTablesInvExtK) : st.objects.invExtK := h.1
 
-/-- Extract irqHandlers invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_irqHandlers {st : SystemState}
-    (h : st.allTablesInvExt) : st.irqHandlers.invExt := h.2.1
+/-- Extract irqHandlers invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_irqHandlers {st : SystemState}
+    (h : st.allTablesInvExtK) : st.irqHandlers.invExtK := h.2.1
 
-/-- Extract services invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_services {st : SystemState}
-    (h : st.allTablesInvExt) : st.services.invExt := h.2.2.2.2.2.2.2.2.2.1
+/-- Extract services invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_services {st : SystemState}
+    (h : st.allTablesInvExtK) : st.services.invExtK := h.2.2.2.2.2.2.2.2.2.1
 
-/-- Extract serviceRegistry invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_serviceRegistry {st : SystemState}
-    (h : st.allTablesInvExt) : st.serviceRegistry.invExt := h.2.2.2.2.2.2.2.2.2.2.2.1
+/-- Extract serviceRegistry invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_serviceRegistry {st : SystemState}
+    (h : st.allTablesInvExtK) : st.serviceRegistry.invExtK := h.2.2.2.2.2.2.2.2.2.2.2.1
 
-/-- Extract interfaceRegistry invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_interfaceRegistry {st : SystemState}
-    (h : st.allTablesInvExt) : st.interfaceRegistry.invExt := h.2.2.2.2.2.2.2.2.2.2.1
+/-- Extract interfaceRegistry invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_interfaceRegistry {st : SystemState}
+    (h : st.allTablesInvExtK) : st.interfaceRegistry.invExtK := h.2.2.2.2.2.2.2.2.2.2.1
 
-/-- Extract objectTypes invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_objectTypes {st : SystemState}
-    (h : st.allTablesInvExt) : st.lifecycle.objectTypes.invExt := h.2.2.2.2.2.1
+/-- Extract objectTypes invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_objectTypes {st : SystemState}
+    (h : st.allTablesInvExtK) : st.lifecycle.objectTypes.invExtK := h.2.2.2.2.2.1
 
-/-- Extract capabilityRefs invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_capabilityRefs {st : SystemState}
-    (h : st.allTablesInvExt) : st.lifecycle.capabilityRefs.invExt := h.2.2.2.2.2.2.1
+/-- Extract capabilityRefs invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_capabilityRefs {st : SystemState}
+    (h : st.allTablesInvExtK) : st.lifecycle.capabilityRefs.invExtK := h.2.2.2.2.2.2.1
 
-/-- Extract objectIndexSet invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_objectIndexSet {st : SystemState}
-    (h : st.allTablesInvExt) : st.objectIndexSet.table.invExt := h.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
+/-- Extract objectIndexSet invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_objectIndexSet {st : SystemState}
+    (h : st.allTablesInvExtK) : st.objectIndexSet.table.invExtK := h.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
 
-/-- Extract asidTable invExt from allTablesInvExt. -/
-private theorem allTablesInvExt_asidTable {st : SystemState}
-    (h : st.allTablesInvExt) : st.asidTable.invExt := h.2.2.1
+/-- Extract asidTable invExtK from allTablesInvExtK. -/
+private theorem allTablesInvExtK_asidTable {st : SystemState}
+    (h : st.allTablesInvExtK) : st.asidTable.invExtK := h.2.2.1
 
 -- ============================================================================
 -- Q3-B.1: registerIrq — insert into irqHandlers
@@ -74,9 +74,9 @@ def registerIrq (ist : IntermediateState) (irq : SeLe4n.Irq) (handler : SeLe4n.O
   state := { ist.state with irqHandlers := ist.state.irqHandlers.insert irq handler }
   hAllTables := by
     have h := ist.hAllTables
-    unfold SystemState.allTablesInvExt at h ⊢
+    unfold SystemState.allTablesInvExtK at h ⊢
     refine ⟨h.1, ?_, h.2.2⟩
-    exact RHTable.insert_preserves_invExt _ _ _ h.2.1
+    exact RHTable.insert_preserves_invExtK _ _ _ h.2.1
   hPerObjectSlots := by
     intro id cn hObj
     exact ist.hPerObjectSlots id cn hObj
@@ -98,12 +98,12 @@ def registerService (ist : IntermediateState) (sid : ServiceId)
   state := { ist.state with serviceRegistry := ist.state.serviceRegistry.insert sid reg }
   hAllTables := by
     have h := ist.hAllTables
-    unfold SystemState.allTablesInvExt at h ⊢
+    unfold SystemState.allTablesInvExtK at h ⊢
     exact ⟨h.1, h.2.1, h.2.2.1, h.2.2.2.1, h.2.2.2.2.1,
            h.2.2.2.2.2.1, h.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.2.1,
-           RHTable.insert_preserves_invExt _ _ _ h.2.2.2.2.2.2.2.2.2.2.2.1,
+           RHTable.insert_preserves_invExtK _ _ _ h.2.2.2.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.2.2.2⟩
   hPerObjectSlots := by
     intro id cn hObj; exact ist.hPerObjectSlots id cn hObj
@@ -124,11 +124,11 @@ def addServiceGraph (ist : IntermediateState) (sid : ServiceId)
   state := { ist.state with services := ist.state.services.insert sid entry }
   hAllTables := by
     have h := ist.hAllTables
-    unfold SystemState.allTablesInvExt at h ⊢
+    unfold SystemState.allTablesInvExtK at h ⊢
     exact ⟨h.1, h.2.1, h.2.2.1, h.2.2.2.1, h.2.2.2.2.1,
            h.2.2.2.2.2.1, h.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.1,
-           RHTable.insert_preserves_invExt _ _ _ h.2.2.2.2.2.2.2.2.2.1,
+           RHTable.insert_preserves_invExtK _ _ _ h.2.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.2⟩
   hPerObjectSlots := by
     intro id cn hObj; exact ist.hPerObjectSlots id cn hObj
@@ -173,55 +173,55 @@ def createObject (ist : IntermediateState)
   }
   hAllTables := by
     have h := ist.hAllTables
-    unfold SystemState.allTablesInvExt at h ⊢
-    refine ⟨RHTable.insert_preserves_invExt _ _ _ h.1,
+    unfold SystemState.allTablesInvExtK at h ⊢
+    refine ⟨RHTable.insert_preserves_invExtK _ _ _ h.1,
            h.2.1, h.2.2.1, h.2.2.2.1, h.2.2.2.2.1,
-           RHTable.insert_preserves_invExt _ _ _ h.2.2.2.2.2.1,
+           RHTable.insert_preserves_invExtK _ _ _ h.2.2.2.2.2.1,
            h.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.2.2.2.2.1,
            ?_, h.2.2.2.2.2.2.2.2.2.2.2.2.2.2.2⟩
-    exact RHSet.insert_preserves_invExt ist.state.objectIndexSet id h.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
+    exact RHSet.insert_preserves_invExtK ist.state.objectIndexSet id h.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
   hPerObjectSlots := by
     unfold perObjectSlotsInvariant
     intro oid cn hObj
-    have hObjInv := allTablesInvExt_objects ist.hAllTables
+    have hObjK := allTablesInvExtK_objects ist.hAllTables
     simp only [RHTable_getElem?_eq_get?] at hObj
     by_cases hEq : id = oid
     · subst hEq
-      rw [RHTable.getElem?_insert_self ist.state.objects id obj hObjInv] at hObj
+      rw [RHTable.getElem?_insert_self ist.state.objects id obj hObjK.1] at hObj
       cases hObj; exact hSlots cn rfl
     · have hNe : ¬((id == oid) = true) := by intro heq; exact hEq (eq_of_beq heq)
-      rw [RHTable.getElem?_insert_ne ist.state.objects id oid obj hNe hObjInv] at hObj
+      rw [RHTable.getElem?_insert_ne ist.state.objects id oid obj hNe hObjK.1] at hObj
       exact ist.hPerObjectSlots oid cn (by simp only [RHTable_getElem?_eq_get?]; exact hObj)
   hPerObjectMappings := by
     unfold perObjectMappingsInvariant
     intro oid vs hObj
-    have hObjInv := allTablesInvExt_objects ist.hAllTables
+    have hObjK := allTablesInvExtK_objects ist.hAllTables
     simp only [RHTable_getElem?_eq_get?] at hObj
     by_cases hEq : id = oid
     · subst hEq
-      rw [RHTable.getElem?_insert_self ist.state.objects id obj hObjInv] at hObj
+      rw [RHTable.getElem?_insert_self ist.state.objects id obj hObjK.1] at hObj
       cases hObj; exact hMappings vs rfl
     · have hNe : ¬((id == oid) = true) := by intro heq; exact hEq (eq_of_beq heq)
-      rw [RHTable.getElem?_insert_ne ist.state.objects id oid obj hNe hObjInv] at hObj
+      rw [RHTable.getElem?_insert_ne ist.state.objects id oid obj hNe hObjK.1] at hObj
       exact ist.hPerObjectMappings oid vs (by simp only [RHTable_getElem?_eq_get?]; exact hObj)
   hLifecycleConsistent := by
     constructor
     · intro oid
       simp only [SystemState.lookupObjectTypeMeta]
-      have hObjInv := allTablesInvExt_objects ist.hAllTables
-      have hObjTypesInv := allTablesInvExt_objectTypes ist.hAllTables
+      have hObjK := allTablesInvExtK_objects ist.hAllTables
+      have hTypesK := allTablesInvExtK_objectTypes ist.hAllTables
       by_cases hEq : id = oid
       · subst hEq
         simp only [RHTable_getElem?_eq_get?]
-        rw [RHTable.getElem?_insert_self _ _ _ hObjTypesInv,
-            RHTable.getElem?_insert_self _ _ _ hObjInv]; simp
+        rw [RHTable.getElem?_insert_self _ _ _ hTypesK.1,
+            RHTable.getElem?_insert_self _ _ _ hObjK.1]; simp
       · have hNe : ¬((id == oid) = true) := by intro heq; exact hEq (eq_of_beq heq)
         simp only [RHTable_getElem?_eq_get?]
-        rw [RHTable.getElem?_insert_ne _ _ _ _ hNe hObjTypesInv,
-            RHTable.getElem?_insert_ne _ _ _ _ hNe hObjInv]
+        rw [RHTable.getElem?_insert_ne _ _ _ _ hNe hTypesK.1,
+            RHTable.getElem?_insert_ne _ _ _ _ hNe hObjK.1]
         exact ist.hLifecycleConsistent.1 oid
     · intro ref
       simp [SystemState.lookupCapabilityRefMeta, SystemState.lookupSlotCap,
@@ -234,11 +234,9 @@ def createObject (ist : IntermediateState)
 /-- Q3-B: Delete a kernel object from the builder state.
 Erases the object and its objectTypes metadata entry.
 
-Requires `size < capacity` for RHTable erase correctness. -/
+Uses `invExtK` which bundles `size < capacity` — no separate size hypotheses needed. -/
 def deleteObject (ist : IntermediateState)
     (id : SeLe4n.ObjId)
-    (hObjSize : ist.state.objects.size < ist.state.objects.capacity)
-    (hTypesSize : ist.state.lifecycle.objectTypes.size < ist.state.lifecycle.objectTypes.capacity)
     : IntermediateState where
   state := {
     ist.state with
@@ -250,52 +248,52 @@ def deleteObject (ist : IntermediateState)
   }
   hAllTables := by
     have h := ist.hAllTables
-    unfold SystemState.allTablesInvExt at h ⊢
-    exact ⟨RHTable.erase_preserves_invExt _ _ h.1 hObjSize,
+    unfold SystemState.allTablesInvExtK at h ⊢
+    exact ⟨RHTable.erase_preserves_invExtK _ _ h.1,
            h.2.1, h.2.2.1, h.2.2.2.1, h.2.2.2.2.1,
-           RHTable.erase_preserves_invExt _ _ h.2.2.2.2.2.1 hTypesSize,
+           RHTable.erase_preserves_invExtK _ _ h.2.2.2.2.2.1,
            h.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.2.2.2.1,
            h.2.2.2.2.2.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.2.2.2.2.2⟩
   hPerObjectSlots := by
     unfold perObjectSlotsInvariant
     intro oid cn hObj
-    have hObjInv := allTablesInvExt_objects ist.hAllTables
+    have hObjK := allTablesInvExtK_objects ist.hAllTables
     simp only [RHTable_getElem?_eq_get?] at hObj
     by_cases hEq : id = oid
     · subst hEq
-      rw [RHTable.getElem?_erase_self ist.state.objects id hObjInv] at hObj
+      rw [RHTable.getElem?_erase_self ist.state.objects id hObjK.1] at hObj
       cases hObj
     · have hNe : ¬((id == oid) = true) := by intro heq; exact hEq (eq_of_beq heq)
-      rw [RHTable.getElem?_erase_ne ist.state.objects id oid hNe hObjInv hObjSize] at hObj
+      rw [RHTable.getElem?_erase_ne_K ist.state.objects id oid hNe hObjK] at hObj
       exact ist.hPerObjectSlots oid cn (by simp only [RHTable_getElem?_eq_get?]; exact hObj)
   hPerObjectMappings := by
     unfold perObjectMappingsInvariant
     intro oid vs hObj
-    have hObjInv := allTablesInvExt_objects ist.hAllTables
+    have hObjK := allTablesInvExtK_objects ist.hAllTables
     simp only [RHTable_getElem?_eq_get?] at hObj
     by_cases hEq : id = oid
     · subst hEq
-      rw [RHTable.getElem?_erase_self ist.state.objects id hObjInv] at hObj
+      rw [RHTable.getElem?_erase_self ist.state.objects id hObjK.1] at hObj
       cases hObj
     · have hNe : ¬((id == oid) = true) := by intro heq; exact hEq (eq_of_beq heq)
-      rw [RHTable.getElem?_erase_ne ist.state.objects id oid hNe hObjInv hObjSize] at hObj
+      rw [RHTable.getElem?_erase_ne_K ist.state.objects id oid hNe hObjK] at hObj
       exact ist.hPerObjectMappings oid vs (by simp only [RHTable_getElem?_eq_get?]; exact hObj)
   hLifecycleConsistent := by
     constructor
     · intro oid
       simp only [SystemState.lookupObjectTypeMeta]
-      have hObjInv := allTablesInvExt_objects ist.hAllTables
-      have hObjTypesInv := allTablesInvExt_objectTypes ist.hAllTables
+      have hObjK := allTablesInvExtK_objects ist.hAllTables
+      have hTypesK := allTablesInvExtK_objectTypes ist.hAllTables
       by_cases hEq : id = oid
       · subst hEq
         simp only [RHTable_getElem?_eq_get?]
-        rw [RHTable.getElem?_erase_self _ _ hObjTypesInv,
-            RHTable.getElem?_erase_self _ _ hObjInv]; simp
+        rw [RHTable.getElem?_erase_self _ _ hTypesK.1,
+            RHTable.getElem?_erase_self _ _ hObjK.1]; simp
       · have hNe : ¬((id == oid) = true) := by intro heq; exact hEq (eq_of_beq heq)
         simp only [RHTable_getElem?_eq_get?]
-        rw [RHTable.getElem?_erase_ne _ _ _ hNe hObjTypesInv hTypesSize,
-            RHTable.getElem?_erase_ne _ _ _ hNe hObjInv hObjSize]
+        rw [RHTable.getElem?_erase_ne_K _ _ _ hNe hTypesK,
+            RHTable.getElem?_erase_ne_K _ _ _ hNe hObjK]
         exact ist.hLifecycleConsistent.1 oid
     · intro ref
       simp [SystemState.lookupCapabilityRefMeta, SystemState.lookupSlotCap,
@@ -309,13 +307,6 @@ def deleteObject (ist : IntermediateState)
 
 Looks up the CNode at `cnodeId`, inserts `cap` at `slot`, stores the updated
 CNode back. Requires the slot to be initially empty for deterministic boot. -/
-private theorem insert_capacity_ge4 [BEq α] [Hashable α]
-    (t : RHTable α β) (k : α) (v : β) (hCapGe4 : 4 ≤ t.capacity) :
-    4 ≤ (t.insert k v).capacity := by
-  unfold RHTable.insert; split
-  · rw [RHTable.insertNoResize_capacity, t.resize_fold_capacity]; omega
-  · rw [RHTable.insertNoResize_capacity]; exact hCapGe4
-
 def insertCap (ist : IntermediateState)
     (cnodeId : SeLe4n.ObjId) (slot : SeLe4n.Slot) (cap : Capability)
     (cn : CNode)
@@ -326,10 +317,7 @@ def insertCap (ist : IntermediateState)
     (fun cn'' hEq => by
       cases hEq
       have hSU := ist.hPerObjectSlots cnodeId cn hLookup
-      unfold CNode.slotsUnique at hSU ⊢
-      exact ⟨RHTable.insert_preserves_invExt _ _ _ hSU.1,
-             RHTable.insert_size_lt_capacity cn.slots slot cap hSU.1 hSU.2.1 hSU.2.2,
-             insert_capacity_ge4 cn.slots slot cap hSU.2.2⟩)
+      exact RHTable.insert_preserves_invExtK cn.slots slot cap hSU)
     (fun vs hEq => by cases hEq)
 
 -- ============================================================================

--- a/SeLe4n/Model/FreezeProofs.lean
+++ b/SeLe4n/Model/FreezeProofs.lean
@@ -588,7 +588,7 @@ theorem lookup_freeze_objects (ist : IntermediateState) (k : SeLe4n.ObjId) :
   -- (freeze ist).objects is definitionally freezeMapWith ist.state.objects freezeObject
   have hDef : (freeze ist).objects = freezeMapWith ist.state.objects freezeObject := rfl
   rw [hDef]
-  exact freezeMapWith_get?_eq ist.state.objects freezeObject k ist.hAllTables.1
+  exact freezeMapWith_get?_eq ist.state.objects freezeObject k ist.hAllTables.1.1
 
 -- ============================================================================
 -- Q6-A: Per-field lookup equivalence theorems
@@ -603,64 +603,64 @@ witness provides the `invExt` precondition for each field's RHTable. -/
 /-- Q6-A: irqHandlers lookup preserved by freeze. -/
 theorem lookup_freeze_irqHandlers (ist : IntermediateState) (k : SeLe4n.Irq) :
     ist.state.irqHandlers.get? k = (freeze ist).irqHandlers.get? k := by
-  exact freezeMap_get?_eq ist.state.irqHandlers k ist.hAllTables.2.1
+  exact freezeMap_get?_eq ist.state.irqHandlers k ist.hAllTables.2.1.1
 
 /-- Q6-A: asidTable lookup preserved by freeze. -/
 theorem lookup_freeze_asidTable (ist : IntermediateState) (k : SeLe4n.ASID) :
     ist.state.asidTable.get? k = (freeze ist).asidTable.get? k := by
-  exact freezeMap_get?_eq ist.state.asidTable k ist.hAllTables.2.2.1
+  exact freezeMap_get?_eq ist.state.asidTable k ist.hAllTables.2.2.1.1
 
 /-- Q6-A: serviceRegistry lookup preserved by freeze. -/
 theorem lookup_freeze_serviceRegistry (ist : IntermediateState) (k : SeLe4n.ServiceId) :
     ist.state.serviceRegistry.get? k = (freeze ist).serviceRegistry.get? k := by
-  exact freezeMap_get?_eq ist.state.serviceRegistry k ist.hAllTables.2.2.2.2.2.2.2.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.serviceRegistry k ist.hAllTables.2.2.2.2.2.2.2.2.2.2.2.1.1
 
 /-- Q6-A: interfaceRegistry lookup preserved by freeze. -/
 theorem lookup_freeze_interfaceRegistry (ist : IntermediateState) (k : SeLe4n.InterfaceId) :
     ist.state.interfaceRegistry.get? k = (freeze ist).interfaceRegistry.get? k := by
-  exact freezeMap_get?_eq ist.state.interfaceRegistry k ist.hAllTables.2.2.2.2.2.2.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.interfaceRegistry k ist.hAllTables.2.2.2.2.2.2.2.2.2.2.1.1
 
 /-- Q6-A: services lookup preserved by freeze. -/
 theorem lookup_freeze_services (ist : IntermediateState) (k : SeLe4n.ServiceId) :
     ist.state.services.get? k = (freeze ist).services.get? k := by
-  exact freezeMap_get?_eq ist.state.services k ist.hAllTables.2.2.2.2.2.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.services k ist.hAllTables.2.2.2.2.2.2.2.2.2.1.1
 
 /-- Q6-A: cdtChildMap lookup preserved by freeze. -/
 theorem lookup_freeze_cdtChildMap (ist : IntermediateState) (k : CdtNodeId) :
     ist.state.cdt.childMap.get? k = (freeze ist).cdtChildMap.get? k := by
-  exact freezeMap_get?_eq ist.state.cdt.childMap k ist.hAllTables.2.2.2.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.cdt.childMap k ist.hAllTables.2.2.2.2.2.2.2.1.1
 
 /-- Q6-A: cdtParentMap lookup preserved by freeze. -/
 theorem lookup_freeze_cdtParentMap (ist : IntermediateState) (k : CdtNodeId) :
     ist.state.cdt.parentMap.get? k = (freeze ist).cdtParentMap.get? k := by
-  exact freezeMap_get?_eq ist.state.cdt.parentMap k ist.hAllTables.2.2.2.2.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.cdt.parentMap k ist.hAllTables.2.2.2.2.2.2.2.2.1.1
 
 /-- Q6-A: cdtSlotNode lookup preserved by freeze. -/
 theorem lookup_freeze_cdtSlotNode (ist : IntermediateState) (k : SlotRef) :
     ist.state.cdtSlotNode.get? k = (freeze ist).cdtSlotNode.get? k := by
-  exact freezeMap_get?_eq ist.state.cdtSlotNode k ist.hAllTables.2.2.2.1
+  exact freezeMap_get?_eq ist.state.cdtSlotNode k ist.hAllTables.2.2.2.1.1
 
 /-- Q6-A: cdtNodeSlot lookup preserved by freeze. -/
 theorem lookup_freeze_cdtNodeSlot (ist : IntermediateState) (k : CdtNodeId) :
     ist.state.cdtNodeSlot.get? k = (freeze ist).cdtNodeSlot.get? k := by
-  exact freezeMap_get?_eq ist.state.cdtNodeSlot k ist.hAllTables.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.cdtNodeSlot k ist.hAllTables.2.2.2.2.1.1
 
 /-- Q6-A: objectTypes lookup preserved by freeze. -/
 theorem lookup_freeze_objectTypes (ist : IntermediateState) (k : SeLe4n.ObjId) :
     ist.state.lifecycle.objectTypes.get? k = (freeze ist).objectTypes.get? k := by
-  exact freezeMap_get?_eq ist.state.lifecycle.objectTypes k ist.hAllTables.2.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.lifecycle.objectTypes k ist.hAllTables.2.2.2.2.2.1.1
 
 /-- Q6-A: capabilityRefs lookup preserved by freeze. -/
 theorem lookup_freeze_capabilityRefs (ist : IntermediateState) (k : SlotRef) :
     ist.state.lifecycle.capabilityRefs.get? k = (freeze ist).capabilityRefs.get? k := by
-  exact freezeMap_get?_eq ist.state.lifecycle.capabilityRefs k ist.hAllTables.2.2.2.2.2.2.1
+  exact freezeMap_get?_eq ist.state.lifecycle.capabilityRefs k ist.hAllTables.2.2.2.2.2.2.1.1
 
 /-- Q6-A: objectIndexSet membership preserved by freeze. -/
 theorem lookup_freeze_objectIndexSet (ist : IntermediateState) (k : SeLe4n.ObjId) :
     ist.state.objectIndexSet.table.get? k =
       (freeze ist).objectIndexSet.get? k := by
   exact freezeMap_get?_eq ist.state.objectIndexSet.table k
-    ist.hAllTables.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
+    ist.hAllTables.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1.1
 
 -- ============================================================================
 -- Q6-B: CNode Radix Lookup Equivalence
@@ -1261,8 +1261,8 @@ theorem thread_store_commutes_at_key (ist : IntermediateState)
   rw [← freezeMapWith_get?_eq
     (ist.state.objects.insert tid.toObjId (KernelObject.tcb tcb))
     freezeObject tid.toObjId
-    (ist.state.objects.insert_preserves_invExt tid.toObjId _ ist.hAllTables.1)]
-  rw [RHTable.getElem?_insert_self ist.state.objects tid.toObjId _ ist.hAllTables.1]
+    (ist.state.objects.insert_preserves_invExt tid.toObjId _ ist.hAllTables.1.1)]
+  rw [RHTable.getElem?_insert_self ist.state.objects tid.toObjId _ ist.hAllTables.1.1]
   simp [freezeObject]
 
 /-- Thread store preserves non-object fields: modifying the objects table

--- a/SeLe4n/Model/IntermediateState.lean
+++ b/SeLe4n/Model/IntermediateState.lean
@@ -47,8 +47,8 @@ def perObjectMappingsInvariant (st : SystemState) : Prop :=
 /-- Q3-A: Builder-phase state: all maps verified, all invariants carried.
 
 The four proof fields guarantee:
-1. **`hAllTables`** — every RHTable/RHSet in `SystemState` satisfies `invExt`
-   (WF ∧ distCorrect ∧ noDupKeys ∧ probeChainDominant).
+1. **`hAllTables`** — every RHTable/RHSet in `SystemState` satisfies `invExtK`
+   (invExt ∧ size < capacity ∧ 4 ≤ capacity).
 2. **`hPerObjectSlots`** — for every CNode in the object store, its `slots`
    RHTable satisfies `slotsUnique` (invExt ∧ size < capacity ∧ 4 ≤ capacity).
 3. **`hPerObjectMappings`** — for every VSpaceRoot in the object store, its
@@ -57,7 +57,7 @@ The four proof fields guarantee:
    is mutually consistent with the object store. -/
 structure IntermediateState where
   state : SystemState
-  hAllTables : state.allTablesInvExt
+  hAllTables : state.allTablesInvExtK
   hPerObjectSlots : perObjectSlotsInvariant state
   hPerObjectMappings : perObjectMappingsInvariant state
   hLifecycleConsistent : SystemState.lifecycleMetadataConsistent state
@@ -85,7 +85,7 @@ theorem perObjectMappingsInvariant_default :
 /-- Q3-A: The default (empty) SystemState yields a valid IntermediateState. -/
 def mkEmptyIntermediateState : IntermediateState where
   state := default
-  hAllTables := default_allTablesInvExt
+  hAllTables := default_allTablesInvExtK
   hPerObjectSlots := perObjectSlotsInvariant_default
   hPerObjectMappings := perObjectMappingsInvariant_default
   hLifecycleConsistent := default_systemState_lifecycleConsistent
@@ -93,7 +93,7 @@ def mkEmptyIntermediateState : IntermediateState where
 /-- Q3-A: `mkEmptyIntermediateState` is well-formed. -/
 theorem mkEmptyIntermediateState_valid :
     let e := mkEmptyIntermediateState
-    e.state.allTablesInvExt ∧
+    e.state.allTablesInvExtK ∧
     perObjectSlotsInvariant e.state ∧
     perObjectMappingsInvariant e.state ∧
     SystemState.lifecycleMetadataConsistent e.state :=

--- a/SeLe4n/Model/Object/Structures.lean
+++ b/SeLe4n/Model/Object/Structures.lean
@@ -312,14 +312,13 @@ theorem lookup_mapPage_ne
         (paddr, perms) (fun h => hNe (eq_of_beq h)) hExt
 
 /-- TPI-001 helper: unmapPage at vaddr does not affect lookup of a different vaddr'.
-Maps to `RHTable.getElem?_erase_ne` with the inequality hypothesis.
-Requires `invExt` and `size < capacity` for RHTable erase correctness. -/
+Maps to `RHTable.getElem?_erase_ne_K` with the inequality hypothesis.
+Requires `invExtK` for RHTable erase correctness. -/
 theorem lookup_unmapPage_ne
     (root root' : VSpaceRoot)
     (vaddr vaddr' : SeLe4n.VAddr)
     (hNe : vaddr ≠ vaddr')
-    (hExt : root.mappings.invExt)
-    (hSize : root.mappings.size < root.mappings.capacity)
+    (hK : root.mappings.invExtK)
     (hUnmap : root.unmapPage vaddr = some root') :
     root'.lookup vaddr' = root.lookup vaddr' := by
   unfold unmapPage at hUnmap
@@ -328,8 +327,8 @@ theorem lookup_unmapPage_ne
   | some _ =>
       simp [hLookup] at hUnmap; cases hUnmap
       simp only [lookup]
-      exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne root.mappings vaddr vaddr'
-        (fun h => hNe (eq_of_beq h)) hExt hSize
+      exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K root.mappings vaddr vaddr'
+        (fun h => hNe (eq_of_beq h)) hK
 
 end VSpaceRoot
 
@@ -529,8 +528,7 @@ invariant (`invExt`) and are not full (`size < capacity`).
 WS-N4: With RHTable-backed slots, key uniqueness is enforced by the `noDupKeys`
 component of `invExt`. The `size < capacity` condition is maintained by the
 resize-at-75%-load policy and is required for erase correctness. -/
-def slotsUnique (cn : CNode) : Prop :=
-  cn.slots.invExt ∧ cn.slots.size < cn.slots.capacity ∧ 4 ≤ cn.slots.capacity
+def slotsUnique (cn : CNode) : Prop := cn.slots.invExtK
 
 /-- WS-G5: After removing a slot, lookup returns `none`.
 Maps directly to `RHTable.getElem?_erase_self`. Requires slot invariant
@@ -614,66 +612,33 @@ theorem empty_guardBounded : CNode.empty.guardBounded := by
   simp [empty, guardBounded]
 
 /-- WS-N4: The empty CNode's slots satisfy the slot invariant. -/
-theorem empty_slotsUnique : CNode.empty.slotsUnique := by
-  refine ⟨RHTable.empty_invExt 16 (by omega), ?_, ?_⟩
-  · show (RHTable.empty 16 (by omega : (0 : Nat) < 16)).size <
-      (RHTable.empty 16 (by omega : (0 : Nat) < 16)).capacity
-    simp [RHTable.empty]
-  · show 4 ≤ (RHTable.empty 16 (by omega : (0 : Nat) < 16)).capacity
-    simp [RHTable.empty]
+theorem empty_slotsUnique : CNode.empty.slotsUnique :=
+  RHTable.empty_invExtK 16 (by omega) (by omega)
 
 /-- WS-N4: Insert preserves the slot invariant. -/
 
 theorem insert_slotsUnique
     (cn : CNode) (slot : SeLe4n.Slot) (cap : Capability)
     (hUniq : cn.slotsUnique) :
-    (cn.insert slot cap).slotsUnique := by
-  refine ⟨cn.slots.insert_preserves_invExt slot cap hUniq.1,
-    cn.slots.insert_size_lt_capacity slot cap hUniq.1 hUniq.2.1 hUniq.2.2, ?_⟩
-  · -- capacity ≥ 4: insert either keeps same capacity or doubles it
-    simp only [CNode.insert]; unfold RHTable.insert; split
-    · -- resize branch: capacity doubles
-      rw [RHTable.insertNoResize_capacity, cn.slots.resize_fold_capacity]
-      have := hUniq.2.2; omega
-    · -- no resize: capacity unchanged
-      rw [RHTable.insertNoResize_capacity]; exact hUniq.2.2
+    (cn.insert slot cap).slotsUnique :=
+  cn.slots.insert_preserves_invExtK slot cap hUniq
 
 /-- WS-N4: Erase preserves the slot invariant. -/
 
 theorem remove_slotsUnique
     (cn : CNode) (slot : SeLe4n.Slot)
     (hUniq : cn.slotsUnique) :
-    (cn.remove slot).slotsUnique := by
-  refine ⟨cn.slots.erase_preserves_invExt slot hUniq.1 hUniq.2.1,
-    cn.slots.erase_size_lt_capacity slot hUniq.2.1, ?_⟩
-  · -- erase preserves capacity
-    simp only [CNode.remove]; unfold RHTable.erase; simp only []; split <;> exact hUniq.2.2
+    (cn.remove slot).slotsUnique :=
+  cn.slots.erase_preserves_invExtK slot hUniq
 
 /-- WS-N4: Filter preserves the slot invariant. -/
 
 theorem revokeTargetLocal_slotsUnique
     (cn : CNode) (sourceSlot : SeLe4n.Slot) (target : CapTarget)
     (hUniq : cn.slotsUnique) :
-    (cn.revokeTargetLocal sourceSlot target).slotsUnique := by
-  refine ⟨cn.slots.filter_preserves_invExt
-      (fun s c => s == sourceSlot || !(c.target == target)) hUniq.1,
-    cn.slots.filter_size_lt_capacity
-      (fun s c => s == sourceSlot || !(c.target == target)) hUniq.2.1 hUniq.1.1, ?_⟩
-  · -- filter preserves capacity (it rebuilds with same capacity)
-    simp only [CNode.revokeTargetLocal]; unfold RHTable.filter RHTable.fold
-    exact Array.foldl_induction
-      (motive := fun _ (acc : RHTable SeLe4n.Slot Capability) => 4 ≤ acc.capacity)
-      (by simp [RHTable.empty]; exact hUniq.2.2)
-      (fun i acc hAcc => by
-        simp only []; split
-        · exact hAcc
-        · rename_i entry _
-          by_cases hf : (fun s c => s == sourceSlot || !(c.target == target)) entry.key entry.value
-          · simp only [hf, ite_true]
-            rw [RHTable.insertNoResize_capacity]; exact hAcc
-          · simp only [show ((fun s c => s == sourceSlot || !(c.target == target))
-              entry.key entry.value) = false from Bool.eq_false_iff.mpr hf]
-            exact hAcc)
+    (cn.revokeTargetLocal sourceSlot target).slotsUnique :=
+  cn.slots.filter_preserves_invExtK
+    (fun s c => s == sourceSlot || !(c.target == target)) hUniq
 
 -- ============================================================================
 -- WS-H4: Meaningful CNode slot-count bound predicate
@@ -755,8 +720,8 @@ theorem lookup_remove_ne
     (hUniq : cn.slotsUnique) :
     (cn.remove slot).lookup slot' = cn.lookup slot' := by
   simp only [remove, lookup]
-  exact RHTable.getElem?_erase_ne cn.slots slot slot'
-    (fun h => hNe (eq_of_beq h)) hUniq.1 hUniq.2.1
+  exact RHTable.getElem?_erase_ne_K cn.slots slot slot'
+    (fun h => hNe (eq_of_beq h)) hUniq
 
 end CNode
 
@@ -1275,7 +1240,7 @@ Requires `invExt` and `size < capacity` for RHTable erase correctness. -/
 private theorem foldl_erase_preserves
     (xs : List CdtNodeId) (m : SeLe4n.Kernel.RobinHood.RHTable CdtNodeId CdtNodeId) (k : CdtNodeId)
     (hNotAny : ∀ c ∈ xs, (c == k) = false)
-    (hExt : m.invExt) (hSize : m.size < m.capacity) :
+    (hK : m.invExtK) :
     (xs.foldl (fun acc c => acc.erase c) m)[k]? = m[k]? := by
   induction xs generalizing m with
   | nil => rfl
@@ -1284,56 +1249,53 @@ private theorem foldl_erase_preserves
     have hxk : (x == k) = false := hNotAny x (.head _)
     have hRest : ∀ c ∈ rest, (c == k) = false :=
       fun c hc => hNotAny c (.tail _ hc)
-    have hExtE := m.erase_preserves_invExt x hExt hSize
-    have hSizeE := m.erase_size_lt_capacity x hSize
-    have h1 := ih _ hRest hExtE hSizeE
-    have h2 := SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne m x k (by simp [hxk]) hExt hSize
+    have hKE := m.erase_preserves_invExtK x hK
+    have h1 := ih _ hRest hKE
+    have h2 := SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K m x k (by simp [hxk]) hK
     -- h1 : foldl[k]? = (m.erase x)[k]?, h2 : (m.erase x).get? k = m.get? k
     -- Both [k]? and .get? are definitionally equal for RHTable
     exact h1.trans h2
 
 /-- M-P02: Helper — once `[k]? = none`, further `foldl erase` keeps it none.
-Requires `invExt` and `size < capacity` for RHTable erase correctness. -/
+Requires `invExtK` for RHTable erase correctness. -/
 private theorem foldl_erase_none
     (xs : List CdtNodeId) (m : SeLe4n.Kernel.RobinHood.RHTable CdtNodeId CdtNodeId) (k : CdtNodeId)
     (hNone : m[k]? = none)
-    (hExt : m.invExt) (hSize : m.size < m.capacity) :
+    (hK : m.invExtK) :
     (xs.foldl (fun acc c => acc.erase c) m)[k]? = none := by
   induction xs generalizing m with
   | nil => exact hNone
   | cons x rest ih =>
     simp only [List.foldl_cons]
-    have hExtE := m.erase_preserves_invExt x hExt hSize
-    have hSizeE := m.erase_size_lt_capacity x hSize
-    apply ih _ _ hExtE hSizeE
+    have hKE := m.erase_preserves_invExtK x hK
+    apply ih _ _ hKE
     show (m.erase x).get? k = none
     by_cases hxk : (x == k) = true
     · have hkEq : x = k := eq_of_beq hxk
-      rw [hkEq]; exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self m k hExt
-    · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne m x k hxk hExt hSize]; exact hNone
+      rw [hkEq]; exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self m k hK.1
+    · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K m x k hxk hK]; exact hNone
 
 /-- M-P02: Helper — `foldl erase` erases entries for keys in the list.
-Requires `invExt` and `size < capacity` for RHTable erase correctness. -/
+Requires `invExtK` for RHTable erase correctness. -/
 private theorem foldl_erase_mem
     (xs : List CdtNodeId) (m : SeLe4n.Kernel.RobinHood.RHTable CdtNodeId CdtNodeId) (k : CdtNodeId)
     (hMem : ∃ c ∈ xs, (c == k) = true)
-    (hExt : m.invExt) (hSize : m.size < m.capacity) :
+    (hK : m.invExtK) :
     (xs.foldl (fun acc c => acc.erase c) m)[k]? = none := by
   induction xs generalizing m with
   | nil => obtain ⟨_, hMem, _⟩ := hMem; cases hMem
   | cons x rest ih =>
     simp only [List.foldl_cons]
-    have hExtE := m.erase_preserves_invExt x hExt hSize
-    have hSizeE := m.erase_size_lt_capacity x hSize
+    have hKE := m.erase_preserves_invExtK x hK
     obtain ⟨c, hcMem, hck⟩ := hMem
     rcases List.mem_cons.mp hcMem with hcx | hTail
     · -- c = x, so x == k is true
       have hxk : (x == k) = true := hcx ▸ hck
       have hkEq : x = k := eq_of_beq hxk
-      apply foldl_erase_none _ _ _ _ hExtE hSizeE
+      apply foldl_erase_none _ _ _ _ hKE
       show (m.erase x).get? k = none
-      rw [hkEq]; exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self m k hExt
-    · exact ih _ ⟨c, hTail, hck⟩ hExtE hSizeE
+      rw [hkEq]; exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self m k hK.1
+    · exact ih _ ⟨c, hTail, hck⟩ hKE
 
 /-- M-P02: `removeNode` preserves `parentMapConsistent`.
 
@@ -1345,28 +1307,25 @@ theorem removeNode_parentMapConsistent
     (cdt : CapDerivationTree) (node : CdtNodeId)
     (hCon : cdt.parentMapConsistent)
     (hChildCon : cdt.childMapConsistent)
-    (hExt : cdt.parentMap.invExt) (hSizePM : cdt.parentMap.size < cdt.parentMap.capacity) :
+    (hK : cdt.parentMap.invExtK) :
     (cdt.removeNode node).parentMapConsistent := by
   intro child parent
   simp only [removeNode]
-  -- Establish invExt/size for the fold result via auxiliary lemma
-  have foldl_erase_invExt : ∀ (xs : List CdtNodeId)
+  -- Establish invExtK for the fold result via auxiliary lemma
+  have foldl_erase_invExtK : ∀ (xs : List CdtNodeId)
       (m : SeLe4n.Kernel.RobinHood.RHTable CdtNodeId CdtNodeId),
-      m.invExt → m.size < m.capacity →
-      (xs.foldl (fun acc c => acc.erase c) m).invExt ∧
-      (xs.foldl (fun acc c => acc.erase c) m).size <
-      (xs.foldl (fun acc c => acc.erase c) m).capacity := by
+      m.invExtK →
+      (xs.foldl (fun acc c => acc.erase c) m).invExtK := by
     intro xs
     induction xs with
-    | nil => intro m hE hS; exact ⟨hE, hS⟩
+    | nil => intro m hM; exact hM
     | cons x rest ih =>
-      intro m hE hS
+      intro m hM
       simp only [List.foldl_cons]
-      exact ih _ (m.erase_preserves_invExt x hE hS) (m.erase_size_lt_capacity x hS)
-  have hFoldBoth := foldl_erase_invExt
-    ((cdt.childMap.get? node).getD []) cdt.parentMap hExt hSizePM
-  have hFoldExt := hFoldBoth.1
-  have hFoldSize := hFoldBoth.2
+      exact ih _ (m.erase_preserves_invExtK x hM)
+  have hFoldK := foldl_erase_invExtK
+    ((cdt.childMap.get? node).getD []) cdt.parentMap hK
+  have hFoldExt := hFoldK.1
   constructor
   · -- Forward: parentMapFinal[child]? = some parent → surviving edge exists
     intro hIn
@@ -1380,8 +1339,8 @@ theorem removeNode_parentMapConsistent
       rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ node hFoldExt] at hIn
       cases hIn
     · -- child ≠ node
-      rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node child hNeNodeBool
-        hFoldExt hFoldSize] at hIn
+      rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node child hNeNodeBool
+        hFoldK] at hIn
       have hNotChild : ∀ c ∈ (cdt.childMap.get? node).getD [], (c == child) = false := by
         intro c hc
         cases h : (c == child)
@@ -1389,11 +1348,11 @@ theorem removeNode_parentMapConsistent
         · exfalso
           have hNone : (List.foldl (fun acc c => acc.erase c) cdt.parentMap
             ((cdt.childMap.get? node).getD [])).get? child = none :=
-            foldl_erase_mem _ cdt.parentMap child ⟨c, hc, h⟩ hExt hSizePM
+            foldl_erase_mem _ cdt.parentMap child ⟨c, hc, h⟩ hK
           rw [hNone] at hIn; exact absurd hIn (by simp)
       have hPreserves : (List.foldl (fun acc c => acc.erase c) cdt.parentMap
         ((cdt.childMap.get? node).getD [])).get? child = cdt.parentMap.get? child :=
-        foldl_erase_preserves _ _ _ hNotChild hExt hSizePM
+        foldl_erase_preserves _ _ _ hNotChild hK
       rw [hPreserves] at hIn
       have ⟨e, heMem, hep, hec⟩ := (hCon child parent).mp hIn
       refine ⟨e, List.mem_filter.mpr ⟨heMem, ?_⟩, hep, hec⟩
@@ -1428,8 +1387,8 @@ theorem removeNode_parentMapConsistent
     -- Normalize [k]? to .get? for RHTable rewriting
     show ((List.foldl (fun m c => m.erase c) cdt.parentMap
       ((cdt.childMap.get? node).getD [])).erase node).get? child = some parent
-    rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node child hNeNode
-      hFoldExt hFoldSize]
+    rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node child hNeNode
+      hFoldK]
     -- Now goal is foldl result .get? child = some parent
     show (List.foldl (fun m c => m.erase c) cdt.parentMap
       ((cdt.childMap.get? node).getD [])).get? child = some parent
@@ -1451,7 +1410,7 @@ theorem removeNode_parentMapConsistent
         exact hNotParent (decide_eq_true hep)
     have hPreserves : (List.foldl (fun m c => m.erase c) cdt.parentMap
       ((cdt.childMap.get? node).getD [])).get? child = cdt.parentMap.get? child :=
-      foldl_erase_preserves _ _ _ hNotInChildren hExt hSizePM
+      foldl_erase_preserves _ _ _ hNotInChildren hK
     rw [hPreserves]
     exact (hCon child parent).mpr ⟨e, heMemOrig, hep, hec⟩
 
@@ -1465,14 +1424,13 @@ theorem removeNode_childMapConsistent
     (cdt : CapDerivationTree) (node : CdtNodeId)
     (hCon : cdt.childMapConsistent)
     (hParentCon : cdt.parentMapConsistent)
-    (hExt : cdt.childMap.invExt)
-    (hSizeCM : cdt.childMap.size < cdt.childMap.capacity) :
+    (hK : cdt.childMap.invExtK) :
     (cdt.removeNode node).childMapConsistent := by
   intro parent child
   simp only [removeNode]
-  -- Establish invExt/size for childMap.erase node
-  have hEraseExt := cdt.childMap.erase_preserves_invExt node hExt hSizeCM
-  have hEraseSize := cdt.childMap.erase_size_lt_capacity node hSizeCM
+  -- Establish invExtK for childMap.erase node
+  have hKE := cdt.childMap.erase_preserves_invExtK node hK
+  have hEraseExt := hKE.1
   constructor
   · -- Forward: child ∈ (childMapFinal.get? parent).getD [] → ∃ e ∈ edgesFiltered, ...
     intro hIn
@@ -1491,13 +1449,12 @@ theorem removeNode_childMapConsistent
         · -- parent = node: erased, so get? node = none, contradiction
           have hNodeEq : node = parent := eq_of_beq hpn
           subst hNodeEq
-          have hEraseP_ext := (cdt.childMap.erase node).erase_preserves_invExt p hEraseExt hEraseSize
           have : ((cdt.childMap.erase node).erase p).get? node = none := by
             by_cases hpn2 : (p == node) = true
             · have := eq_of_beq hpn2; subst this
               exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hEraseExt
-            · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ p node hpn2 hEraseExt hEraseSize]
-              exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hExt
+            · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ p node hpn2 hKE]
+              exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hK.1
           rw [this] at hIn; simp at hIn
         · by_cases hpp : (p == parent) = true
           · -- parent = p: erased, so get? p = none, contradiction
@@ -1507,10 +1464,8 @@ theorem removeNode_childMapConsistent
               SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hEraseExt
             rw [this] at hIn; simp at hIn
           · -- parent ≠ node and parent ≠ p: both erases are no-ops for parent
-            have hEraseP_ext := (cdt.childMap.erase node).erase_preserves_invExt p hEraseExt hEraseSize
-            have hEraseP_size := (cdt.childMap.erase node).erase_size_lt_capacity p hEraseSize
-            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ p parent hpp hEraseExt hEraseSize] at hIn
-            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node parent hpn hExt hSizeCM] at hIn
+            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ p parent hpp hKE] at hIn
+            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node parent hpn hK] at hIn
             have ⟨e, heMem, hep, hec⟩ := (hCon parent child).mp hIn
             refine ⟨e, List.mem_filter.mpr ⟨heMem, ?_⟩, hep, hec⟩
             simp only [decide_eq_true_eq]
@@ -1539,9 +1494,9 @@ theorem removeNode_childMapConsistent
           by_cases hpn2 : (node == p) = true
           · have hNodeP : node = p := eq_of_beq hpn2
             subst hNodeP
-            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hExt] at hSib
+            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hK.1] at hSib
             simp at hSib
-          · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node p hpn2 hExt hSizeCM] at hSib
+          · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node p hpn2 hK] at hSib
             have ⟨e, heMem, hep, hec⟩ := (hCon p child).mp hSib
             refine ⟨e, List.mem_filter.mpr ⟨heMem, ?_⟩, hep, hec⟩
             simp only [decide_eq_true_eq]
@@ -1561,9 +1516,9 @@ theorem removeNode_childMapConsistent
           by_cases hpn2 : (node == parent) = true
           · have hNodeEq : node = parent := eq_of_beq hpn2
             subst hNodeEq
-            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hExt] at hIn
+            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hK.1] at hIn
             simp at hIn
-          · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node parent hpn2 hExt hSizeCM] at hIn
+          · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node parent hpn2 hK] at hIn
             have ⟨e, heMem, hep, hec⟩ := (hCon parent child).mp hIn
             refine ⟨e, List.mem_filter.mpr ⟨heMem, ?_⟩, hep, hec⟩
             simp only [decide_eq_true_eq]
@@ -1582,9 +1537,9 @@ theorem removeNode_childMapConsistent
       by_cases hpn : (node == parent) = true
       · have hNodeEq : node = parent := eq_of_beq hpn
         subst hNodeEq
-        rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hExt] at hIn
+        rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_self _ _ hK.1] at hIn
         simp at hIn
-      · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node parent hpn hExt hSizeCM] at hIn
+      · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node parent hpn hK] at hIn
         have ⟨e, heMem, hep, hec⟩ := (hCon parent child).mp hIn
         refine ⟨e, List.mem_filter.mpr ⟨heMem, ?_⟩, hep, hec⟩
         simp only [decide_eq_true_eq]
@@ -1643,7 +1598,7 @@ theorem removeNode_childMapConsistent
             -- parent = node, contradiction with hParentNeNode
             simp at hParentNeNode
           · have hSiblings : (cdt.childMap.erase node).get? p = cdt.childMap.get? p :=
-              SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node p hpn2 hExt hSizeCM
+              SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node p hpn2 hK
             -- child ∈ original siblings
             -- child ∈ siblings (after erase node from childMap, but key is p ≠ node)
             have hChildInSibs : child ∈ ((cdt.childMap.erase node).get? p).getD [] := by
@@ -1661,8 +1616,8 @@ theorem removeNode_childMapConsistent
             rw [this] at hChildSurvives; cases hChildSurvives
         · -- parent ≠ p: both erases are no-ops for parent
           rw [show ((cdt.childMap.erase node).erase p).get? parent = cdt.childMap.get? parent from by
-            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ p parent hpp hEraseExt hEraseSize]
-            exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node parent hParentNeNode hExt hSizeCM]
+            rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ p parent hpp hKE]
+            exact SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node parent hParentNeNode hK]
           exact hOriginal
       · -- filtered.isEmpty = false → childMapFinal = (childMap.erase node).insert p filtered
         rename_i hNotEmpty
@@ -1680,17 +1635,17 @@ theorem removeNode_childMapConsistent
             by_cases hpn2 : (node == p) = true
             · have hNodeP : node = p := eq_of_beq hpn2
               subst hNodeP; simp at hParentNeNode
-            · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node p hpn2 hExt hSizeCM]
+            · rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node p hpn2 hK]
               exact hOriginal
           · simp only [bne_iff_ne, ne_eq]
             intro h; apply hChildNeNode; exact beq_of_eq h.symm
         · -- parent ≠ p
           rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_insert_ne _ _ _ _ hpp hEraseExt]
-          rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node parent hParentNeNode hExt hSizeCM]
+          rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node parent hParentNeNode hK]
           exact hOriginal
     · -- none
       rename_i hNoParent
-      rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne _ node parent hParentNeNode hExt hSizeCM]
+      rw [SeLe4n.Kernel.RobinHood.RHTable.getElem?_erase_ne_K _ node parent hParentNeNode hK]
       exact hOriginal
 
 /-- Slot-address view of a CDT edge (projection through slot backpointers). -/

--- a/SeLe4n/Model/State.lean
+++ b/SeLe4n/Model/State.lean
@@ -275,71 +275,71 @@ instance : Inhabited SystemState where
 satisfies the Robin Hood invariant extension (WF ∧ distCorrect ∧ noDupKeys ∧
 probeChainDominant). This is the global well-formedness condition for the
 builder-phase state representation. -/
-def SystemState.allTablesInvExt (st : SystemState) : Prop :=
+def SystemState.allTablesInvExtK (st : SystemState) : Prop :=
   -- SystemState direct fields
-  st.objects.invExt ∧
-  st.irqHandlers.invExt ∧
-  st.asidTable.invExt ∧
-  st.cdtSlotNode.invExt ∧
-  st.cdtNodeSlot.invExt ∧
+  st.objects.invExtK ∧
+  st.irqHandlers.invExtK ∧
+  st.asidTable.invExtK ∧
+  st.cdtSlotNode.invExtK ∧
+  st.cdtNodeSlot.invExtK ∧
   -- LifecycleMetadata
-  st.lifecycle.objectTypes.invExt ∧
-  st.lifecycle.capabilityRefs.invExt ∧
+  st.lifecycle.objectTypes.invExtK ∧
+  st.lifecycle.capabilityRefs.invExtK ∧
   -- CDT
-  st.cdt.childMap.invExt ∧
-  st.cdt.parentMap.invExt ∧
+  st.cdt.childMap.invExtK ∧
+  st.cdt.parentMap.invExtK ∧
   -- Service and registry
-  st.services.invExt ∧
-  st.interfaceRegistry.invExt ∧
-  st.serviceRegistry.invExt ∧
+  st.services.invExtK ∧
+  st.interfaceRegistry.invExtK ∧
+  st.serviceRegistry.invExtK ∧
   -- RunQueue
-  st.scheduler.runQueue.byPriority.invExt ∧
-  st.scheduler.runQueue.threadPriority.invExt ∧
-  -- RHSet invExt (via table field)
-  st.objectIndexSet.table.invExt ∧
-  st.scheduler.runQueue.membership.table.invExt
+  st.scheduler.runQueue.byPriority.invExtK ∧
+  st.scheduler.runQueue.threadPriority.invExtK ∧
+  -- RHSet invExtK (via table field)
+  st.objectIndexSet.table.invExtK ∧
+  st.scheduler.runQueue.membership.table.invExtK
 
-/-- The default SystemState satisfies `allTablesInvExt` because all tables are
-empty, and empty RHTables trivially satisfy `invExt`. -/
-theorem default_allTablesInvExt : (default : SystemState).allTablesInvExt := by
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExt' 16 (by omega)
-  constructor; exact SeLe4n.Kernel.RobinHood.RHSet.empty_invExt
-  exact SeLe4n.Kernel.RobinHood.RHSet.empty_invExt
+/-- The default SystemState satisfies `allTablesInvExtK` because all tables are
+empty, and empty RHTables with capacity 16 trivially satisfy `invExtK`. -/
+theorem default_allTablesInvExtK : (default : SystemState).allTablesInvExtK := by
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHTable.empty_invExtK 16 (by omega) (by omega)
+  constructor; exact SeLe4n.Kernel.RobinHood.RHSet.empty_invExtK
+  exact SeLe4n.Kernel.RobinHood.RHSet.empty_invExtK
 
-/-- U2-M: Compile-time completeness witness for `allTablesInvExt`.
-    This theorem destructures `allTablesInvExt` into exactly 16 named conjuncts.
+/-- U2-M: Compile-time completeness witness for `allTablesInvExtK`.
+    This theorem destructures `allTablesInvExtK` into exactly 16 named conjuncts.
     If a new RHTable field is added to `SystemState` and included in
-    `allTablesInvExt` without updating this witness, the proof fails. -/
-theorem allTablesInvExt_witness (st : SystemState) (h : st.allTablesInvExt) :
-    st.objects.invExt ∧
-    st.irqHandlers.invExt ∧
-    st.asidTable.invExt ∧
-    st.cdtSlotNode.invExt ∧
-    st.cdtNodeSlot.invExt ∧
-    st.lifecycle.objectTypes.invExt ∧
-    st.lifecycle.capabilityRefs.invExt ∧
-    st.cdt.childMap.invExt ∧
-    st.cdt.parentMap.invExt ∧
-    st.services.invExt ∧
-    st.interfaceRegistry.invExt ∧
-    st.serviceRegistry.invExt ∧
-    st.scheduler.runQueue.byPriority.invExt ∧
-    st.scheduler.runQueue.threadPriority.invExt ∧
-    st.objectIndexSet.table.invExt ∧
-    st.scheduler.runQueue.membership.table.invExt := h
+    `allTablesInvExtK` without updating this witness, the proof fails. -/
+theorem allTablesInvExtK_witness (st : SystemState) (h : st.allTablesInvExtK) :
+    st.objects.invExtK ∧
+    st.irqHandlers.invExtK ∧
+    st.asidTable.invExtK ∧
+    st.cdtSlotNode.invExtK ∧
+    st.cdtNodeSlot.invExtK ∧
+    st.lifecycle.objectTypes.invExtK ∧
+    st.lifecycle.capabilityRefs.invExtK ∧
+    st.cdt.childMap.invExtK ∧
+    st.cdt.parentMap.invExtK ∧
+    st.services.invExtK ∧
+    st.interfaceRegistry.invExtK ∧
+    st.serviceRegistry.invExtK ∧
+    st.scheduler.runQueue.byPriority.invExtK ∧
+    st.scheduler.runQueue.threadPriority.invExtK ∧
+    st.objectIndexSet.table.invExtK ∧
+    st.scheduler.runQueue.membership.table.invExtK := h
 
 abbrev Kernel := SeLe4n.KernelM SystemState KernelError
 
@@ -1220,6 +1220,17 @@ theorem capabilityRefs_fold_preserves_invExt
   RHTable.fold_preserves cn.slots cleared _ (fun t => t.invExt) hInv
     (fun acc _ _ hAcc => RHTable.insert_preserves_invExt acc _ _ hAcc)
 
+/-- V3-B: capabilityRefs fold insert preserves invExtK. -/
+theorem capabilityRefs_fold_preserves_invExtK
+    (cn : CNode)
+    (cleared : RHTable SlotRef CapTarget)
+    (id : SeLe4n.ObjId)
+    (hInvK : cleared.invExtK) :
+    (cn.slots.fold (init := cleared) fun refs slot cap =>
+      refs.insert { cnode := id, slot := slot } cap.target).invExtK :=
+  RHTable.fold_preserves cn.slots cleared _ (fun t => t.invExtK) hInvK
+    (fun acc _ _ hAcc => RHTable.insert_preserves_invExtK acc _ _ hAcc)
+
 -- ============================================================================
 -- T2-G (M-NEW-2): Bundled storeObject preserves allTablesInvExt
 -- ============================================================================
@@ -1235,16 +1246,15 @@ theorem capabilityRefs_fold_preserves_invExt
     `insert`, `filter`, or `erase` — all of which preserve `invExt` — and
     leaves unchanged fields (scheduler, CDT maps, services) structurally equal
     to the pre-state. -/
-theorem storeObject_preserves_allTablesInvExt
+theorem storeObject_preserves_allTablesInvExtK
     (st st' : SystemState)
     (id : SeLe4n.ObjId)
     (obj : KernelObject)
-    (hAll : st.allTablesInvExt)
-    (hAsidSize : st.asidTable.size < st.asidTable.capacity)
+    (hAll : st.allTablesInvExtK)
     (hStore : storeObject id obj st = .ok ((), st')) :
-    st'.allTablesInvExt := by
+    st'.allTablesInvExtK := by
   unfold storeObject at hStore; cases hStore
-  unfold SystemState.allTablesInvExt at hAll ⊢
+  unfold SystemState.allTablesInvExtK at hAll ⊢
   simp only
   -- Extract components from pre-state invariant
   have hObj := hAll.1
@@ -1263,37 +1273,37 @@ theorem storeObject_preserves_allTablesInvExt
   have hThreadPri := hAll.2.2.2.2.2.2.2.2.2.2.2.2.2.1
   have hObjIdxSet := hAll.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
   have hMembership := hAll.2.2.2.2.2.2.2.2.2.2.2.2.2.2.2
-  -- Prove objects insert preserves invExt
-  have hObj' := RHTable.insert_preserves_invExt st.objects id obj hObj
-  -- Prove objectTypes insert preserves invExt
-  have hObjTypes' := RHTable.insert_preserves_invExt st.lifecycle.objectTypes id obj.objectType hObjTypes
-  -- Prove capabilityRefs filter+fold preserves invExt
-  have hFiltered := capabilityRefs_filter_preserves_invExt st.lifecycle.capabilityRefs id hCapRefs
+  -- Prove objects insert preserves invExtK
+  have hObj' := RHTable.insert_preserves_invExtK st.objects id obj hObj
+  -- Prove objectTypes insert preserves invExtK
+  have hObjTypes' := RHTable.insert_preserves_invExtK st.lifecycle.objectTypes id obj.objectType hObjTypes
+  -- Prove capabilityRefs filter+fold preserves invExtK
+  have hFiltered := RHTable.filter_preserves_invExtK st.lifecycle.capabilityRefs (fun ref _ => ref.cnode ≠ id) hCapRefs
   have hCapRefs' : (match obj with
       | .cnode cn => cn.slots.fold (init := st.lifecycle.capabilityRefs.filter (fun ref _ => ref.cnode ≠ id))
           fun refs slot cap => refs.insert { cnode := id, slot := slot } cap.target
-      | _ => st.lifecycle.capabilityRefs.filter (fun ref _ => ref.cnode ≠ id)).invExt := by
+      | _ => st.lifecycle.capabilityRefs.filter (fun ref _ => ref.cnode ≠ id)).invExtK := by
     cases obj with
-    | cnode cn => exact capabilityRefs_fold_preserves_invExt cn _ id hFiltered
+    | cnode cn => exact capabilityRefs_fold_preserves_invExtK cn _ id hFiltered
     | _ => exact hFiltered
-  -- Prove objectIndexSet insert preserves invExt
-  have hObjIdxSet' := RHSet.insert_preserves_invExt st.objectIndexSet id hObjIdxSet
-  -- Prove asidTable preserves invExt (erase + insert depending on obj type)
+  -- Prove objectIndexSet insert preserves invExtK
+  have hObjIdxSet' := RHSet.insert_preserves_invExtK st.objectIndexSet id hObjIdxSet
+  -- Prove asidTable preserves invExtK (erase + insert depending on obj type)
   have hAsid' : (let cleared := match st.objects[id]? with
         | some (.vspaceRoot oldRoot) => st.asidTable.erase oldRoot.asid
         | _ => st.asidTable
       match obj with
       | .vspaceRoot newRoot => cleared.insert newRoot.asid id
-      | _ => cleared).invExt := by
-    -- The cleared table preserves invExt via erase or identity
+      | _ => cleared).invExtK := by
+    -- The cleared table preserves invExtK via erase or identity
     have hCleared : (match st.objects[id]? with
         | some (.vspaceRoot oldRoot) => st.asidTable.erase oldRoot.asid
-        | _ => st.asidTable).invExt := by
+        | _ => st.asidTable).invExtK := by
       split
-      · rename_i r _; exact RHTable.erase_preserves_invExt st.asidTable r.asid hAsid hAsidSize
+      · rename_i r _; exact RHTable.erase_preserves_invExtK st.asidTable r.asid hAsid
       · exact hAsid
     cases obj with
-    | vspaceRoot vs => exact RHTable.insert_preserves_invExt _ _ _ hCleared
+    | vspaceRoot vs => exact RHTable.insert_preserves_invExtK _ _ _ hCleared
     | _ => exact hCleared
   -- Compose all 16 components
   exact ⟨hObj', hIrq, hAsid', hCdtSN, hCdtNS, hObjTypes', hCapRefs',

--- a/SeLe4n/Platform/Boot.lean
+++ b/SeLe4n/Platform/Boot.lean
@@ -116,9 +116,9 @@ theorem bootFromPlatform_empty :
     bootFromPlatform { irqTable := [], initialObjects := [] } =
     mkEmptyIntermediateState := rfl
 
-/-- Q3-C: The booted state satisfies allTablesInvExt. -/
-theorem bootFromPlatform_allTablesInvExt (config : PlatformConfig) :
-    (bootFromPlatform config).state.allTablesInvExt :=
+/-- Q3-C: The booted state satisfies allTablesInvExtK. -/
+theorem bootFromPlatform_allTablesInvExtK (config : PlatformConfig) :
+    (bootFromPlatform config).state.allTablesInvExtK :=
   (bootFromPlatform config).hAllTables
 
 /-- Q3-C: The booted state satisfies per-object CNode slots invariant. -/
@@ -139,11 +139,11 @@ theorem bootFromPlatform_lifecycleConsistent (config : PlatformConfig) :
 /-- Q3-C: Master validity theorem — boot produces a fully valid state. -/
 theorem bootFromPlatform_valid (config : PlatformConfig) :
     let ist := bootFromPlatform config
-    ist.state.allTablesInvExt ∧
+    ist.state.allTablesInvExtK ∧
     perObjectSlotsInvariant ist.state ∧
     perObjectMappingsInvariant ist.state ∧
     SystemState.lifecycleMetadataConsistent ist.state :=
-  ⟨bootFromPlatform_allTablesInvExt config,
+  ⟨bootFromPlatform_allTablesInvExtK config,
    bootFromPlatform_perObjectSlots config,
    bootFromPlatform_perObjectMappings config,
    bootFromPlatform_lifecycleConsistent config⟩

--- a/SeLe4n/Prelude.lean
+++ b/SeLe4n/Prelude.lean
@@ -938,6 +938,50 @@ theorem RHTable_empty_invExt {α β : Type} [BEq α] [Hashable α]
     (RHTable.empty cap hPos : RHTable α β).invExt :=
   RHTable.empty_invExt cap hPos
 
+-- ============================================================================
+-- V3-B Phase 2: invExtK re-exports for kernel code
+-- ============================================================================
+
+open SeLe4n.Kernel.RobinHood in
+/-- V3-B: Erase preserves invExtK. -/
+theorem RHTable_erase_preserves_invExtK {α β : Type} [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (k : α) (hK : t.invExtK) :
+    (t.erase k).invExtK :=
+  t.erase_preserves_invExtK k hK
+
+open SeLe4n.Kernel.RobinHood in
+/-- V3-B: Erasing key `k` does not affect lookups of other keys (invExtK API). -/
+theorem RHTable_get?_erase_ne_K {α β : Type} [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (k k' : α) (hNe : ¬(k == k') = true) (hK : t.invExtK) :
+    (t.erase k).get? k' = t.get? k' :=
+  t.getElem?_erase_ne_K k k' hNe hK
+
+open SeLe4n.Kernel.RobinHood in
+/-- V3-B: Combined erase lookup characterization (invExtK API). -/
+theorem RHTable_getElem?_erase_K {α β : Type} [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (k : α) (hK : t.invExtK) (a : α) :
+    (t.erase k).get? a = if k == a then none else t.get? a := by
+  by_cases h : (k == a) = true
+  · simp only [h, ite_true]
+    have hka : a = k := (eq_of_beq h).symm; subst hka
+    exact RHTable.getElem?_erase_self t a hK.1
+  · simp only [show (k == a) = false from Bool.eq_false_iff.mpr h]
+    exact RHTable.getElem?_erase_ne_K t k a h hK
+
+open SeLe4n.Kernel.RobinHood in
+/-- V3-B: Insert preserves invExtK. -/
+theorem RHTable_insert_preserves_invExtK {α β : Type} [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (k : α) (v : β) (hK : t.invExtK) :
+    (t.insert k v).invExtK :=
+  t.insert_preserves_invExtK k v hK
+
+open SeLe4n.Kernel.RobinHood in
+/-- V3-B: Filter preserves invExtK. -/
+theorem RHTable_filter_preserves_invExtK {α β : Type} [BEq α] [Hashable α] [LawfulBEq α]
+    (t : RHTable α β) (f : α → β → Bool) (hK : t.invExtK) :
+    (t.filter f).invExtK :=
+  RHTable.filter_preserves_invExtK t f hK
+
 open SeLe4n.Kernel.RobinHood in
 /-- Q2-A: Filter preserves invExt. -/
 theorem RHTable_filter_preserves_invExt {α β : Type} [BEq α] [Hashable α] [LawfulBEq α]

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -28,7 +28,12 @@ WS-V addresses 95 findings from three comprehensive audits of v0.21.7 (5 HIGH,
 
 - **V3 (Proof Chain Hardening) COMPLETE** (v0.22.2): 26 sub-tasks (V3-A through V3-M).
   All 8 `True := trivial` documentation theorems replaced with real machine-checked
-  proofs. **Machine-checked**: `invExtFull` bundle + `erase_preserves_invExtFull`
+  proofs. **V3-B `invExtK` migration**: Kernel-level `invExtK` bundle
+  (`invExt ∧ size < capacity ∧ 4 ≤ capacity`) in Bridge.lean eliminates 59
+  kernel-facing `hSize`/`hCapGe4` parameters across 13 files. RunQueue fields
+  reduced 9→3. `slotsUnique` = `invExtK` (transparent alias). `allTablesInvExtK`
+  replaces `allTablesInvExt` with 16 `invExtK` conjuncts. Zero sorry/axiom.
+  **Machine-checked**: `invExtFull` bundle + `erase_preserves_invExtFull`
   eliminating redundant `hSize` (H-RH-1). `uniqueRadixIndices_sufficient` radix
   precondition chain (H-RAD-1). `extractBits_identity` + `buildCNodeRadix_hNoPhantom_auto_discharge`
   closing `hNoPhantom` gap (M-DS-4). CDT acyclicity: `cdtShrinkingOps_preserve_acyclicity`

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/phase-1-bundle-wrapper-Wx0z6",
-      "commit_sha": "fd9107ef0b82a5c7565ead70a60be31b20ff35ac",
-      "tree_sha": "7a1edb0d8e17d045898fa93ae486db418b39bf48",
-      "committed_at_utc": "2026-03-26T04:14:45-04:00"
+      "commit_sha": "820ba43dbcdfcade8683e0a25385eb377e60644f",
+      "tree_sha": "b183c4ffcb8c828e6e5138de428bc8cf4895b34f",
+      "committed_at_utc": "2026-03-26T17:43:02+00:00"
     }
   },
   "source_sync": {

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "claude/optimize-proof-chain-hardening-eoEVs",
-      "commit_sha": "ebbf648994b0097dd995c20eea3569c6d7870769",
-      "tree_sha": "44bf86e53828a84970bdefb94e81ef91e471ebcd",
-      "committed_at_utc": "2026-03-26T06:57:48+00:00"
+      "branch": "claude/phase-1-bundle-wrapper-Wx0z6",
+      "commit_sha": "fd9107ef0b82a5c7565ead70a60be31b20ff35ac",
+      "tree_sha": "7a1edb0d8e17d045898fa93ae486db418b39bf48",
+      "committed_at_utc": "2026-03-26T04:14:45-04:00"
     }
   },
   "source_sync": {
@@ -17,20 +17,20 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "5e2c69ff0b3441f650a79e9e4fc1bf7251c07eef88bae4c1512cf44de44587ac"
+    "source_digest": "6858b4e4d7d5e0e98c18da7f7c2730d401fd66c719004b2d89ac24dad48ca040"
   },
   "summary": {
     "module_count": 110,
-    "declaration_count": 3475
+    "declaration_count": 3509
   },
   "readme_sync": {
     "version": "0.22.2",
     "lean_toolchain": "v4.28.0",
     "production_files": 100,
-    "production_loc": 66008,
+    "production_loc": 66043,
     "test_files": 10,
     "test_loc": 8315,
-    "proved_theorem_lemma_decls": 1916,
+    "proved_theorem_lemma_decls": 1948,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
   "modules": [
@@ -3745,6 +3745,7 @@
             "capacity",
             "erase",
             "invExt",
+            "invExtK",
             "none",
             "resolveAsidRoot",
             "resolveAsidRoot_some_implies_obj",
@@ -3762,7 +3763,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_after_map",
-          "line": 579,
+          "line": 578,
           "called": [
             "ASID",
             "ObjId",
@@ -3793,7 +3794,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_map_other",
-          "line": 628,
+          "line": 627,
           "called": [
             "ASID",
             "ObjId",
@@ -3824,7 +3825,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_after_unmap",
-          "line": 681,
+          "line": 680,
           "called": [
             "ASID",
             "ObjId",
@@ -3853,23 +3854,22 @@
         {
           "kind": "theorem",
           "name": "vspaceLookup_unmap_other",
-          "line": 725,
+          "line": 724,
           "called": [
             "ASID",
             "ObjId",
             "SystemState",
             "VAddr",
             "VSpaceRoot",
-            "capacity",
             "erase",
             "invExt",
+            "invExtK",
             "lookupAddr",
             "lookup_unmapPage_ne",
             "none",
             "resolveAsidRoot",
             "resolveAsidRoot_of_asidTable_entry",
             "resolveAsidRoot_some_implies_obj",
-            "size",
             "storeObject",
             "storeObject_asidTable_vspaceRoot",
             "storeObject_objects_eq",
@@ -3883,7 +3883,7 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPageChecked_success_preserves_vspaceInvariantBundle",
-          "line": 779,
+          "line": 774,
           "called": [
             "ASID",
             "ObjId",
@@ -3907,7 +3907,7 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPageChecked_error_preserves_vspaceInvariantBundle",
-          "line": 810,
+          "line": 805,
           "called": [
             "ASID",
             "PAddr",
@@ -3921,7 +3921,7 @@
         {
           "kind": "theorem",
           "name": "vspaceLookupFull_after_map",
-          "line": 825,
+          "line": 820,
           "called": [
             "ASID",
             "ObjId",
@@ -3952,7 +3952,7 @@
         {
           "kind": "theorem",
           "name": "vspaceMapPage_resolveAsidRoot_agreement",
-          "line": 879,
+          "line": 874,
           "called": [
             "ASID",
             "ObjId",
@@ -3978,7 +3978,7 @@
         {
           "kind": "theorem",
           "name": "vspaceUnmapPage_resolveAsidRoot_agreement",
-          "line": 920,
+          "line": 915,
           "called": [
             "ASID",
             "ObjId",
@@ -5453,7 +5453,6 @@
             "CSpaceAddr",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
             "cdtAcyclicity",
             "cdtAcyclicity_of_cdt_eq",
             "cdtAcyclicity_of_detachSlotFromCdt",
@@ -5476,11 +5475,11 @@
             "detachSlotFromCdt",
             "detachSlotFromCdt_objects_eq",
             "invExt",
+            "invExtK",
             "none",
             "remove",
             "remove_slotCountBounded",
             "remove_slotsUnique",
-            "size",
             "storeCapabilityRef",
             "storeCapabilityRef_cdt_eq",
             "storeCapabilityRef_preserves_objects",
@@ -5495,34 +5494,29 @@
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
-          "line": 309,
+          "line": 307,
           "called": [
             "CSpaceAddr",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
             "cspaceDeleteSlot",
             "cspaceDeleteSlotCore_preserves_capabilityInvariantBundle",
-            "invExt",
-            "size"
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlotCore_preserves_cdtNodeSlot",
-          "line": 324,
+          "line": 321,
           "called": [
             "CSpaceAddr",
-            "RHTable.erase_size_lt_capacity",
             "SystemState",
-            "capacity",
             "cspaceDeleteSlotCore",
             "detachSlotFromCdt",
-            "erase_preserves_invExt",
-            "invExt",
+            "erase_preserves_invExtK",
+            "invExtK",
             "none",
             "remove",
-            "size",
             "storeCapabilityRef",
             "storeCapabilityRef_cdt_eq",
             "storeObject",
@@ -5532,21 +5526,19 @@
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_preserves_cdtNodeSlot",
-          "line": 365,
+          "line": 358,
           "called": [
             "CSpaceAddr",
             "SystemState",
-            "capacity",
             "cspaceDeleteSlot",
             "cspaceDeleteSlotCore_preserves_cdtNodeSlot",
-            "invExt",
-            "size"
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
           "name": "cspaceRevoke_preserves_capabilityInvariantBundle",
-          "line": 379,
+          "line": 371,
           "called": [
             "CSpaceAddr",
             "SystemState",
@@ -5586,7 +5578,7 @@
         {
           "kind": "theorem",
           "name": "cspaceCopy_preserves_capabilityInvariantBundle",
-          "line": 478,
+          "line": 470,
           "called": [
             "CSpaceAddr",
             "SystemState",
@@ -5613,14 +5605,13 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_preserves_capabilityInvariantBundle",
-          "line": 525,
+          "line": 517,
           "called": [
             "CSpaceAddr",
             "SystemState",
             "attachSlotToCdtNode",
             "attachSlotToCdtNode_objects_eq",
             "capabilityInvariantBundle",
-            "capacity",
             "cdtAcyclicity",
             "cdtCompleteness",
             "cspaceDeleteSlotCore",
@@ -5635,12 +5626,11 @@
             "cspaceSlotCountBounded_of_objects_eq",
             "cspaceSlotUnique_of_objects_eq",
             "insert",
-            "invExt",
+            "invExtK",
             "lookup",
             "lookupCdtNodeOfSlot",
             "none",
             "objects_invExt_of_capabilityInvariantBundle",
-            "size",
             "slotCountBounded",
             "storeCapabilityRef_cdt_eq",
             "storeObject",
@@ -5650,7 +5640,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMintWithCdt_preserves_capabilityInvariantBundle",
-          "line": 600,
+          "line": 591,
           "called": [
             "AccessRightSet",
             "Badge",
@@ -5676,7 +5666,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMutate_preserves_capabilityInvariantBundle",
-          "line": 645,
+          "line": 636,
           "called": [
             "AccessRightSet",
             "Badge",
@@ -5719,7 +5709,7 @@
         {
           "kind": "theorem",
           "name": "capabilityInvariantBundle_of_cdt_update",
-          "line": 758,
+          "line": 749,
           "called": [
             "CapDerivationTree",
             "SystemState",
@@ -5733,33 +5723,29 @@
         {
           "kind": "theorem",
           "name": "processRevokeNode_preserves_cdtNodeSlot",
-          "line": 773,
+          "line": 764,
           "called": [
             "CdtNodeId",
-            "RHTable.erase_size_lt_capacity",
             "SystemState",
-            "capacity",
             "cspaceDeleteSlotCore",
             "cspaceDeleteSlotCore_preserves_cdtNodeSlot",
             "detachSlotFromCdt",
-            "erase_preserves_invExt",
-            "invExt",
+            "erase_preserves_invExtK",
+            "invExtK",
             "lookupCdtSlotOfNode",
             "none",
-            "processRevokeNode",
-            "size"
+            "processRevokeNode"
           ]
         },
         {
           "kind": "theorem",
           "name": "processRevokeNode_preserves_capabilityInvariantBundle",
-          "line": 817,
+          "line": 804,
           "called": [
             "CdtNodeId",
             "SystemState",
             "capabilityInvariantBundle",
             "capabilityInvariantBundle_of_cdt_update",
-            "capacity",
             "cdtAcyclicity_of_detachSlotFromCdt",
             "cdtCompleteness_of_detachSlotFromCdt",
             "cspaceDeleteSlotCore",
@@ -5772,18 +5758,17 @@
             "detachSlotFromCdt",
             "detachSlotFromCdt_objects_eq",
             "edgeWellFounded_sub",
-            "invExt",
+            "invExtK",
             "lookupCdtSlotOfNode",
             "none",
             "processRevokeNode",
-            "removeNode_edges_sub",
-            "size"
+            "removeNode_edges_sub"
           ]
         },
         {
           "kind": "def",
           "name": "revokeCdtFoldBody",
-          "line": 858,
+          "line": 844,
           "called": [
             "CdtNodeId",
             "KernelError",
@@ -5794,24 +5779,22 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_preserves",
-          "line": 870,
+          "line": 856,
           "called": [
             "CdtNodeId",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
-            "invExt",
+            "invExtK",
             "processRevokeNode",
             "processRevokeNode_preserves_capabilityInvariantBundle",
             "processRevokeNode_preserves_cdtNodeSlot",
-            "revokeCdtFoldBody",
-            "size"
+            "revokeCdtFoldBody"
           ]
         },
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_error",
-          "line": 888,
+          "line": 872,
           "called": [
             "CdtNodeId",
             "KernelError",
@@ -5821,7 +5804,7 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFoldBody_foldl_error",
-          "line": 893,
+          "line": 877,
           "called": [
             "CdtNodeId",
             "KernelError",
@@ -5832,41 +5815,37 @@
         {
           "kind": "theorem",
           "name": "revokeCdtFold_preserves",
-          "line": 901,
+          "line": 885,
           "called": [
             "CdtNodeId",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
-            "invExt",
+            "invExtK",
             "revokeCdtFoldBody",
             "revokeCdtFoldBody_foldl_error",
-            "revokeCdtFoldBody_preserves",
-            "size"
+            "revokeCdtFoldBody_preserves"
           ]
         },
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdt_preserves_capabilityInvariantBundle",
-          "line": 926,
+          "line": 909,
           "called": [
             "CSpaceAddr",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
             "cspaceLookupSlot",
             "cspaceLookupSlot_preserves_state",
             "cspaceRevoke",
             "cspaceRevokeCdt",
             "cspaceRevoke_preserves_capabilityInvariantBundle",
             "descendantsOf",
-            "invExt",
+            "invExtK",
             "none",
             "revokeAndClearRefsState_cdt_eq",
             "revokeCdtFoldBody",
             "revokeCdtFold_preserves",
             "revokeTargetLocal",
-            "size",
             "storeObject",
             "storeObject_cdtNodeSlot_eq"
           ]
@@ -5874,7 +5853,7 @@
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdt_error_propagation_consistent",
-          "line": 979,
+          "line": 959,
           "called": [
             "CSpaceAddr",
             "CdtNodeId",
@@ -5889,7 +5868,7 @@
         {
           "kind": "theorem",
           "name": "streamingRevokeBFS_fuel_exhaustion_returns_error",
-          "line": 993,
+          "line": 973,
           "called": [
             "CdtNodeId",
             "SystemState",
@@ -5899,16 +5878,14 @@
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdtStrict_preserves_capabilityInvariantBundle",
-          "line": 1003,
+          "line": 983,
           "called": [
             "CSpaceAddr",
             "CdtNodeId",
-            "RHTable.erase_size_lt_capacity",
             "RevokeCdtStrictReport",
             "SystemState",
             "capabilityInvariantBundle",
             "capabilityInvariantBundle_of_cdt_update",
-            "capacity",
             "cdtAcyclicity_of_detachSlotFromCdt",
             "cdtCompleteness_of_detachSlotFromCdt",
             "cspaceDeleteSlotCore",
@@ -5927,15 +5904,14 @@
             "detachSlotFromCdt",
             "detachSlotFromCdt_objects_eq",
             "edgeWellFounded_sub",
-            "erase_preserves_invExt",
-            "invExt",
+            "erase_preserves_invExtK",
+            "invExtK",
             "lookupCdtSlotOfNode",
             "none",
             "removeNode",
             "removeNode_edges_sub",
             "revokeAndClearRefsState_cdt_eq",
             "revokeTargetLocal",
-            "size",
             "storeObject",
             "storeObject_cdtNodeSlot_eq"
           ]
@@ -5943,31 +5919,27 @@
         {
           "kind": "theorem",
           "name": "streamingRevokeBFS_step_preserves",
-          "line": 1141,
+          "line": 1114,
           "called": [
             "CdtNodeId",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
-            "invExt",
+            "invExtK",
             "processRevokeNode",
-            "processRevokeNode_preserves_capabilityInvariantBundle",
-            "size"
+            "processRevokeNode_preserves_capabilityInvariantBundle"
           ]
         },
         {
           "kind": "theorem",
           "name": "streamingRevokeBFS_preserves",
-          "line": 1157,
+          "line": 1129,
           "called": [
             "CdtNodeId",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
-            "invExt",
+            "invExtK",
             "processRevokeNode",
             "processRevokeNode_preserves_cdtNodeSlot",
-            "size",
             "streamingRevokeBFS",
             "streamingRevokeBFS_step_preserves"
           ]
@@ -5975,22 +5947,20 @@
         {
           "kind": "theorem",
           "name": "cspaceRevokeCdtStreaming_preserves_capabilityInvariantBundle",
-          "line": 1188,
+          "line": 1159,
           "called": [
             "CSpaceAddr",
             "SystemState",
             "capabilityInvariantBundle",
-            "capacity",
             "cspaceLookupSlot",
             "cspaceLookupSlot_preserves_state",
             "cspaceRevoke",
             "cspaceRevokeCdtStreaming",
             "cspaceRevoke_preserves_capabilityInvariantBundle",
-            "invExt",
+            "invExtK",
             "none",
             "revokeAndClearRefsState_cdt_eq",
             "revokeTargetLocal",
-            "size",
             "storeObject",
             "storeObject_cdtNodeSlot_eq",
             "streamingRevokeBFS_preserves"
@@ -5999,7 +5969,7 @@
         {
           "kind": "theorem",
           "name": "capabilityInvariantBundle_of_storeTcbAndEnsureRunnable",
-          "line": 1242,
+          "line": 1212,
           "called": [
             "CNode",
             "IpcMessage",
@@ -6034,7 +6004,7 @@
         {
           "kind": "theorem",
           "name": "endpointReply_preserves_capabilityInvariantBundle",
-          "line": 1289,
+          "line": 1259,
           "called": [
             "IpcMessage",
             "SystemState",
@@ -6055,7 +6025,7 @@
         {
           "kind": "def",
           "name": "coreIpcInvariantBundle",
-          "line": 1355,
+          "line": 1325,
           "called": [
             "SystemState",
             "capabilityInvariantBundle",
@@ -6066,7 +6036,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_ipcInvariant",
-          "line": 1360,
+          "line": 1330,
           "called": [
             "SystemState",
             "coreIpcInvariantBundle",
@@ -6076,7 +6046,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_dualQueueSystemInvariant",
-          "line": 1365,
+          "line": 1335,
           "called": [
             "SystemState",
             "coreIpcInvariantBundle",
@@ -6086,7 +6056,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_allPendingMessagesBounded",
-          "line": 1370,
+          "line": 1340,
           "called": [
             "SystemState",
             "allPendingMessagesBounded",
@@ -6096,7 +6066,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_badgeWellFormed",
-          "line": 1375,
+          "line": 1345,
           "called": [
             "SystemState",
             "badgeWellFormed",
@@ -6106,7 +6076,7 @@
         {
           "kind": "theorem",
           "name": "coreIpcInvariantBundle_to_waitingThreadsPendingMessageNone",
-          "line": 1380,
+          "line": 1350,
           "called": [
             "SystemState",
             "coreIpcInvariantBundle",
@@ -6116,7 +6086,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerRunnableReadyComponent",
-          "line": 1385,
+          "line": 1355,
           "called": [
             "SystemState",
             "runnableThreadIpcReady"
@@ -6125,7 +6095,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedSendComponent",
-          "line": 1389,
+          "line": 1359,
           "called": [
             "SystemState",
             "blockedOnSendNotRunnable"
@@ -6134,7 +6104,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedReceiveComponent",
-          "line": 1393,
+          "line": 1363,
           "called": [
             "SystemState",
             "blockedOnReceiveNotRunnable"
@@ -6143,7 +6113,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedCallComponent",
-          "line": 1397,
+          "line": 1367,
           "called": [
             "SystemState",
             "blockedOnCallNotRunnable"
@@ -6152,7 +6122,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedReplyComponent",
-          "line": 1401,
+          "line": 1371,
           "called": [
             "SystemState",
             "blockedOnReplyNotRunnable"
@@ -6161,7 +6131,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerBlockedNotificationComponent",
-          "line": 1405,
+          "line": 1375,
           "called": [
             "SystemState",
             "blockedOnNotificationNotRunnable"
@@ -6170,7 +6140,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerCoherenceComponent",
-          "line": 1409,
+          "line": 1379,
           "called": [
             "SystemState",
             "ipcSchedulerBlockedCallComponent",
@@ -6184,7 +6154,7 @@
         {
           "kind": "theorem",
           "name": "ipcSchedulerCoherenceComponent_iff_contractPredicates",
-          "line": 1417,
+          "line": 1387,
           "called": [
             "SystemState",
             "ipcSchedulerCoherenceComponent",
@@ -6194,7 +6164,7 @@
         {
           "kind": "def",
           "name": "ipcSchedulerCouplingInvariantBundle",
-          "line": 1427,
+          "line": 1397,
           "called": [
             "SystemState",
             "contextMatchesCurrent",
@@ -6206,7 +6176,7 @@
         {
           "kind": "def",
           "name": "lifecycleCompositionInvariantBundle",
-          "line": 1433,
+          "line": 1403,
           "called": [
             "SystemState",
             "ipcSchedulerCouplingInvariantBundle",
@@ -6216,7 +6186,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_schedulerInvariantBundle",
-          "line": 1436,
+          "line": 1406,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6232,7 +6202,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
-          "line": 1455,
+          "line": 1425,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6266,7 +6236,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_ipcInvariant",
-          "line": 1512,
+          "line": 1482,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6284,7 +6254,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_coreIpcInvariantBundle",
-          "line": 1539,
+          "line": 1509,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6312,7 +6282,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRetypeObject_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1566,
+          "line": 1536,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6345,7 +6315,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle",
-          "line": 1599,
+          "line": 1569,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6353,13 +6323,12 @@
             "SystemState",
             "bitsConsumed",
             "capabilityInvariantBundle",
-            "capacity",
             "cspaceDeleteSlot_preserves_capabilityInvariantBundle",
             "cspaceLookupSlot",
             "cspaceLookupSlot_preserves_state",
             "cspaceRevoke",
             "cspaceRevoke_preserves_capabilityInvariantBundle",
-            "invExt",
+            "invExtK",
             "lifecycleRetypeObject_preserves_capabilityInvariantBundle",
             "lifecycleRevokeDeleteRetype",
             "lifecycleRevokeDeleteRetype_ok_implies_staged_steps",
@@ -6367,7 +6336,6 @@
             "none",
             "revokeAndClearRefsState_cdt_eq",
             "revokeTargetLocal",
-            "size",
             "slotCountBounded",
             "slotsUnique",
             "storeObject",
@@ -6378,7 +6346,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_preserves_lifecycleCapabilityStaleAuthorityInvariant",
-          "line": 1647,
+          "line": 1616,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6386,11 +6354,11 @@
             "SystemState",
             "bitsConsumed",
             "capabilityInvariantBundle",
-            "capacity",
             "cspaceDeleteSlot",
             "cspaceLookupSlot",
             "cspaceRevoke",
             "invExt",
+            "invExtK",
             "lifecycleAuthorityMonotonicity_holds",
             "lifecycleCapabilityStaleAuthorityInvariant",
             "lifecycleCapabilityStaleAuthorityInvariant_of_bundles",
@@ -6400,7 +6368,6 @@
             "lifecycleRevokeDeleteRetype_ok_implies_staged_steps",
             "lifecycleRevokeDeleteRetype_preserves_capabilityInvariantBundle",
             "maxCSpaceDepth",
-            "size",
             "slotCountBounded",
             "slotsUnique",
             "wellFormed"
@@ -6409,7 +6376,7 @@
         {
           "kind": "theorem",
           "name": "lifecycleRevokeDeleteRetype_error_preserves_lifecycleCompositionInvariantBundle",
-          "line": 1694,
+          "line": 1662,
           "called": [
             "CSpaceAddr",
             "KernelObject",
@@ -6423,7 +6390,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_of_storeTcbIpcState",
-          "line": 1707,
+          "line": 1675,
           "called": [
             "SystemState",
             "ThreadId",
@@ -6441,7 +6408,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_blocking_path",
-          "line": 1727,
+          "line": 1695,
           "called": [
             "Endpoint",
             "ObjId",
@@ -6463,7 +6430,7 @@
         {
           "kind": "theorem",
           "name": "cspaceSlotUnique_through_handshake_path",
-          "line": 1742,
+          "line": 1710,
           "called": [
             "Endpoint",
             "ObjId",
@@ -6485,7 +6452,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_cnode_preserves_notificationBadgesWellFormed",
-          "line": 1762,
+          "line": 1730,
           "called": [
             "CNode",
             "ObjId",
@@ -6499,7 +6466,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_cnode_preserves_capabilityBadgesWellFormed",
-          "line": 1773,
+          "line": 1741,
           "called": [
             "CNode",
             "ObjId",
@@ -6516,7 +6483,7 @@
         {
           "kind": "theorem",
           "name": "badgeWellFormed_of_objects_eq",
-          "line": 1789,
+          "line": 1757,
           "called": [
             "SystemState",
             "badgeWellFormed"
@@ -6525,7 +6492,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMint_preserves_badgeWellFormed",
-          "line": 1800,
+          "line": 1768,
           "called": [
             "AccessRightSet",
             "Badge",
@@ -6554,7 +6521,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMutate_preserves_badgeWellFormed",
-          "line": 1863,
+          "line": 1831,
           "called": [
             "AccessRightSet",
             "Badge",
@@ -6584,7 +6551,7 @@
         {
           "kind": "theorem",
           "name": "ipcTransferSingleCap_preserves_capabilityInvariantBundle",
-          "line": 1942,
+          "line": 1910,
           "called": [
             "CSpaceAddr",
             "CapTransferResult",
@@ -6615,7 +6582,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_capabilityInvariantBundle_noGrant",
-          "line": 2017,
+          "line": 1985,
           "called": [
             "CapTransferSummary",
             "IpcMessage",
@@ -6629,7 +6596,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMint_preserves_cdtMapsConsistent",
-          "line": 2036,
+          "line": 2004,
           "called": [
             "AccessRightSet",
             "Badge",
@@ -6647,7 +6614,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlotCore_preserves_cdtMapsConsistent",
-          "line": 2058,
+          "line": 2026,
           "called": [
             "CSpaceAddr",
             "SystemState",
@@ -6665,7 +6632,7 @@
         {
           "kind": "theorem",
           "name": "cspaceDeleteSlot_preserves_cdtMapsConsistent",
-          "line": 2087,
+          "line": 2055,
           "called": [
             "CSpaceAddr",
             "SystemState",
@@ -6677,7 +6644,7 @@
         {
           "kind": "theorem",
           "name": "cspaceCopy_preserves_cdtMapsConsistent",
-          "line": 2100,
+          "line": 2068,
           "called": [
             "CSpaceAddr",
             "SystemState",
@@ -6688,7 +6655,7 @@
         {
           "kind": "theorem",
           "name": "cspaceMove_preserves_cdtMapsConsistent",
-          "line": 2108,
+          "line": 2076,
           "called": [
             "CSpaceAddr",
             "SystemState",
@@ -6699,7 +6666,7 @@
         {
           "kind": "theorem",
           "name": "cspaceRevoke_preserves_cdtMapsConsistent",
-          "line": 2117,
+          "line": 2085,
           "called": [
             "CSpaceAddr",
             "SystemState",
@@ -6718,7 +6685,7 @@
         {
           "kind": "theorem",
           "name": "cdtExpandingOp_preserves_bundle_with_hypothesis",
-          "line": 2194,
+          "line": 2162,
           "called": [
             "SystemState",
             "capabilityInvariantBundle",
@@ -6729,7 +6696,7 @@
         {
           "kind": "theorem",
           "name": "cdtShrinkingOps_preserve_acyclicity",
-          "line": 2206,
+          "line": 2174,
           "called": [
             "Kernel",
             "SystemState",
@@ -23229,7 +23196,7 @@
     {
       "module": "SeLe4n.Kernel.RobinHood.Bridge",
       "path": "SeLe4n/Kernel/RobinHood/Bridge.lean",
-      "declaration_count": 37,
+      "declaration_count": 52,
       "declarations": [
         {
           "kind": "namespace",
@@ -23758,6 +23725,184 @@
           "called": [
             "RHTable",
             "RHTable.empty"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "RHTable.invExtK",
+          "line": 904,
+          "called": [
+            "RHTable",
+            "capacity",
+            "invExt",
+            "size"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.invExtK_invExt",
+          "line": 908,
+          "called": [
+            "RHTable",
+            "invExt",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.invExtK_size_lt_capacity",
+          "line": 911,
+          "called": [
+            "RHTable",
+            "capacity",
+            "invExtK",
+            "size"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.invExtK_capacity_ge4",
+          "line": 914,
+          "called": [
+            "RHTable",
+            "capacity",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.mk_invExtK",
+          "line": 918,
+          "called": [
+            "RHTable",
+            "capacity",
+            "invExt",
+            "invExtK",
+            "size"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.empty_invExtK",
+          "line": 927,
+          "called": [
+            "RHTable",
+            "RHTable.empty",
+            "RHTable.empty_invExt",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.erase_capacity_eq",
+          "line": 939,
+          "called": [
+            "RHTable",
+            "RHTable.erase",
+            "capacity",
+            "erase"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.erase_preserves_invExtK",
+          "line": 946,
+          "called": [
+            "RHTable",
+            "erase",
+            "erase_capacity_eq",
+            "erase_preserves_invExt",
+            "erase_size_lt_capacity",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.insert_capacity_ge4",
+          "line": 958,
+          "called": [
+            "RHTable",
+            "RHTable.insert",
+            "RHTable.insertNoResize_capacity",
+            "capacity",
+            "insert",
+            "resize_fold_capacity"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.insert_preserves_invExtK",
+          "line": 967,
+          "called": [
+            "RHTable",
+            "insert",
+            "insert_capacity_ge4",
+            "insert_preserves_invExt",
+            "insert_size_lt_capacity",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.getElem",
+          "line": 980,
+          "called": [
+            "RHTable",
+            "erase",
+            "get",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.filter_capacity_eq",
+          "line": 991,
+          "called": [
+            "RHTable",
+            "RHTable.empty",
+            "RHTable.filter",
+            "RHTable.fold",
+            "RHTable.insertNoResize_capacity",
+            "capacity",
+            "filter"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.filter_preserves_invExtK",
+          "line": 1011,
+          "called": [
+            "RHTable",
+            "filter",
+            "filter_capacity_eq",
+            "filter_preserves_invExt",
+            "filter_size_lt_capacity",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.ofList_capacity_ge4",
+          "line": 1023,
+          "called": [
+            "RHTable",
+            "RHTable.empty",
+            "RHTable.ofList",
+            "capacity",
+            "insert",
+            "insert_capacity_ge4"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable.ofList_invExtK",
+          "line": 1037,
+          "called": [
+            "RHTable.ofList",
+            "RHTable.ofList_capacity_ge4",
+            "RHTable.ofList_invExt",
+            "RHTable.ofList_size_lt_capacity",
+            "invExtK"
           ]
         }
       ]
@@ -25820,7 +25965,7 @@
     {
       "module": "SeLe4n.Kernel.RobinHood.Set",
       "path": "SeLe4n/Kernel/RobinHood/Set.lean",
-      "declaration_count": 26,
+      "declaration_count": 31,
       "declarations": [
         {
           "kind": "namespace",
@@ -26089,6 +26234,60 @@
           "called": [
             "RHSet",
             "contains"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "RHSet.invExtK",
+          "line": 168,
+          "called": [
+            "RHSet"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHSet.empty_invExtK",
+          "line": 171,
+          "called": [
+            "RHSet",
+            "RHSet.empty",
+            "RHTable.empty_invExtK",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHSet.insert_preserves_invExtK",
+          "line": 176,
+          "called": [
+            "RHSet",
+            "insert",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHSet.erase_preserves_invExtK",
+          "line": 182,
+          "called": [
+            "RHSet",
+            "erase",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHSet.contains_erase_ne_K",
+          "line": 188,
+          "called": [
+            "RHSet",
+            "RHSet.contains",
+            "RHSet.erase",
+            "RHTable.contains",
+            "RHTable.getElem",
+            "contains",
+            "erase",
+            "invExtK"
           ]
         }
       ]
@@ -26366,6 +26565,7 @@
             "mem_toList_iff_mem",
             "queueCurrentConsistent",
             "schedulerPriorityMatch",
+            "threadPrio_invExt",
             "toObjId"
           ]
         },
@@ -26423,7 +26623,9 @@
             "get",
             "insert",
             "insert_threadPriority",
+            "mem_invExt",
             "none",
+            "threadPrio_invExt",
             "threadPriority_membership_consistent"
           ]
         },
@@ -26440,8 +26642,12 @@
             "RunQueue",
             "ThreadId",
             "erase",
+            "mem_invExt",
+            "mem_sizeOk",
             "none",
             "remove",
+            "threadPrio_invExt",
+            "threadPrio_sizeOk",
             "threadPriority_membership_consistent"
           ]
         }
@@ -27791,6 +27997,7 @@
             "runnable",
             "schedule_preserves_edfCurrentHasEarliestDeadline",
             "schedulerPriorityMatch",
+            "threadPrio_invExt",
             "toList",
             "toObjId",
             "wellFormed"
@@ -27821,6 +28028,7 @@
             "schedule_preserves_edfCurrentHasEarliestDeadline",
             "schedulerPriorityMatch",
             "threadId_ne_objId_beq_false",
+            "threadPrio_invExt",
             "tick",
             "timerTick",
             "toList",
@@ -27919,6 +28127,8 @@
             "schedule",
             "schedulerPriorityMatch",
             "setCurrentThread",
+            "threadPrio_invExt",
+            "threadPrio_sizeOk",
             "toObjId"
           ]
         },
@@ -27944,6 +28154,7 @@
             "runnable",
             "schedule_preserves_schedulerPriorityMatch",
             "schedulerPriorityMatch",
+            "threadPrio_invExt",
             "toObjId"
           ]
         },
@@ -27968,6 +28179,7 @@
             "runnable",
             "schedule_preserves_schedulerPriorityMatch",
             "schedulerPriorityMatch",
+            "threadPrio_invExt",
             "timerTick",
             "toObjId"
           ]
@@ -28237,7 +28449,7 @@
     {
       "module": "SeLe4n.Kernel.Scheduler.RunQueue",
       "path": "SeLe4n/Kernel/Scheduler/RunQueue.lean",
-      "declaration_count": 61,
+      "declaration_count": 70,
       "declarations": [
         {
           "kind": "namespace",
@@ -28254,41 +28466,121 @@
             "RHSet",
             "RHTable",
             "ThreadId",
-            "capacity",
             "contains",
-            "invExt",
+            "invExtK",
             "size"
           ]
         },
         {
           "kind": "namespace",
           "name": "RunQueue",
-          "line": 53,
+          "line": 41,
           "called": []
+        },
+        {
+          "kind": "theorem",
+          "name": "mem_invExt",
+          "line": 44,
+          "called": [
+            "RunQueue",
+            "invExt"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "mem_sizeOk",
+          "line": 45,
+          "called": [
+            "RunQueue",
+            "capacity",
+            "size"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "mem_capGe4",
+          "line": 46,
+          "called": [
+            "RunQueue",
+            "capacity"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "byPrio_invExt",
+          "line": 47,
+          "called": [
+            "RunQueue",
+            "invExt"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "byPrio_sizeOk",
+          "line": 48,
+          "called": [
+            "RunQueue",
+            "capacity",
+            "size"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "byPrio_capGe4",
+          "line": 49,
+          "called": [
+            "RunQueue",
+            "capacity"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "threadPrio_invExt",
+          "line": 50,
+          "called": [
+            "RunQueue",
+            "invExt"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "threadPrio_sizeOk",
+          "line": 51,
+          "called": [
+            "RunQueue",
+            "capacity",
+            "size"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "threadPrio_capGe4",
+          "line": 52,
+          "called": [
+            "RunQueue",
+            "capacity"
+          ]
         },
         {
           "kind": "def",
           "name": "empty",
           "line": 54,
           "called": [
-            "Priority",
             "RHSet",
             "RHSet.contains_empty",
             "RHSet.empty",
-            "RHSet.empty_invExt",
-            "RHTable",
-            "RHTable.empty_invExt'",
+            "RHSet.empty_invExtK",
+            "RHTable.empty_invExtK",
             "RunQueue",
             "ThreadId",
-            "capacity",
             "none",
             "size"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:85>",
-          "line": 85,
+          "name": "<anonymous:instance:65>",
+          "line": 65,
           "called": [
             "RunQueue",
             "empty"
@@ -28296,8 +28588,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:86>",
-          "line": 86,
+          "name": "<anonymous:instance:66>",
+          "line": 66,
           "called": [
             "RunQueue",
             "empty"
@@ -28305,8 +28597,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:87>",
-          "line": 87,
+          "name": "<anonymous:instance:67>",
+          "line": 67,
           "called": [
             "RunQueue"
           ]
@@ -28314,7 +28606,7 @@
         {
           "kind": "def",
           "name": "contains",
-          "line": 88,
+          "line": 68,
           "called": [
             "RunQueue",
             "ThreadId"
@@ -28322,8 +28614,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:90>",
-          "line": 90,
+          "name": "<anonymous:instance:70>",
+          "line": 70,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28333,8 +28625,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:92>",
-          "line": 92,
+          "name": "<anonymous:instance:72>",
+          "line": 72,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28344,7 +28636,7 @@
         {
           "kind": "def",
           "name": "recomputeMaxPriority",
-          "line": 111,
+          "line": 91,
           "called": [
             "Priority",
             "RHTable",
@@ -28357,23 +28649,18 @@
         {
           "kind": "def",
           "name": "insert",
-          "line": 119,
+          "line": 99,
           "called": [
             "Priority",
             "RHSet.contains_insert_ne",
             "RHSet.contains_insert_self",
-            "RHSet.insert",
-            "RHSet.insert_preserves_invExt",
-            "RHTable.insert",
-            "RHTable.insertNoResize_capacity",
+            "RHSet.insert_preserves_invExtK",
             "RunQueue",
             "ThreadId",
-            "capacity",
             "contains",
-            "insert_preserves_invExt",
-            "insert_size_lt_capacity",
+            "insert_preserves_invExtK",
+            "mem_invExt",
             "none",
-            "resize_fold_capacity",
             "size",
             "toNat"
           ]
@@ -28381,56 +28668,46 @@
         {
           "kind": "def",
           "name": "remove",
-          "line": 192,
+          "line": 146,
           "called": [
             "RHSet.contains_erase_ne",
             "RHSet.contains_erase_self",
-            "RHSet.erase",
-            "RHSet.erase_preserves_invExt",
-            "RHTable.erase",
-            "RHTable.insert",
-            "RHTable.insertNoResize_capacity",
+            "RHSet.erase_preserves_invExtK",
             "RunQueue",
             "ThreadId",
-            "capacity",
             "contains",
             "erase",
-            "erase_preserves_invExt",
-            "erase_size_lt_capacity",
+            "erase_preserves_invExtK",
             "filter",
             "get",
             "insert",
-            "insert_preserves_invExt",
-            "insert_size_lt_capacity",
-            "invExt",
+            "insert_preserves_invExtK",
+            "invExtK",
+            "mem_invExt",
+            "mem_sizeOk",
             "none",
             "recomputeMaxPriority",
-            "resize_fold_capacity",
             "size"
           ]
         },
         {
           "kind": "def",
           "name": "rotateToBack",
-          "line": 310,
+          "line": 210,
           "called": [
-            "RHTable.insert",
-            "RHTable.insertNoResize_capacity",
             "RunQueue",
             "ThreadId",
             "contains",
             "erase",
             "filter",
             "insert",
-            "insert_preserves_invExt",
-            "insert_size_lt_capacity",
-            "resize_fold_capacity"
+            "insert_preserves_invExtK"
           ]
         },
         {
           "kind": "def",
           "name": "toList",
-          "line": 341,
+          "line": 234,
           "called": [
             "RunQueue",
             "ThreadId"
@@ -28439,7 +28716,7 @@
         {
           "kind": "def",
           "name": "atPriority",
-          "line": 342,
+          "line": 235,
           "called": [
             "Priority",
             "RunQueue",
@@ -28449,7 +28726,7 @@
         {
           "kind": "def",
           "name": "maxPriorityBucket",
-          "line": 346,
+          "line": 239,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28460,7 +28737,7 @@
         {
           "kind": "def",
           "name": "ofList",
-          "line": 351,
+          "line": 244,
           "called": [
             "Priority",
             "RunQueue",
@@ -28472,7 +28749,7 @@
         {
           "kind": "theorem",
           "name": "mem_iff_contains",
-          "line": 356,
+          "line": 249,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28482,7 +28759,7 @@
         {
           "kind": "theorem",
           "name": "contains_false_of_not_mem",
-          "line": 359,
+          "line": 252,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28492,7 +28769,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_empty",
-          "line": 363,
+          "line": 256,
           "called": [
             "RHSet",
             "RHSet.contains_empty",
@@ -28507,7 +28784,7 @@
         {
           "kind": "theorem",
           "name": "mem_insert",
-          "line": 372,
+          "line": 265,
           "called": [
             "Priority",
             "RHSet.contains_insert_ne",
@@ -28515,26 +28792,29 @@
             "RunQueue",
             "ThreadId",
             "contains",
-            "insert"
+            "insert",
+            "mem_invExt"
           ]
         },
         {
           "kind": "theorem",
           "name": "mem_remove",
-          "line": 396,
+          "line": 289,
           "called": [
             "RHSet.contains_erase_ne",
             "RHSet.contains_erase_self",
             "RunQueue",
             "ThreadId",
             "contains",
+            "mem_invExt",
+            "mem_sizeOk",
             "remove"
           ]
         },
         {
           "kind": "theorem",
           "name": "mem_rotateToBack",
-          "line": 416,
+          "line": 309,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28545,7 +28825,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_remove_self",
-          "line": 424,
+          "line": 317,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28556,7 +28836,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_toList_of_not_mem",
-          "line": 430,
+          "line": 323,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28567,7 +28847,7 @@
         {
           "kind": "theorem",
           "name": "membership_implies_flat",
-          "line": 438,
+          "line": 331,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28578,7 +28858,7 @@
         {
           "kind": "theorem",
           "name": "mem_toList_iff_mem",
-          "line": 444,
+          "line": 337,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28590,7 +28870,7 @@
         {
           "kind": "theorem",
           "name": "toList_empty",
-          "line": 452,
+          "line": 345,
           "called": [
             "RunQueue",
             "empty",
@@ -28600,7 +28880,7 @@
         {
           "kind": "theorem",
           "name": "toList_insert_not_mem",
-          "line": 454,
+          "line": 347,
           "called": [
             "Priority",
             "RunQueue",
@@ -28614,7 +28894,7 @@
         {
           "kind": "theorem",
           "name": "filter_filter_ne_of_false",
-          "line": 465,
+          "line": 358,
           "called": [
             "filter"
           ]
@@ -28622,7 +28902,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_insert_neg",
-          "line": 478,
+          "line": 371,
           "called": [
             "Priority",
             "RunQueue",
@@ -28635,7 +28915,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_insert_neg'",
-          "line": 487,
+          "line": 380,
           "called": [
             "Priority",
             "RunQueue",
@@ -28650,7 +28930,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_insert_congr",
-          "line": 500,
+          "line": 393,
           "called": [
             "Priority",
             "RunQueue",
@@ -28667,7 +28947,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_remove_neg",
-          "line": 530,
+          "line": 423,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28680,7 +28960,7 @@
         {
           "kind": "theorem",
           "name": "toList_nodup_of_flat_nodup",
-          "line": 538,
+          "line": 431,
           "called": [
             "RunQueue"
           ]
@@ -28688,7 +28968,7 @@
         {
           "kind": "theorem",
           "name": "not_mem_remove_toList",
-          "line": 542,
+          "line": 435,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28699,7 +28979,7 @@
         {
           "kind": "theorem",
           "name": "mem_toList_rotateToBack_self",
-          "line": 551,
+          "line": 444,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28712,7 +28992,7 @@
         {
           "kind": "theorem",
           "name": "toList_rotateToBack_nodup",
-          "line": 559,
+          "line": 452,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28726,7 +29006,7 @@
         {
           "kind": "theorem",
           "name": "mem_toList_rotateToBack_ne",
-          "line": 577,
+          "line": 470,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28737,7 +29017,7 @@
         {
           "kind": "theorem",
           "name": "filter_erase_of_false",
-          "line": 593,
+          "line": 486,
           "called": [
             "erase",
             "filter"
@@ -28746,7 +29026,7 @@
         {
           "kind": "theorem",
           "name": "toList_filter_rotateToBack_neg",
-          "line": 608,
+          "line": 501,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28759,7 +29039,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 634,
+          "line": 527,
           "called": [
             "RunQueue",
             "contains"
@@ -28768,7 +29048,7 @@
         {
           "kind": "theorem",
           "name": "maxPriorityBucket_subset",
-          "line": 643,
+          "line": 536,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28781,7 +29061,7 @@
         {
           "kind": "theorem",
           "name": "maxPriorityBucket_threadPriority",
-          "line": 655,
+          "line": 548,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28793,7 +29073,7 @@
         {
           "kind": "theorem",
           "name": "mem_maxPriorityBucket_of_threadPriority",
-          "line": 667,
+          "line": 560,
           "called": [
             "Priority",
             "RunQueue",
@@ -28807,7 +29087,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_membership",
-          "line": 685,
+          "line": 578,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28817,7 +29097,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_threadPriority",
-          "line": 691,
+          "line": 584,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28827,7 +29107,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_maxPriority",
-          "line": 697,
+          "line": 590,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28837,7 +29117,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_contains",
-          "line": 703,
+          "line": 596,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28849,7 +29129,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_mem_iff",
-          "line": 708,
+          "line": 601,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28861,7 +29141,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_flat_subset",
-          "line": 713,
+          "line": 606,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28871,7 +29151,7 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_flat_superset",
-          "line": 725,
+          "line": 618,
           "called": [
             "RunQueue",
             "ThreadId",
@@ -28881,13 +29161,14 @@
         {
           "kind": "theorem",
           "name": "rotateToBack_preserves_wellFormed",
-          "line": 737,
+          "line": 630,
           "called": [
             "Priority",
             "RHTable",
             "RHTable_get",
             "RunQueue",
             "ThreadId",
+            "byPrio_invExt",
             "contains",
             "get",
             "rotateToBack",
@@ -28897,7 +29178,7 @@
         {
           "kind": "theorem",
           "name": "insert_threadPriority",
-          "line": 803,
+          "line": 696,
           "called": [
             "Priority",
             "RunQueue",
@@ -28909,7 +29190,7 @@
         {
           "kind": "theorem",
           "name": "insert_preserves_wellFormed",
-          "line": 813,
+          "line": 706,
           "called": [
             "Priority",
             "RHSet.contains_insert_ne",
@@ -28918,22 +29199,27 @@
             "RHTable_get",
             "RunQueue",
             "ThreadId",
+            "byPrio_invExt",
             "contains",
             "get",
             "insert",
+            "mem_invExt",
+            "threadPrio_invExt",
             "wellFormed"
           ]
         },
         {
           "kind": "theorem",
           "name": "remove_byPrio_to_orig",
-          "line": 904,
+          "line": 797,
           "called": [
             "Priority",
             "RHTable_get",
             "RHTable_getElem",
             "RunQueue",
             "ThreadId",
+            "byPrio_invExt",
+            "byPrio_sizeOk",
             "get",
             "remove"
           ]
@@ -28941,13 +29227,15 @@
         {
           "kind": "theorem",
           "name": "remove_byPrio_from_orig",
-          "line": 925,
+          "line": 818,
           "called": [
             "Priority",
             "RHTable_get",
             "RHTable_getElem",
             "RunQueue",
             "ThreadId",
+            "byPrio_invExt",
+            "byPrio_sizeOk",
             "filter",
             "get",
             "remove"
@@ -28956,13 +29244,15 @@
         {
           "kind": "theorem",
           "name": "remove_tid_not_in_bucket",
-          "line": 959,
+          "line": 852,
           "called": [
             "Priority",
             "RHTable_get",
             "RHTable_getElem",
             "RunQueue",
             "ThreadId",
+            "byPrio_invExt",
+            "byPrio_sizeOk",
             "get",
             "remove",
             "wellFormed"
@@ -28971,7 +29261,7 @@
         {
           "kind": "theorem",
           "name": "remove_preserves_wellFormed",
-          "line": 993,
+          "line": 886,
           "called": [
             "RHSet.contains_erase_ne",
             "RHSet.contains_erase_self",
@@ -28982,17 +29272,21 @@
             "contains",
             "erase",
             "get",
+            "mem_invExt",
+            "mem_sizeOk",
             "remove",
             "remove_byPrio_from_orig",
             "remove_byPrio_to_orig",
             "remove_tid_not_in_bucket",
+            "threadPrio_invExt",
+            "threadPrio_sizeOk",
             "wellFormed"
           ]
         },
         {
           "kind": "theorem",
           "name": "insert_maxPriority_consistency",
-          "line": 1044,
+          "line": 937,
           "called": [
             "Kernel",
             "Priority",
@@ -31726,7 +32020,7 @@
     {
       "module": "SeLe4n.Model.Builder",
       "path": "SeLe4n/Model/Builder.lean",
-      "declaration_count": 18,
+      "declaration_count": 17,
       "declarations": [
         {
           "kind": "namespace",
@@ -31736,92 +32030,92 @@
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_objects",
+          "name": "allTablesInvExtK_objects",
           "line": 31,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_irqHandlers",
+          "name": "allTablesInvExtK_irqHandlers",
           "line": 35,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_services",
+          "name": "allTablesInvExtK_services",
           "line": 39,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_serviceRegistry",
+          "name": "allTablesInvExtK_serviceRegistry",
           "line": 43,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_interfaceRegistry",
+          "name": "allTablesInvExtK_interfaceRegistry",
           "line": 47,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_objectTypes",
+          "name": "allTablesInvExtK_objectTypes",
           "line": 51,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_capabilityRefs",
+          "name": "allTablesInvExtK_capabilityRefs",
           "line": 55,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_objectIndexSet",
+          "name": "allTablesInvExtK_objectIndexSet",
           "line": 59,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_asidTable",
+          "name": "allTablesInvExtK_asidTable",
           "line": 63,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
@@ -31832,8 +32126,8 @@
             "IntermediateState",
             "Irq",
             "ObjId",
-            "RHTable.insert_preserves_invExt",
-            "SystemState.allTablesInvExt",
+            "RHTable.insert_preserves_invExtK",
+            "SystemState.allTablesInvExtK",
             "insert"
           ]
         },
@@ -31843,10 +32137,10 @@
           "line": 96,
           "called": [
             "IntermediateState",
-            "RHTable.insert_preserves_invExt",
+            "RHTable.insert_preserves_invExtK",
             "ServiceId",
             "ServiceRegistration",
-            "SystemState.allTablesInvExt",
+            "SystemState.allTablesInvExtK",
             "insert"
           ]
         },
@@ -31856,10 +32150,10 @@
           "line": 122,
           "called": [
             "IntermediateState",
-            "RHTable.insert_preserves_invExt",
+            "RHTable.insert_preserves_invExtK",
             "ServiceGraphEntry",
             "ServiceId",
-            "SystemState.allTablesInvExt",
+            "SystemState.allTablesInvExtK",
             "insert"
           ]
         },
@@ -31871,13 +32165,13 @@
             "IntermediateState",
             "KernelObject",
             "ObjId",
-            "RHSet.insert_preserves_invExt",
+            "RHSet.insert_preserves_invExtK",
             "RHTable.getElem",
-            "RHTable.insert_preserves_invExt",
+            "RHTable.insert_preserves_invExtK",
             "RHTable_getElem",
-            "SystemState.allTablesInvExt",
-            "allTablesInvExt_objectTypes",
-            "allTablesInvExt_objects",
+            "SystemState.allTablesInvExtK",
+            "allTablesInvExtK_objectTypes",
+            "allTablesInvExtK_objects",
             "contains",
             "insert",
             "invExt",
@@ -31898,60 +32192,42 @@
           "called": [
             "IntermediateState",
             "ObjId",
-            "RHTable.erase_preserves_invExt",
+            "RHTable.erase_preserves_invExtK",
             "RHTable.getElem",
             "RHTable_getElem",
-            "SystemState.allTablesInvExt",
-            "allTablesInvExt_objectTypes",
-            "allTablesInvExt_objects",
-            "capacity",
+            "SystemState.allTablesInvExtK",
+            "allTablesInvExtK_objectTypes",
+            "allTablesInvExtK_objects",
             "erase",
             "lookupCNode",
             "lookupCapabilityRefMeta",
             "lookupObjectTypeMeta",
             "lookupSlotCap",
             "perObjectMappingsInvariant",
-            "perObjectSlotsInvariant",
-            "size"
-          ]
-        },
-        {
-          "kind": "theorem",
-          "name": "insert_capacity_ge4",
-          "line": 312,
-          "called": [
-            "RHTable",
-            "RHTable.insert",
-            "RHTable.insertNoResize_capacity",
-            "capacity",
-            "insert",
-            "resize_fold_capacity"
+            "perObjectSlotsInvariant"
           ]
         },
         {
           "kind": "def",
           "name": "insertCap",
-          "line": 319,
+          "line": 310,
           "called": [
             "CNode",
             "Capability",
             "IntermediateState",
             "ObjId",
-            "RHTable.insert_preserves_invExt",
-            "RHTable.insert_size_lt_capacity",
+            "RHTable.insert_preserves_invExtK",
             "Slot",
             "cnodeId",
             "createObject",
             "insert",
-            "insert_capacity_ge4",
-            "none",
-            "slotsUnique"
+            "none"
           ]
         },
         {
           "kind": "def",
           "name": "mapPage",
-          "line": 343,
+          "line": 331,
           "called": [
             "IntermediateState",
             "ObjId",
@@ -33335,7 +33611,7 @@
           "line": 58,
           "called": [
             "SystemState",
-            "allTablesInvExt",
+            "allTablesInvExtK",
             "lifecycleMetadataConsistent",
             "perObjectMappingsInvariant",
             "perObjectSlotsInvariant"
@@ -33369,7 +33645,7 @@
           "line": 86,
           "called": [
             "IntermediateState",
-            "default_allTablesInvExt",
+            "default_allTablesInvExtK",
             "default_systemState_lifecycleConsistent",
             "perObjectMappingsInvariant_default",
             "perObjectSlotsInvariant_default"
@@ -33380,7 +33656,7 @@
           "name": "mkEmptyIntermediateState_valid",
           "line": 94,
           "called": [
-            "allTablesInvExt",
+            "allTablesInvExtK",
             "lifecycleMetadataConsistent",
             "mkEmptyIntermediateState",
             "perObjectMappingsInvariant",
@@ -33732,18 +34008,16 @@
             "RHTable.getElem",
             "VAddr",
             "VSpaceRoot",
-            "capacity",
-            "invExt",
+            "invExtK",
             "lookup",
             "none",
-            "size",
             "unmapPage"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:340>",
-          "line": 340,
+          "name": "<anonymous:instance:339>",
+          "line": 339,
           "called": [
             "VSpaceRoot",
             "fold",
@@ -33753,7 +34027,7 @@
         {
           "kind": "theorem",
           "name": "VSpaceRoot.beq_sound",
-          "line": 355,
+          "line": 354,
           "called": [
             "VSpaceRoot",
             "size"
@@ -33762,19 +34036,19 @@
         {
           "kind": "namespace",
           "name": "CNode",
-          "line": 360,
+          "line": 359,
           "called": []
         },
         {
           "kind": "inductive",
           "name": "ResolveError",
-          "line": 364,
+          "line": 363,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 369,
+          "line": 368,
           "called": [
             "CNode",
             "RHTable.empty"
@@ -33783,7 +34057,7 @@
         {
           "kind": "def",
           "name": "mk'",
-          "line": 375,
+          "line": 374,
           "called": [
             "CNode",
             "Capability",
@@ -33795,7 +34069,7 @@
         {
           "kind": "def",
           "name": "slotCount",
-          "line": 380,
+          "line": 379,
           "called": [
             "CNode"
           ]
@@ -33803,7 +34077,7 @@
         {
           "kind": "def",
           "name": "bitsConsumed",
-          "line": 384,
+          "line": 383,
           "called": [
             "CNode"
           ]
@@ -33811,15 +34085,15 @@
         {
           "kind": "def",
           "name": "guardBounded",
-          "line": 390,
+          "line": 389,
           "called": [
             "CNode"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:393>",
-          "line": 393,
+          "name": "<anonymous:instance:392>",
+          "line": 392,
           "called": [
             "CNode",
             "guardBounded"
@@ -33828,7 +34102,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 399,
+          "line": 398,
           "called": [
             "CNode",
             "bitsConsumed",
@@ -33838,7 +34112,7 @@
         {
           "kind": "def",
           "name": "resolveSlot",
-          "line": 412,
+          "line": 411,
           "called": [
             "CNode",
             "CPtr",
@@ -33853,7 +34127,7 @@
         {
           "kind": "theorem",
           "name": "resolveSlot_mask_idempotent",
-          "line": 431,
+          "line": 430,
           "called": [
             "machineWordMax"
           ]
@@ -33861,7 +34135,7 @@
         {
           "kind": "def",
           "name": "lookup",
-          "line": 436,
+          "line": 435,
           "called": [
             "CNode",
             "Capability",
@@ -33872,7 +34146,7 @@
         {
           "kind": "def",
           "name": "insert",
-          "line": 441,
+          "line": 440,
           "called": [
             "CNode",
             "Capability",
@@ -33882,7 +34156,7 @@
         {
           "kind": "def",
           "name": "remove",
-          "line": 445,
+          "line": 444,
           "called": [
             "CNode",
             "Slot",
@@ -33892,7 +34166,7 @@
         {
           "kind": "def",
           "name": "findFirstEmptySlot",
-          "line": 455,
+          "line": 454,
           "called": [
             "CNode",
             "Slot",
@@ -33905,7 +34179,7 @@
         {
           "kind": "theorem",
           "name": "findFirstEmptySlot_spec",
-          "line": 465,
+          "line": 464,
           "called": [
             "CNode",
             "Slot",
@@ -33917,7 +34191,7 @@
         {
           "kind": "theorem",
           "name": "findFirstEmptySlot_zero",
-          "line": 480,
+          "line": 479,
           "called": [
             "CNode",
             "Slot",
@@ -33928,7 +34202,7 @@
         {
           "kind": "theorem",
           "name": "findFirstEmptySlot_none_iff",
-          "line": 485,
+          "line": 484,
           "called": [
             "CNode",
             "Slot",
@@ -33944,7 +34218,7 @@
         {
           "kind": "def",
           "name": "revokeTargetLocal",
-          "line": 516,
+          "line": 515,
           "called": [
             "CNode",
             "CapTarget",
@@ -33955,18 +34229,16 @@
         {
           "kind": "def",
           "name": "slotsUnique",
-          "line": 532,
+          "line": 531,
           "called": [
             "CNode",
-            "capacity",
-            "invExt",
-            "size"
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
           "name": "lookup_remove_eq_none",
-          "line": 539,
+          "line": 537,
           "called": [
             "CNode",
             "RHTable.getElem",
@@ -33980,7 +34252,7 @@
         {
           "kind": "theorem",
           "name": "lookup_mem_of_some",
-          "line": 548,
+          "line": 546,
           "called": [
             "CNode",
             "Capability",
@@ -33992,7 +34264,7 @@
         {
           "kind": "theorem",
           "name": "resolveSlot_depthMismatch",
-          "line": 553,
+          "line": 551,
           "called": [
             "CNode",
             "CPtr",
@@ -34003,7 +34275,7 @@
         {
           "kind": "theorem",
           "name": "resolveSlot_guardMismatch_of_not_guardBounded",
-          "line": 571,
+          "line": 569,
           "called": [
             "CNode",
             "CPtr",
@@ -34017,7 +34289,7 @@
         {
           "kind": "theorem",
           "name": "lookup_revokeTargetLocal_source_eq_lookup",
-          "line": 601,
+          "line": 599,
           "called": [
             "CNode",
             "CapTarget",
@@ -34031,7 +34303,7 @@
         {
           "kind": "theorem",
           "name": "empty_guardBounded",
-          "line": 613,
+          "line": 611,
           "called": [
             "empty",
             "guardBounded"
@@ -34040,42 +34312,33 @@
         {
           "kind": "theorem",
           "name": "empty_slotsUnique",
-          "line": 617,
+          "line": 615,
           "called": [
-            "RHTable.empty",
-            "RHTable.empty_invExt",
-            "capacity",
-            "size",
+            "RHTable.empty_invExtK",
             "slotsUnique"
           ]
         },
         {
           "kind": "theorem",
           "name": "insert_slotsUnique",
-          "line": 627,
+          "line": 620,
           "called": [
             "CNode",
             "Capability",
-            "RHTable.insert",
-            "RHTable.insertNoResize_capacity",
             "Slot",
             "insert",
-            "insert_preserves_invExt",
-            "insert_size_lt_capacity",
-            "resize_fold_capacity",
+            "insert_preserves_invExtK",
             "slotsUnique"
           ]
         },
         {
           "kind": "theorem",
           "name": "remove_slotsUnique",
-          "line": 643,
+          "line": 628,
           "called": [
             "CNode",
-            "RHTable.erase",
             "Slot",
-            "erase_preserves_invExt",
-            "erase_size_lt_capacity",
+            "erase_preserves_invExtK",
             "remove",
             "slotsUnique"
           ]
@@ -34083,20 +34346,12 @@
         {
           "kind": "theorem",
           "name": "revokeTargetLocal_slotsUnique",
-          "line": 654,
+          "line": 636,
           "called": [
             "CNode",
             "CapTarget",
-            "Capability",
-            "RHTable",
-            "RHTable.empty",
-            "RHTable.filter",
-            "RHTable.fold",
-            "RHTable.insertNoResize_capacity",
             "Slot",
-            "capacity",
-            "filter_preserves_invExt",
-            "filter_size_lt_capacity",
+            "filter_preserves_invExtK",
             "revokeTargetLocal",
             "slotsUnique"
           ]
@@ -34104,7 +34359,7 @@
         {
           "kind": "def",
           "name": "slotCountBounded",
-          "line": 686,
+          "line": 651,
           "called": [
             "CNode",
             "size",
@@ -34114,7 +34369,7 @@
         {
           "kind": "theorem",
           "name": "empty_slotCountBounded",
-          "line": 690,
+          "line": 655,
           "called": [
             "RHTable.empty",
             "empty",
@@ -34125,7 +34380,7 @@
         {
           "kind": "theorem",
           "name": "remove_slotCountBounded",
-          "line": 696,
+          "line": 661,
           "called": [
             "CNode",
             "RHTable.size_erase_le",
@@ -34139,7 +34394,7 @@
         {
           "kind": "theorem",
           "name": "revokeTargetLocal_slotCountBounded",
-          "line": 706,
+          "line": 671,
           "called": [
             "CNode",
             "CapTarget",
@@ -34155,7 +34410,7 @@
         {
           "kind": "theorem",
           "name": "mem_lookup_of_slotsUnique",
-          "line": 720,
+          "line": 685,
           "called": [
             "CNode",
             "RHTable.mem_iff_isSome_getElem",
@@ -34167,7 +34422,7 @@
         {
           "kind": "theorem",
           "name": "lookup_insert_eq",
-          "line": 730,
+          "line": 695,
           "called": [
             "CNode",
             "Capability",
@@ -34181,7 +34436,7 @@
         {
           "kind": "theorem",
           "name": "lookup_insert_ne",
-          "line": 740,
+          "line": 705,
           "called": [
             "CNode",
             "Capability",
@@ -34195,7 +34450,7 @@
         {
           "kind": "theorem",
           "name": "lookup_remove_ne",
-          "line": 752,
+          "line": 717,
           "called": [
             "CNode",
             "RHTable.getElem",
@@ -34207,8 +34462,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:767>",
-          "line": 767,
+          "name": "<anonymous:instance:732>",
+          "line": 732,
           "called": [
             "CNode",
             "fold",
@@ -34219,7 +34474,7 @@
         {
           "kind": "theorem",
           "name": "CNode.beq_sound",
-          "line": 776,
+          "line": 741,
           "called": [
             "CNode",
             "size"
@@ -34228,7 +34483,7 @@
         {
           "kind": "def",
           "name": "cnodeWellFormed",
-          "line": 794,
+          "line": 759,
           "called": [
             "CNode",
             "bitsConsumed"
@@ -34237,7 +34492,7 @@
         {
           "kind": "theorem",
           "name": "CNode.empty_not_wellFormed",
-          "line": 799,
+          "line": 764,
           "called": [
             "bitsConsumed",
             "empty",
@@ -34247,7 +34502,7 @@
         {
           "kind": "abbrev",
           "name": "SlotAddr",
-          "line": 808,
+          "line": 773,
           "called": [
             "ObjId",
             "Slot"
@@ -34256,19 +34511,19 @@
         {
           "kind": "inductive",
           "name": "DerivationOp",
-          "line": 811,
+          "line": 776,
           "called": []
         },
         {
           "kind": "structure",
           "name": "CdtNodeId",
-          "line": 825,
+          "line": 790,
           "called": []
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:831>",
-          "line": 831,
+          "name": "<anonymous:instance:796>",
+          "line": 796,
           "called": [
             "CdtNodeId"
           ]
@@ -34276,13 +34531,13 @@
         {
           "kind": "namespace",
           "name": "CdtNodeId",
-          "line": 834,
+          "line": 799,
           "called": []
         },
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 837,
+          "line": 802,
           "called": [
             "CdtNodeId"
           ]
@@ -34290,15 +34545,15 @@
         {
           "kind": "def",
           "name": "toNat",
-          "line": 840,
+          "line": 805,
           "called": [
             "CdtNodeId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:842>",
-          "line": 842,
+          "name": "<anonymous:instance:807>",
+          "line": 807,
           "called": [
             "CdtNodeId",
             "toNat"
@@ -34306,24 +34561,24 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:848>",
-          "line": 848,
+          "name": "<anonymous:instance:813>",
+          "line": 813,
           "called": [
             "CdtNodeId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:852>",
-          "line": 852,
+          "name": "<anonymous:instance:817>",
+          "line": 817,
           "called": [
             "CdtNodeId"
           ]
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:855>",
-          "line": 855,
+          "name": "<anonymous:instance:820>",
+          "line": 820,
           "called": [
             "CdtNodeId"
           ]
@@ -34331,7 +34586,7 @@
         {
           "kind": "structure",
           "name": "CapDerivationEdge",
-          "line": 864,
+          "line": 829,
           "called": [
             "CdtNodeId",
             "DerivationOp"
@@ -34340,13 +34595,13 @@
         {
           "kind": "namespace",
           "name": "CapDerivationEdge",
-          "line": 870,
+          "line": 835,
           "called": []
         },
         {
           "kind": "def",
           "name": "isChildOf",
-          "line": 872,
+          "line": 837,
           "called": [
             "CapDerivationEdge",
             "CdtNodeId"
@@ -34355,7 +34610,7 @@
         {
           "kind": "def",
           "name": "isParentOf",
-          "line": 875,
+          "line": 840,
           "called": [
             "CapDerivationEdge",
             "CdtNodeId"
@@ -34364,7 +34619,7 @@
         {
           "kind": "structure",
           "name": "CapDerivationTree",
-          "line": 892,
+          "line": 857,
           "called": [
             "CapDerivationEdge",
             "CdtNodeId",
@@ -34374,13 +34629,13 @@
         {
           "kind": "namespace",
           "name": "CapDerivationTree",
-          "line": 904,
+          "line": 869,
           "called": []
         },
         {
           "kind": "def",
           "name": "empty",
-          "line": 908,
+          "line": 873,
           "called": [
             "CapDerivationTree"
           ]
@@ -34388,7 +34643,7 @@
         {
           "kind": "def",
           "name": "addEdge",
-          "line": 912,
+          "line": 877,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34400,7 +34655,7 @@
         {
           "kind": "def",
           "name": "childrenOf",
-          "line": 921,
+          "line": 886,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34410,7 +34665,7 @@
         {
           "kind": "def",
           "name": "parentOf",
-          "line": 927,
+          "line": 892,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -34419,7 +34674,7 @@
         {
           "kind": "def",
           "name": "removeAsChild",
-          "line": 934,
+          "line": 899,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34434,7 +34689,7 @@
         {
           "kind": "def",
           "name": "removeAsParent",
-          "line": 949,
+          "line": 914,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34447,7 +34702,7 @@
         {
           "kind": "def",
           "name": "removeNode",
-          "line": 959,
+          "line": 924,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34463,7 +34718,7 @@
         {
           "kind": "def",
           "name": "descendantsOf",
-          "line": 985,
+          "line": 950,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34474,7 +34729,7 @@
         {
           "kind": "def",
           "name": "acyclic",
-          "line": 998,
+          "line": 963,
           "called": [
             "CapDerivationTree",
             "descendantsOf"
@@ -34483,7 +34738,7 @@
         {
           "kind": "theorem",
           "name": "empty_acyclic",
-          "line": 1001,
+          "line": 966,
           "called": [
             "acyclic",
             "empty"
@@ -34492,7 +34747,7 @@
         {
           "kind": "def",
           "name": "edgeWellFounded",
-          "line": 1013,
+          "line": 978,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -34501,7 +34756,7 @@
         {
           "kind": "theorem",
           "name": "empty_edgeWellFounded",
-          "line": 1023,
+          "line": 988,
           "called": [
             "edgeWellFounded",
             "empty"
@@ -34510,7 +34765,7 @@
         {
           "kind": "theorem",
           "name": "edgeWellFounded_sub",
-          "line": 1032,
+          "line": 997,
           "called": [
             "CapDerivationTree",
             "edgeWellFounded"
@@ -34519,7 +34774,7 @@
         {
           "kind": "theorem",
           "name": "removeNode_edges_sub",
-          "line": 1043,
+          "line": 1008,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34529,7 +34784,7 @@
         {
           "kind": "theorem",
           "name": "addEdge_preserves_edgeWellFounded_fresh",
-          "line": 1060,
+          "line": 1025,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34542,7 +34797,7 @@
         {
           "kind": "def",
           "name": "addEdgeWouldBeSafe",
-          "line": 1127,
+          "line": 1092,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34552,7 +34807,7 @@
         {
           "kind": "def",
           "name": "childMapConsistent",
-          "line": 1132,
+          "line": 1097,
           "called": [
             "CapDerivationTree",
             "get"
@@ -34561,7 +34816,7 @@
         {
           "kind": "theorem",
           "name": "empty_childMapConsistent",
-          "line": 1137,
+          "line": 1102,
           "called": [
             "CdtNodeId",
             "RHTable",
@@ -34575,7 +34830,7 @@
         {
           "kind": "theorem",
           "name": "addEdge_childMapConsistent",
-          "line": 1147,
+          "line": 1112,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34589,7 +34844,7 @@
         {
           "kind": "def",
           "name": "parentMapConsistent",
-          "line": 1196,
+          "line": 1161,
           "called": [
             "CapDerivationTree"
           ]
@@ -34597,7 +34852,7 @@
         {
           "kind": "theorem",
           "name": "empty_parentMapConsistent",
-          "line": 1201,
+          "line": 1166,
           "called": [
             "CdtNodeId",
             "RHTable",
@@ -34610,7 +34865,7 @@
         {
           "kind": "theorem",
           "name": "addEdge_parentMapConsistent",
-          "line": 1211,
+          "line": 1176,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34627,7 +34882,7 @@
         {
           "kind": "theorem",
           "name": "addEdge_preserves_cdtMapsConsistent",
-          "line": 1261,
+          "line": 1226,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34644,110 +34899,95 @@
         {
           "kind": "theorem",
           "name": "foldl_erase_preserves",
-          "line": 1275,
+          "line": 1240,
           "called": [
             "CdtNodeId",
             "RHTable",
             "RHTable.getElem",
-            "capacity",
             "erase",
-            "erase_preserves_invExt",
-            "erase_size_lt_capacity",
-            "invExt",
-            "size"
+            "erase_preserves_invExtK",
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
           "name": "foldl_erase_none",
-          "line": 1297,
+          "line": 1261,
           "called": [
             "CdtNodeId",
             "RHTable",
             "RHTable.getElem",
-            "capacity",
             "erase",
-            "erase_preserves_invExt",
-            "erase_size_lt_capacity",
+            "erase_preserves_invExtK",
             "get",
-            "invExt",
-            "none",
-            "size"
+            "invExtK",
+            "none"
           ]
         },
         {
           "kind": "theorem",
           "name": "foldl_erase_mem",
-          "line": 1317,
+          "line": 1280,
           "called": [
             "CdtNodeId",
             "RHTable",
             "RHTable.getElem",
-            "capacity",
             "erase",
-            "erase_preserves_invExt",
-            "erase_size_lt_capacity",
+            "erase_preserves_invExtK",
             "foldl_erase_none",
             "get",
-            "invExt",
-            "none",
-            "size"
+            "invExtK",
+            "none"
           ]
         },
         {
           "kind": "theorem",
           "name": "removeNode_parentMapConsistent",
-          "line": 1344,
+          "line": 1306,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
             "RHTable",
             "RHTable.getElem",
-            "capacity",
             "childMapConsistent",
             "erase",
-            "erase_preserves_invExt",
-            "erase_size_lt_capacity",
+            "erase_preserves_invExtK",
             "foldl_erase_mem",
             "foldl_erase_preserves",
             "get",
-            "invExt",
+            "invExtK",
             "isChildOf",
             "isParentOf",
             "none",
             "parentMapConsistent",
-            "removeNode",
-            "size"
+            "removeNode"
           ]
         },
         {
           "kind": "theorem",
           "name": "removeNode_childMapConsistent",
-          "line": 1464,
+          "line": 1423,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
             "RHTable.getElem",
-            "capacity",
             "childMapConsistent",
             "erase",
-            "erase_preserves_invExt",
-            "erase_size_lt_capacity",
+            "erase_preserves_invExtK",
             "filter",
             "get",
-            "invExt",
+            "invExtK",
             "isChildOf",
             "isParentOf",
             "none",
             "parentMapConsistent",
-            "removeNode",
-            "size"
+            "removeNode"
           ]
         },
         {
           "kind": "structure",
           "name": "ObservedDerivationEdge",
-          "line": 1697,
+          "line": 1652,
           "called": [
             "DerivationOp",
             "SlotAddr"
@@ -34756,7 +34996,7 @@
         {
           "kind": "def",
           "name": "projectObservedEdges",
-          "line": 1704,
+          "line": 1659,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34768,7 +35008,7 @@
         {
           "kind": "def",
           "name": "isAncestor",
-          "line": 1715,
+          "line": 1670,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34778,7 +35018,7 @@
         {
           "kind": "theorem",
           "name": "addEdge_preserves_edgeWellFounded_noParent",
-          "line": 1737,
+          "line": 1692,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34791,7 +35031,7 @@
         {
           "kind": "def",
           "name": "cdtMapsConsistent",
-          "line": 1869,
+          "line": 1824,
           "called": [
             "CapDerivationTree",
             "get"
@@ -34800,7 +35040,7 @@
         {
           "kind": "theorem",
           "name": "rhtable_default_get",
-          "line": 1881,
+          "line": 1836,
           "called": [
             "RHTable",
             "RHTable.getElem",
@@ -34811,7 +35051,7 @@
         {
           "kind": "theorem",
           "name": "empty_cdtMapsConsistent",
-          "line": 1888,
+          "line": 1843,
           "called": [
             "CdtNodeId",
             "RHTable",
@@ -34825,7 +35065,7 @@
         {
           "kind": "def",
           "name": "removeEdge",
-          "line": 1910,
+          "line": 1865,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34838,7 +35078,7 @@
         {
           "kind": "theorem",
           "name": "removeEdge_surviving_child_ne",
-          "line": 1922,
+          "line": 1877,
           "called": [
             "CapDerivationEdge",
             "CapDerivationTree",
@@ -34848,7 +35088,7 @@
         {
           "kind": "theorem",
           "name": "removeEdge_preserves_cdtMapsConsistent",
-          "line": 1939,
+          "line": 1894,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34860,7 +35100,7 @@
         {
           "kind": "def",
           "name": "revokeDerivationEdge",
-          "line": 1957,
+          "line": 1912,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34870,7 +35110,7 @@
         {
           "kind": "def",
           "name": "mk_checked",
-          "line": 1969,
+          "line": 1924,
           "called": [
             "CapDerivationEdge",
             "CapDerivationTree",
@@ -34882,7 +35122,7 @@
         {
           "kind": "theorem",
           "name": "mk_checked_cdtMapsConsistent",
-          "line": 1978,
+          "line": 1933,
           "called": [
             "CapDerivationEdge",
             "CdtNodeId",
@@ -34894,7 +35134,7 @@
         {
           "kind": "inductive",
           "name": "CdtChildReachable",
-          "line": 1992,
+          "line": 1947,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34904,7 +35144,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_go_cons",
-          "line": 1998,
+          "line": 1953,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34915,7 +35155,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_go_nil",
-          "line": 2007,
+          "line": 1962,
           "called": [
             "CapDerivationTree",
             "CdtNodeId"
@@ -34924,7 +35164,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_go_acc_subset",
-          "line": 2014,
+          "line": 1969,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34937,7 +35177,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_go_children_found",
-          "line": 2031,
+          "line": 1986,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34950,7 +35190,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_children_subset",
-          "line": 2047,
+          "line": 2002,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34962,7 +35202,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_go_fuel_mono",
-          "line": 2059,
+          "line": 2014,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34974,7 +35214,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_go_head_children_found",
-          "line": 2084,
+          "line": 2039,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34987,7 +35227,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_fuel_bound",
-          "line": 2101,
+          "line": 2056,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -34998,7 +35238,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_fuel_sufficiency",
-          "line": 2129,
+          "line": 2084,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -35010,7 +35250,7 @@
         {
           "kind": "theorem",
           "name": "descendantsOf_go_queue_pos_children_found",
-          "line": 2145,
+          "line": 2100,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -35023,13 +35263,13 @@
         {
           "kind": "theorem",
           "name": "list_mem_split",
-          "line": 2169,
+          "line": 2124,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "descendantsOf_go_mem_children_found",
-          "line": 2184,
+          "line": 2139,
           "called": [
             "CapDerivationTree",
             "CdtNodeId",
@@ -35041,7 +35281,7 @@
         {
           "kind": "inductive",
           "name": "KernelObject",
-          "line": 2200,
+          "line": 2155,
           "called": [
             "CNode",
             "Endpoint",
@@ -35053,8 +35293,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:2211>",
-          "line": 2211,
+          "name": "<anonymous:instance:2166>",
+          "line": 2166,
           "called": [
             "KernelObject"
           ]
@@ -35062,19 +35302,19 @@
         {
           "kind": "inductive",
           "name": "KernelObjectType",
-          "line": 2221,
+          "line": 2176,
           "called": []
         },
         {
           "kind": "namespace",
           "name": "KernelObjectType",
-          "line": 2230,
+          "line": 2185,
           "called": []
         },
         {
           "kind": "def",
           "name": "toNat",
-          "line": 2234,
+          "line": 2189,
           "called": [
             "KernelObjectType"
           ]
@@ -35082,7 +35322,7 @@
         {
           "kind": "def",
           "name": "ofNat",
-          "line": 2244,
+          "line": 2199,
           "called": [
             "KernelObjectType",
             "none"
@@ -35091,7 +35331,7 @@
         {
           "kind": "theorem",
           "name": "ofNat_toNat",
-          "line": 2254,
+          "line": 2209,
           "called": [
             "KernelObjectType",
             "ofNat",
@@ -35101,7 +35341,7 @@
         {
           "kind": "theorem",
           "name": "toNat_injective",
-          "line": 2258,
+          "line": 2213,
           "called": [
             "KernelObjectType",
             "toNat"
@@ -35110,13 +35350,13 @@
         {
           "kind": "namespace",
           "name": "KernelObject",
-          "line": 2263,
+          "line": 2218,
           "called": []
         },
         {
           "kind": "def",
           "name": "objectType",
-          "line": 2265,
+          "line": 2220,
           "called": [
             "KernelObject",
             "KernelObjectType"
@@ -35125,7 +35365,7 @@
         {
           "kind": "def",
           "name": "wellFormed",
-          "line": 2285,
+          "line": 2240,
           "called": [
             "KernelObject",
             "ObjId",
@@ -35136,8 +35376,8 @@
         },
         {
           "kind": "instance",
-          "name": "<anonymous:instance:2298>",
-          "line": 2298,
+          "name": "<anonymous:instance:2253>",
+          "line": 2253,
           "called": [
             "KernelObject",
             "ObjId",
@@ -35148,7 +35388,7 @@
         {
           "kind": "def",
           "name": "makeObjectCap",
-          "line": 2312,
+          "line": 2267,
           "called": [
             "AccessRight",
             "Capability",
@@ -36278,7 +36518,7 @@
     {
       "module": "SeLe4n.Model.State",
       "path": "SeLe4n/Model/State.lean",
-      "declaration_count": 116,
+      "declaration_count": 117,
       "declarations": [
         {
           "kind": "namespace",
@@ -36479,32 +36719,32 @@
         },
         {
           "kind": "def",
-          "name": "SystemState.allTablesInvExt",
+          "name": "SystemState.allTablesInvExtK",
           "line": 278,
           "called": [
             "SystemState",
-            "invExt"
+            "invExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "default_allTablesInvExt",
+          "name": "default_allTablesInvExtK",
           "line": 304,
           "called": [
-            "RHSet.empty_invExt",
-            "RHTable.empty_invExt'",
+            "RHSet.empty_invExtK",
+            "RHTable.empty_invExtK",
             "SystemState",
-            "allTablesInvExt"
+            "allTablesInvExtK"
           ]
         },
         {
           "kind": "theorem",
-          "name": "allTablesInvExt_witness",
+          "name": "allTablesInvExtK_witness",
           "line": 326,
           "called": [
             "SystemState",
-            "allTablesInvExt",
-            "invExt"
+            "allTablesInvExtK",
+            "invExtK"
           ]
         },
         {
@@ -37546,34 +37786,49 @@
         },
         {
           "kind": "theorem",
-          "name": "storeObject_preserves_allTablesInvExt",
-          "line": 1238,
+          "name": "capabilityRefs_fold_preserves_invExtK",
+          "line": 1224,
+          "called": [
+            "CNode",
+            "CapTarget",
+            "ObjId",
+            "RHTable",
+            "RHTable.fold_preserves",
+            "RHTable.insert_preserves_invExtK",
+            "SlotRef",
+            "fold",
+            "insert",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "storeObject_preserves_allTablesInvExtK",
+          "line": 1249,
           "called": [
             "KernelObject",
             "ObjId",
-            "RHSet.insert_preserves_invExt",
-            "RHTable.erase_preserves_invExt",
-            "RHTable.insert_preserves_invExt",
+            "RHSet.insert_preserves_invExtK",
+            "RHTable.erase_preserves_invExtK",
+            "RHTable.filter_preserves_invExtK",
+            "RHTable.insert_preserves_invExtK",
             "SystemState",
-            "SystemState.allTablesInvExt",
-            "allTablesInvExt",
-            "capabilityRefs_filter_preserves_invExt",
-            "capabilityRefs_fold_preserves_invExt",
-            "capacity",
+            "SystemState.allTablesInvExtK",
+            "allTablesInvExtK",
+            "capabilityRefs_fold_preserves_invExtK",
             "erase",
             "filter",
             "fold",
             "insert",
-            "invExt",
+            "invExtK",
             "objectType",
-            "size",
             "storeObject"
           ]
         },
         {
           "kind": "theorem",
           "name": "default_systemState_lifecycleConsistent",
-          "line": 1311,
+          "line": 1321,
           "called": [
             "RHTable.getElem",
             "SystemState",
@@ -37588,7 +37843,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_metadata_sync_type_change",
-          "line": 1333,
+          "line": 1343,
           "called": [
             "KernelObject",
             "ObjId",
@@ -37602,7 +37857,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_metadata_sync_capref_at_stored",
-          "line": 1351,
+          "line": 1361,
           "called": [
             "KernelObject",
             "ObjId",
@@ -37622,7 +37877,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_objectIndex_monotone",
-          "line": 1374,
+          "line": 1384,
           "called": [
             "KernelObject",
             "ObjId",
@@ -37634,7 +37889,7 @@
         {
           "kind": "def",
           "name": "objectIndexLive",
-          "line": 1399,
+          "line": 1409,
           "called": [
             "ObjId",
             "SystemState",
@@ -37644,7 +37899,7 @@
         {
           "kind": "theorem",
           "name": "objectIndexLive_default",
-          "line": 1403,
+          "line": 1413,
           "called": [
             "objectIndexLive"
           ]
@@ -37652,7 +37907,7 @@
         {
           "kind": "theorem",
           "name": "storeObject_preserves_objectIndexLive",
-          "line": 1412,
+          "line": 1422,
           "called": [
             "KernelObject",
             "ObjId",
@@ -37785,11 +38040,11 @@
         },
         {
           "kind": "theorem",
-          "name": "bootFromPlatform_allTablesInvExt",
+          "name": "bootFromPlatform_allTablesInvExtK",
           "line": 120,
           "called": [
             "PlatformConfig",
-            "allTablesInvExt",
+            "allTablesInvExtK",
             "bootFromPlatform",
             "config"
           ]
@@ -37833,9 +38088,9 @@
           "line": 140,
           "called": [
             "PlatformConfig",
-            "allTablesInvExt",
+            "allTablesInvExtK",
             "bootFromPlatform",
-            "bootFromPlatform_allTablesInvExt",
+            "bootFromPlatform_allTablesInvExtK",
             "bootFromPlatform_lifecycleConsistent",
             "bootFromPlatform_perObjectMappings",
             "bootFromPlatform_perObjectSlots",
@@ -39272,7 +39527,7 @@
     {
       "module": "SeLe4n.Prelude",
       "path": "SeLe4n/Prelude.lean",
-      "declaration_count": 285,
+      "declaration_count": 290,
       "declarations": [
         {
           "kind": "namespace",
@@ -41007,8 +41262,66 @@
         },
         {
           "kind": "theorem",
+          "name": "RHTable_erase_preserves_invExtK",
+          "line": 947,
+          "called": [
+            "RHTable",
+            "erase",
+            "erase_preserves_invExtK",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable_get",
+          "line": 954,
+          "called": [
+            "RHTable",
+            "erase",
+            "get",
+            "getElem",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable_getElem",
+          "line": 961,
+          "called": [
+            "RHTable",
+            "RHTable.getElem",
+            "erase",
+            "get",
+            "invExtK",
+            "none"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable_insert_preserves_invExtK",
+          "line": 973,
+          "called": [
+            "RHTable",
+            "insert",
+            "insert_preserves_invExtK",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
+          "name": "RHTable_filter_preserves_invExtK",
+          "line": 980,
+          "called": [
+            "RHTable",
+            "RHTable.filter_preserves_invExtK",
+            "filter",
+            "invExtK"
+          ]
+        },
+        {
+          "kind": "theorem",
           "name": "RHTable_filter_preserves_invExt",
-          "line": 943,
+          "line": 987,
           "called": [
             "RHTable",
             "RHTable.filter_preserves_invExt",
@@ -41019,7 +41332,7 @@
         {
           "kind": "theorem",
           "name": "RHTable_filter_preserves_key",
-          "line": 950,
+          "line": 994,
           "called": [
             "RHTable",
             "RHTable.filter_preserves_key",
@@ -41031,7 +41344,7 @@
         {
           "kind": "theorem",
           "name": "RHTable_filter_filter_getElem",
-          "line": 959,
+          "line": 1003,
           "called": [
             "RHTable",
             "RHTable.filter_filter_getElem",
@@ -41043,7 +41356,7 @@
         {
           "kind": "theorem",
           "name": "RHTable_size_insert_bound",
-          "line": 967,
+          "line": 1011,
           "called": [
             "RHTable",
             "RHTable.size_insert_le",
@@ -41055,7 +41368,7 @@
         {
           "kind": "theorem",
           "name": "RHTable_size_erase_bound",
-          "line": 974,
+          "line": 1018,
           "called": [
             "RHTable",
             "RHTable.size_erase_le",
@@ -41066,7 +41379,7 @@
         {
           "kind": "theorem",
           "name": "RHTable_fold_preserves",
-          "line": 981,
+          "line": 1025,
           "called": [
             "RHTable",
             "RHTable.fold_preserves",
@@ -41076,7 +41389,7 @@
         {
           "kind": "theorem",
           "name": "List.foldl_preserves_contains",
-          "line": 994,
+          "line": 1038,
           "called": [
             "contains",
             "insert"
@@ -41085,7 +41398,7 @@
         {
           "kind": "theorem",
           "name": "List.foldl_not_contains_when_absent",
-          "line": 1008,
+          "line": 1052,
           "called": [
             "contains",
             "insert"
@@ -41094,7 +41407,7 @@
         {
           "kind": "theorem",
           "name": "List.foldl_preserves_when_pred_false",
-          "line": 1028,
+          "line": 1072,
           "called": [
             "contains",
             "insert"
@@ -41103,7 +41416,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.default_eq_sentinel",
-          "line": 1056,
+          "line": 1100,
           "called": [
             "ObjId",
             "sentinel"
@@ -41112,7 +41425,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.default_eq_sentinel",
-          "line": 1059,
+          "line": 1103,
           "called": [
             "ThreadId",
             "sentinel"
@@ -41121,7 +41434,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.sentinel_isReserved",
-          "line": 1062,
+          "line": 1106,
           "called": [
             "isReserved"
           ]
@@ -41129,7 +41442,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.sentinel_isReserved",
-          "line": 1065,
+          "line": 1109,
           "called": [
             "isReserved"
           ]
@@ -41137,7 +41450,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.valid_iff_not_reserved",
-          "line": 1068,
+          "line": 1112,
           "called": [
             "ObjId",
             "isReserved",
@@ -41147,7 +41460,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.default_eq_sentinel",
-          "line": 1073,
+          "line": 1117,
           "called": [
             "ServiceId",
             "sentinel"
@@ -41156,7 +41469,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.sentinel_isReserved",
-          "line": 1076,
+          "line": 1120,
           "called": [
             "isReserved"
           ]
@@ -41164,7 +41477,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.toNat_ofNat",
-          "line": 1083,
+          "line": 1127,
           "called": [
             "ofNat",
             "toNat"
@@ -41173,7 +41486,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.ofNat_toNat",
-          "line": 1085,
+          "line": 1129,
           "called": [
             "ObjId",
             "ofNat",
@@ -41183,7 +41496,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.ofNat_injective",
-          "line": 1087,
+          "line": 1131,
           "called": [
             "ofNat"
           ]
@@ -41191,7 +41504,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.ext",
-          "line": 1090,
+          "line": 1134,
           "called": [
             "ObjId"
           ]
@@ -41199,7 +41512,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.toNat_ofNat",
-          "line": 1094,
+          "line": 1138,
           "called": [
             "ofNat",
             "toNat"
@@ -41208,7 +41521,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.ofNat_toNat",
-          "line": 1096,
+          "line": 1140,
           "called": [
             "ThreadId",
             "ofNat",
@@ -41218,7 +41531,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.ofNat_injective",
-          "line": 1098,
+          "line": 1142,
           "called": [
             "ofNat"
           ]
@@ -41226,7 +41539,7 @@
         {
           "kind": "theorem",
           "name": "DomainId.toNat_ofNat",
-          "line": 1102,
+          "line": 1146,
           "called": [
             "ofNat",
             "toNat"
@@ -41235,7 +41548,7 @@
         {
           "kind": "theorem",
           "name": "DomainId.ofNat_toNat",
-          "line": 1104,
+          "line": 1148,
           "called": [
             "DomainId",
             "ofNat",
@@ -41245,7 +41558,7 @@
         {
           "kind": "theorem",
           "name": "DomainId.ofNat_injective",
-          "line": 1106,
+          "line": 1150,
           "called": [
             "ofNat"
           ]
@@ -41253,7 +41566,7 @@
         {
           "kind": "theorem",
           "name": "DomainId.ext",
-          "line": 1109,
+          "line": 1153,
           "called": [
             "DomainId"
           ]
@@ -41261,7 +41574,7 @@
         {
           "kind": "theorem",
           "name": "Priority.toNat_ofNat",
-          "line": 1113,
+          "line": 1157,
           "called": [
             "ofNat",
             "toNat"
@@ -41270,7 +41583,7 @@
         {
           "kind": "theorem",
           "name": "Priority.ofNat_toNat",
-          "line": 1115,
+          "line": 1159,
           "called": [
             "Priority",
             "ofNat",
@@ -41280,7 +41593,7 @@
         {
           "kind": "theorem",
           "name": "Priority.ofNat_injective",
-          "line": 1117,
+          "line": 1161,
           "called": [
             "ofNat"
           ]
@@ -41288,7 +41601,7 @@
         {
           "kind": "theorem",
           "name": "Priority.ext",
-          "line": 1120,
+          "line": 1164,
           "called": [
             "Priority"
           ]
@@ -41296,7 +41609,7 @@
         {
           "kind": "theorem",
           "name": "Deadline.toNat_ofNat",
-          "line": 1124,
+          "line": 1168,
           "called": [
             "ofNat",
             "toNat"
@@ -41305,7 +41618,7 @@
         {
           "kind": "theorem",
           "name": "Deadline.ofNat_toNat",
-          "line": 1126,
+          "line": 1170,
           "called": [
             "Deadline",
             "ofNat",
@@ -41315,7 +41628,7 @@
         {
           "kind": "theorem",
           "name": "Deadline.ofNat_injective",
-          "line": 1128,
+          "line": 1172,
           "called": [
             "ofNat"
           ]
@@ -41323,7 +41636,7 @@
         {
           "kind": "theorem",
           "name": "Deadline.ext",
-          "line": 1131,
+          "line": 1175,
           "called": [
             "Deadline"
           ]
@@ -41331,7 +41644,7 @@
         {
           "kind": "theorem",
           "name": "Irq.toNat_ofNat",
-          "line": 1135,
+          "line": 1179,
           "called": [
             "ofNat",
             "toNat"
@@ -41340,7 +41653,7 @@
         {
           "kind": "theorem",
           "name": "Irq.ofNat_toNat",
-          "line": 1137,
+          "line": 1181,
           "called": [
             "Irq",
             "ofNat",
@@ -41350,7 +41663,7 @@
         {
           "kind": "theorem",
           "name": "Irq.ofNat_injective",
-          "line": 1139,
+          "line": 1183,
           "called": [
             "ofNat"
           ]
@@ -41358,7 +41671,7 @@
         {
           "kind": "theorem",
           "name": "Irq.ext",
-          "line": 1142,
+          "line": 1186,
           "called": [
             "Irq"
           ]
@@ -41366,7 +41679,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.toNat_ofNat",
-          "line": 1146,
+          "line": 1190,
           "called": [
             "ofNat",
             "toNat"
@@ -41375,7 +41688,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.ofNat_toNat",
-          "line": 1148,
+          "line": 1192,
           "called": [
             "ServiceId",
             "ofNat",
@@ -41385,7 +41698,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.ofNat_injective",
-          "line": 1150,
+          "line": 1194,
           "called": [
             "ofNat"
           ]
@@ -41393,7 +41706,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.ext",
-          "line": 1153,
+          "line": 1197,
           "called": [
             "ServiceId"
           ]
@@ -41401,7 +41714,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.toNat_ofNat",
-          "line": 1157,
+          "line": 1201,
           "called": [
             "ofNat",
             "toNat"
@@ -41410,7 +41723,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.ofNat_toNat",
-          "line": 1159,
+          "line": 1203,
           "called": [
             "CPtr",
             "ofNat",
@@ -41420,7 +41733,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.ofNat_injective",
-          "line": 1161,
+          "line": 1205,
           "called": [
             "ofNat"
           ]
@@ -41428,7 +41741,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.ext",
-          "line": 1164,
+          "line": 1208,
           "called": [
             "CPtr"
           ]
@@ -41436,7 +41749,7 @@
         {
           "kind": "theorem",
           "name": "Slot.toNat_ofNat",
-          "line": 1168,
+          "line": 1212,
           "called": [
             "ofNat",
             "toNat"
@@ -41445,7 +41758,7 @@
         {
           "kind": "theorem",
           "name": "Slot.ofNat_toNat",
-          "line": 1170,
+          "line": 1214,
           "called": [
             "Slot",
             "ofNat",
@@ -41455,7 +41768,7 @@
         {
           "kind": "theorem",
           "name": "Slot.ofNat_injective",
-          "line": 1172,
+          "line": 1216,
           "called": [
             "ofNat"
           ]
@@ -41463,7 +41776,7 @@
         {
           "kind": "theorem",
           "name": "Slot.ext",
-          "line": 1175,
+          "line": 1219,
           "called": [
             "Slot"
           ]
@@ -41471,7 +41784,7 @@
         {
           "kind": "theorem",
           "name": "Badge.toNat_ofNatMasked",
-          "line": 1179,
+          "line": 1223,
           "called": [
             "machineWordMax",
             "ofNatMasked",
@@ -41481,7 +41794,7 @@
         {
           "kind": "theorem",
           "name": "Badge.ofNatMasked_toNat",
-          "line": 1182,
+          "line": 1226,
           "called": [
             "Badge",
             "machineWordBits",
@@ -41494,7 +41807,7 @@
         {
           "kind": "theorem",
           "name": "Badge.val_injective",
-          "line": 1187,
+          "line": 1231,
           "called": [
             "Badge"
           ]
@@ -41502,7 +41815,7 @@
         {
           "kind": "theorem",
           "name": "Badge.ext",
-          "line": 1190,
+          "line": 1234,
           "called": [
             "Badge"
           ]
@@ -41510,7 +41823,7 @@
         {
           "kind": "theorem",
           "name": "ASID.toNat_ofNat",
-          "line": 1194,
+          "line": 1238,
           "called": [
             "ofNat",
             "toNat"
@@ -41519,7 +41832,7 @@
         {
           "kind": "theorem",
           "name": "ASID.ofNat_toNat",
-          "line": 1196,
+          "line": 1240,
           "called": [
             "ASID",
             "ofNat",
@@ -41529,7 +41842,7 @@
         {
           "kind": "theorem",
           "name": "ASID.ofNat_injective",
-          "line": 1198,
+          "line": 1242,
           "called": [
             "ofNat"
           ]
@@ -41537,7 +41850,7 @@
         {
           "kind": "theorem",
           "name": "ASID.ext",
-          "line": 1201,
+          "line": 1245,
           "called": [
             "ASID"
           ]
@@ -41545,7 +41858,7 @@
         {
           "kind": "theorem",
           "name": "VAddr.toNat_ofNat",
-          "line": 1205,
+          "line": 1249,
           "called": [
             "ofNat",
             "toNat"
@@ -41554,7 +41867,7 @@
         {
           "kind": "theorem",
           "name": "VAddr.ofNat_toNat",
-          "line": 1207,
+          "line": 1251,
           "called": [
             "VAddr",
             "ofNat",
@@ -41564,7 +41877,7 @@
         {
           "kind": "theorem",
           "name": "VAddr.ofNat_injective",
-          "line": 1209,
+          "line": 1253,
           "called": [
             "ofNat"
           ]
@@ -41572,7 +41885,7 @@
         {
           "kind": "theorem",
           "name": "VAddr.ext",
-          "line": 1212,
+          "line": 1256,
           "called": [
             "VAddr"
           ]
@@ -41580,7 +41893,7 @@
         {
           "kind": "theorem",
           "name": "PAddr.toNat_ofNat",
-          "line": 1216,
+          "line": 1260,
           "called": [
             "ofNat",
             "toNat"
@@ -41589,7 +41902,7 @@
         {
           "kind": "theorem",
           "name": "PAddr.ofNat_toNat",
-          "line": 1218,
+          "line": 1262,
           "called": [
             "PAddr",
             "ofNat",
@@ -41599,7 +41912,7 @@
         {
           "kind": "theorem",
           "name": "PAddr.ofNat_injective",
-          "line": 1220,
+          "line": 1264,
           "called": [
             "ofNat"
           ]
@@ -41607,7 +41920,7 @@
         {
           "kind": "theorem",
           "name": "PAddr.ext",
-          "line": 1223,
+          "line": 1267,
           "called": [
             "PAddr"
           ]
@@ -41615,7 +41928,7 @@
         {
           "kind": "def",
           "name": "ThreadId.valid",
-          "line": 1231,
+          "line": 1275,
           "called": [
             "ThreadId"
           ]
@@ -41623,7 +41936,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.valid_iff_not_reserved",
-          "line": 1234,
+          "line": 1278,
           "called": [
             "ThreadId",
             "ThreadId.valid",
@@ -41634,7 +41947,7 @@
         {
           "kind": "theorem",
           "name": "ThreadId.sentinel_not_valid",
-          "line": 1239,
+          "line": 1283,
           "called": [
             "ThreadId.valid",
             "sentinel",
@@ -41644,7 +41957,7 @@
         {
           "kind": "def",
           "name": "ServiceId.valid",
-          "line": 1243,
+          "line": 1287,
           "called": [
             "ServiceId"
           ]
@@ -41652,7 +41965,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.valid_iff_not_reserved",
-          "line": 1246,
+          "line": 1290,
           "called": [
             "ServiceId",
             "ServiceId.valid",
@@ -41663,7 +41976,7 @@
         {
           "kind": "theorem",
           "name": "ServiceId.sentinel_not_valid",
-          "line": 1251,
+          "line": 1295,
           "called": [
             "ServiceId.valid",
             "sentinel",
@@ -41673,7 +41986,7 @@
         {
           "kind": "def",
           "name": "CPtr.valid",
-          "line": 1255,
+          "line": 1299,
           "called": [
             "CPtr"
           ]
@@ -41681,7 +41994,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.valid_iff_not_reserved",
-          "line": 1258,
+          "line": 1302,
           "called": [
             "CPtr",
             "CPtr.valid",
@@ -41692,7 +42005,7 @@
         {
           "kind": "theorem",
           "name": "CPtr.sentinel_not_valid",
-          "line": 1263,
+          "line": 1307,
           "called": [
             "CPtr.valid",
             "sentinel",
@@ -41702,7 +42015,7 @@
         {
           "kind": "theorem",
           "name": "ObjId.sentinel_not_valid",
-          "line": 1267,
+          "line": 1311,
           "called": [
             "sentinel",
             "valid"

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -286,6 +286,9 @@ probeChainDominant preservation (`Invariant/Preservation.lean`):
 - `invExtFull` — extended invariant plus load factor bound (V3-A, H-RH-1)
 - `invExtFull_implies_size_lt_capacity` — strict size bound from load factor (V3-A)
 - `erase_preserves_invExtFull` — erase without redundant `hSize` hypothesis (V3-B)
+- `invExtK` — kernel-level bundle: `invExt ∧ size < capacity ∧ 4 ≤ capacity` (V3-B)
+- `erase_preserves_invExtK`, `insert_preserves_invExtK`, `filter_preserves_invExtK`,
+  `getElem?_erase_ne_K`, `ofList_invExtK`, `empty_invExtK` — kernel wrappers (V3-B)
 
 Helper infrastructure (`Invariant/Preservation.lean`):
 - `offset_injective` — injectivity of modular offsets from same base

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -41,8 +41,8 @@ in Projection.lean) is intentionally retained.
   `empty` or `mk_checked` (which requires `cdtMapsConsistent` witness) (H-2).
 - `FrozenSystemState.tlb` field added; `freeze_preserves_tlb` correctness
   theorem proves TLB state is preserved across freeze (M-NEW-1).
-- `storeObject_preserves_allTablesInvExt` — bundled theorem composing 16+
-  component preservation proofs for `storeObject` (M-NEW-2).
+- `storeObject_preserves_allTablesInvExtK` — bundled theorem composing 16+
+  component preservation proofs for `storeObject` using `invExtK` (M-NEW-2, V3-B).
 - `capabilityRefs_filter_preserves_invExt` + `capabilityRefs_fold_preserves_invExt`
   — filter-then-fold chain in `storeObject` preserves `invExt` (M-NEW-3).
 - `CNode.guardBounded` predicate added to `CNode.wellFormed` — guard value

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -411,8 +411,9 @@ The Lean model bridges abstract `Nat` semantics to 64-bit hardware:
   construction requires `mk_checked` with `cdtMapsConsistent` witness (T2-B/C/H-2).
 - **Frozen TLB**: `FrozenSystemState.tlb` field preserves TLB state across freeze;
   `freeze_preserves_tlb` correctness theorem (T2-D/E/F/M-NEW-1).
-- **storeObject preservation**: Bundled `storeObject_preserves_allTablesInvExt`
-  theorem composing 16+ component proofs (T2-G/M-NEW-2).
+- **storeObject preservation**: Bundled `storeObject_preserves_allTablesInvExtK`
+  theorem composing 16+ component proofs (T2-G/M-NEW-2). Uses `invExtK` kernel-level
+  invariant bundle (V3-B) — eliminates separate `hSize`/`hCapGe4` threading.
 
 ### 8.3 Memory Alignment Model Gap
 


### PR DESCRIPTION
## Summary

- Workstream(s) advanced: **V3-B (Proof Chain Hardening)** — Phase 1-2
- Recommendation IDs closed: None (internal refactoring)
- Scope notes: Consolidates three separate invariant conditions (`invExt`, `size < capacity`, `4 ≤ capacity`) into a single kernel-level bundle `invExtK` across RHTable, RHSet, and all SystemState tables. Reduces proof obligation boilerplate and improves maintainability.

## Changes Overview

### Core Invariant Bundle Definition
- **`SeLe4n/Kernel/RobinHood/Bridge.lean`**: Introduced `RHTable.invExtK` as the kernel-level extended invariant combining:
  - `invExt` (data-structure invariant: WF ∧ distCorrect ∧ noDupKeys ∧ probeChainDominant)
  - `size < capacity` (erase lookup correctness prerequisite)
  - `4 ≤ capacity` (insert size bound prerequisite)
  - Added projection lemmas (`invExtK_invExt`, `invExtK_size_lt_capacity`, `invExtK_capacity_ge4`)
  - Added constructor lemma `mk_invExtK`
  - Proved `empty_invExtK` and `erase_preserves_invExtK`

- **`SeLe4n/Kernel/RobinHood/Set.lean`**: Added `RHSet.invExtK` wrapper delegating to `RHTable.invExtK`

### SystemState Integration
- **`SeLe4n/Model/State.lean`**: Renamed `allTablesInvExt` → `allTablesInvExtK`; all 14 table fields now use `invExtK` instead of separate `invExt`, `size < capacity`, and `4 ≤ capacity` conditions
- **`SeLe4n/Model/Builder.lean`**: Updated all decomposition/recomposition helpers to reference `invExtK`
- **`SeLe4n/Platform/Boot.lean`**: Updated boot theorem to use `allTablesInvExtK`

### Proof Simplifications
- **`SeLe4n/Model/Object/Structures.lean`**: 
  - `lookup_unmapPage_ne`: Reduced from 2 hypotheses (`hExt`, `hSize`) to 1 (`hK`)
  - `CNode.slotsUnique`: Simplified from 3-conjunct definition to single `invExtK` field
  - `empty_slotsUnique`: Proof reduced from 3 branches to direct application of `empty_invExtK`
  - `insert_slotsUnique`: Proof simplified by delegating to `insert_preserves_invExtK`

- **`SeLe4n/Kernel/Capability/Invariant/Preservation.lean`**:
  - `cspaceDeleteSlotCore_preserves_capabilityInvariantBundle`: Reduced from 2 hypotheses to 1 (`hNodeSlotK`)
  - `cspaceDeleteSlot_preserves_capabilityInvariantBundle`: Simplified accordingly
  - `cspaceDeleteSlotCore_preserves_cdtNodeSlot`: Return type changed from 2-conjunct to single `invExtK`

- **`SeLe4n/Kernel/Scheduler/RunQueue.lean`**: Consolidated 9 separate invariant fields into 3 `invExtK` fields; added backward-compatibility projection theorems for downstream code

### Documentation & Re-exports
- **`SeLe4n/Prelude.lean`**: Added re-exports for `RHTable_erase_preserves_invExtK` and `RHTable_getElem?_erase_ne_K` for kernel code
- **`docs/WORKSTREAM_HISTORY.md`**: Updated V3 completion notes
- **`docs/spec/SELE4N_SPEC.md`**: Minor

https://claude.ai/code/session_01CvoCEk1Ahzd6vgXer6v28V