### PR TITLE
WS-AD Phase AD2: Code Quality Hardening (F-02, F-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## v0.25.12 — WS-AD Phase AD2: Code Quality Hardening (F-02, F-03)
+
+Phase AD2 of WS-AD Pre-Release Audit Remediation. 4 sub-tasks. All tests pass
+(full build + test_smoke.sh). Zero sorry/axiom.
+
+### Changes
+- **AD2-A (F-02)**: Added `endpointQueuePopHeadFresh` convenience wrapper in
+  `DualQueue/Core.lean` that returns the post-state TCB with cleared queue
+  links, avoiding the stale-snapshot footgun documented under WS-L1/L1-A.
+  The original `endpointQueuePopHead` returns the pre-dequeue TCB whose
+  queue link fields are stale; the new variant re-fetches from post-state.
+- **AD2-B (F-02)**: Added staleness annotations at all 3 call sites of
+  `endpointQueuePopHead` in `DualQueue/Transport.lean` (`endpointSendDual`,
+  `endpointReceiveDual`, `endpointCall`), noting that the returned TCB has
+  stale queue links and callers should use `st'` for current state.
+- **AD2-C (F-03)**: Enhanced module-level docstring in
+  `IPC/Operations/CapTransfer.lean` with explicit F-03 error-to-noSlot
+  conversion documentation. Clarifies that `ipcTransferSingleCap` errors
+  are intentionally converted to `.noSlot` by `ipcUnwrapCapsLoop`, matching
+  seL4's cursor-preservation semantics. No capability can be silently
+  installed or lost.
+- **AD2-D**: Gate verification — module builds (Core, CapTransfer, Transport),
+  full build (236 jobs), and smoke tests all pass.
+- Codebase map regenerated; version bump 0.25.11 → 0.25.12.
+
 ## v0.25.11 — WS-AD Phase AD1: Integration Fix (F-01)
 
 Phase AD1 of WS-AD Pre-Release Audit Remediation. 3 sub-tasks. All tests pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 seLe4n is a production-oriented microkernel written in Lean 4 with machine-checked
 proofs, improving on seL4 architecture. Every kernel transition is an executable
 pure function with zero `sorry`/`axiom`. First hardware target: Raspberry Pi 5.
-Lean 4.28.0 toolchain, Lake build system, version 0.25.10.
+Lean 4.28.0 toolchain, Lake build system, version 0.25.12.
 
 ## Build and run
 
@@ -495,6 +495,7 @@ under `docs/` and `docs/gitbook/`.
 
 ## Active workstream context
 
+- **WS-AD Phase AD2 COMPLETE** (v0.25.12): Pre-Release Audit Remediation — Phase AD2 Code Quality Hardening (F-02, F-03): `endpointQueuePopHeadFresh` convenience wrapper added (stale-TCB footgun mitigation), staleness annotations at all call sites, CapTransfer error-to-noSlot documentation. Zero sorry/axiom. See `docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md`
 - **WS-AD Phase AD1 COMPLETE** (v0.25.11): Pre-Release Audit Remediation — Phase AD1 Integration Fix (F-01): 21 orphaned SchedContext preservation theorems integrated via CrossSubsystem.lean (import-cycle resolution). Zero sorry/axiom. See `docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md`
 - **WS-AC PORTFOLIO COMPLETE** (v0.25.3–v0.25.10): Comprehensive Audit Remediation — 6 phases (AC1–AC6), 42 sub-tasks. 3 HIGH, 9 MEDIUM, 9 LOW findings addressed. Phase AC6 COMPLETE (documentation, testing & closure: T-03 DecodingSuite, audit errata, workstream history). Zero sorry/axiom. See `docs/audits/AUDIT_v0.25.3_WORKSTREAM_PLAN.md`
 - **WS-AB PORTFOLIO COMPLETE** (v0.24.0–v0.25.5): Deferred Operations & Liveness Completion — 6 phases, 90 sub-tasks. All 5 deferred seL4 operations implemented: suspend/resume (D1), setPriority/setMCPriority (D2), setIPCBuffer (D3). Priority Inheritance Protocol (D4). Bounded Latency Theorem WCRT = D*L_max + N*(B+P) (D5). API Surface Integration & Closure (D6). Rust ABI synchronized (SyscallId 25, KernelError 44). Zero sorry/axiom. See `docs/dev_history/planning/WS_AB_DEFERRED_OPERATIONS_WORKSTREAM_PLAN.md`

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ history is in [`docs/WORKSTREAM_HISTORY.md`](docs/WORKSTREAM_HISTORY.md).
 
 | Workstream | Scope | Version |
 |------------|-------|---------|
-| **WS-AD** | Pre-Release Audit Remediation — 21 findings (7 actionable), Phase AD1: orphaned SchedContext preservation module integration with import-cycle resolution (3 tasks) | v0.25.11 |
+| **WS-AD** | Pre-Release Audit Remediation — 21 findings (7 actionable), Phase AD1: orphaned SchedContext preservation module integration (3 tasks), Phase AD2: code quality hardening with fresh-TCB helper and CapTransfer docstring (4 tasks) | v0.25.11–v0.25.12 |
 | **WS-AC** | Comprehensive Audit Remediation — 3 HIGH, 9 MEDIUM, 9 LOW findings addressed across scheduler, IPC, capability, architecture, and cross-cutting subsystems (6 phases, 42 tasks) | v0.25.3–v0.25.10 |
 | **WS-AB** | Deferred Operations & Liveness — suspend/resume, setPriority/setMCPriority, setIPCBuffer, Priority Inheritance Protocol, Bounded Latency Theorem (6 phases, 90 tasks) | v0.24.0–v0.25.5 |
 | **WS-Z** | Composable Performance Objects — `SchedContext` as 7th kernel object, CBS budget engine, replenishment queue, passive server donation, timeout endpoints (10 phases, 213 tasks) | v0.23.0–v0.23.21 |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/lean_action_ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml"><img src="https://github.com/hatter6822/seLe4n/actions/workflows/platform_security_baseline.yml/badge.svg" alt="Security" /></a>
-  <img src="https://img.shields.io/badge/version-0.25.11-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.25.12-blue" alt="Version" />
   <img src="https://img.shields.io/badge/Lean-v4.28.0-blueviolet" alt="Lean 4" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License" /></a>
 </p>
@@ -85,9 +85,9 @@ architectural improvements enabled by the Lean 4 proof framework:
 
 | Attribute | Value |
 |-----------|-------|
-| **Version** | `0.25.11` |
+| **Version** | `0.25.12` |
 | **Lean toolchain** | `v4.28.0` |
-| **Production Lean LoC** | 84,028 across 133 files |
+| **Production Lean LoC** | 84,061 across 133 files |
 | **Test Lean LoC** | 11,318 across 16 test suites |
 | **Proved declarations** | 2,479 theorem/lemma declarations (zero sorry/axiom) |
 | **Target hardware** | Raspberry Pi 5 (BCM2712 / ARM Cortex-A76 / ARMv8-A) |
@@ -207,7 +207,7 @@ per-file inventory, see [`docs/codebase_map.json`](docs/codebase_map.json).
 | **Bounded latency** | No formal WCRT bound | `WCRT = D × L_max + N × (B + P)` proven across 7 liveness modules |
 | **Object stores** | Linked lists and arrays | Verified Robin Hood hash tables (`RHTable`/`RHSet`) with O(1) hot paths |
 | **Service management** | Not in kernel | First-class orchestration with dependency graph and acyclicity proofs |
-| **Proofs** | Isabelle/HOL, post-hoc | Lean 4 type-checker, co-located with transitions (2,479 theorems, zero sorry/axiom) |
+| **Proofs** | Isabelle/HOL, post-hoc | Lean 4 type-checker, co-located with transitions (2,479 proved declarations, zero sorry/axiom) |
 | **Platform** | C-level HAL | `PlatformBinding` typeclass with typed boundary contracts |
 
 ## What's next

--- a/SeLe4n/Kernel/IPC/DualQueue.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue.lean
@@ -15,7 +15,7 @@ import SeLe4n.Kernel.IPC.Operations.Timeout
 
 Decomposed into:
 - **Core**: Dual-queue endpoint operations (storeTcbQueueLinks, endpointQueuePopHead,
-  endpointQueueEnqueue, endpointQueueRemove).
+  endpointQueuePopHeadFresh, endpointQueueEnqueue, endpointQueueRemove).
 - **Transport**: Transport lemmas proving scheduler/object/endpoint/notification
   backward preservation for all dual-queue primitives.
 - **Timeout**: Z6 timeout-driven IPC unblocking (timeoutThread, timeoutAwareReceive).

--- a/SeLe4n/Kernel/IPC/DualQueue/Core.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue/Core.lean
@@ -281,6 +281,25 @@ def endpointQueuePopHead
   | some _ => .error .invalidCapability
   | none => .error .objectNotFound
 
+/-- WS-L1/L1-A (AD2-A): Convenience wrapper that returns the *post-state* TCB
+    with cleared queue links, avoiding the stale-snapshot footgun.
+    `endpointQueuePopHead` returns the pre-dequeue TCB whose queue link fields
+    (queuePrev, queuePPrev, queueNext) are stale — they reflect the pre-state,
+    not the post-state where links have been cleared. Use this variant when the
+    caller needs accurate queue link fields from the post-state.
+    Non-queue fields (ipcState, pendingMessage, priority, domain) are identical
+    in both variants. -/
+def endpointQueuePopHeadFresh
+    (endpointId : SeLe4n.ObjId)
+    (isReceiveQ : Bool)
+    (st : SystemState) : Except KernelError (SeLe4n.ThreadId × TCB × SystemState) :=
+  match endpointQueuePopHead endpointId isReceiveQ st with
+  | .ok (tid, _staleTcb, st') =>
+    match st'.objects[tid.toObjId]? with
+    | some (.tcb freshTcb) => .ok (tid, freshTcb, st')
+    | _ => .error .objectNotFound  -- unreachable: popHead stores cleared TCB
+  | .error e => .error e
+
 def endpointQueueEnqueue
     (endpointId : SeLe4n.ObjId)
     (isReceiveQ : Bool)

--- a/SeLe4n/Kernel/IPC/DualQueue/Transport.lean
+++ b/SeLe4n/Kernel/IPC/DualQueue/Transport.lean
@@ -1595,6 +1595,7 @@ def endpointSendDual (endpointId : SeLe4n.ObjId) (sender : SeLe4n.ThreadId)
         match ep.receiveQ.head with
         | some _ =>
             -- WS-L1/L1-A: PopHead now returns (ThreadId × TCB × SystemState)
+            -- Note: _tcb has stale queue links (WS-L1/L1-A); use st' for current state
             match endpointQueuePopHead endpointId true st with
             | .error e => .error e
             | .ok (receiver, _tcb, st') =>
@@ -1637,6 +1638,7 @@ def endpointReceiveDual (endpointId : SeLe4n.ObjId) (receiver : SeLe4n.ThreadId)
         match ep.sendQ.head with
         | some _ =>
             -- WS-L1/L1-A: PopHead returns pre-dequeue TCB; read fields directly
+            -- Note: senderTcb has stale queue links (WS-L1/L1-A); use st' for current state
             match endpointQueuePopHead endpointId false st with
             | .error e => .error e
             | .ok (sender, senderTcb, st') =>
@@ -1719,6 +1721,7 @@ def endpointCall (endpointId : SeLe4n.ObjId) (caller : SeLe4n.ThreadId)
         match ep.receiveQ.head with
         | some _ =>
             -- WS-L1/L1-A: PopHead now returns (ThreadId × TCB × SystemState)
+            -- Note: _tcb has stale queue links (WS-L1/L1-A); use st' for current state
             match endpointQueuePopHead endpointId true st with
             | .error e => .error e
             | .ok (receiver, _tcb, st') =>

--- a/SeLe4n/Kernel/IPC/Operations/CapTransfer.lean
+++ b/SeLe4n/Kernel/IPC/Operations/CapTransfer.lean
@@ -30,6 +30,17 @@ and the loop short-circuits: all remaining caps are filled with `.noSlot` via
 aligns with seL4's cursor-preservation semantics, while the short-circuit
 exploits the observation that error conditions persist (the receiver's CSpace
 root hasn't changed, so subsequent transfers would fail identically).
+
+**Error-to-noSlot conversion (F-03/AD2-C):** When `ipcTransferSingleCap` fails
+(e.g., receiver CSpace root not found, or slot insertion error), the error is
+converted to `.noSlot` in the transfer results array by `ipcUnwrapCapsLoop`.
+Remaining capabilities in the batch are padded with `.noSlot` via short-circuit
+semantics. This matches seL4's cursor-preservation behavior: the receiver sees
+a consistent result count regardless of individual transfer failures. The
+conversion is intentional and does NOT mask security-relevant failures — the
+receiver simply sees fewer successfully transferred capabilities, which is the
+correct degraded behavior. No capability can be silently installed or lost;
+the sender retains all originals.
 -/
 
 namespace SeLe4n.Kernel

--- a/docs/WORKSTREAM_HISTORY.md
+++ b/docs/WORKSTREAM_HISTORY.md
@@ -27,9 +27,11 @@ WS-AA Phase AA1 complete. Phase AA2 complete.
 WS-AB Phase D1 complete. Phase D2 complete. Phase D3 complete. Phase D4 complete. Phase D5 complete. Phase D6 complete. **WS-AB PORTFOLIO COMPLETE.**
 WS-AC Phase AC6 complete. **WS-AC PORTFOLIO COMPLETE.**
 WS-AD Phase AD1 complete.
+WS-AD Phase AD2 complete.
 
 ### WS-AD: Pre-Release Audit Remediation v0.25.10 (IN PROGRESS)
 
+- **Phase AD2 COMPLETE** (v0.25.12): Code Quality Hardening (F-02, F-03) — 4 sub-tasks (AD2-A through AD2-D). F-02: Added `endpointQueuePopHeadFresh` convenience wrapper in `DualQueue/Core.lean` that returns the post-state TCB with cleared queue links, avoiding the stale-snapshot footgun documented under WS-L1/L1-A. Staleness annotations added at all 3 call sites in `Transport.lean` (`endpointSendDual`, `endpointReceiveDual`, `endpointCall`). F-03: Enhanced module-level docstring in `IPC/Operations/CapTransfer.lean` with explicit error-to-noSlot conversion documentation — clarifies that `ipcTransferSingleCap` errors are intentionally converted to `.noSlot` by `ipcUnwrapCapsLoop`, matching seL4's cursor-preservation semantics. Full build (236 jobs) and smoke tests pass. Zero sorry/axiom.
 - **Phase AD1 COMPLETE** (v0.25.11): Integration Fix (F-01) — 3 sub-tasks (AD1-A through AD1-C). F-01: Integrated 2 orphaned SchedContext preservation modules (`Preservation.lean`: 7 theorems covering Z5-M/Z5-I/Z5-K/Z5-L/Z5-N1/N2; `PriorityPreservation.lean`: 14 theorems covering D2-G/H/I/J transport lemmas and authority non-escalation) into the production proof chain. Import-cycle constraint discovered and resolved: direct import into `SchedContext/Invariant.lean` creates cycle via `Object/Types → SchedContext → Invariant → Preservation → Operations → Model.State → Object/Types`; resolved by importing from `CrossSubsystem.lean` (downstream of cycle boundary, natural integration point for cross-subsystem preservation composition). 21 theorems now reachable via `CrossSubsystem → Architecture/Invariant → API.lean`. Full build (236 jobs), `test_full.sh` (Tier 0–3), and sorry/axiom scan all pass. Zero sorry/axiom.
 
 ### WS-AC: Comprehensive Audit Remediation v0.25.3 (COMPLETE)

--- a/docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md
@@ -288,20 +288,21 @@ is additive and does not modify `endpointQueuePopHead`.
 TCB has stale queue links. While the function itself is well-documented, the
 call sites may benefit from a one-line annotation.
 
-**Change**: Audit all callers of `endpointQueuePopHead` in the codebase (expected
-in `Endpoint.lean`, `DualQueue/WithCaps.lean`) and add a brief inline comment
-at each call site:
+**Change**: Audit all callers of `endpointQueuePopHead` in the codebase.
+Actual call sites are in `DualQueue/Transport.lean` (3 call sites:
+`endpointSendDual`, `endpointReceiveDual`, `endpointCall`), not in
+`Endpoint.lean` or `WithCaps.lean` as originally expected. Added inline
+comments at each call site:
 
 ```lean
--- Note: headTcb has stale queue links (WS-L1/L1-A); use st' for current state
+-- Note: _tcb/senderTcb has stale queue links (WS-L1/L1-A); use st' for current state
 ```
 
 **Proof impact**: None — comments only.
 
-**Build verification**: `lake build SeLe4n.Kernel.IPC.Operations.Endpoint`
+**Build verification**: `lake build SeLe4n.Kernel.IPC.DualQueue.Transport`
 
-**Files modified**: `Endpoint.lean`, `DualQueue/WithCaps.lean` (~2–4 comment
-lines each).
+**Files modified**: `DualQueue/Transport.lean` (3 comment lines added).
 **Estimated effort**: Minimal.
 
 ### AD2-C: Add module-boundary docstring to CapTransfer.lean (F-03) ✅
@@ -788,10 +789,9 @@ avoid merge conflicts in documentation files.
 |------|-------|-------------|-------|
 | `SchedContext/Invariant.lean` | AD1 | Doc note (cycle constraint) | ~10 |
 | `CrossSubsystem.lean` | AD1 | 2 import lines + comment | ~6 |
-| `IPC/DualQueue/Core.lean` | AD2 | New helper function | ~12 |
-| `IPC/Operations/Endpoint.lean` | AD2 | Comments | ~4 |
-| `IPC/DualQueue/WithCaps.lean` | AD2 | Comments | ~2 |
-| `IPC/Operations/CapTransfer.lean` | AD2 | Module docstring | ~15 |
+| `IPC/DualQueue/Core.lean` | AD2 | New helper function | ~19 |
+| `IPC/DualQueue/Transport.lean` | AD2 | Staleness comments (3 call sites) | ~3 |
+| `IPC/Operations/CapTransfer.lean` | AD2 | Module docstring enhancement | ~11 |
 | `docs/DEPLOYMENT_GUIDE.md` | AD3 | New file | ~80–100 |
 | `docs/spec/SELE4N_SPEC.md` | AD3 | NI scope section | ~10–15 |
 | `docs/SECURITY_ADVISORY.md` | AD3 | Cross-refs + SA-4 | ~15–20 |

--- a/docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md
+++ b/docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md
@@ -239,15 +239,16 @@ import SeLe4n.Kernel.SchedContext.Invariant.PriorityPreservation
 
 ---
 
-## 4. Phase AD2 — Code Quality Hardening (F-02, F-03)
+## 4. Phase AD2 — Code Quality Hardening (F-02, F-03) ✅ COMPLETE
 
 **Goal**: Address two LOW-severity code quality findings with minimal,
 targeted improvements — a convenience helper for stale-TCB handling and
 a module-boundary documentation annotation.
 **Gate**: `lake build` (full) + `./scripts/test_smoke.sh`.
 **Dependencies**: AD1 (ensures clean build baseline).
+**Status**: COMPLETE — all 4 sub-tasks verified; full build + smoke tests pass.
 
-### AD2-A: Add fresh-TCB retrieval helper (F-02)
+### AD2-A: Add fresh-TCB retrieval helper (F-02) ✅
 
 **Finding**: `endpointQueuePopHead` (DualQueue/Core.lean:243–282) returns the
 pre-dequeue TCB snapshot with stale queue link fields (queuePrev, queueNext
@@ -281,7 +282,7 @@ is additive and does not modify `endpointQueuePopHead`.
 **Files modified**: `DualQueue/Core.lean` (~12 lines added).
 **Estimated effort**: Minimal.
 
-### AD2-B: Add staleness documentation to endpointQueuePopHead callers (F-02)
+### AD2-B: Add staleness documentation to endpointQueuePopHead callers (F-02) ✅
 
 **Finding**: Callers of `endpointQueuePopHead` should be aware that the returned
 TCB has stale queue links. While the function itself is well-documented, the
@@ -303,7 +304,7 @@ at each call site:
 lines each).
 **Estimated effort**: Minimal.
 
-### AD2-C: Add module-boundary docstring to CapTransfer.lean (F-03)
+### AD2-C: Add module-boundary docstring to CapTransfer.lean (F-03) ✅
 
 **Finding**: `ipcTransferSingleCap` errors are converted to `.noSlot` by
 `ipcUnwrapCapsLoop` in `CapTransfer.lean:71–86`. The conversion is documented
@@ -339,14 +340,23 @@ capabilities, which is the correct degraded behavior.
 **Files modified**: `CapTransfer.lean` (~15 lines added).
 **Estimated effort**: Minimal.
 
-### AD2-D: Phase AD2 gate verification
+### AD2-D: Phase AD2 gate verification ✅
 
 **Steps**:
 1. Full build: `source ~/.elan/env && lake build`
 2. Smoke test: `./scripts/test_smoke.sh`
 3. Verify no regressions in IPC test suites
 
-**Gate condition**: All commands pass with zero errors.
+**Verified**:
+1. Module build: `lake build SeLe4n.Kernel.IPC.DualQueue.Core` — 30 jobs, PASS
+2. Module build: `lake build SeLe4n.Kernel.IPC.Operations.CapTransfer` — 26 jobs, PASS
+3. Module build: `lake build SeLe4n.Kernel.IPC.DualQueue.Transport` — 31 jobs, PASS
+4. Full build: `lake build` — 236 jobs, PASS
+5. Smoke test: `./scripts/test_smoke.sh` — all checks passed
+6. Zero sorry/axiom in modified files
+7. Codebase map regenerated
+
+**Gate condition**: All commands pass with zero errors. ✅
 
 **Files modified**: None (verification only).
 

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -5,9 +5,9 @@
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
       "branch": "claude/optimize-code-quality-SDnko",
-      "commit_sha": "c3ac45f6dc4d6521d5ebb77e246053605ca9b21a",
-      "tree_sha": "2cd208c0119f715021dec1cc653a598df3a91f7b",
-      "committed_at_utc": "2026-04-05T21:30:40-04:00"
+      "commit_sha": "6d835ffdfb77170489d301852632ed31f5b83983",
+      "tree_sha": "0ebcf8a88329cb61624c759c6342dbaf506f0787",
+      "committed_at_utc": "2026-04-06T01:46:29+00:00"
     }
   },
   "source_sync": {
@@ -17,7 +17,7 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "5871a6901a682be22a1d2a88369e7ddac5a5c365ac0a99e40e108a97825fd37e"
+    "source_digest": "211fd50e42095e588d7cfec5cecdb972bbaaf6f5746b8ab66d0014e1c153cf1e"
   },
   "summary": {
     "module_count": 149,

--- a/docs/codebase_map.json
+++ b/docs/codebase_map.json
@@ -4,10 +4,10 @@
     "name": "hatter6822/seLe4n",
     "url": "https://github.com/hatter6822/seLe4n",
     "head": {
-      "branch": "claude/optimize-phase-ad1-integration-eqojX",
-      "commit_sha": "0da8bd1b9db4e45246232f07f73a1136b5a63717",
-      "tree_sha": "a363b2d3a4ac0ccb3f36341a4713c5db49b63212",
-      "committed_at_utc": "2026-04-06T01:13:44+00:00"
+      "branch": "claude/optimize-code-quality-SDnko",
+      "commit_sha": "c3ac45f6dc4d6521d5ebb77e246053605ca9b21a",
+      "tree_sha": "2cd208c0119f715021dec1cc653a598df3a91f7b",
+      "committed_at_utc": "2026-04-05T21:30:40-04:00"
     }
   },
   "source_sync": {
@@ -17,17 +17,17 @@
       "tests/**/*.lean"
     ],
     "digest_algorithm": "sha256",
-    "source_digest": "ef5cb5fa215c9d86f3bcaaf71dbb00225797912862e2664ec865cdbe3d3c5309"
+    "source_digest": "5871a6901a682be22a1d2a88369e7ddac5a5c365ac0a99e40e108a97825fd37e"
   },
   "summary": {
     "module_count": 149,
-    "declaration_count": 4524
+    "declaration_count": 4525
   },
   "readme_sync": {
-    "version": "0.25.11",
+    "version": "0.25.12",
     "lean_toolchain": "v4.28.0",
     "production_files": 133,
-    "production_loc": 84028,
+    "production_loc": 84061,
     "test_files": 16,
     "test_loc": 11318,
     "proved_theorem_lemma_decls": 2479,
@@ -10829,7 +10829,7 @@
     {
       "module": "SeLe4n.Kernel.IPC.DualQueue.Core",
       "path": "SeLe4n/Kernel/IPC/DualQueue/Core.lean",
-      "declaration_count": 18,
+      "declaration_count": 19,
       "declarations": [
         {
           "kind": "namespace",
@@ -11062,8 +11062,23 @@
         },
         {
           "kind": "def",
+          "name": "endpointQueuePopHeadFresh",
+          "line": 292,
+          "called": [
+            "KernelError",
+            "ObjId",
+            "SystemState",
+            "TCB",
+            "ThreadId",
+            "endpointId",
+            "endpointQueuePopHead",
+            "toObjId"
+          ]
+        },
+        {
+          "kind": "def",
           "name": "endpointQueueEnqueue",
-          "line": 284,
+          "line": 303,
           "called": [
             "Endpoint",
             "IntrusiveQueue",
@@ -11081,7 +11096,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueuePopHead_preserves_objects_invExt",
-          "line": 323,
+          "line": 342,
           "called": [
             "ObjId",
             "SystemState",
@@ -11101,7 +11116,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_preserves_objects_invExt",
-          "line": 377,
+          "line": 396,
           "called": [
             "ObjId",
             "SystemState",
@@ -11120,7 +11135,7 @@
         {
           "kind": "def",
           "name": "endpointQueueRemove",
-          "line": 461,
+          "line": 480,
           "called": [
             "IntrusiveQueue",
             "KernelError",
@@ -11137,7 +11152,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemove_preserves_objects_invExt",
-          "line": 507,
+          "line": 526,
           "called": [
             "ObjId",
             "RHTable.insert_preserves_invExt",
@@ -11604,7 +11619,7 @@
         {
           "kind": "def",
           "name": "endpointReceiveDual",
-          "line": 1632,
+          "line": 1633,
           "called": [
             "Kernel",
             "ObjId",
@@ -11623,7 +11638,7 @@
         {
           "kind": "def",
           "name": "endpointCall",
-          "line": 1710,
+          "line": 1712,
           "called": [
             "IpcMessage",
             "Kernel",
@@ -11645,7 +11660,7 @@
         {
           "kind": "def",
           "name": "endpointReply",
-          "line": 1754,
+          "line": 1757,
           "called": [
             "IpcMessage",
             "Kernel",
@@ -11662,7 +11677,7 @@
         {
           "kind": "def",
           "name": "endpointReplyRecv",
-          "line": 1782,
+          "line": 1785,
           "called": [
             "IpcMessage",
             "Kernel",
@@ -11682,7 +11697,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_preserves_tail_of_nonTail",
-          "line": 1823,
+          "line": 1826,
           "called": [
             "Endpoint",
             "ObjId",
@@ -11707,7 +11722,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemoveDual_tail_update",
-          "line": 1922,
+          "line": 1925,
           "called": [
             "Endpoint",
             "ObjId",
@@ -11732,7 +11747,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_empty_sets_head",
-          "line": 2011,
+          "line": 2014,
           "called": [
             "Endpoint",
             "ObjId",
@@ -11755,7 +11770,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_empty_queueNext_none",
-          "line": 2053,
+          "line": 2056,
           "called": [
             "Endpoint",
             "ObjId",
@@ -11780,7 +11795,7 @@
         {
           "kind": "theorem",
           "name": "lookupTcb_of_objects",
-          "line": 2116,
+          "line": 2119,
           "called": [
             "SystemState",
             "TCB",
@@ -11793,7 +11808,7 @@
         {
           "kind": "theorem",
           "name": "tid_not_reserved_of_enqueue",
-          "line": 2127,
+          "line": 2130,
           "called": [
             "ObjId",
             "SystemState",
@@ -11808,7 +11823,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueEnqueue_then_popHead_succeeds",
-          "line": 2150,
+          "line": 2153,
           "called": [
             "Endpoint",
             "ObjId",
@@ -11833,7 +11848,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemove_scheduler_eq",
-          "line": 2214,
+          "line": 2217,
           "called": [
             "ObjId",
             "SystemState",
@@ -11847,7 +11862,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemove_cdt_eq",
-          "line": 2235,
+          "line": 2238,
           "called": [
             "ObjId",
             "SystemState",
@@ -11861,7 +11876,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemove_lifecycle_eq",
-          "line": 2256,
+          "line": 2259,
           "called": [
             "ObjId",
             "SystemState",
@@ -11875,7 +11890,7 @@
         {
           "kind": "theorem",
           "name": "endpointQueueRemove_services_eq",
-          "line": 2277,
+          "line": 2280,
           "called": [
             "Kernel",
             "ObjId",
@@ -18652,13 +18667,13 @@
         {
           "kind": "namespace",
           "name": "SeLe4n.Kernel",
-          "line": 35,
+          "line": 46,
           "called": []
         },
         {
           "kind": "def",
           "name": "fillRemainingNoSlot",
-          "line": 44,
+          "line": 55,
           "called": [
             "CapTransferResult",
             "Capability",
@@ -18668,7 +18683,7 @@
         {
           "kind": "def",
           "name": "ipcUnwrapCapsLoop",
-          "line": 57,
+          "line": 68,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18687,7 +18702,7 @@
         {
           "kind": "def",
           "name": "ipcUnwrapCaps",
-          "line": 111,
+          "line": 122,
           "called": [
             "CapTransferSummary",
             "IpcMessage",
@@ -18701,7 +18716,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_preserves_scheduler",
-          "line": 125,
+          "line": 136,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18721,7 +18736,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_scheduler",
-          "line": 158,
+          "line": 169,
           "called": [
             "CapTransferSummary",
             "IpcMessage",
@@ -18735,7 +18750,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_preserves_services",
-          "line": 171,
+          "line": 182,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18755,7 +18770,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_services",
-          "line": 204,
+          "line": 215,
           "called": [
             "CapTransferSummary",
             "IpcMessage",
@@ -18769,7 +18784,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_preserves_objects_ne",
-          "line": 217,
+          "line": 228,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18791,7 +18806,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_objects_ne",
-          "line": 255,
+          "line": 266,
           "called": [
             "CapTransferSummary",
             "IpcMessage",
@@ -18806,7 +18821,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_preserves_ntfn_objects",
-          "line": 269,
+          "line": 280,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18829,7 +18844,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_ntfn_objects",
-          "line": 310,
+          "line": 321,
           "called": [
             "CapTransferSummary",
             "IpcMessage",
@@ -18845,7 +18860,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_receiverRoot_not_ntfn",
-          "line": 325,
+          "line": 336,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18867,7 +18882,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_preserves_ep_objects",
-          "line": 362,
+          "line": 373,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18890,7 +18905,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_ep_objects",
-          "line": 401,
+          "line": 412,
           "called": [
             "CapTransferSummary",
             "Endpoint",
@@ -18906,7 +18921,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_preserves_tcb_objects",
-          "line": 416,
+          "line": 427,
           "called": [
             "CapTransferResult",
             "CapTransferSummary",
@@ -18929,7 +18944,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_tcb_objects",
-          "line": 455,
+          "line": 466,
           "called": [
             "CapTransferSummary",
             "IpcMessage",
@@ -18945,7 +18960,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCapsLoop_preserves_cnode_at_root",
-          "line": 473,
+          "line": 484,
           "called": [
             "CNode",
             "CapTransferResult",
@@ -18968,7 +18983,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_preserves_cnode_at_root",
-          "line": 513,
+          "line": 524,
           "called": [
             "CNode",
             "CapTransferSummary",
@@ -18984,7 +18999,7 @@
         {
           "kind": "theorem",
           "name": "ipcUnwrapCaps_receiverRoot_not_ntfn",
-          "line": 531,
+          "line": 542,
           "called": [
             "CapTransferSummary",
             "IpcMessage",

--- a/docs/gitbook/03-architecture-and-module-map.md
+++ b/docs/gitbook/03-architecture-and-module-map.md
@@ -240,6 +240,12 @@ seLe4n uses a layered architecture so semantic changes can be reviewed and prove
 and adding `_fromTcb` variants for `storeTcbIpcState`/`storeTcbIpcStateAndMessage`.
 22 new queue-consistency theorems (WS-L3). HashMap.fold migration (WS-L2).
 
+**WS-AD/AD2 code quality** (v0.25.12): Added `endpointQueuePopHeadFresh`
+convenience wrapper returning the post-state TCB with cleared queue links,
+avoiding the stale-snapshot footgun (F-02). Staleness annotations added at all
+call sites. CapTransfer module docstring enhanced with F-03 error-to-noSlot
+conversion documentation.
+
 ### Lifecycle subsystem
 
 - `SeLe4n/Kernel/Lifecycle/Operations.lean`

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,7 +5,7 @@
 # under certain conditions. See: https://github.com/hatter6822/seLe4n/blob/main/LICENSE
 
 name = "seLe4n"
-version = "0.25.11"
+version = "0.25.12"
 defaultTargets = ["sele4n"]
 
 [[lean_lib]]


### PR DESCRIPTION
## Summary

- **Workstream(s) advanced**: WS-AD Phase AD2 (Pre-Release Audit Remediation)
- **Recommendation IDs closed**: F-02, F-03
- **Scope notes**: 4 sub-tasks completing Phase AD2 code quality hardening:
  - AD2-A: Added `endpointQueuePopHeadFresh` convenience wrapper
  - AD2-B: Staleness annotations at all call sites
  - AD2-C: Enhanced CapTransfer module docstring
  - AD2-D: Gate verification (full build + smoke tests)

## Changes

### AD2-A: Fresh-TCB retrieval helper (F-02)
Added `endpointQueuePopHeadFresh` in `SeLe4n/Kernel/IPC/DualQueue/Core.lean` (lines 284–301). This convenience wrapper addresses the stale-snapshot footgun documented under WS-L1/L1-A:
- `endpointQueuePopHead` returns the pre-dequeue TCB whose queue link fields (queuePrev, queuePPrev, queueNext) are stale
- `endpointQueuePopHeadFresh` re-fetches the TCB from post-state, returning cleared queue links
- Non-queue fields (ipcState, pendingMessage, priority, domain) are identical in both variants
- ~19 lines added; no proof impact

### AD2-B: Staleness annotations at call sites (F-02)
Added inline comments at all 3 call sites of `endpointQueuePopHead` in `SeLe4n/Kernel/IPC/DualQueue/Transport.lean`:
- `endpointSendDual` (line 1598)
- `endpointReceiveDual` (line 1641)
- `endpointCall` (line 1715)

Each comment notes: "Note: _tcb/senderTcb has stale queue links (WS-L1/L1-A); use st' for current state"

### AD2-C: CapTransfer module docstring enhancement (F-03)
Enhanced module-level docstring in `SeLe4n/Kernel/IPC/Operations/CapTransfer.lean` (lines 33–44) with explicit F-03 error-to-noSlot conversion documentation:
- Clarifies that `ipcTransferSingleCap` errors are intentionally converted to `.noSlot` by `ipcUnwrapCapsLoop`
- Matches seL4's cursor-preservation semantics
- Confirms no capability can be silently installed or lost
- ~11 lines added; no proof impact

### AD2-D: Gate verification
- Module builds: `lake build SeLe4n.Kernel.IPC.DualQueue.Core` (30 jobs, PASS)
- Module builds: `lake build SeLe4n.Kernel.IPC.Operations.CapTransfer` (26 jobs, PASS)
- Module builds: `lake build SeLe4n.Kernel.IPC.DualQueue.Transport` (31 jobs, PASS)
- Full build: `lake build` (236 jobs, PASS)
- Smoke test: `./scripts/test_smoke.sh` (all checks passed)
- Zero sorry/axiom in modified files
- Codebase map regenerated; version bump 0.25.11 → 0.25.12

## Validation evidence

- [x] `./scripts/test_smoke.sh` — PASS
- [x] Full build `lake build` — 236 jobs, PASS
- [x] Module builds (Core, CapTransfer, Transport) — all PASS
- [x] Zero sorry/axiom in modified files
- [x] Codebase map regenerated

## Documentation synchronization checklist

- [x] Canonical source docs updated: `docs/audits/AUDIT_v0.25.10_WORKSTREAM_PLAN.md` (Phase AD2 marked COMPLETE with verification details)
- [x]

https://claude.ai/code/session_01L8bYMAzA23VjbZ8zbTcpHh