### PR TITLE
WS-AD Phase AD1: Integrate orphaned SchedContext preservation theorems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v0.25.11 — WS-AD Phase AD1: Integration Fix (F-01)
+
+Phase AD1 of WS-AD Pre-Release Audit Remediation. 3 sub-tasks. All tests pass
+(full build + test_full.sh Tier 0-3). Zero sorry/axiom.
+
+### Changes
+- **AD1-A/B (F-01)**: Integrated 2 orphaned SchedContext preservation modules
+  into the production proof chain. `Preservation.lean` (7 theorems: Z5-M,
+  Z5-I, Z5-K, Z5-L, Z5-N1/N2) and `PriorityPreservation.lean` (14 theorems:
+  D2-G/H/I/J transport lemmas + authority non-escalation) were fully proven
+  but unreachable — not imported by any production module.
+- **Import cycle resolution**: Direct import into `SchedContext/Invariant.lean`
+  (the re-export hub) would create a dependency cycle via
+  `Object/Types → SchedContext → Invariant → Preservation → Operations →
+  Model.State → Object/Types`. Resolved by importing both modules from
+  `CrossSubsystem.lean`, which sits downstream of the cycle boundary and is
+  the natural integration point for cross-subsystem preservation theorem
+  composition. Chain: `CrossSubsystem → Architecture/Invariant → API.lean`.
+- **AD1-C**: Verified 21 theorems (7 + 14) reachable from production import
+  chain. Module build (69 jobs), full build (236 jobs), smoke test, and
+  full test suite (Tier 0-3) all pass.
+- Workstream plan updated with import-cycle resolution documentation.
+- Version bump 0.25.10 → 0.25.11.
+
 ## v0.25.10 — WS-AC Phase AC6: Documentation, Testing & Closure
 
 Phase AC6 of WS-AC Comprehensive Audit Remediation. 7 sub-tasks. All tests pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,6 +495,7 @@ under `docs/` and `docs/gitbook/`.
 
 ## Active workstream context
 
+- **WS-AD Phase AD1 COMPLETE** (v0.25.11): Pre-Release Audit Remediation — Phase AD1 Integration Fix (F-01): 21 orphaned SchedContext preservation theorems integrated via CrossSubsystem.lean (import-cycle resolution). Zero sorry/axiom. See `docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md`
 - **WS-AC PORTFOLIO COMPLETE** (v0.25.3–v0.25.10): Comprehensive Audit Remediation — 6 phases (AC1–AC6), 42 sub-tasks. 3 HIGH, 9 MEDIUM, 9 LOW findings addressed. Phase AC6 COMPLETE (documentation, testing & closure: T-03 DecodingSuite, audit errata, workstream history). Zero sorry/axiom. See `docs/audits/AUDIT_v0.25.3_WORKSTREAM_PLAN.md`
 - **WS-AB PORTFOLIO COMPLETE** (v0.24.0–v0.25.5): Deferred Operations & Liveness Completion — 6 phases, 90 sub-tasks. All 5 deferred seL4 operations implemented: suspend/resume (D1), setPriority/setMCPriority (D2), setIPCBuffer (D3). Priority Inheritance Protocol (D4). Bounded Latency Theorem WCRT = D*L_max + N*(B+P) (D5). API Surface Integration & Closure (D6). Rust ABI synchronized (SyscallId 25, KernelError 44). Zero sorry/axiom. See `docs/dev_history/planning/WS_AB_DEFERRED_OPERATIONS_WORKSTREAM_PLAN.md`
 - **WS-AA Phase AA2 COMPLETE**: CI & Infrastructure Hardening — 6 sub-tasks (AA2-A through AA2-F), all complete (v0.23.23). Zero sorry/axiom. See `docs/dev_history/AUDIT_v0.23.21_WORKSTREAM_PLAN.md`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.25.10-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.25.11-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -85,11 +85,11 @@ architectural improvements enabled by the Lean 4 proof framework:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.25.10` |
+| **Version** | `0.25.11` |
 | **Lean toolchain** | `v4.28.0` |
-| **Production Lean LoC** | 84,013 across 133 files |
+| **Production Lean LoC** | 84,028 across 133 files |
 | **Test Lean LoC** | 11,318 across 16 test suites |
-| **Proved declarations** | 2,478 theorem/lemma declarations (zero sorry/axiom) |
+| **Proved declarations** | 2,479 theorem/lemma declarations (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
 | **Latest audit** | [`AUDIT_COMPREHENSIVE_v0.23.21`](docs/dev_history/AUDIT_COMPREHENSIVE_v0.23.21_LEAN_RUST_KERNEL.md) — full-kernel Lean + Rust audit (0 CRIT, 5 HIGH, 8 MED, 30 LOW) |
 | **Codebase map** | [`docs/codebase_map.json`](docs/codebase_map.json) — machine-readable declaration inventory |
@@ -207,7 +207,7 @@ per-file inventory, see [`docs/codebase_map.json`](docs/codebase_map.json).
 | **Bounded latency** | No formal WCRT bound | `WCRT = D × L_max + N × (B + P)` proven across 7 liveness modules |
 | **Object stores** | Linked lists and arrays | Verified Robin Hood hash tables (`RHTable`/`RHSet`) with O(1) hot paths |
 | **Service management** | Not in kernel | First-class orchestration with dependency graph and acyclicity proofs |
-| **Proofs** | Isabelle/HOL, post-hoc | Lean 4 type-checker, co-located with transitions (2,447 theorems, zero sorry/axiom) |
+| **Proofs** | Isabelle/HOL, post-hoc | Lean 4 type-checker, co-located with transitions (2,479 theorems, zero sorry/axiom) |
 | **Platform** | C-level HAL | `PlatformBinding` typeclass with typed boundary contracts |
 
 ## What's next
@@ -219,6 +219,7 @@ history is in [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md).
 
 | Workstream | Scope | Version |
 |------------|-------|---------|
+| **WS-AD** | Pre-Release Audit Remediation — 21 findings (7 actionable), Phase AD1: orphaned SchedContext preservation module integration with import-cycle resolution (3 tasks) | v0.25.11 |
 | **WS-AC** | Comprehensive Audit Remediation — 3 HIGH, 9 MEDIUM, 9 LOW findings addressed across scheduler, IPC, capability, architecture, and cross-cutting subsystems (6 phases, 42 tasks) | v0.25.3–v0.25.10 |
 | **WS-AB** | Deferred Operations & Liveness — suspend/resume, setPriority/setMCPriority, setIPCBuffer, Priority Inheritance Protocol, Bounded Latency Theorem (6 phases, 90 tasks) | v0.24.0–v0.25.5 |
 | **WS-Z** | Composable Performance Objects — `SchedContext` as 7th kernel object, CBS budget engine, replenishment queue, passive server donation, timeout endpoints (10 phases, 213 tasks) | v0.23.0–v0.23.21 |

--- a/SeLe4n/Kernel/CrossSubsystem.lean
+++ b/SeLe4n/Kernel/CrossSubsystem.lean
@@ -9,6 +9,12 @@
 import SeLe4n.Kernel.Service.Registry.Invariant
 import SeLe4n.Kernel.Service.Invariant.Acyclicity
 import SeLe4n.Kernel.SchedContext.Invariant
+-- AD1/F-01: Integrate orphaned SchedContext preservation modules into
+-- the production proof chain. These cannot live in SchedContext/Invariant.lean
+-- (import cycle via Object/Types), so they are imported here at the
+-- cross-subsystem boundary where preservation theorems naturally compose.
+import SeLe4n.Kernel.SchedContext.Invariant.Preservation
+import SeLe4n.Kernel.SchedContext.Invariant.PriorityPreservation
 
 /-!
 # R4-E: Cross-Subsystem Invariant Definitions

--- a/SeLe4n/Kernel/SchedContext/Invariant.lean
+++ b/SeLe4n/Kernel/SchedContext/Invariant.lean
@@ -12,4 +12,13 @@ import SeLe4n.Kernel.SchedContext.Invariant.Defs
 
 Thin re-export hub for SchedContext invariant definitions and proofs.
 Follows the project convention of `Invariant.lean` → `Invariant/Defs.lean`.
+
+**Note (AD1/F-01):** `Preservation.lean` (Z5 per-operation preservation) and
+`PriorityPreservation.lean` (D2 transport lemmas, authority bounds) are NOT
+imported here due to an import-cycle constraint: this hub is transitively
+imported by `Object/Types.lean` via `SchedContext.lean`, and both preservation
+modules depend on `Operations.lean` → `Model.State` → `Object/Types.lean`.
+Instead, they are integrated via `CrossSubsystem.lean`, which sits downstream
+of the cycle boundary and is the natural home for cross-subsystem preservation
+theorem composition.
 -/

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -26,6 +26,11 @@ WS-Z Phases Z1–Z10 complete. **WS-Z PORTFOLIO COMPLETE.**
 WS-AA Phase AA1 complete. Phase AA2 complete.
 WS-AB Phase D1 complete. Phase D2 complete. Phase D3 complete. Phase D4 complete. Phase D5 complete. Phase D6 complete. **WS-AB PORTFOLIO COMPLETE.**
 WS-AC Phase AC6 complete. **WS-AC PORTFOLIO COMPLETE.**
+WS-AD Phase AD1 complete.
+
+### WS-AD: Pre-Release Audit Remediation v0.25.10 (IN PROGRESS)
+
+- **Phase AD1 COMPLETE** (v0.25.11): Integration Fix (F-01) — 3 sub-tasks (AD1-A through AD1-C). F-01: Integrated 2 orphaned SchedContext preservation modules (`Preservation.lean`: 7 theorems covering Z5-M/Z5-I/Z5-K/Z5-L/Z5-N1/N2; `PriorityPreservation.lean`: 14 theorems covering D2-G/H/I/J transport lemmas and authority non-escalation) into the production proof chain. Import-cycle constraint discovered and resolved: direct import into `SchedContext/Invariant.lean` creates cycle via `Object/Types → SchedContext → Invariant → Preservation → Operations → Model.State → Object/Types`; resolved by importing from `CrossSubsystem.lean` (downstream of cycle boundary, natural integration point for cross-subsystem preservation composition). 21 theorems now reachable via `CrossSubsystem → Architecture/Invariant → API.lean`. Full build (236 jobs), `test_full.sh` (Tier 0–3), and sorry/axiom scan all pass. Zero sorry/axiom.
 
 ### WS-AC: Comprehensive Audit Remediation v0.25.3 (COMPLETE)
 

--- a/docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md
@@ -162,63 +162,78 @@ The following findings require no code or documentation changes:
 
 ---
 
-## 3. Phase AD1 — Integration Fix (F-01)
+## 3. Phase AD1 — Integration Fix (F-01) ✅ COMPLETE
 
 **Goal**: Integrate orphaned SchedContext invariant modules into the production
-proof chain by adding missing imports to the re-export hub.
-**Gate**: `lake build SeLe4n.Kernel.SchedContext.Invariant` + `lake build` (full).
+proof chain.
+**Gate**: `lake build SeLe4n.Kernel.CrossSubsystem` + `lake build` (full) +
+`test_smoke.sh`.
 **Dependencies**: None (first phase).
+**Status**: COMPLETE — all 21 theorems (7 + 14) reachable via production chain.
 
-### AD1-A: Add Preservation.lean import to SchedContext/Invariant.lean (F-01)
+### AD1 Implementation Note: Import Cycle Resolution
 
-**Finding**: `SchedContext/Invariant/Preservation.lean` (160 lines) contains 7
-proven theorems covering SchedContext configure, bind, unbind, and yieldTo
-operations (Z5-M, Z5-I, Z5-K, Z5-L, Z5-N1/N2). These are fully proven with
-zero sorry/axiom but are not imported by any module in the codebase.
+The original plan called for adding imports to `SchedContext/Invariant.lean`
+(the re-export hub). During implementation, this was found to create an import
+cycle:
 
-**Change**: In `SeLe4n/Kernel/SchedContext/Invariant.lean`, add:
+```
+Object/Types.lean → SchedContext.lean → SchedContext/Invariant.lean
+  → Preservation.lean → SchedContext/Operations.lean → Model.State
+  → Object/Types.lean  (CYCLE)
+```
+
+The `SchedContext/Invariant.lean` hub is transitively imported by
+`Object/Types.lean` via the `SchedContext.lean` re-export hub, and both
+preservation modules depend on `Operations.lean` which requires `Model.State`.
+
+**Resolution**: Both preservation modules are instead imported from
+`CrossSubsystem.lean`, which:
+1. Already sits downstream of the cycle boundary
+2. Is the natural integration point for cross-subsystem preservation theorems
+3. Feeds into the production chain via `Architecture/Invariant.lean` → `API.lean`
+
+The `SchedContext/Invariant.lean` hub retains a documentation note explaining
+the architectural constraint and pointing to `CrossSubsystem.lean` as the
+integration point.
+
+### AD1-A: Add Preservation.lean import to CrossSubsystem.lean (F-01)
+
+**Finding**: `SchedContext/Invariant/Preservation.lean` contains 7 proven
+theorems covering SchedContext configure, bind, unbind, and yieldTo operations
+(Z5-M, Z5-I, Z5-K, Z5-L, Z5-N1/N2). Zero sorry/axiom, not imported anywhere.
+
+**Change**: In `SeLe4n/Kernel/CrossSubsystem.lean`, add:
 ```lean
 import SeLe4n.Kernel.SchedContext.Invariant.Preservation
 ```
 
-**Proof impact**: None — this is a pure import addition. The theorems are
-already proven; they just become reachable from the production import chain.
+**Files modified**: `CrossSubsystem.lean` (1 import line + comment).
 
-**Build verification**: `lake build SeLe4n.Kernel.SchedContext.Invariant`
+### AD1-B: Add PriorityPreservation.lean import to CrossSubsystem.lean (F-01)
 
-**Files modified**: `SchedContext/Invariant.lean` (1 line added).
+**Finding**: `SchedContext/Invariant/PriorityPreservation.lean` contains 14
+proven theorems covering priority transport lemmas and authority bounds for
+setPriority/setMCPriority operations (D2-G/H/I/J). Orphaned identically.
 
-### AD1-B: Add PriorityPreservation.lean import to SchedContext/Invariant.lean (F-01)
-
-**Finding**: `SchedContext/Invariant/PriorityPreservation.lean` (159 lines)
-contains 11 proven theorems covering priority transport lemmas and authority
-bounds for setPriority/setMCPriority operations (D2-G/H/I/J). These are
-orphaned identically to Preservation.lean.
-
-**Change**: In `SeLe4n/Kernel/SchedContext/Invariant.lean`, add:
+**Change**: In `SeLe4n/Kernel/CrossSubsystem.lean`, add:
 ```lean
 import SeLe4n.Kernel.SchedContext.Invariant.PriorityPreservation
 ```
 
-**Proof impact**: None — pure import addition.
+**Files modified**: `CrossSubsystem.lean` (1 import line).
 
-**Build verification**: `lake build SeLe4n.Kernel.SchedContext.Invariant`
+### AD1-C: Verify integrated proof chain (F-01 closure) ✅
 
-**Files modified**: `SchedContext/Invariant.lean` (1 line added).
+**Verified**:
+1. Module build: `lake build SeLe4n.Kernel.CrossSubsystem` — 69 jobs, PASS
+2. Full build: `lake build` — 236 jobs, PASS
+3. Smoke test: `./scripts/test_smoke.sh` — all checks passed
+4. Theorem reachability: 21 theorems (7 + 14) confirmed reachable via
+   `CrossSubsystem.lean` → `Architecture/Invariant.lean` → `API.lean`
+5. Zero sorry/axiom in modified files
 
-### AD1-C: Verify integrated proof chain (F-01 closure)
-
-**Purpose**: Confirm that the newly-imported theorems compile cleanly as part
-of the full build and do not introduce import cycles or namespace conflicts.
-
-**Steps**:
-1. Build the re-export hub: `lake build SeLe4n.Kernel.SchedContext.Invariant`
-2. Full build: `source ~/.elan/env && lake build`
-3. Smoke test: `./scripts/test_smoke.sh`
-4. Verify the 18 theorems (7 + 11) are now reachable by grepping the Lean
-   environment for their names in a downstream module
-
-**Gate condition**: All 3 commands pass with zero errors.
+**Gate condition**: All commands pass with zero errors. ✅
 
 **Files modified**: None (verification only).
 
@@ -750,7 +765,7 @@ avoid merge conflicts in documentation files.
 
 | Phase | Lean Code | Proofs | Documentation | Total |
 |-------|-----------|--------|---------------|-------|
-| AD1 | 2 lines | 0 | 0 | ~2 lines |
+| AD1 ✅ | 2 import + 10 doc lines | 0 | 0 | ~12 lines |
 | AD2 | ~12 lines | 0 | ~20 lines | ~32 lines |
 | AD3 | 0 | 0 | ~150–200 lines | ~150–200 lines |
 | AD4 | 0 | ~140–200 lines | 0 | ~140–200 lines |
@@ -761,7 +776,8 @@ avoid merge conflicts in documentation files.
 
 | File | Phase | Change Type | Lines |
 |------|-------|-------------|-------|
-| `SchedContext/Invariant.lean` | AD1 | 2 import lines | ~2 |
+| `SchedContext/Invariant.lean` | AD1 | Doc note (cycle constraint) | ~10 |
+| `CrossSubsystem.lean` | AD1 | 2 import lines + comment | ~6 |
 | `IPC/DualQueue/Core.lean` | AD2 | New helper function | ~12 |
 | `IPC/Operations/Endpoint.lean` | AD2 | Comments | ~4 |
 | `IPC/DualQueue/WithCaps.lean` | AD2 | Comments | ~2 |
@@ -781,7 +797,7 @@ avoid merge conflicts in documentation files.
 |------|------------|--------|------------|
 | AD4 composition proofs require unexpected helper lemmas | Medium | Medium | AD4-A audit step identifies gaps before proof work begins |
 | Deployment guide content requires domain expert review | Low | Low | Cross-reference existing SECURITY_ADVISORY.md and formal theorems |
-| F-01 import addition causes namespace conflicts | Very Low | Low | Both modules already compile independently; imports are additive |
+| F-01 import addition causes import cycle | **REALIZED** | Medium | Resolved: imports moved from re-export hub to CrossSubsystem.lean (downstream of cycle boundary) |
 | AD4 proofs introduce sorry | Very Low | High | Gate condition requires sorry-free build; pre-commit hook enforces |
 | Documentation sync misses a cross-reference | Low | Low | AD5-B systematic verification catches gaps |
 

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/optimize-phase-ad1-integration-eqojX",
-      "commit_sha": "ac61607748ac2e5f57d4a2bf2053155eb25e9d88",
-      "tree_sha": "06a06e8c7ddb5d07284704706c2c9d0d5b7f3bb2",
-      "committed_at_utc": "2026-04-05T21:01:09-04:00"
+      "commit_sha": "0da8bd1b9db4e45246232f07f73a1136b5a63717",
+      "tree_sha": "a363b2d3a4ac0ccb3f36341a4713c5db49b63212",
+      "committed_at_utc": "2026-04-06T01:13:44+00:00"
     }
   },
   "source_sync": {
@@ -24,7 +24,7 @@
     "declaration_count": 4524
   },
   "readme_sync": {
-    "version": "0.25.10",
+    "version": "0.25.11",
     "lean_toolchain": "v4.28.0",
     "production_files": 133,
     "production_loc": 84028,

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "claude/optimize-phase-ac6-BVIHr",
-      "commit_sha": "860e2c7c4291744eb9cd5692351a785ec43245ad",
-      "tree_sha": "ea8fb81eb2970a55a98ca32ca0d134adb2d99ade",
-      "committed_at_utc": "2026-04-05T21:48:16+00:00"
+      "branch": "claude/optimize-phase-ad1-integration-eqojX",
+      "commit_sha": "ac61607748ac2e5f57d4a2bf2053155eb25e9d88",
+      "tree_sha": "06a06e8c7ddb5d07284704706c2c9d0d5b7f3bb2",
+      "committed_at_utc": "2026-04-05T21:01:09-04:00"
     }
   },
   "source_sync": {
@@ -17,7 +17,7 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "fbdeb1cb3a4ac4336cf34f4fbff7b189307c3c03528c06fde20b02f460846247"
+    "source_digest": "ef5cb5fa215c9d86f3bcaaf71dbb00225797912862e2664ec865cdbe3d3c5309"
   },
   "summary": {
     "module_count": 149,
@@ -27,10 +27,10 @@
     "version": "0.25.10",
     "lean_toolchain": "v4.28.0",
     "production_files": 133,
-    "production_loc": 84013,
+    "production_loc": 84028,
     "test_files": 16,
     "test_loc": 11318,
-    "proved_theorem_lemma_decls": 2478,
+    "proved_theorem_lemma_decls": 2479,
     "hardware_target": "Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A)"
   },
   "modules": [
@@ -8662,13 +8662,13 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 35,
+          "line": 41,
           "called": []
         },
         {
           "kind": "def",
           "name": "collectQueueMembers",
-          "line": 44,
+          "line": 50,
           "called": [
             "KernelObject",
             "ObjId",
@@ -8681,7 +8681,7 @@
         {
           "kind": "theorem",
           "name": "collectQueueMembers_none",
-          "line": 59,
+          "line": 65,
           "called": [
             "KernelObject",
             "ObjId",
@@ -8693,7 +8693,7 @@
         {
           "kind": "theorem",
           "name": "collectQueueMembers_fuel_sufficiency_documented",
-          "line": 93,
+          "line": 99,
           "called": [
             "KernelObject",
             "ObjId",
@@ -8708,7 +8708,7 @@
         {
           "kind": "theorem",
           "name": "collectQueueMembers_length_bounded",
-          "line": 106,
+          "line": 112,
           "called": [
             "KernelObject",
             "ObjId",
@@ -8723,7 +8723,7 @@
         {
           "kind": "def",
           "name": "noStaleEndpointQueueReferences",
-          "line": 134,
+          "line": 140,
           "called": [
             "Endpoint",
             "ObjId",
@@ -8737,7 +8737,7 @@
         {
           "kind": "def",
           "name": "noStaleNotificationWaitReferences",
-          "line": 152,
+          "line": 158,
           "called": [
             "Notification",
             "ObjId",
@@ -8749,7 +8749,7 @@
         {
           "kind": "def",
           "name": "registryDependencyConsistent",
-          "line": 160,
+          "line": 166,
           "called": [
             "ServiceGraphEntry",
             "ServiceId",
@@ -8760,7 +8760,7 @@
         {
           "kind": "def",
           "name": "schedContextStoreConsistent",
-          "line": 174,
+          "line": 180,
           "called": [
             "SystemState",
             "TCB",
@@ -8772,7 +8772,7 @@
         {
           "kind": "def",
           "name": "schedContextNotDualBound",
-          "line": 188,
+          "line": 194,
           "called": [
             "SchedContextId",
             "SystemState",
@@ -8785,7 +8785,7 @@
         {
           "kind": "def",
           "name": "schedContextRunQueueConsistent",
-          "line": 203,
+          "line": 209,
           "called": [
             "SystemState",
             "TCB",
@@ -8798,7 +8798,7 @@
         {
           "kind": "def",
           "name": "crossSubsystemInvariant",
-          "line": 236,
+          "line": 242,
           "called": [
             "SystemState",
             "noStaleEndpointQueueReferences",
@@ -8814,7 +8814,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemInvariant_to_schedContextStoreConsistent",
-          "line": 247,
+          "line": 253,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -8824,7 +8824,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemInvariant_to_schedContextNotDualBound",
-          "line": 252,
+          "line": 258,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -8834,7 +8834,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemInvariant_to_schedContextRunQueueConsistent",
-          "line": 257,
+          "line": 263,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -8844,7 +8844,7 @@
         {
           "kind": "theorem",
           "name": "default_crossSubsystemInvariant",
-          "line": 263,
+          "line": 269,
           "called": [
             "RHTable.getElem",
             "RHTable_getElem",
@@ -8863,7 +8863,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemInvariant_composition_gap_documented",
-          "line": 328,
+          "line": 334,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -8880,28 +8880,12 @@
         {
           "kind": "inductive",
           "name": "StateField",
-          "line": 358,
+          "line": 364,
           "called": []
         },
         {
           "kind": "def",
           "name": "registryEndpointValid_fields",
-          "line": 377,
-          "called": [
-            "StateField"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "registryDependencyConsistent_fields",
-          "line": 380,
-          "called": [
-            "StateField"
-          ]
-        },
-        {
-          "kind": "def",
-          "name": "noStaleEndpointQueueReferences_fields",
           "line": 383,
           "called": [
             "StateField"
@@ -8909,7 +8893,7 @@
         },
         {
           "kind": "def",
-          "name": "noStaleNotificationWaitReferences_fields",
+          "name": "registryDependencyConsistent_fields",
           "line": 386,
           "called": [
             "StateField"
@@ -8917,7 +8901,7 @@
         },
         {
           "kind": "def",
-          "name": "serviceGraphInvariant_fields",
+          "name": "noStaleEndpointQueueReferences_fields",
           "line": 389,
           "called": [
             "StateField"
@@ -8925,8 +8909,24 @@
         },
         {
           "kind": "def",
+          "name": "noStaleNotificationWaitReferences_fields",
+          "line": 392,
+          "called": [
+            "StateField"
+          ]
+        },
+        {
+          "kind": "def",
+          "name": "serviceGraphInvariant_fields",
+          "line": 395,
+          "called": [
+            "StateField"
+          ]
+        },
+        {
+          "kind": "def",
           "name": "schedContextStoreConsistent_fields",
-          "line": 394,
+          "line": 400,
           "called": [
             "StateField"
           ]
@@ -8934,7 +8934,7 @@
         {
           "kind": "def",
           "name": "schedContextNotDualBound_fields",
-          "line": 399,
+          "line": 405,
           "called": [
             "StateField"
           ]
@@ -8942,7 +8942,7 @@
         {
           "kind": "def",
           "name": "schedContextRunQueueConsistent_fields",
-          "line": 404,
+          "line": 410,
           "called": [
             "StateField"
           ]
@@ -8950,7 +8950,7 @@
         {
           "kind": "def",
           "name": "fieldsDisjoint",
-          "line": 408,
+          "line": 414,
           "called": [
             "StateField",
             "all"
@@ -8959,7 +8959,7 @@
         {
           "kind": "theorem",
           "name": "regDepConsistent_disjoint_staleEndpoint",
-          "line": 413,
+          "line": 419,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -8969,7 +8969,7 @@
         {
           "kind": "theorem",
           "name": "regDepConsistent_disjoint_staleNotification",
-          "line": 419,
+          "line": 425,
           "called": [
             "fieldsDisjoint",
             "noStaleNotificationWaitReferences_fields",
@@ -8979,7 +8979,7 @@
         {
           "kind": "theorem",
           "name": "serviceGraph_disjoint_staleEndpoint",
-          "line": 425,
+          "line": 431,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -8989,7 +8989,7 @@
         {
           "kind": "theorem",
           "name": "serviceGraph_disjoint_staleNotification",
-          "line": 431,
+          "line": 437,
           "called": [
             "fieldsDisjoint",
             "noStaleNotificationWaitReferences_fields",
@@ -8999,7 +8999,7 @@
         {
           "kind": "theorem",
           "name": "regDepConsistent_disjoint_regEndpointValid",
-          "line": 439,
+          "line": 445,
           "called": [
             "fieldsDisjoint",
             "registryDependencyConsistent_fields",
@@ -9009,7 +9009,7 @@
         {
           "kind": "theorem",
           "name": "serviceGraph_disjoint_regEndpointValid",
-          "line": 445,
+          "line": 451,
           "called": [
             "fieldsDisjoint",
             "registryEndpointValid_fields",
@@ -9019,7 +9019,7 @@
         {
           "kind": "theorem",
           "name": "staleEndpoint_shares_staleNotification",
-          "line": 452,
+          "line": 458,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9029,7 +9029,7 @@
         {
           "kind": "theorem",
           "name": "regEndpointValid_shares_staleEndpoint",
-          "line": 458,
+          "line": 464,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9039,7 +9039,7 @@
         {
           "kind": "theorem",
           "name": "regEndpointValid_shares_staleNotification",
-          "line": 464,
+          "line": 470,
           "called": [
             "fieldsDisjoint",
             "noStaleNotificationWaitReferences_fields",
@@ -9049,7 +9049,7 @@
         {
           "kind": "theorem",
           "name": "regDepConsistent_shares_serviceGraph",
-          "line": 470,
+          "line": 476,
           "called": [
             "fieldsDisjoint",
             "registryDependencyConsistent_fields",
@@ -9059,7 +9059,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxStore_disjoint_regDepConsistent",
-          "line": 483,
+          "line": 489,
           "called": [
             "fieldsDisjoint",
             "registryDependencyConsistent_fields",
@@ -9069,7 +9069,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxStore_disjoint_serviceGraph",
-          "line": 489,
+          "line": 495,
           "called": [
             "fieldsDisjoint",
             "schedContextStoreConsistent_fields",
@@ -9079,7 +9079,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxNotDualBound_disjoint_regDepConsistent",
-          "line": 495,
+          "line": 501,
           "called": [
             "fieldsDisjoint",
             "registryDependencyConsistent_fields",
@@ -9089,7 +9089,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxNotDualBound_disjoint_serviceGraph",
-          "line": 501,
+          "line": 507,
           "called": [
             "fieldsDisjoint",
             "schedContextNotDualBound_fields",
@@ -9099,7 +9099,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxRunQueue_disjoint_regDepConsistent",
-          "line": 507,
+          "line": 513,
           "called": [
             "fieldsDisjoint",
             "registryDependencyConsistent_fields",
@@ -9109,7 +9109,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxRunQueue_disjoint_serviceGraph",
-          "line": 513,
+          "line": 519,
           "called": [
             "fieldsDisjoint",
             "schedContextRunQueueConsistent_fields",
@@ -9119,7 +9119,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxStore_shares_regEndpointValid",
-          "line": 519,
+          "line": 525,
           "called": [
             "fieldsDisjoint",
             "registryEndpointValid_fields",
@@ -9129,7 +9129,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxStore_shares_staleEndpoint",
-          "line": 525,
+          "line": 531,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9139,7 +9139,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxStore_shares_staleNotification",
-          "line": 531,
+          "line": 537,
           "called": [
             "fieldsDisjoint",
             "noStaleNotificationWaitReferences_fields",
@@ -9149,7 +9149,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxStore_shares_schedCtxNotDualBound",
-          "line": 537,
+          "line": 543,
           "called": [
             "fieldsDisjoint",
             "schedContextNotDualBound_fields",
@@ -9159,7 +9159,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxStore_shares_schedCtxRunQueue",
-          "line": 543,
+          "line": 549,
           "called": [
             "fieldsDisjoint",
             "schedContextRunQueueConsistent_fields",
@@ -9169,7 +9169,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxNotDualBound_shares_regEndpointValid",
-          "line": 549,
+          "line": 555,
           "called": [
             "fieldsDisjoint",
             "registryEndpointValid_fields",
@@ -9179,7 +9179,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxNotDualBound_shares_staleEndpoint",
-          "line": 555,
+          "line": 561,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9189,7 +9189,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxNotDualBound_shares_staleNotification",
-          "line": 561,
+          "line": 567,
           "called": [
             "fieldsDisjoint",
             "noStaleNotificationWaitReferences_fields",
@@ -9199,7 +9199,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxNotDualBound_shares_schedCtxRunQueue",
-          "line": 567,
+          "line": 573,
           "called": [
             "fieldsDisjoint",
             "schedContextNotDualBound_fields",
@@ -9209,7 +9209,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxRunQueue_shares_regEndpointValid",
-          "line": 573,
+          "line": 579,
           "called": [
             "fieldsDisjoint",
             "registryEndpointValid_fields",
@@ -9219,7 +9219,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxRunQueue_shares_staleEndpoint",
-          "line": 579,
+          "line": 585,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9229,7 +9229,7 @@
         {
           "kind": "theorem",
           "name": "schedCtxRunQueue_shares_staleNotification",
-          "line": 585,
+          "line": 591,
           "called": [
             "fieldsDisjoint",
             "noStaleNotificationWaitReferences_fields",
@@ -9239,7 +9239,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystem_pairwise_coverage_complete",
-          "line": 606,
+          "line": 612,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9255,7 +9255,7 @@
         {
           "kind": "def",
           "name": "storeObject_modifiedFields",
-          "line": 628,
+          "line": 634,
           "called": [
             "StateField"
           ]
@@ -9263,7 +9263,7 @@
         {
           "kind": "def",
           "name": "serviceRegisterDependency_modifiedFields",
-          "line": 633,
+          "line": 639,
           "called": [
             "StateField"
           ]
@@ -9271,7 +9271,7 @@
         {
           "kind": "def",
           "name": "lifecycleRetypeObject_modifiedFields",
-          "line": 638,
+          "line": 644,
           "called": [
             "StateField"
           ]
@@ -9279,7 +9279,7 @@
         {
           "kind": "def",
           "name": "ipcEndpointOp_modifiedFields",
-          "line": 645,
+          "line": 651,
           "called": [
             "StateField"
           ]
@@ -9287,7 +9287,7 @@
         {
           "kind": "def",
           "name": "capabilityOp_modifiedFields",
-          "line": 652,
+          "line": 658,
           "called": [
             "StateField"
           ]
@@ -9295,7 +9295,7 @@
         {
           "kind": "def",
           "name": "revokeService_modifiedFields",
-          "line": 658,
+          "line": 664,
           "called": [
             "StateField"
           ]
@@ -9303,7 +9303,7 @@
         {
           "kind": "theorem",
           "name": "noStaleEndpointQueueReferences_frame",
-          "line": 668,
+          "line": 674,
           "called": [
             "SystemState",
             "noStaleEndpointQueueReferences"
@@ -9312,7 +9312,7 @@
         {
           "kind": "theorem",
           "name": "noStaleNotificationWaitReferences_frame",
-          "line": 690,
+          "line": 696,
           "called": [
             "SystemState",
             "noStaleNotificationWaitReferences"
@@ -9321,7 +9321,7 @@
         {
           "kind": "theorem",
           "name": "registryEndpointValid_frame",
-          "line": 702,
+          "line": 708,
           "called": [
             "SystemState",
             "registryEndpointValid"
@@ -9330,7 +9330,7 @@
         {
           "kind": "theorem",
           "name": "fieldDisjointness_frameIndependence_documented",
-          "line": 754,
+          "line": 760,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9343,7 +9343,7 @@
         {
           "kind": "def",
           "name": "crossSubsystemFieldSets",
-          "line": 771,
+          "line": 777,
           "called": [
             "StateField",
             "noStaleEndpointQueueReferences_fields",
@@ -9359,13 +9359,13 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemFieldSets_count",
-          "line": 782,
+          "line": 788,
           "called": []
         },
         {
           "kind": "theorem",
           "name": "registryDependencyConsistent_frame",
-          "line": 788,
+          "line": 794,
           "called": [
             "SystemState",
             "registryDependencyConsistent"
@@ -9374,7 +9374,7 @@
         {
           "kind": "theorem",
           "name": "serviceGraphInvariant_frame",
-          "line": 806,
+          "line": 812,
           "called": [
             "SystemState",
             "lookupService",
@@ -9387,7 +9387,7 @@
         {
           "kind": "theorem",
           "name": "schedContextStoreConsistent_frame",
-          "line": 836,
+          "line": 842,
           "called": [
             "SystemState",
             "scId",
@@ -9397,7 +9397,7 @@
         {
           "kind": "theorem",
           "name": "schedContextNotDualBound_frame",
-          "line": 849,
+          "line": 855,
           "called": [
             "SystemState",
             "scId",
@@ -9407,7 +9407,7 @@
         {
           "kind": "theorem",
           "name": "schedContextRunQueueConsistent_frame",
-          "line": 859,
+          "line": 865,
           "called": [
             "SystemState",
             "runnable",
@@ -9418,7 +9418,7 @@
         {
           "kind": "theorem",
           "name": "serviceGraphInvariant_monotone",
-          "line": 880,
+          "line": 886,
           "called": [
             "SystemState",
             "lookupService",
@@ -9431,7 +9431,7 @@
         {
           "kind": "theorem",
           "name": "revokeService_preserves_noStaleNotificationWaitReferences",
-          "line": 911,
+          "line": 917,
           "called": [
             "ServiceId",
             "SystemState",
@@ -9444,7 +9444,7 @@
         {
           "kind": "theorem",
           "name": "sharingPair1_objects_frame",
-          "line": 950,
+          "line": 956,
           "called": [
             "SystemState",
             "noStaleEndpointQueueReferences",
@@ -9456,7 +9456,7 @@
         {
           "kind": "theorem",
           "name": "sharingPair23_objects_frame",
-          "line": 963,
+          "line": 969,
           "called": [
             "SystemState",
             "noStaleEndpointQueueReferences",
@@ -9470,7 +9470,7 @@
         {
           "kind": "theorem",
           "name": "sharingPair4_services_frame",
-          "line": 981,
+          "line": 987,
           "called": [
             "SystemState",
             "registryDependencyConsistent",
@@ -9482,7 +9482,7 @@
         {
           "kind": "theorem",
           "name": "revokeService_preserves_sharingPairs_objects",
-          "line": 995,
+          "line": 1001,
           "called": [
             "ServiceId",
             "SystemState",
@@ -9497,7 +9497,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemInvariant_objects_frame",
-          "line": 1011,
+          "line": 1017,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -9515,7 +9515,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemInvariant_services_change",
-          "line": 1035,
+          "line": 1041,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -9533,7 +9533,7 @@
         {
           "kind": "theorem",
           "name": "crossSubsystemInvariant_composition_complete",
-          "line": 1076,
+          "line": 1082,
           "called": [
             "fieldsDisjoint",
             "noStaleEndpointQueueReferences_fields",
@@ -9549,7 +9549,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_schedContextStoreConsistent",
-          "line": 1124,
+          "line": 1130,
           "called": [
             "SystemState",
             "schedContextStoreConsistent",
@@ -9559,7 +9559,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_schedContextNotDualBound",
-          "line": 1134,
+          "line": 1140,
           "called": [
             "SystemState",
             "schedContextNotDualBound",
@@ -9569,7 +9569,7 @@
         {
           "kind": "theorem",
           "name": "timerTick_preserves_schedContextRunQueueConsistent",
-          "line": 1144,
+          "line": 1150,
           "called": [
             "SystemState",
             "runnable",
@@ -9580,7 +9580,7 @@
         {
           "kind": "theorem",
           "name": "schedule_preserves_schedContextPredicates",
-          "line": 1155,
+          "line": 1161,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -9596,7 +9596,7 @@
         {
           "kind": "theorem",
           "name": "donation_frame_preserves_schedContextNotDualBound",
-          "line": 1173,
+          "line": 1179,
           "called": [
             "SystemState",
             "schedContextNotDualBound",
@@ -9606,7 +9606,7 @@
         {
           "kind": "theorem",
           "name": "donation_frame_preserves_schedContextStoreConsistent",
-          "line": 1185,
+          "line": 1191,
           "called": [
             "SystemState",
             "schedContextStoreConsistent",
@@ -9616,7 +9616,7 @@
         {
           "kind": "theorem",
           "name": "cleanup_frame_preserves_schedContextPredicates",
-          "line": 1198,
+          "line": 1204,
           "called": [
             "SystemState",
             "crossSubsystemInvariant",
@@ -9630,7 +9630,7 @@
         {
           "kind": "theorem",
           "name": "threadCleanup_frame_preserves_schedContextPredicates",
-          "line": 1215,
+          "line": 1221,
           "called": [
             "Kernel",
             "SystemState",

--- a/docs/gitbook/12-proof-and-invariant-map.md
+++ b/docs/gitbook/12-proof-and-invariant-map.md
@@ -2457,6 +2457,14 @@ Phase Z9 composes SchedContext invariants into the cross-subsystem and top-level
 proof surfaces, closing the gap between per-subsystem CBS proofs (Z2–Z8) and the
 kernel-wide invariant bundle.
 
+**SchedContext preservation integration** (AD1/F-01, `CrossSubsystem.lean`):
+- `Preservation.lean` (7 theorems: Z5 per-operation preservation) and
+  `PriorityPreservation.lean` (14 theorems: D2 transport lemmas, authority bounds)
+  are imported here rather than the `SchedContext/Invariant.lean` re-export hub,
+  due to an import-cycle constraint (`Object/Types → SchedContext → Invariant →
+  Preservation → Operations → Model.State → Object/Types`). This makes all 21
+  theorems reachable via the production chain: `CrossSubsystem → Architecture/Invariant → API`.
+
 **Cross-subsystem invariant extension** (`CrossSubsystem.lean`):
 - `schedContextStoreConsistent` — every SchedContext in the object store satisfies `schedContextWellFormed`
 - `schedContextNotDualBound` — no SchedContext is simultaneously bound to two different threads

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,7 +5,7 @@
 # under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 
 name = "seLe4n"
-version = "0.25.10"
+version = "0.25.11"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced**: WS-AD Phase AD1 (Pre-Release Audit Remediation)
- **Recommendation IDs closed**: F-01
- **Scope notes**: Integration of 21 orphaned but fully-proven SchedContext preservation theorems into the production proof chain via import cycle resolution

## Changes

### Core Integration (AD1-A/B)
Integrated two orphaned SchedContext preservation modules into the production proof chain:

1. **`Preservation.lean`** (7 theorems): Z5 per-operation preservation for configure, bind, unbind, and yieldTo operations
2. **`PriorityPreservation.lean`** (14 theorems): D2 transport lemmas and authority non-escalation bounds for setPriority/setMCPriority

Both modules were fully proven (zero sorry/axiom) but unreachable—not imported by any production module.

### Import Cycle Resolution (AD1 Implementation Note)
Direct import into `SchedContext/Invariant.lean` (the re-export hub) would create a dependency cycle:
```
Object/Types → SchedContext → SchedContext/Invariant → Preservation → 
Operations → Model.State → Object/Types (CYCLE)
```

**Resolution**: Both preservation modules are imported from `CrossSubsystem.lean` instead, which:
- Sits downstream of the cycle boundary
- Is the natural integration point for cross-subsystem preservation theorem composition
- Feeds into production chain: `CrossSubsystem → Architecture/Invariant → API.lean`

### Files Modified
- **`SeLe4n/Kernel/CrossSubsystem.lean`**: Added 2 import lines + explanatory comment for AD1/F-01
- **`SeLe4n/Kernel/SchedContext/Invariant.lean`**: Added documentation note explaining the architectural constraint and pointing to `CrossSubsystem.lean` as the integration point
- **Version/metadata**: Bumped v0.25.10 → v0.25.11; updated codebase_map.json, README.md, CHANGELOG.md, audit workstream plan, and proof map documentation

## Validation evidence

- [x] `./scripts/test_smoke.sh` — PASS
- [x] `./scripts/test_full.sh` — PASS (Tier 0-3, all checks)
- [x] Module build: `lake build SeLe4n.Kernel.CrossSubsystem` — 69 jobs, PASS
- [x] Full build: `lake build` — 236 jobs, PASS
- [x] Theorem reachability verified: 21 theorems (7 + 14) confirmed reachable via production chain
- [x] Zero sorry/axiom in modified files

## Documentation synchronization checklist

- [x] Canonical source docs updated first (`docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md`)
- [x] GitBook mirrors synchronized (`docs/gitbook/12-proof-and-invariant-map.md`)
- [x] Workstream history updated (`docs/WORKSTREAM_HISTORY.md`)
- [x] Active slice status synchronized (`README.md`, `CLAUDE.md`)
- [x] CHANGELOG.md entry added with full context
- [x] Codebase metadata refreshed (`docs/codebase_map.json`)

## Risks / follow-ups

- **Residual risks**: None. Import cycle constraint is architectural and well-documented. All 21 theorems verified reachable from production chain.
- **Deferred items**: None. Phase AD1 complete; AD2–AD5 remain in WS-AD backlog.

https://claude.ai/code/session_01TB4jmViTsSzZ39n4iQEaZg