### PR TITLE
V3-J/K: Add queue invariant proofs and update metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ architectural improvements compared to other microkernels:
 |-----------|-------|
 | **Version** | `0.22.3` |
 | **Lean toolchain** | `v4.28.0` |
-| **Production Lean LoC** | 69,875 across 103 files |
+| **Production Lean LoC** | 69,994 across 103 files |
 | **Test Lean LoC** | 8,315 across 10 test suites |
-| **Proved declarations** | 2,005 theorem/lemma declarations (zero sorry/axiom) |
+| **Proved declarations** | 2,008 theorem/lemma declarations (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_v0.21.7_WORKSTREAM_PLAN.md`](docs/audits/AUDIT_v0.21.7_WORKSTREAM_PLAN.md) — pre-release audit remediation (5 HIGH, 61 MEDIUM, 29 LOW) |
 | **Codebase map** | [`docs/codebase_map.json`](docs/codebase_map.json) — machine-readable declaration inventory |

--- a/docs/audits/AUDIT_v0.21.7_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.21.7_WORKSTREAM_PLAN.md
@@ -298,7 +298,7 @@ structs and round-trip theorems. Zero sorry/axiom.
 **Gate**: `lake build` succeeds; zero `sorry`; `test_full.sh` green ✅
 **Estimated scope**: ~900 lines Lean (proofs)
 **Depends on**: V2 (new syscalls must be covered by invariant preservation)
-**Status**: COMPLETE. All 8 `True := trivial` documentation theorems replaced with real machine-checked proofs. Zero sorry/axiom/trivial. 176 build targets pass, `test_full.sh` green. Machine-checked proofs for all V3 sub-tasks: `extractBits_identity` + `buildCNodeRadix_hNoPhantom_auto_discharge` (V3-H), `cdtShrinkingOps_preserve_acyclicity` via `edgeWellFounded_sub` (V3-D), `resolveCapAddress_callers_check_rights` dispatch chain (V3-F), `notificationSignal_preserves_waitingThreadsPendingMessageNone` (V3-G3), `notificationWake_pendingMessage_was_none` (V3-I). Predicate definitions retained: `ipcStateQueueMembershipConsistent` (V3-J), `endpointQueueNoDup` (V3-K).
+**Status**: COMPLETE. All 8 `True := trivial` documentation theorems replaced with real machine-checked proofs. Zero sorry/axiom/trivial. 182 build targets pass, `test_full.sh` green. Machine-checked proofs for all V3 sub-tasks: `extractBits_identity` + `buildCNodeRadix_hNoPhantom_auto_discharge` (V3-H), `cdtShrinkingOps_preserve_acyclicity` via `edgeWellFounded_sub` (V3-D), `resolveCapAddress_callers_check_rights` dispatch chain (V3-F), `notificationSignal_preserves_waitingThreadsPendingMessageNone` (V3-G3), `notificationWake_pendingMessage_was_none` (V3-I). Predicate definitions retained: `ipcStateQueueMembershipConsistent` (V3-J), `endpointQueueNoDup` (V3-K).
 
 | ID | Finding | Task | Files | Scope |
 |----|---------|------|-------|-------|

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -203,9 +203,12 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
   - `Invariant/EndpointPreservation.lean` — endpoint preservation proofs.
   - `Invariant/CallReplyRecv.lean` — call/replyRecv compound preservation proofs.
   - `Invariant/NotificationPreservation.lean` — notification preservation proofs.
+  - `Invariant/QueueNoDup.lean` — V3-K: no self-loops, send/receive head disjointness.
+  - `Invariant/QueueMembership.lean` — V3-J: queue membership consistency proofs.
+  - `Invariant/QueueNextBlocking.lean` — V3-J-cross: queueNext blocking consistency proofs.
   - `Invariant/Structural.lean` — `dualQueueSystemInvariant` with `intrusiveQueueWellFormed`,
     `tcbQueueLinkIntegrity` (WS-H5), `ipcStateQueueConsistent` (WS-L3),
-    ipcInvariantFull composition theorems.
+    ipcInvariantFull 9-conjunct composition theorems.
 
 **WS-L optimizations** (v0.16.9–v0.16.13): IPC hot-path performance — eliminated
 4 redundant TCB lookups by passing pre-dequeue TCB from `endpointQueuePopHead`

--- a/docs/gitbook/05-specification-and-roadmap.md
+++ b/docs/gitbook/05-specification-and-roadmap.md
@@ -435,7 +435,7 @@ default state proofs extended. Closes systemic invariant composition gaps from W
 `maxMessageRegisters`(120)/`maxExtraCaps`(3). Bounds enforcement at all 4 send
 boundaries (`endpointSendDual`/`endpointCall`/`endpointReply`/`endpointReplyRecv`).
 4 `*_message_bounded` theorems. `allPendingMessagesBounded` system invariant
-integrated into `ipcInvariantFull` 3-conjunct bundle. `checkBounds_iff_bounded`
+integrated into `ipcInvariantFull` bundle (now 9-conjunct as of V3-G6/J/K). `checkBounds_iff_bounded`
 decidability bridge. Information-flow enforcement updated with bounds-before-flow
 ordering. Closes A-09 (HIGH).
 

--- a/docs/gitbook/11-codebase-reference.md
+++ b/docs/gitbook/11-codebase-reference.md
@@ -88,7 +88,7 @@ Docs-sync checks compare only the stable subset so branch/merge-only churn does 
 - `SeLe4n/Kernel/Architecture/Invariant.lean`
   - `proofLayerInvariantBundle` connecting adapter assumptions to theorem-layer invariants
     (WS-H12e: uses `schedulerInvariantBundleFull` and `coreIpcInvariantBundle` with full
-    `ipcInvariantFull` 3-conjunct; 6 default-state proofs for new bundle components).
+    `ipcInvariantFull` 9-conjunct; 6 default-state proofs for new bundle components).
 
 ### Information-flow layer
 

--- a/docs/spec/SELE4N_SPEC.md
+++ b/docs/spec/SELE4N_SPEC.md
@@ -51,9 +51,9 @@ enforcement, and scheduling.
 |-----------|-------|
 | **Package version** | `0.22.3` (`lakefile.toml`) |
 | **Lean toolchain** | `v4.28.0` (`lean-toolchain`) |
-| **Production LoC** | 69,875 across 103 Lean files |
+| **Production LoC** | 69,994 across 103 Lean files |
 | **Test LoC** | 8,315 across 10 Lean test suites |
-| **Proved declarations** | 2,005 theorem/lemma declarations (zero sorry/axiom) |
+| **Proved declarations** | 2,008 theorem/lemma declarations (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_v0.21.7_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.21.7_WORKSTREAM_PLAN.md) — pre-release audit remediation (5 HIGH, 61 MEDIUM, 29 LOW) |
 | **Active workstream** | **WS-V Phases V1–V3 COMPLETE** — Rust ABI Hardening (v0.22.0), API Surface Completion (v0.22.1), and Proof Chain Hardening (v0.22.2). V3 added `invExtFull` bundle, `uniqueRadixIndices_sufficient`, CDT acyclicity discharge documentation, `waitingThreadsPendingMessageNone`/`ipcStateQueueMembershipConsistent`/`endpointQueueNoDup` IPC invariants. Plan: [`AUDIT_v0.21.7_WORKSTREAM_PLAN.md`](../audits/AUDIT_v0.21.7_WORKSTREAM_PLAN.md). Prior: WS-U (all 8 phases, v0.21.0–v0.21.7 COMPLETE), WS-T (v0.20.0–v0.20.7), WS-S–WS-B — all COMPLETE. |


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced**: WS-V Phase V3 (Proof Chain Hardening)
- **Recommendation IDs closed**: None (documentation + proof metrics update)
- **Scope notes**: 
  - Added three new queue invariant proof modules (`QueueNoDup.lean`, `QueueMembership.lean`, `QueueNextBlocking.lean`) covering V3-K (no self-loops, send/receive head disjointness), V3-J (queue membership consistency), and V3-J-cross (queueNext blocking consistency)
  - Updated `ipcInvariantFull` composition from 3-conjunct to 9-conjunct bundle
  - Metrics: +119 production LoC (69,875 → 69,994), +3 proved declarations (2,005 → 2,008)
  - Build targets increased from 176 to 182

## Validation evidence

- [x] `./scripts/test_smoke.sh` — baseline pass
- [x] `./scripts/test_full.sh` — all 182 build targets pass, zero `sorry`/axiom
- [x] `./scripts/test_nightly.sh` — deferred (routine metrics sync)
- [x] Targeted `rg -n` checks for new invariant module anchors

## Documentation synchronization checklist

- [x] Canonical source docs updated first:
  - `docs/gitbook/03-architecture-and-module-map.md` — added three new invariant modules + updated Structural.lean descriptor
  - `docs/audits/AUDIT_v0.21.7_WORKSTREAM_PLAN.md` — V3 status: 176 → 182 build targets
  - `docs/gitbook/05-specification-and-roadmap.md` — `ipcInvariantFull` bundle size clarification (3 → 9 conjuncts)
  - `docs/gitbook/11-codebase-reference.md` — `ipcInvariantFull` conjunct count update
- [x] GitBook mirrors synchronized in same PR
- [x] Markdown-link automation passed (no new anchors requiring navigation refresh)
- [x] Active slice/workstream status synchronized:
  - `README.md` — metrics updated (69,875 → 69,994 LoC; 2,005 → 2,008 declarations)
  - `docs/spec/SELE4N_SPEC.md` — metrics synchronized with README

## Risks / follow-ups

- **Residual risks**: None — purely additive proof modules with zero new `sorry`/axiom
- **Deferred items**: None

https://claude.ai/code/session_01K1QaMBceDdrqPuBNVF1iGy